### PR TITLE
SPEC-020-R005: accepted-but-stuck session recovery (#1235 child A″)

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/AcceptedSessionRecoveryTracker.swift
+++ b/phase3-binary/Sources/macprovider-cli/AcceptedSessionRecoveryTracker.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+/// SPEC-020-R005 accepted-but-stuck session recovery counter.
+///
+/// Tracks consecutive coordinator-recommendation forward-progress failures for
+/// the *current* recommendation identity `(recommended_binary_version,
+/// recommended_compatibility_set_id)`. A single failure cycle is EITHER one
+/// recorded cooldown/failure for a recommended target OR one observation that the
+/// recommendation yields no installable compatibility-set target (a missing
+/// `recommended_compatibility_set_id`). Both kinds increment the same counter.
+///
+/// The provider becomes eligible to invoke the SPEC-020-R001 signed recovery rail
+/// only once the count reaches `failureThreshold` (default 3) for the current
+/// recommendation. The counter resets to zero when the recommendation identity
+/// changes or the coordinator-recommendation path next makes forward progress, so
+/// recovery eligibility never persists past the stuck condition.
+///
+/// This value type is the single place the R005 counter state lives; it is pure
+/// and owned by `CoordinatorClient` (which serializes access via its actor
+/// isolation and emits the R-6.8 observability events returned here).
+struct AcceptedSessionRecoveryTracker {
+    static let defaultFailureThreshold = 3
+
+    let failureThreshold: Int
+    private(set) var identity: String?
+    private(set) var consecutiveFailureCount = 0
+
+    init(failureThreshold: Int = AcceptedSessionRecoveryTracker.defaultFailureThreshold) {
+        self.failureThreshold = max(1, failureThreshold)
+    }
+
+    /// True once the current recommendation has accumulated at least
+    /// `failureThreshold` consecutive forward-progress failures.
+    var isEligible: Bool { consecutiveFailureCount >= failureThreshold }
+
+    enum IncrementReason: String, Equatable {
+        /// The coordinator advertised a recommended version with no installable
+        /// compatibility-set target.
+        case missingTarget = "missing_target"
+        /// A recorded target failure (compat mismatch, prepare/download, topology).
+        case recordedFailure = "recorded_failure"
+        /// An active discovery/target cooldown skipped the attempt.
+        case cooldown
+    }
+
+    enum ResetReason: String, Equatable {
+        case identityChanged = "identity_changed"
+        case forwardProgress = "forward_progress"
+    }
+
+    /// Observability events (R-6.8) produced by a single `register` call, each
+    /// carrying the counter value at the moment it was emitted.
+    enum Event: Equatable {
+        case increment(reason: IncrementReason, count: Int)
+        case reset(reason: ResetReason, count: Int)
+        case eligible(count: Int, threshold: Int)
+    }
+
+    struct Transition: Equatable {
+        var events: [Event]
+        var identity: String
+        var count: Int
+        var eligible: Bool
+    }
+
+    /// Fold a coordinator-recommendation outcome into the counter, returning the
+    /// observability events the caller must emit and the resulting state.
+    mutating func register(
+        outcome: AutoUpdater.RecommendationOutcome,
+        identity newIdentity: String
+    ) -> Transition {
+        var events: [Event] = []
+
+        // Identity change resets the counter before the new outcome is applied:
+        // a fresh recommendation starts its own consecutive-failure run.
+        if identity != newIdentity {
+            if consecutiveFailureCount != 0 {
+                consecutiveFailureCount = 0
+                events.append(.reset(reason: .identityChanged, count: 0))
+            }
+            identity = newIdentity
+        }
+
+        // Prior-eligibility is measured AFTER the identity reset so that a new
+        // identity which arms within this same call (e.g. threshold == 1) still
+        // emits a becoming-eligible event.
+        let wasEligible = isEligible
+
+        switch outcome {
+        case .notAttempted:
+            // Never engaged a real target: leave the counter unchanged.
+            break
+        case .forwardProgress:
+            if consecutiveFailureCount != 0 {
+                consecutiveFailureCount = 0
+                events.append(.reset(reason: .forwardProgress, count: 0))
+            }
+        case .missingTarget:
+            consecutiveFailureCount += 1
+            events.append(.increment(reason: .missingTarget, count: consecutiveFailureCount))
+        case .forwardProgressFailure:
+            consecutiveFailureCount += 1
+            events.append(.increment(reason: .recordedFailure, count: consecutiveFailureCount))
+        case .cooldownActive:
+            consecutiveFailureCount += 1
+            events.append(.increment(reason: .cooldown, count: consecutiveFailureCount))
+        }
+
+        // Distinct becoming-eligible event, only on the transition into
+        // eligibility (never re-emitted while the count stays at/above threshold).
+        if !wasEligible, isEligible {
+            events.append(.eligible(count: consecutiveFailureCount, threshold: failureThreshold))
+        }
+
+        return Transition(
+            events: events,
+            identity: newIdentity,
+            count: consecutiveFailureCount,
+            eligible: isEligible
+        )
+    }
+}

--- a/phase3-binary/Sources/macprovider-cli/AutoUpdater.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutoUpdater.swift
@@ -27,6 +27,24 @@ private final class AutoUpdateCommitTracker {
     var committedSwap = false
 }
 
+/// Decision returned by the swap-boundary gate, evaluated inside the swap critical
+/// section (no await between it and `activateReleasePayload`). This is the SINGLE
+/// authoritative precedence/trust gate for the swap:
+/// - `.proceed`: swap (non-accepted signed rail — no gate);
+/// - `.ensureTrust`: run `ensureEligible(.swap)` then swap (primary rail — throws
+///   `AutoUpdateError.trustStateLost` on degradation, preserving its rollback path);
+/// - `.abort(reason:)`: do not swap; throw `AutoUpdateSwapPrecedenceAborted` so the
+///   caller records the reason (the accepted-session R005 rail: trust/precedence).
+enum AutoUpdateSwapBoundaryDecision: Sendable, Equatable {
+    case proceed
+    case ensureTrust
+    case abort(reason: String)
+}
+
+struct AutoUpdateSwapPrecedenceAborted: Error {
+    let reason: String
+}
+
 struct AutoUpdater: Sendable {
     typealias TrustProvider = @Sendable () async -> AutoUpdateTrustState
     typealias Drain = @Sendable (_ target: String) async throws -> Bool
@@ -101,34 +119,66 @@ struct AutoUpdater: Sendable {
         self.evictStaleLocalStatusOwner = evictStaleLocalStatusOwner
     }
 
-    func handleCoordinatorRecommendation(_ rawRecommended: String) async {
+    /// Lightweight outcome of a single coordinator-recommendation cycle, used by
+    /// the caller (CoordinatorClient) to drive SPEC-020-R005 accepted-session
+    /// recovery. The mapping to exit points is:
+    /// - `.notAttempted`: trust-skip, autoupdate-disabled, an invalid/unparseable
+    ///   recommended version, or `target_not_newer`. Not counted, not reset — the
+    ///   recommendation never engaged a real target and recorded no failure.
+    /// - `.missingTarget`: the coordinator advertised a `recommended_binary_version`
+    ///   with no installable compatibility-set target
+    ///   (`coordinator_compatibility_target_missing`).
+    /// - `.cooldownActive`: an active discovery/target cooldown skipped the attempt.
+    /// - `.forwardProgressFailure`: any `fail(...)` for a present target before the
+    ///   compatibility-target gate is cleared (target-revoked/below-minimum,
+    ///   topology/observer, release-not-found, prepare/download failure,
+    ///   compatibility-set mismatch).
+    /// - `.forwardProgress`: execution reached past the compatibility-target gate
+    ///   (a successful detect→prepare with a matching compatibility set), or the
+    ///   update succeeded. Later transient failures past the gate still count as
+    ///   forward progress because the stuck condition has been cleared.
+    enum RecommendationOutcome: Sendable, Equatable {
+        case notAttempted
+        case missingTarget
+        case cooldownActive
+        case forwardProgressFailure
+        case forwardProgress
+    }
+
+    @discardableResult
+    func handleCoordinatorRecommendation(_ rawRecommended: String) async -> RecommendationOutcome {
         let updateID = UUID().uuidString.lowercased()
         let entryTrust = await trustProvider()
         guard !SessionAutoupdateGate.shared.isDisabled else {
             await record(updateID: updateID, target: "<session-disabled>", phase: .eligibility, outcome: .skipped, reason: "signed_policy_persist_failed", attempt: 1)
-            return
+            return .notAttempted
         }
         guard entryTrust.isEligible else {
             await record(updateID: updateID, target: "<notify-only>", phase: .eligibility, outcome: .skipped, reason: entryTrust.lossReason, attempt: 1)
-            return
+            return .notAttempted
         }
         let validated: AutoUpdateRecommendation
         do {
             validated = try AutoUpdateRecommendation.validate(rawRecommended)
         } catch let AutoUpdateValidationError.versionTooLong(sha) {
             await record(updateID: updateID, target: "<redacted>", phase: .eligibility, outcome: .failure, reason: "version_too_long", attempt: 1, failure: .recommendedVersionInvalid, sha: sha)
-            return
+            return .notAttempted
         } catch AutoUpdateValidationError.componentTooLong {
             await record(updateID: updateID, target: "<invalid>", phase: .eligibility, outcome: .failure, reason: "version_component_too_long", attempt: 1, failure: .recommendedVersionInvalid)
-            return
+            return .notAttempted
         } catch {
             await record(updateID: updateID, target: "<invalid>", phase: .eligibility, outcome: .failure, reason: "recommended_version_invalid", attempt: 1, failure: .recommendedVersionInvalid)
-            return
+            return .notAttempted
         }
 
         let target = validated.normalized
         await record(updateID: updateID, target: target, phase: .detection, outcome: .inProgress, reason: "recommended_binary_version_detected", attempt: 1)
         let commitTracker = AutoUpdateCommitTracker()
+        // Set once execution clears the compatibility-target gate; from that point
+        // any later failure is still forward progress for R005 accounting because
+        // the stuck condition (cannot get an installable target past the gate) is
+        // resolved.
+        var forwardProgressReached = false
         var mutationLock: AutoUpdateLock?
         defer { withExtendedLifetime(mutationLock) {} }
         var maintenanceLease: ProviderLifecycleLeaseRecord?
@@ -141,31 +191,34 @@ struct AutoUpdater: Sendable {
 
         guard SelfUpdate.compareSemver(currentVersion, target) == .orderedAscending else {
             await record(updateID: updateID, target: target, phase: .eligibility, outcome: .noop, reason: "target_not_newer", attempt: 1)
-            return
+            return .notAttempted
         }
         guard AutoUpdateConfig.enabled(config) else {
             print("A newer version is available (v\(target)), but autoupdate is disabled.")
             await record(updateID: updateID, target: target, phase: .eligibility, outcome: .skipped, reason: "autoupdate_disabled", attempt: 1)
-            return
+            return .notAttempted
         }
         do {
             let policy = markerStore.effectivePolicy()
             if let minimum = policy.minimum, SelfUpdate.compareSemver(target, minimum) == .orderedAscending || policy.revoked.contains(target) {
+                // fail(...) records a cooldown/failure for this target, so per
+                // SPEC-020-R005 this is a recorded forward-progress failure cycle
+                // and MUST increment the counter (not .notAttempted).
                 await fail(updateID: updateID, target: target, phase: .eligibility, failure: .targetRevokedOrBelowMinimum, reason: "target_revoked_or_below_minimum")
-                return
+                return .forwardProgressFailure
             }
             guard launchdProviderAvailable() else {
                 await fail(updateID: updateID, target: target, phase: .eligibility, failure: .other, reason: "unsupported_install_topology")
-                return
+                return .forwardProgressFailure
             }
             guard rollbackObserverAvailable() else {
                 await fail(updateID: updateID, target: target, phase: .eligibility, failure: .rollbackObserverUnavailable, reason: "rollback_observer_unavailable")
-                return
+                return .forwardProgressFailure
             }
             try markerStore.ensureTrustedRoot()
             if let activeCooldown = markerStore.activeCooldown(target: target) {
                 await record(updateID: updateID, target: target, phase: .cooldown, outcome: .skipped, reason: "cooldown_\(activeCooldown.failureClass.rawValue)_until_\(ISO8601DateFormatter.autoupdate.string(from: activeCooldown.until))", attempt: activeCooldown.attempt)
-                return
+                return .cooldownActive
             }
             try await ensureEligible(phase: .eligibility)
             let heldMutationLock = try acquireUpdateLockAndFenceReloadJobs()
@@ -177,7 +230,7 @@ struct AutoUpdater: Sendable {
                 release = try await update.resolveReleaseByTags(normalizedTarget: target)
             } catch UpdateError.releaseNotFound {
                 await fail(updateID: updateID, target: target, phase: .download, failure: .targetReleaseNotFound, reason: "target_release_not_found")
-                return
+                return .forwardProgressFailure
             }
             // The coordinator's recommended compatibility-set target is a precondition
             // known without downloading the release payload. Check it here — after the
@@ -195,7 +248,7 @@ struct AutoUpdater: Sendable {
                     failure: .other,
                     reason: "coordinator_compatibility_target_missing"
                 )
-                return
+                return .missingTarget
             }
             let prepared: PreparedSelfUpdate
             do {
@@ -203,7 +256,7 @@ struct AutoUpdater: Sendable {
             } catch {
                 let failure = Self.failureClass(for: error)
                 await fail(updateID: updateID, target: target, phase: Self.phase(for: error), failure: failure, reason: Self.redactedReason(for: error))
-                return
+                return .forwardProgressFailure
             }
             defer { prepared.cleanup() }
             guard prepared.compatibilityManifest.compatibilitySetID == expectedCompatibilitySetID else {
@@ -214,8 +267,12 @@ struct AutoUpdater: Sendable {
                     failure: .other,
                     reason: "coordinator_compatibility_target_mismatch"
                 )
-                return
+                return .forwardProgressFailure
             }
+            // Past the compatibility-target gate: a matching installable target was
+            // resolved and prepared, so R005 treats this recommendation as making
+            // forward progress even if a later transient (drain/restart) fails.
+            forwardProgressReached = true
             if try markerStore.preflightInstalledMalibuAppReplacement() != nil,
                prepared.stagedMalibuApp == nil {
                 await fail(
@@ -225,7 +282,7 @@ struct AutoUpdater: Sendable {
                     failure: .other,
                     reason: "signed_malibu_bundle_missing"
                 )
-                return
+                return .forwardProgress
             }
             maintenanceLease = try lifecycleLeaseStore.acquire(
                 kind: .maintenance,
@@ -237,7 +294,7 @@ struct AutoUpdater: Sendable {
             guard drained else {
                 await fail(updateID: updateID, target: target, phase: .drain, failure: .drainTimeout, reason: "drain_timeout")
                 try? await sendReady()
-                return
+                return .forwardProgress
             }
             try await ensureEligible(phase: .backup)
             try await preserveMarkerAndSwap(
@@ -247,7 +304,7 @@ struct AutoUpdater: Sendable {
                 tracker: commitTracker,
                 authorityMode: "coordinator_recommendation",
                 discoveryHead: nil,
-                requireCurrentTrustAtSwap: true,
+                swapBoundaryGate: { .ensureTrust },
                 whileHolding: heldMutationLock
             )
             if let signedPolicy = prepared.signedPolicy {
@@ -273,7 +330,7 @@ struct AutoUpdater: Sendable {
                 }
                 startupHandoffPrepared = false
                 await fail(updateID: updateID, target: target, phase: .restart, failure: .other, reason: Self.redactedReason(for: error))
-                return
+                return .forwardProgress
             }
             await record(updateID: updateID, target: target, phase: .restart, outcome: .inProgress, reason: "launchctl_restart_invoked", attempt: 1)
         } catch AutoUpdateMarkerError.lockContended {
@@ -299,16 +356,44 @@ struct AutoUpdater: Sendable {
         } catch {
             await fail(updateID: updateID, target: target, phase: .eligibility, failure: .other, reason: Self.redactedReason(for: error))
         }
+        // Success path falls through here (forwardProgressReached == true). Every
+        // caught failure also reaches here: forward progress if it happened past
+        // the compatibility-target gate, otherwise a forward-progress failure.
+        return forwardProgressReached ? .forwardProgress : .forwardProgressFailure
     }
 
-    func handleSignedReleaseDiscovery() async {
+    func handleSignedReleaseDiscovery(
+        attribution: [String: String] = [:],
+        preSwapGuard: (@Sendable () async -> String?)? = nil,
+        swapBoundaryGate: (@Sendable () async -> AutoUpdateSwapBoundaryDecision)? = nil
+    ) async {
         let updateID = UUID().uuidString.lowercased()
+        // SPEC-020-R005 / R-6.8 (round-4 MEDIUM-2): the coordinator only ever sees
+        // `last_autoupdate_event`, so if any terminal event on an R005-triggered
+        // invocation dropped the attribution, a later plain `github_poll` event
+        // would overwrite the R005 marker and the invocation would be
+        // indistinguishable from an ordinary poll. These helpers stamp the R005
+        // `attribution` (empty for the non-accepted path, i.e. unchanged) onto
+        // EVERY record/fail in this invocation so whichever event lands last still
+        // carries the marker.
+        func recordR005(target: String, phase: AutoUpdatePhase, outcome: AutoUpdateOutcome, reason: String, attempt: Int = 1) async {
+            await record(updateID: updateID, target: target, source: .githubPoll, phase: phase, outcome: outcome, reason: reason, attempt: attempt, extraMetadata: attribution)
+        }
+        func failR005(target: String, phase: AutoUpdatePhase, failure: AutoUpdateFailureClass, reason: String) async {
+            await fail(updateID: updateID, target: target, source: .githubPoll, phase: phase, failure: failure, reason: reason, extraMetadata: attribution)
+        }
+
+        // When invoked to recover an accepted-but-stuck session, emit a distinct,
+        // attributable marker up front.
+        if !attribution.isEmpty {
+            await recordR005(target: "<discovery>", phase: .eligibility, outcome: .inProgress, reason: "accepted_session_recovery_signed_rail_invoked")
+        }
         guard !SessionAutoupdateGate.shared.isDisabled else {
-            await record(updateID: updateID, target: "<session-disabled>", source: .githubPoll, phase: .eligibility, outcome: .skipped, reason: "signed_policy_persist_failed", attempt: 1)
+            await recordR005(target: "<session-disabled>", phase: .eligibility, outcome: .skipped, reason: "signed_policy_persist_failed")
             return
         }
         guard AutoUpdateConfig.enabled(config) else {
-            await record(updateID: updateID, target: "<disabled>", source: .githubPoll, phase: .eligibility, outcome: .skipped, reason: "autoupdate_disabled", attempt: 1)
+            await recordR005(target: "<disabled>", phase: .eligibility, outcome: .skipped, reason: "autoupdate_disabled")
             return
         }
         let commitTracker = AutoUpdateCommitTracker()
@@ -322,16 +407,16 @@ struct AutoUpdater: Sendable {
 
         do {
             guard launchdProviderAvailable() else {
-                await fail(updateID: updateID, target: "<unknown>", source: .githubPoll, phase: .eligibility, failure: .other, reason: "unsupported_install_topology")
+                await failR005(target: "<unknown>", phase: .eligibility, failure: .other, reason: "unsupported_install_topology")
                 return
             }
             guard rollbackObserverAvailable() else {
-                await fail(updateID: updateID, target: "<unknown>", source: .githubPoll, phase: .eligibility, failure: .rollbackObserverUnavailable, reason: "rollback_observer_unavailable")
+                await failR005(target: "<unknown>", phase: .eligibility, failure: .rollbackObserverUnavailable, reason: "rollback_observer_unavailable")
                 return
             }
             try markerStore.ensureTrustedRoot()
             if let activeCooldown = markerStore.activeCooldown(target: "<discovery>") {
-                await record(updateID: updateID, target: "<discovery>", source: .githubPoll, phase: .cooldown, outcome: .skipped, reason: "cooldown_\(activeCooldown.failureClass.rawValue)_until_\(ISO8601DateFormatter.autoupdate.string(from: activeCooldown.until))", attempt: activeCooldown.attempt)
+                await recordR005(target: "<discovery>", phase: .cooldown, outcome: .skipped, reason: "cooldown_\(activeCooldown.failureClass.rawValue)_until_\(ISO8601DateFormatter.autoupdate.string(from: activeCooldown.until))", attempt: activeCooldown.attempt)
                 return
             }
             let update = SelfUpdate(currentVersion: currentVersion, releasesAPIURL: releasesAPIURL, session: session)
@@ -343,17 +428,17 @@ struct AutoUpdater: Sendable {
                     revoked: head.signedPolicyRevoked
                 )
             } catch UpdateError.discoveryHeadReplay {
-                await fail(updateID: updateID, target: "<discovery>", source: .githubPoll, phase: .eligibility, failure: .discoveryHeadReplay, reason: "discovery_head_replay")
+                await failR005(target: "<discovery>", phase: .eligibility, failure: .discoveryHeadReplay, reason: "discovery_head_replay")
                 return
             } catch UpdateError.discoveryHeadEquivocation {
-                await fail(updateID: updateID, target: "<discovery>", source: .githubPoll, phase: .eligibility, failure: .discoveryHeadEquivocation, reason: "discovery_head_equivocation")
+                await failR005(target: "<discovery>", phase: .eligibility, failure: .discoveryHeadEquivocation, reason: "discovery_head_equivocation")
                 return
             } catch UpdateError.discoveryHeadExpired {
-                await fail(updateID: updateID, target: "<discovery>", source: .githubPoll, phase: .eligibility, failure: .discoveryHeadExpired, reason: "discovery_head_expired")
+                await failR005(target: "<discovery>", phase: .eligibility, failure: .discoveryHeadExpired, reason: "discovery_head_expired")
                 return
             }
             let target = head.targetVersion
-            await record(updateID: updateID, target: target, source: .githubPoll, phase: .detection, outcome: .inProgress, reason: "signed_release_discovery_detected", attempt: 1)
+            await recordR005(target: target, phase: .detection, outcome: .inProgress, reason: "signed_release_discovery_detected")
             let canonicalBinary = currentBinaryURL()
             let installedReleaseVersion = CompatibilitySetManifest.loadInstalledPreferringInstallAuthority(
                 launchedExecutableURL: Bundle.main.executableURL,
@@ -367,16 +452,16 @@ struct AutoUpdater: Sendable {
                 _ = try? markerStore.ensurePathEntrypointMatchesInstallAuthority(
                     launchedExecutableURL: Bundle.main.executableURL
                 )
-                await record(updateID: updateID, target: target, source: .githubPoll, phase: .eligibility, outcome: .noop, reason: "target_not_newer", attempt: 1)
+                await recordR005(target: target, phase: .eligibility, outcome: .noop, reason: "target_not_newer")
                 return
             }
             let policy = markerStore.effectivePolicy()
             if let minimum = policy.minimum, SelfUpdate.compareSemver(target, minimum) == .orderedAscending || policy.revoked.contains(target) {
-                await fail(updateID: updateID, target: target, source: .githubPoll, phase: .eligibility, failure: .targetRevokedOrBelowMinimum, reason: "target_revoked_or_below_minimum")
+                await failR005(target: target, phase: .eligibility, failure: .targetRevokedOrBelowMinimum, reason: "target_revoked_or_below_minimum")
                 return
             }
             if let activeCooldown = markerStore.activeCooldown(target: target) {
-                await record(updateID: updateID, target: target, source: .githubPoll, phase: .cooldown, outcome: .skipped, reason: "cooldown_\(activeCooldown.failureClass.rawValue)_until_\(ISO8601DateFormatter.autoupdate.string(from: activeCooldown.until))", attempt: activeCooldown.attempt)
+                await recordR005(target: target, phase: .cooldown, outcome: .skipped, reason: "cooldown_\(activeCooldown.failureClass.rawValue)_until_\(ISO8601DateFormatter.autoupdate.string(from: activeCooldown.until))", attempt: activeCooldown.attempt)
                 return
             }
             let lock = try acquireUpdateLockAndFenceReloadJobs()
@@ -390,12 +475,20 @@ struct AutoUpdater: Sendable {
             try SelfUpdate.requireDiscoveryHead(head, matches: prepared)
             let providerTarget = prepared.compatibilityManifest.providerCLIVersion
             guard prepared.compatibilityManifest.compatibilitySetID == head.targetCompatibilitySetID else {
-                await fail(updateID: updateID, target: target, source: .githubPoll, phase: .eligibility, failure: .other, reason: "discovery_compatibility_target_mismatch")
+                await failR005(target: target, phase: .eligibility, failure: .other, reason: "discovery_compatibility_target_mismatch")
                 return
             }
             if try markerStore.preflightInstalledMalibuAppReplacement() != nil,
                prepared.stagedMalibuApp == nil {
-                await fail(updateID: updateID, target: target, source: .githubPoll, phase: .eligibility, failure: .other, reason: "signed_malibu_bundle_missing")
+                await failR005(target: target, phase: .eligibility, failure: .other, reason: "signed_malibu_bundle_missing")
+                return
+            }
+            // round-4 HIGH-1(b): re-validate the accepted-session invariants after
+            // the suspending discovery/prepare awaits and BEFORE any coordinator-
+            // visible drain or the swap. Trust-loss or primary-rail forward progress
+            // in the interim aborts the cycle (a later re-observation retries).
+            if let preSwapGuard, let abortReason = await preSwapGuard() {
+                await recordR005(target: providerTarget, phase: .eligibility, outcome: .skipped, reason: abortReason)
                 return
             }
             maintenanceLease = try lifecycleLeaseStore.acquire(
@@ -405,21 +498,36 @@ struct AutoUpdater: Sendable {
             )
             let drained = try await drain(providerTarget)
             guard drained else {
-                await fail(updateID: updateID, target: providerTarget, source: .githubPoll, phase: .drain, failure: .drainTimeout, reason: "drain_timeout")
+                await failR005(target: providerTarget, phase: .drain, failure: .drainTimeout, reason: "drain_timeout")
                 try? await sendReady()
                 return
             }
-            try await preserveMarkerAndSwap(
-                updateID: updateID,
-                target: providerTarget,
-                prepared: prepared,
-                tracker: commitTracker,
-                authorityMode: "signed_release",
-                discoveryHead: head,
-                requireCurrentTrustAtSwap: false,
-                whileHolding: lock
-            )
-            await record(updateID: updateID, target: providerTarget, source: .githubPoll, phase: .swap, outcome: .success, reason: "binary_swap_complete", attempt: 1)
+            do {
+                try await preserveMarkerAndSwap(
+                    updateID: updateID,
+                    target: providerTarget,
+                    prepared: prepared,
+                    tracker: commitTracker,
+                    authorityMode: "signed_release",
+                    discoveryHead: head,
+                    // round-6 HIGH: the swap-boundary gate is the SINGLE authoritative
+                    // precedence/trust check, evaluated inside the swap critical
+                    // section with no await before activateReleasePayload. For the
+                    // accepted-session rail it re-runs the FULL trust + generation +
+                    // identity + eligibility decision AT the swap boundary, so a
+                    // context change during the drain await aborts the swap. The
+                    // non-accepted rail passes nil → { .proceed }, unchanged.
+                    swapBoundaryGate: swapBoundaryGate ?? { .proceed },
+                    whileHolding: lock
+                )
+            } catch let abort as AutoUpdateSwapPrecedenceAborted {
+                // Accepted-session precedence/trust abort AT the swap boundary: the
+                // marker/backup were already unwound by preserveMarkerAndSwap; record
+                // the R005-attributed skip and do not proceed.
+                await recordR005(target: providerTarget, phase: .swap, outcome: .skipped, reason: abort.reason)
+                return
+            }
+            await recordR005(target: providerTarget, phase: .swap, outcome: .success, reason: "binary_swap_complete")
             do {
                 try await prepareStartupHandoffEvictAndRestart(
                     maintenanceLease: maintenanceLease,
@@ -437,17 +545,17 @@ struct AutoUpdater: Sendable {
                     _ = try? lifecycleLeaseStore.clear(ifLeaseID: maintenanceLease.leaseID)
                 }
                 startupHandoffPrepared = false
-                await fail(updateID: updateID, target: providerTarget, source: .githubPoll, phase: .restart, failure: .other, reason: Self.redactedReason(for: error))
+                await failR005(target: providerTarget, phase: .restart, failure: .other, reason: Self.redactedReason(for: error))
                 return
             }
-            await record(updateID: updateID, target: providerTarget, source: .githubPoll, phase: .restart, outcome: .inProgress, reason: "launchctl_restart_invoked", attempt: 1)
+            await recordR005(target: providerTarget, phase: .restart, outcome: .inProgress, reason: "launchctl_restart_invoked")
         } catch AutoUpdateMarkerError.lockContended {
-            await fail(updateID: updateID, target: "<unknown>", source: .githubPoll, phase: .eligibility, failure: .autoupdateAlreadyPending, reason: "provider_mutation_in_progress")
+            await failR005(target: "<unknown>", phase: .eligibility, failure: .autoupdateAlreadyPending, reason: "provider_mutation_in_progress")
         } catch AutoUpdateMarkerError.transactionPending {
-            await fail(updateID: updateID, target: "<unknown>", source: .githubPoll, phase: .eligibility, failure: .autoupdateAlreadyPending, reason: "autoupdate_already_pending")
+            await failR005(target: "<unknown>", phase: .eligibility, failure: .autoupdateAlreadyPending, reason: "autoupdate_already_pending")
         } catch {
             let failure = Self.failureClass(for: error)
-            await fail(updateID: updateID, target: "<unknown>", source: .githubPoll, phase: Self.phase(for: error), failure: failure, reason: Self.redactedReason(for: error))
+            await failR005(target: "<unknown>", phase: Self.phase(for: error), failure: failure, reason: Self.redactedReason(for: error))
         }
     }
 
@@ -458,7 +566,7 @@ struct AutoUpdater: Sendable {
         tracker: AutoUpdateCommitTracker,
         authorityMode: String,
         discoveryHead: SignedReleaseDiscoveryHead?,
-        requireCurrentTrustAtSwap: Bool,
+        swapBoundaryGate: @Sendable () async -> AutoUpdateSwapBoundaryDecision,
         whileHolding lock: AutoUpdateLock
     ) async throws {
         defer { withExtendedLifetime(lock) {} }
@@ -482,8 +590,18 @@ struct AutoUpdater: Sendable {
         do {
             try markerStore.writePending(marker)
             tracker.committedMarker = true
-            if requireCurrentTrustAtSwap {
+            // Swap-boundary gate: the authoritative precedence/trust check. There is
+            // NO await between this decision and activateReleasePayload below (the
+            // `.abort` and `.proceed` arms are synchronous, and the single await in
+            // `.ensureTrust` is the primary rail's own trust check under its own held
+            // lock), so nothing can interleave between the decision and the swap.
+            switch await swapBoundaryGate() {
+            case .proceed:
+                break
+            case .ensureTrust:
                 try await ensureEligible(phase: .swap)
+            case let .abort(reason):
+                throw AutoUpdateSwapPrecedenceAborted(reason: reason)
             }
             try markerStore.activateReleasePayload(
                 from: prepared.newBinary.deletingLastPathComponent(),
@@ -493,6 +611,22 @@ struct AutoUpdater: Sendable {
                 rollbackMarker: marker
             )
             tracker.committedSwap = true
+        } catch let abort as AutoUpdateSwapPrecedenceAborted where !tracker.committedSwap {
+            // round-7 HIGH: a swap-boundary precedence/trust abort is a PRE-activation
+            // abort — nothing was swapped (committedSwap == false; activateReleasePayload
+            // never ran, the live binary is unchanged). Fully roll back the pending
+            // transaction: clear the pending marker AND release the lock, leaving NO
+            // durable pending state. Otherwise the primary rail that SUPERSEDED this
+            // recovery would be locked out by the leftover `awaiting_previous_readiness`
+            // pending marker (acquireLock rejects any pending marker) — inverting the
+            // precedence the abort was meant to enforce. This is deliberately NOT the
+            // restoreBackupAfterFencing preserve-for-startup path, which exists only for
+            // genuine mid/post-activation fencing failures where partial state must
+            // survive; the discrimination is strictly on the abort error type with no
+            // activation side effect, never broadened to arbitrary thrown errors.
+            markerStore.removeRollbackBackups(marker)
+            markerStore.clearPendingAndLock(target: nil)
+            throw abort
         } catch {
             if tracker.committedMarker {
                 do {
@@ -549,6 +683,7 @@ struct AutoUpdater: Sendable {
     ) async throws {
         let lock = try acquireUpdateLockAndFenceReloadJobs()
         defer { withExtendedLifetime(lock) {} }
+        let decision: AutoUpdateSwapBoundaryDecision = requireCurrentTrustAtSwap ? .ensureTrust : .proceed
         try await preserveMarkerAndSwap(
             updateID: updateID,
             target: target,
@@ -556,7 +691,29 @@ struct AutoUpdater: Sendable {
             tracker: AutoUpdateCommitTracker(),
             authorityMode: authorityMode,
             discoveryHead: discoveryHead,
-            requireCurrentTrustAtSwap: requireCurrentTrustAtSwap,
+            swapBoundaryGate: { decision },
+            whileHolding: lock
+        )
+    }
+
+    func preserveMarkerAndSwapForTest(
+        updateID: String,
+        target: String,
+        prepared: PreparedSelfUpdate,
+        authorityMode: String,
+        discoveryHead: SignedReleaseDiscoveryHead?,
+        swapBoundaryGate: @escaping @Sendable () async -> AutoUpdateSwapBoundaryDecision
+    ) async throws {
+        let lock = try acquireUpdateLockAndFenceReloadJobs()
+        defer { withExtendedLifetime(lock) {} }
+        try await preserveMarkerAndSwap(
+            updateID: updateID,
+            target: target,
+            prepared: prepared,
+            tracker: AutoUpdateCommitTracker(),
+            authorityMode: authorityMode,
+            discoveryHead: discoveryHead,
+            swapBoundaryGate: swapBoundaryGate,
             whileHolding: lock
         )
     }
@@ -714,12 +871,12 @@ struct AutoUpdater: Sendable {
         _ = phase
     }
 
-    private func fail(updateID: String, target: String, source: AutoUpdateSource = .coordinator, phase: AutoUpdatePhase, failure: AutoUpdateFailureClass, reason: String) async {
+    private func fail(updateID: String, target: String, source: AutoUpdateSource = .coordinator, phase: AutoUpdatePhase, failure: AutoUpdateFailureClass, reason: String, extraMetadata: [String: String] = [:]) async {
         markerStore.recordCooldown(target: target, failureClass: failure)
-        await record(updateID: updateID, target: target, source: source, phase: phase, outcome: .failure, reason: reason, attempt: 1, failure: failure)
+        await record(updateID: updateID, target: target, source: source, phase: phase, outcome: .failure, reason: reason, attempt: 1, failure: failure, extraMetadata: extraMetadata)
     }
 
-    private func record(updateID: String, target: String, source: AutoUpdateSource = .coordinator, phase: AutoUpdatePhase, outcome: AutoUpdateOutcome, reason: String, attempt: Int, failure: AutoUpdateFailureClass? = nil, sha: String? = nil) async {
+    private func record(updateID: String, target: String, source: AutoUpdateSource = .coordinator, phase: AutoUpdatePhase, outcome: AutoUpdateOutcome, reason: String, attempt: Int, failure: AutoUpdateFailureClass? = nil, sha: String? = nil, extraMetadata: [String: String] = [:]) async {
         let inflight = await providerStatus.snapshot().requestsInFlight
         await AutoUpdateEventStore.shared.record(AutoUpdateEvent(
             updateID: updateID,
@@ -732,7 +889,8 @@ struct AutoUpdater: Sendable {
             attempt: attempt,
             failureClass: failure,
             inflightRequests: phase == .drain ? inflight : nil,
-            recommendedBinaryVersionSHA256: sha
+            recommendedBinaryVersionSHA256: sha,
+            extraMetadata: extraMetadata
         ))
     }
 

--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -240,6 +240,38 @@ actor CoordinatorClient {
     private var autoupdateDrainExtensions = false
     private var autoupdateAttemptedTargets = Set<String>()
     private var lastSignedRecoveryDiscoveryAttempt: Date?
+    // SPEC-020-R005: consecutive coordinator-recommendation forward-progress
+    // failure counter for the current recommendation identity. Drives accepted-
+    // but-stuck session recovery via the signed rail once it reaches threshold.
+    private var acceptedSessionRecoveryTracker = AcceptedSessionRecoveryTracker()
+    // SPEC-020-R005: the raw coordinator recommendation for the current accepted
+    // session, retained so the periodic heartbeat tick can re-observe a stuck
+    // recommendation and accumulate the counter across ticks (the recommendation
+    // is otherwise evaluated only once at session acceptance). Cleared when the
+    // session resets.
+    private var currentCoordinatorRecommendation: String?
+    private var acceptedRecoveryReobservationInFlight = false
+    private var lastAcceptedRecoveryReobservation: Date?
+    // SPEC-020-R005 (re-audit HIGH-1): the normalized identity of the coordinator
+    // recommendation whose PRIMARY (mutating) rail is currently in flight. The
+    // pure re-observation path skips entirely while this is set for its identity,
+    // so an observation can never race the primary rail or be misclassified.
+    private var coordinatorRecommendationInFlightIdentity: String?
+    // SPEC-020-R005 (round-4 HIGH-2): monotonically bumped whenever the coordinator
+    // recommendation context changes (compat-set target reassigned, or the session
+    // reset). An outcome computed against a captured generation is DISCARDED if the
+    // generation has advanced by the time it resolves, so a re-entrant
+    // disconnect/reconnect or changed payload can never fold a stale outcome into
+    // the wrong identity's counter.
+    private var coordinatorRecommendationGeneration = 0
+    private var signedRecoveryInvocationStubbedForTest = false
+    #if DEBUG
+    // Test-only trust override, compiled out of release builds so it can never
+    // bypass the real autoupdate trust gate in production.
+    private var autoupdateTrustOverrideForTest: (@Sendable () -> AutoUpdateTrustState)?
+    #endif
+    private var testSignedRecoveryInvocationCount = 0
+    private var testLastSignedRecoveryWasAcceptedRecovery: Bool?
     private var recommendedCompatibilitySetID: String?
     private var webSocket: ProviderWebSocketTask?
     private var coordinatorSessionAccepted = false
@@ -580,6 +612,8 @@ actor CoordinatorClient {
         autoupdateDemotionReason = "coordinator_disconnected"
         autoupdateDisabledForSessionReason = nil
         recommendedCompatibilitySetID = nil
+        currentCoordinatorRecommendation = nil
+        coordinatorRecommendationGeneration &+= 1
         try? autoupdateMarkerStore.clearCompatibilityAdmission()
         autoupdateTrustState = AutoUpdateTrustState(
             v2Accepted: false,
@@ -1850,6 +1884,8 @@ actor CoordinatorClient {
         autoupdateAssignedProviderTokenAdopted = false
         autoupdateDemotionReason = "coordinator_disconnected"
         recommendedCompatibilitySetID = nil
+        currentCoordinatorRecommendation = nil
+        coordinatorRecommendationGeneration &+= 1
         try? autoupdateMarkerStore.clearCompatibilityAdmission()
         autoupdateTrustState = AutoUpdateTrustState(
             v2Accepted: false,
@@ -2288,6 +2324,143 @@ actor CoordinatorClient {
         lastSignedRecoveryDiscoveryAttempt = Date()
     }
 
+    // SPEC-020-R005 test seams.
+    func configureAcceptedRecoveryForTest(
+        accepted: Bool,
+        recommendation: String?,
+        compatibilitySetID: String?
+    ) {
+        coordinatorSessionAccepted = accepted
+        currentCoordinatorRecommendation = recommendation
+        recommendedCompatibilitySetID = compatibilitySetID
+        coordinatorRecommendationGeneration &+= 1
+    }
+
+    func setRecordedCooldownForTest(target: String, failureClass: AutoUpdateFailureClass) {
+        autoupdateMarkerStore.recordCooldown(target: target, failureClass: failureClass)
+    }
+
+    func markTargetAttemptedForTest(_ normalizedVersion: String) {
+        autoupdateAttemptedTargets.insert(normalizedVersion)
+    }
+
+    func setCoordinatorRecommendationInFlightForTest(_ normalizedIdentity: String?) {
+        coordinatorRecommendationInFlightIdentity = normalizedIdentity
+    }
+
+    func recommendationGenerationForTest() -> Int {
+        coordinatorRecommendationGeneration
+    }
+
+    func recommendedCompatibilitySetIDForTest() -> String? {
+        recommendedCompatibilitySetID
+    }
+
+    func mutateRecommendedCompatibilitySetIDForTest(_ compatibilitySetID: String?) {
+        recommendedCompatibilitySetID = compatibilitySetID
+        coordinatorRecommendationGeneration &+= 1
+    }
+
+    func setAutoupdateDisabledForSessionReasonForTest(_ reason: String?) {
+        autoupdateDisabledForSessionReason = reason
+    }
+
+    #if DEBUG
+    func setAutoupdateTrustOverrideForTest(_ override: (@Sendable () -> AutoUpdateTrustState)?) {
+        autoupdateTrustOverrideForTest = override
+    }
+    #endif
+
+    @discardableResult
+    func registerRecommendationOutcomeForTest(
+        _ outcome: AutoUpdater.RecommendationOutcome,
+        normalizedVersion: String,
+        capturedCompatibilitySetID: String?,
+        capturedGeneration: Int
+    ) async -> Bool {
+        await registerCoordinatorRecommendationOutcome(
+            outcome,
+            normalizedVersion: normalizedVersion,
+            capturedCompatibilitySetID: capturedCompatibilitySetID,
+            capturedGeneration: capturedGeneration
+        )
+    }
+
+    func acceptedRecoveryPreSwapAbortReasonForTest() -> String? {
+        acceptedRecoveryPreSwapAbortReason(
+            capturedGeneration: coordinatorRecommendationGeneration,
+            capturedIdentity: acceptedSessionRecoveryTracker.identity ?? "<none>"
+        )
+    }
+
+    func acceptedRecoveryPreSwapAbortReasonForTest(
+        capturedGeneration: Int,
+        capturedIdentity: String
+    ) -> String? {
+        acceptedRecoveryPreSwapAbortReason(
+            capturedGeneration: capturedGeneration,
+            capturedIdentity: capturedIdentity
+        )
+    }
+
+    func acceptedSessionRecoveryIdentityForTest() -> String? {
+        acceptedSessionRecoveryTracker.identity
+    }
+
+    func acceptedRecoverySwapBoundaryDecisionForTest(
+        capturedGeneration: Int,
+        capturedIdentity: String
+    ) -> AutoUpdateSwapBoundaryDecision {
+        acceptedRecoverySwapBoundaryDecision(
+            capturedGeneration: capturedGeneration,
+            capturedIdentity: capturedIdentity
+        )
+    }
+
+    func runSignedRecoveryDiscoveryForTest(now: Date) async {
+        await runSignedRecoveryDiscoveryIfDue(now: now)
+    }
+
+    func applyPrimaryRecommendationOutcomeForTest(
+        _ outcome: AutoUpdater.RecommendationOutcome,
+        normalizedVersion: String
+    ) async {
+        await applyPrimaryRecommendationOutcome(
+            outcome,
+            normalizedVersion: normalizedVersion,
+            capturedCompatibilitySetID: recommendedCompatibilitySetID,
+            capturedGeneration: coordinatorRecommendationGeneration
+        )
+    }
+
+    func currentCoordinatorRecommendationForTest() -> String? {
+        currentCoordinatorRecommendation
+    }
+
+    func stubSignedRecoveryInvocationForTest() {
+        signedRecoveryInvocationStubbedForTest = true
+    }
+
+    func reobserveAcceptedSessionRecoveryForTest(now: Date) async {
+        await reobserveAcceptedSessionRecoveryIfDue(now: now)
+    }
+
+    func acceptedSessionRecoveryEligibleForTest() -> Bool {
+        acceptedSessionRecoveryTracker.isEligible
+    }
+
+    func acceptedSessionRecoveryFailureCountForTest() -> Int {
+        acceptedSessionRecoveryTracker.consecutiveFailureCount
+    }
+
+    func signedRecoveryInvocationCountForTest() -> Int {
+        testSignedRecoveryInvocationCount
+    }
+
+    func lastSignedRecoveryWasAcceptedRecoveryForTest() -> Bool? {
+        testLastSignedRecoveryWasAcceptedRecovery
+    }
+
     // Issue #189 R1 security MEDIUM: assert that any inbound frame
     // bumps the heartbeat success timestamp via handle().
     func handleForTest(_ message: URLSessionWebSocketTask.Message) async throws {
@@ -2721,6 +2894,7 @@ actor CoordinatorClient {
         autoupdateDrainExtensions = payload["autoupdate_drain_extensions"] as? Bool == true
         autoupdateAttemptedTargets.removeAll()
         recommendedCompatibilitySetID = compatibilityAdmission?.recommended
+        coordinatorRecommendationGeneration &+= 1
         autoupdateDisabledForSessionReason = nil
         do {
             if let compatibilityAdmission {
@@ -3803,6 +3977,12 @@ actor CoordinatorClient {
                     // not silently absorb every tick for hours.
                     try await self?.sendHeartbeatBounded(resetWindow: rollWindow)
                     await self?.recordHeartbeatSuccess()
+                    // SPEC-020-R005 (HIGH-1): re-observe a stuck coordinator
+                    // recommendation on the periodic tick so the accepted-session
+                    // recovery counter can accumulate to the threshold. Self-
+                    // throttled and single-in-flight; a no-op unless accepted and
+                    // a recommendation is pending.
+                    await self?.reobserveAcceptedSessionRecoveryIfDue()
                 } catch {
                     Self.keepaliveDebug("keepalive_send_error error=\(error)")
                     await self?.closeWebSocketAfterKeepaliveFailure()
@@ -4159,35 +4339,101 @@ actor CoordinatorClient {
     }
 
     private func runAutoupdateIfEligible(_ recommended: String) async {
-        if let parsed = try? AutoUpdateRecommendation.validate(recommended) {
-            let trust = currentAutoupdateTrustState()
-            guard trust.isEligible else {
-                await AutoUpdateEventStore.shared.record(AutoUpdateEvent(
-                    updateID: UUID().uuidString.lowercased(),
-                    currentVersion: Self.binaryVersion,
-                    targetVersion: parsed.normalized,
-                    phase: .eligibility,
-                    outcome: .skipped,
-                    reason: trust.lossReason,
-                    attempt: 1
-                ))
-                return
-            }
-            guard !autoupdateAttemptedTargets.contains(parsed.normalized) else {
-                await AutoUpdateEventStore.shared.record(AutoUpdateEvent(
-                    updateID: UUID().uuidString.lowercased(),
-                    currentVersion: Self.binaryVersion,
-                    targetVersion: parsed.normalized,
-                    phase: .cooldown,
-                    outcome: .skipped,
-                    reason: "already_attempted_this_session",
-                    attempt: 1
-                ))
-                return
-            }
-            autoupdateAttemptedTargets.insert(parsed.normalized)
+        // MEDIUM-1: validate/normalize the recommendation ONCE. An invalid
+        // recommendation still emits the invalid-version event (via the updater)
+        // but never enters the R005 identity/counter path — a raw, unnormalized,
+        // or unvalidated version must never become an R005 identity or land in an
+        // unredacted event target_version.
+        guard let parsed = try? AutoUpdateRecommendation.validate(recommended) else {
+            _ = await makeCoordinatorRecommendationUpdater().handleCoordinatorRecommendation(recommended)
+            return
         }
-        let updater = AutoUpdater(
+        let normalized = parsed.normalized
+        let trust = currentAutoupdateTrustState()
+        guard trust.isEligible else {
+            await AutoUpdateEventStore.shared.record(AutoUpdateEvent(
+                updateID: UUID().uuidString.lowercased(),
+                currentVersion: Self.binaryVersion,
+                targetVersion: normalized,
+                phase: .eligibility,
+                outcome: .skipped,
+                reason: trust.lossReason,
+                attempt: 1
+            ))
+            return
+        }
+        // SPEC-020-R005 (HIGH-1): remember the active recommendation so the
+        // heartbeat tick can re-observe it while the accepted session persists, and
+        // mark this identity in flight so a pure re-observation can never interleave
+        // with (or be evaluated against) the primary rail. The in-flight mark covers
+        // the whole remainder of this method — including its own signed-recovery
+        // invocation — and is cleared on exit.
+        currentCoordinatorRecommendation = recommended
+        coordinatorRecommendationInFlightIdentity = normalized
+        defer {
+            if coordinatorRecommendationInFlightIdentity == normalized {
+                coordinatorRecommendationInFlightIdentity = nil
+            }
+        }
+        guard !autoupdateAttemptedTargets.contains(normalized) else {
+            await AutoUpdateEventStore.shared.record(AutoUpdateEvent(
+                updateID: UUID().uuidString.lowercased(),
+                currentVersion: Self.binaryVersion,
+                targetVersion: normalized,
+                phase: .cooldown,
+                outcome: .skipped,
+                reason: "already_attempted_this_session",
+                attempt: 1
+            ))
+            return
+        }
+        autoupdateAttemptedTargets.insert(normalized)
+        // HIGH-2: capture the recommendation context BEFORE the evaluating await, so
+        // a re-entrant change (disconnect/reconnect, changed payload) that mutates
+        // the live context is detected and the stale outcome discarded.
+        let capturedCompat = recommendedCompatibilitySetID
+        let capturedGeneration = coordinatorRecommendationGeneration
+        let outcome = await makeCoordinatorRecommendationUpdater().handleCoordinatorRecommendation(recommended)
+        await applyPrimaryRecommendationOutcome(
+            outcome,
+            normalizedVersion: normalized,
+            capturedCompatibilitySetID: capturedCompat,
+            capturedGeneration: capturedGeneration
+        )
+    }
+
+    /// Post-outcome handling shared by the primary coordinator rail. Folds the
+    /// outcome into the R005 counter and, while still holding an accepted session,
+    /// invokes the signed recovery rail if the recommendation is now persistently
+    /// stuck. handleCoordinatorRecommendation has fully returned (its mutation lock
+    /// released) so the two rails run strictly sequentially, never concurrently for
+    /// the same target.
+    private func applyPrimaryRecommendationOutcome(
+        _ outcome: AutoUpdater.RecommendationOutcome,
+        normalizedVersion: String,
+        capturedCompatibilitySetID: String?,
+        capturedGeneration: Int
+    ) async {
+        let applied = await registerCoordinatorRecommendationOutcome(
+            outcome,
+            normalizedVersion: normalizedVersion,
+            capturedCompatibilitySetID: capturedCompatibilitySetID,
+            capturedGeneration: capturedGeneration
+        )
+        if applied, outcome == .forwardProgress {
+            // HIGH-2: a recommendation that reached forward progress is resolved.
+            // Drop the cached recommendation so no later heartbeat re-observation
+            // can re-arm eligibility for this identity — only a NEW coordinator
+            // recommendation may drive R005 again. Only when the outcome actually
+            // applied to the current identity (a stale/discarded outcome must not
+            // clear a newer recommendation's cache).
+            currentCoordinatorRecommendation = nil
+        }
+        await runSignedRecoveryDiscoveryIfDue()
+    }
+
+    private func makeCoordinatorRecommendationUpdater() -> AutoUpdater {
+        AutoUpdater(
             config: appConfig,
             currentVersion: Self.binaryVersion,
             providerStatus: providerStatus,
@@ -4197,28 +4443,344 @@ actor CoordinatorClient {
             drain: { target in try await self.autoupdateDrain(target: target) },
             sendReady: { try await self.sendStateUpdate(state: .ready, reason: "autoupdate_timeout_skipped_ready") }
         )
-        await updater.handleCoordinatorRecommendation(recommended)
+    }
+
+    /// SPEC-020-R005 (re-audit HIGH-1/HIGH-2): while an accepted session persists
+    /// and its coordinator recommendation stays stuck, the recommendation is
+    /// otherwise evaluated only once (at acceptance) — a duplicate primary
+    /// evaluation exits via `already_attempted_this_session` before registering an
+    /// outcome, so the counter would freeze at 1 and never reach the threshold.
+    ///
+    /// This periodic re-observation (hooked into the heartbeat tick) is a PURE,
+    /// READ-ONLY observation: it never calls `handleCoordinatorRecommendation`,
+    /// never acquires the mutation lock, and never installs. It only reads the
+    /// valid R005 stuck-state signals for the cached recommendation and, when one
+    /// is present, routes that observation through the counter. This is what keeps
+    /// it from racing the primary rail (HIGH-1) or re-arming after forward progress
+    /// via a re-triggered cooldown (HIGH-2).
+    private func reobserveAcceptedSessionRecoveryIfDue(now: Date = Date()) async {
+        guard coordinatorSessionAccepted else { return }
+        guard let recommended = currentCoordinatorRecommendation else { return }
+        guard let parsed = try? AutoUpdateRecommendation.validate(recommended) else { return }
+        let normalized = parsed.normalized
+        // HIGH-1: never observe while the primary rail owns this identity.
+        guard coordinatorRecommendationInFlightIdentity != normalized else { return }
+        guard !acceptedRecoveryReobservationInFlight else { return }
+        if let lastAcceptedRecoveryReobservation,
+           now.timeIntervalSince(lastAcceptedRecoveryReobservation) < acceptedRecoveryReobservationIntervalSeconds() {
+            return
+        }
+        acceptedRecoveryReobservationInFlight = true
+        lastAcceptedRecoveryReobservation = now
+        defer { acceptedRecoveryReobservationInFlight = false }
+
+        let capturedCompat = recommendedCompatibilitySetID
+        let capturedGeneration = coordinatorRecommendationGeneration
+        guard let outcome = observeAcceptedSessionRecoveryStuckState(normalizedVersion: normalized) else {
+            // No stuck signal → observe nothing (no increment, no signed rail).
+            return
+        }
+        await registerCoordinatorRecommendationOutcome(
+            outcome,
+            normalizedVersion: normalized,
+            capturedCompatibilitySetID: capturedCompat,
+            capturedGeneration: capturedGeneration
+        )
+        await runSignedRecoveryDiscoveryIfDue(now: now)
+    }
+
+    /// Pure, read-only classification of the current recommendation's R005
+    /// stuck-state. Returns `.missingTarget` when the coordinator advertises a
+    /// newer binary version with no installable compatibility-set target, or
+    /// `.cooldownActive` when a recorded cooldown/failure keeps the target
+    /// unusable; `nil` (observe nothing) otherwise. NEVER mutates, NEVER acquires
+    /// the mutation lock, NEVER runs the installer.
+    private func observeAcceptedSessionRecoveryStuckState(
+        normalizedVersion: String
+    ) -> AutoUpdater.RecommendationOutcome? {
+        // A disabled provider is intentionally not updating — not stuck — and the
+        // signed rail would no-op anyway.
+        guard AutoUpdateConfig.enabled(appConfig) else { return nil }
+        // round-6 MEDIUM: R005 eligibility is for a CURRENT recommendation that
+        // cannot make forward progress, NOT a not-newer / no-op target. A
+        // recommendation that is not strictly newer than the running binary is a
+        // no-op (the primary rail returns target_not_newer), so it can never be a
+        // stuck signal — never count its (possibly stale) cooldown. This gate must
+        // precede BOTH the missing-target and the cooldown observation.
+        guard SelfUpdate.compareSemver(Self.binaryVersion, normalizedVersion) == .orderedAscending else {
+            return nil
+        }
+        // Missing installable compatibility target: newer recommended version with
+        // no compatibility-set id (the live production stuck state). Unchanged — this
+        // classifies every tick regardless of cooldown and reaches threshold.
+        if recommendedCompatibilitySetID == nil {
+            return .missingTarget
+        }
+        // round-8 HIGH: has-compat-set repeatedly-unusable target. The robust stuck
+        // signal is "this newer target was ATTEMPTED this session and made no forward
+        // progress" — because `autoupdateAttemptedTargets` blocks any further primary
+        // progress on it for the session, it is persistently unusable whether or not a
+        // cooldown is momentarily active. Keying on a momentary cooldown was fragile:
+        // the single ~300s cooldown expires before the (>= 300s) re-observation
+        // interval, so the counter plateaued at 1 and never armed. (The not-newer
+        // guard above still excludes no-op targets, so an attempted not-newer target
+        // is never counted — round-6 MEDIUM stays fixed.) A cooldown that IS active is
+        // kept as an OR for the pre-attempt-record window.
+        if autoupdateAttemptedTargets.contains(normalizedVersion)
+            || autoupdateMarkerStore.activeCooldown(target: normalizedVersion) != nil {
+            return .cooldownActive
+        }
+        return nil
+    }
+
+    private func acceptedRecoveryReobservationIntervalSeconds() -> TimeInterval {
+        let jitter = TimeInterval(Int.random(in: 0...30))
+        return 300 + jitter
+    }
+
+    private func recommendationIdentity(normalizedVersion: String, compatibilitySetID: String?) -> String {
+        "\(normalizedVersion)|\(compatibilitySetID ?? "<none>")"
+    }
+
+    /// SPEC-020-R005 counter + R-6.8 observability. Increments on
+    /// missing-target/recorded-failure/cooldown, resets on forward progress or a
+    /// recommendation-identity change, and emits the per-increment, per-reset, and
+    /// becoming-eligible events. Identity = (NORMALIZED recommended version,
+    /// recommended compatibility-set id) — the caller passes a validated, normalized
+    /// version so `v1.7.0` and `1.7.0` map to one identity and no raw text lands in
+    /// the (unredacted) event `target_version`.
+    ///
+    /// round-4 HIGH-2: the outcome was computed against a captured recommendation
+    /// context (`capturedCompatibilitySetID` + `capturedGeneration`). Because the
+    /// actor is re-entrant across the evaluating await, a disconnect/reconnect or
+    /// changed coordinator payload can mutate that context before the outcome
+    /// resolves. If the captured context no longer matches live state, the outcome
+    /// is DISCARDED (the tracker is not touched) so a stale outcome can never fold
+    /// into the wrong identity's counter. Returns true iff the outcome was applied.
+    @discardableResult
+    private func registerCoordinatorRecommendationOutcome(
+        _ outcome: AutoUpdater.RecommendationOutcome,
+        normalizedVersion: String,
+        capturedCompatibilitySetID: String?,
+        capturedGeneration: Int
+    ) async -> Bool {
+        let identity = recommendationIdentity(normalizedVersion: normalizedVersion, compatibilitySetID: capturedCompatibilitySetID)
+        let liveIdentity = recommendationIdentity(normalizedVersion: normalizedVersion, compatibilitySetID: recommendedCompatibilitySetID)
+        guard capturedGeneration == coordinatorRecommendationGeneration, identity == liveIdentity else {
+            await emitAcceptedRecoveryEvent(
+                reason: "accepted_session_recovery_outcome_discarded_stale",
+                version: normalizedVersion,
+                identity: identity,
+                count: acceptedSessionRecoveryTracker.consecutiveFailureCount,
+                extra: ["live_identity": liveIdentity]
+            )
+            return false
+        }
+        let transition = acceptedSessionRecoveryTracker.register(outcome: outcome, identity: identity)
+        for event in transition.events {
+            switch event {
+            case let .increment(reason, count):
+                await emitAcceptedRecoveryEvent(
+                    reason: "accepted_session_recovery_failure_increment",
+                    version: normalizedVersion,
+                    identity: identity,
+                    count: count,
+                    extra: ["increment_reason": reason.rawValue]
+                )
+            case let .reset(reason, count):
+                await emitAcceptedRecoveryEvent(
+                    reason: "accepted_session_recovery_counter_reset",
+                    version: normalizedVersion,
+                    identity: identity,
+                    count: count,
+                    extra: ["reset_reason": reason.rawValue]
+                )
+            case let .eligible(count, threshold):
+                await emitAcceptedRecoveryEvent(
+                    reason: "accepted_session_recovery_eligible",
+                    version: normalizedVersion,
+                    identity: identity,
+                    count: count,
+                    extra: ["failure_threshold": String(threshold)]
+                )
+            }
+        }
+        return true
+    }
+
+    private func emitAcceptedRecoveryEvent(
+        reason: String,
+        version: String,
+        identity: String,
+        count: Int,
+        extra: [String: String]
+    ) async {
+        var meta = extra
+        meta["recommendation_identity"] = identity
+        meta["consecutive_failure_count"] = String(count)
+        // R-6.8 events reuse the redaction-bearing AutoUpdateEvent (R-6.6). They
+        // are counter observations, not update attempts, so they carry the
+        // coordinator source with an eligibility phase / skipped outcome.
+        await AutoUpdateEventStore.shared.record(AutoUpdateEvent(
+            updateID: UUID().uuidString.lowercased(),
+            currentVersion: Self.binaryVersion,
+            targetVersion: version,
+            source: .coordinator,
+            phase: .eligibility,
+            outcome: .skipped,
+            reason: reason,
+            attempt: 1,
+            extraMetadata: meta
+        ))
     }
 
     private func runSignedRecoveryDiscoveryIfDue(now: Date = Date()) async {
-        guard !coordinatorSessionAccepted else { return }
+        // SPEC-020-R005: the signed rail fires when the provider holds no accepted
+        // session (the original SPEC-020-R001 reach) OR when it holds an accepted
+        // session but the current coordinator recommendation is persistently stuck
+        // (consecutive-failure count has reached the threshold).
+        let acceptedRecovery = coordinatorSessionAccepted
+        if acceptedRecovery, !acceptedSessionRecoveryTracker.isEligible {
+            return
+        }
+        // round-4 HIGH-1(a): for the ACCEPTED-session R005 trigger, re-check current
+        // autoupdate trust BEFORE invoking the signed rail. Trust-loss (token /
+        // attestation degraded) must take precedence — the accepted-session recovery
+        // must not install while the coordinator session's trust is gone. The
+        // non-accepted (disconnected) signed-recovery path is unchanged: it
+        // intentionally does not gate on coordinator-session trust.
+        if acceptedRecovery, !currentAutoupdateTrustState().isEligible {
+            await emitAcceptedRecoveryEvent(
+                reason: "accepted_session_recovery_trust_lost_preinvocation",
+                version: "<discovery>",
+                identity: acceptedSessionRecoveryTracker.identity ?? "<none>",
+                count: acceptedSessionRecoveryTracker.consecutiveFailureCount,
+                extra: ["loss_reason": currentAutoupdateTrustState().lossReason]
+            )
+            return
+        }
         if let lastSignedRecoveryDiscoveryAttempt,
            now.timeIntervalSince(lastSignedRecoveryDiscoveryAttempt) < signedRecoveryDiscoveryIntervalSeconds() {
             return
         }
         lastSignedRecoveryDiscoveryAttempt = now
+        if signedRecoveryInvocationStubbedForTest {
+            testSignedRecoveryInvocationCount += 1
+            testLastSignedRecoveryWasAcceptedRecovery = acceptedRecovery
+            return
+        }
+        // AC-V0.1-R005-4: an accepted-session recovery that still holds a live
+        // coordinator session MUST drain via the coordinator-aware path
+        // (state_update + drain_status) so the coordinator stops routing buyers
+        // while the swap runs. MEDIUM: the drain mode is decided at DRAIN TIME from
+        // live session state (not captured here), and falls back to the local drain
+        // if the session dropped between discovery and drain. Signed-release
+        // authority for the swap is unchanged.
         let updater = AutoUpdater(
             config: appConfig,
             currentVersion: Self.binaryVersion,
             providerStatus: providerStatus,
             markerStore: autoupdateMarkerStore,
             trustProvider: { await self.currentAutoupdateTrustState() },
-            drain: { target in await self.autoupdateLocalDrain(target: target) },
-            sendReady: {
-                await self.providerStatus.setState(.ready, reason: "autoupdate_timeout_skipped_ready")
-            }
+            drain: { target in await self.signedRecoveryDrain(target: target) },
+            sendReady: { try await self.signedRecoverySendReady() }
         )
-        await updater.handleSignedReleaseDiscovery()
+        var attribution: [String: String] = [:]
+        var preSwapGuard: (@Sendable () async -> String?)?
+        var swapBoundaryGate: (@Sendable () async -> AutoUpdateSwapBoundaryDecision)?
+        if acceptedRecovery {
+            // R-6.8: attribute the accepted-session invocation to R005. The
+            // `source` stays github_poll per R-6.4; attribution rides in metadata.
+            attribution = [
+                "accepted_session_recovery": "true",
+                "recommendation_identity": acceptedSessionRecoveryTracker.identity ?? "<none>",
+                "consecutive_failure_count": String(acceptedSessionRecoveryTracker.consecutiveFailureCount),
+            ]
+            // round-5 HIGH: capture the recommendation identity + generation at the
+            // point the R005 recovery run is INVOKED, so the guard detects a context
+            // change even before the lagging tracker eligibility catches up.
+            let capturedGeneration = coordinatorRecommendationGeneration
+            let capturedIdentity = acceptedSessionRecoveryTracker.identity ?? "<none>"
+            // Cheap pre-drain early-out — avoids a pointless drain if already
+            // superseded/trust-lost. NOT authoritative (a suspension, the drain,
+            // follows it); the swap-boundary gate below is the authority.
+            preSwapGuard = { [weak self] in
+                guard let self else { return "accepted_session_recovery_client_gone" }
+                return await self.acceptedRecoveryPreSwapAbortReason(
+                    capturedGeneration: capturedGeneration,
+                    capturedIdentity: capturedIdentity
+                )
+            }
+            // round-6 HIGH: the authoritative gate, evaluated AT the swap boundary
+            // (no await before the swap). It re-runs the FULL trust + generation +
+            // identity + eligibility decision, so a context change during the drain
+            // await aborts the swap. Session-dropped → nil abort reason → .proceed as
+            // the disconnected R001 rail (no coordinator-session trust gate), which is
+            // the round-5 accepted→disconnected fallback.
+            swapBoundaryGate = { [weak self] in
+                guard let self else { return .abort(reason: "accepted_session_recovery_client_gone") }
+                return await self.acceptedRecoverySwapBoundaryDecision(
+                    capturedGeneration: capturedGeneration,
+                    capturedIdentity: capturedIdentity
+                )
+            }
+        }
+        await updater.handleSignedReleaseDiscovery(
+            attribution: attribution,
+            preSwapGuard: preSwapGuard,
+            swapBoundaryGate: swapBoundaryGate
+        )
+    }
+
+    /// round-4 HIGH-1 + round-5/6 HIGH: pre-swap re-validation for the accepted-
+    /// session R005 rail, used both as the cheap pre-drain early-out and as the
+    /// authoritative swap-boundary gate. Aborts if the accepted-session invariants no
+    /// longer hold: trust lost, the recommendation context changed since invocation
+    /// (generation or identity), or the tracker is no longer eligible. Returns nil to
+    /// proceed. When the session has dropped entirely, returns nil so recovery can
+    /// proceed on the disconnected R001 rail (whose swap does not gate on session
+    /// trust).
+    private func acceptedRecoveryPreSwapAbortReason(
+        capturedGeneration: Int,
+        capturedIdentity: String
+    ) -> String? {
+        guard coordinatorSessionAccepted else {
+            // Session dropped mid-flight: no accepted-session invariant to protect;
+            // let the (now disconnected-authority) swap proceed as an R001 recovery.
+            return nil
+        }
+        guard currentAutoupdateTrustState().isEligible else {
+            return "trust_state_lost"
+        }
+        // round-5 HIGH: a context change (generation bump, or the tracker's identity
+        // moved) means the primary rail is viable again for a NEW recommendation.
+        // Tracker eligibility lags a generation change by one outcome registration,
+        // so never rely on `isEligible` alone.
+        guard coordinatorRecommendationGeneration == capturedGeneration,
+              (acceptedSessionRecoveryTracker.identity ?? "<none>") == capturedIdentity else {
+            return "accepted_session_recovery_superseded_by_primary"
+        }
+        guard acceptedSessionRecoveryTracker.isEligible else {
+            return "accepted_session_recovery_superseded_by_primary"
+        }
+        return nil
+    }
+
+    /// round-6 HIGH: single source of truth for the accepted-session swap-boundary
+    /// decision. Wraps `acceptedRecoveryPreSwapAbortReason` into the swap gate's
+    /// decision type. Used verbatim by the production swap-boundary closure so a test
+    /// exercises exactly the production decision.
+    private func acceptedRecoverySwapBoundaryDecision(
+        capturedGeneration: Int,
+        capturedIdentity: String
+    ) -> AutoUpdateSwapBoundaryDecision {
+        if let reason = acceptedRecoveryPreSwapAbortReason(
+            capturedGeneration: capturedGeneration,
+            capturedIdentity: capturedIdentity
+        ) {
+            return .abort(reason: reason)
+        }
+        return .proceed
     }
 
     private func signedRecoveryDiscoveryIntervalSeconds() -> TimeInterval {
@@ -4227,6 +4789,11 @@ actor CoordinatorClient {
     }
 
     private func currentAutoupdateTrustState() -> AutoUpdateTrustState {
+        #if DEBUG
+        if let autoupdateTrustOverrideForTest {
+            return autoupdateTrustOverrideForTest()
+        }
+        #endif
         if let reason = autoupdateDisabledForSessionReason {
             return AutoUpdateTrustState(
                 v2Accepted: false,
@@ -4358,12 +4925,26 @@ actor CoordinatorClient {
         return Date() >= deadline
     }
 
-    private func autoupdateDrain(target: String) async throws -> Bool {
+    /// Reference flag set once a coordinator-visible drain side effect (the
+    /// `state_update(draining)` frame, or a drain_status send) has SUCCEEDED, so a
+    /// caller can distinguish a throw before any coordinator side effect from one
+    /// after. Actor-isolated in practice; only ever touched on the actor.
+    private final class CoordinatorDrainSideEffect {
+        var fired = false
+    }
+
+    private func autoupdateDrain(
+        target: String,
+        sideEffect: CoordinatorDrainSideEffect? = nil
+    ) async throws -> Bool {
         heartbeatTask?.cancel()
         heartbeatTask = nil
         heartbeatWatchdogTask?.cancel()
         heartbeatWatchdogTask = nil
         try await sendStateUpdate(state: .draining, reason: "autoupdate_to_\(target)")
+        // The coordinator has now seen the draining frame (it stops routing buyers);
+        // any later throw must be reconciled, not silently degraded.
+        sideEffect?.fired = true
         try await sendDrainStatus(phase: "starting")
         try await sendDrainStatus(phase: "in_progress")
         let softDrained = await providerStatus.waitUntilDrained(timeoutSeconds: 120)
@@ -4421,6 +5002,76 @@ actor CoordinatorClient {
 
     func autoupdateLocalDrainForTest(target: String) async -> Bool {
         await autoupdateLocalDrain(target: target)
+    }
+
+    /// SPEC-020-R005 drain selector for the signed recovery rail. The mode is
+    /// decided at DRAIN TIME from live session state — coordinator-aware only while
+    /// an accepted session is still present.
+    ///
+    /// MEDIUM (round-3): the coordinator-aware drain can throw AFTER it has already
+    /// emitted a coordinator-visible side effect (the `state_update(draining)`
+    /// frame). Silently falling back to the local drain there would leave the
+    /// coordinator holding a stale draining/routing view for a live accepted
+    /// session (AC-V0.1-R005-4 nonconformance). So:
+    /// - throw BEFORE any coordinator side effect fired → local fallback is fine
+    ///   (the coordinator never saw draining);
+    /// - throw AFTER a side effect fired → best-effort send a terminal ready so the
+    ///   coordinator abandons the draining view, and ABORT this drain cycle (do not
+    ///   swap under a half-broken coordinator view; a later re-observation retries);
+    /// - if that terminal ready ALSO fails the session is genuinely dead → local
+    ///   fallback is acceptable, logged.
+    private func signedRecoveryDrain(target: String) async -> Bool {
+        if coordinatorSessionAccepted {
+            let sideEffect = CoordinatorDrainSideEffect()
+            do {
+                return try await autoupdateDrain(target: target, sideEffect: sideEffect)
+            } catch {
+                Self.keepaliveDebug("signed_recovery_coordinator_drain_fallback error=\(Self.sanitizedDiagnosticText(String(describing: error)))")
+                if sideEffect.fired {
+                    // round-4 MEDIUM-1: a coordinator-visible drain side effect (the
+                    // draining frame) already fired. Attempt the terminal ready
+                    // reconcile best-effort, but ABORT the recovery cycle regardless
+                    // of whether that send succeeds — never fall through to a local
+                    // drain + swap behind a partially committed coordinator drain (on
+                    // a transient ready failure the coordinator can still hold the
+                    // stale draining view while the swap proceeds). A later re-
+                    // observation tick retries if still stuck.
+                    _ = await sendCoordinatorReadyBestEffort(reason: "autoupdate_drain_aborted_partial")
+                    return false
+                }
+            }
+        }
+        return await autoupdateLocalDrain(target: target)
+    }
+
+    /// Best-effort tell the coordinator the provider is ready again (used to undo a
+    /// partially committed coordinator drain). Returns true if the ready frame was
+    /// sent; on failure it still reconciles local state to ready and returns false.
+    private func sendCoordinatorReadyBestEffort(reason: String) async -> Bool {
+        do {
+            try await sendStateUpdate(state: .ready, reason: reason)
+            return true
+        } catch {
+            Self.keepaliveDebug("signed_recovery_ready_send_failed error=\(Self.sanitizedDiagnosticText(String(describing: error)))")
+            await providerStatus.setState(.ready, reason: reason)
+            return false
+        }
+    }
+
+    private func signedRecoverySendReady() async throws {
+        if coordinatorSessionAccepted {
+            do {
+                try await sendStateUpdate(state: .ready, reason: "autoupdate_timeout_skipped_ready")
+                return
+            } catch {
+                Self.keepaliveDebug("signed_recovery_coordinator_ready_fallback error=\(Self.sanitizedDiagnosticText(String(describing: error)))")
+            }
+        }
+        await providerStatus.setState(.ready, reason: "autoupdate_timeout_skipped_ready")
+    }
+
+    func signedRecoveryDrainForTest(target: String) async -> Bool {
+        await signedRecoveryDrain(target: target)
     }
 
     // resetWindow=true rolls the since-last metrics window (the coordinator-

--- a/phase3-binary/Tests/macprovider-cliTests/AcceptedSessionRecoveryTrackerTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/AcceptedSessionRecoveryTrackerTests.swift
@@ -1,0 +1,199 @@
+import XCTest
+@testable import macprovider_cli
+
+/// SPEC-020-R005 accepted-but-stuck session recovery counter coverage,
+/// AC-V0.1-R005-1 through AC-V0.1-R005-4.
+final class AcceptedSessionRecoveryTrackerTests: XCTestCase {
+    private let identityA = "1.9.0|<none>"
+    private let identityB = "1.9.0|set-42"
+    private let identityC = "1.9.1|<none>"
+
+    private func increments(_ events: [AcceptedSessionRecoveryTracker.Event]) -> [AcceptedSessionRecoveryTracker.IncrementReason] {
+        events.compactMap { if case let .increment(reason, _) = $0 { return reason } else { return nil } }
+    }
+
+    private func resets(_ events: [AcceptedSessionRecoveryTracker.Event]) -> [AcceptedSessionRecoveryTracker.ResetReason] {
+        events.compactMap { if case let .reset(reason, _) = $0 { return reason } else { return nil } }
+    }
+
+    private func becameEligible(_ events: [AcceptedSessionRecoveryTracker.Event]) -> Bool {
+        events.contains { if case .eligible = $0 { return true } else { return false } }
+    }
+
+    // AC-V0.1-R005-1: threshold counting, not transience. N-1 consecutive
+    // missing-target outcomes must NOT arm recovery; the Nth must.
+    func testMissingTargetArmsOnlyAtThreshold() {
+        var tracker = AcceptedSessionRecoveryTracker(failureThreshold: 3)
+
+        let t1 = tracker.register(outcome: .missingTarget, identity: identityA)
+        XCTAssertEqual(t1.count, 1)
+        XCTAssertFalse(t1.eligible)
+        XCTAssertEqual(increments(t1.events), [.missingTarget])
+        XCTAssertFalse(becameEligible(t1.events))
+
+        let t2 = tracker.register(outcome: .missingTarget, identity: identityA)
+        XCTAssertEqual(t2.count, 2)
+        XCTAssertFalse(t2.eligible)
+        XCTAssertFalse(becameEligible(t2.events))
+
+        let t3 = tracker.register(outcome: .missingTarget, identity: identityA)
+        XCTAssertEqual(t3.count, 3)
+        XCTAssertTrue(t3.eligible)
+        XCTAssertTrue(becameEligible(t3.events))
+        // The becoming-eligible event names the threshold.
+        XCTAssertTrue(t3.events.contains(.eligible(count: 3, threshold: 3)))
+    }
+
+    // AC-V0.1-R005-1 (mixed): recorded failures and cooldowns fold into the SAME
+    // counter as missing-target observations.
+    func testRecordedFailureAndCooldownShareTheCounter() {
+        var tracker = AcceptedSessionRecoveryTracker(failureThreshold: 3)
+        _ = tracker.register(outcome: .missingTarget, identity: identityA)
+        _ = tracker.register(outcome: .forwardProgressFailure, identity: identityA)
+        let t3 = tracker.register(outcome: .cooldownActive, identity: identityA)
+        XCTAssertEqual(t3.count, 3)
+        XCTAssertTrue(t3.eligible)
+        XCTAssertTrue(becameEligible(t3.events))
+    }
+
+    // AC-V0.1-R005-2: target-missing is stuck only when persistent. A single
+    // missing-target observation followed by a valid target (rollout transient)
+    // resets the counter and grants no eligibility.
+    func testSingleMissingTargetThenValidTargetResetsWithoutEligibility() {
+        var tracker = AcceptedSessionRecoveryTracker(failureThreshold: 3)
+
+        let t1 = tracker.register(outcome: .missingTarget, identity: identityA)
+        XCTAssertEqual(t1.count, 1)
+        XCTAssertFalse(t1.eligible)
+
+        // A valid installable target now makes forward progress: reset, no arm.
+        let t2 = tracker.register(outcome: .forwardProgress, identity: identityA)
+        XCTAssertEqual(t2.count, 0)
+        XCTAssertFalse(t2.eligible)
+        XCTAssertEqual(resets(t2.events), [.forwardProgress])
+        XCTAssertFalse(becameEligible(t2.events))
+
+        // And it stays unarmed on the next missing-target: the run restarts at 1.
+        let t3 = tracker.register(outcome: .missingTarget, identity: identityA)
+        XCTAssertEqual(t3.count, 1)
+        XCTAssertFalse(t3.eligible)
+    }
+
+    // AC-V0.1-R005-2 variant: the "valid target" arrives as a changed identity
+    // (a compatibility-set id is now present), which also resets the counter.
+    func testMissingTargetThenIdentityGainsCompatSetResets() {
+        var tracker = AcceptedSessionRecoveryTracker(failureThreshold: 3)
+        let t1 = tracker.register(outcome: .missingTarget, identity: identityA)
+        XCTAssertEqual(t1.count, 1)
+
+        let t2 = tracker.register(outcome: .forwardProgress, identity: identityB)
+        XCTAssertEqual(t2.count, 0)
+        XCTAssertFalse(t2.eligible)
+        // Identity change resets before the outcome is applied.
+        XCTAssertEqual(resets(t2.events), [.identityChanged])
+    }
+
+    // AC-V0.1-R005-3: primary-rail precedence and reset. Forward progress mid-run
+    // resets, and the run must re-accumulate from scratch to re-arm.
+    func testForwardProgressMidRunResetsAndRequiresFullReaccumulation() {
+        var tracker = AcceptedSessionRecoveryTracker(failureThreshold: 3)
+        _ = tracker.register(outcome: .missingTarget, identity: identityA)
+        _ = tracker.register(outcome: .forwardProgressFailure, identity: identityA)
+        let reset = tracker.register(outcome: .forwardProgress, identity: identityA)
+        XCTAssertEqual(reset.count, 0)
+        XCTAssertEqual(resets(reset.events), [.forwardProgress])
+
+        // Two more failures are not enough after the reset.
+        _ = tracker.register(outcome: .missingTarget, identity: identityA)
+        let two = tracker.register(outcome: .missingTarget, identity: identityA)
+        XCTAssertEqual(two.count, 2)
+        XCTAssertFalse(two.eligible)
+        let three = tracker.register(outcome: .missingTarget, identity: identityA)
+        XCTAssertTrue(three.eligible)
+        XCTAssertTrue(becameEligible(three.events))
+    }
+
+    // AC-V0.1-R005-3: recommendation identity change resets the counter.
+    func testIdentityChangeResetsCounter() {
+        var tracker = AcceptedSessionRecoveryTracker(failureThreshold: 3)
+        _ = tracker.register(outcome: .missingTarget, identity: identityA)
+        let two = tracker.register(outcome: .missingTarget, identity: identityA)
+        XCTAssertEqual(two.count, 2)
+
+        // The coordinator advertises a different recommended version: reset.
+        let changed = tracker.register(outcome: .missingTarget, identity: identityC)
+        XCTAssertEqual(changed.count, 1)
+        XCTAssertFalse(changed.eligible)
+        XCTAssertEqual(resets(changed.events), [.identityChanged])
+        XCTAssertEqual(increments(changed.events), [.missingTarget])
+    }
+
+    // notAttempted outcomes (trust-skip, disabled, target-not-newer, revoked) must
+    // leave the counter unchanged and emit no events.
+    func testNotAttemptedLeavesCounterUnchanged() {
+        var tracker = AcceptedSessionRecoveryTracker(failureThreshold: 3)
+        let t1 = tracker.register(outcome: .missingTarget, identity: identityA)
+        XCTAssertEqual(t1.count, 1)
+
+        let noop = tracker.register(outcome: .notAttempted, identity: identityA)
+        XCTAssertEqual(noop.count, 1)
+        XCTAssertFalse(noop.eligible)
+        XCTAssertTrue(noop.events.isEmpty)
+    }
+
+    // The becoming-eligible event fires exactly once on the transition, not again
+    // while the count stays at or above threshold.
+    func testEligibleEventEmittedOnceOnTransition() {
+        var tracker = AcceptedSessionRecoveryTracker(failureThreshold: 2)
+        _ = tracker.register(outcome: .missingTarget, identity: identityA)
+        let arm = tracker.register(outcome: .missingTarget, identity: identityA)
+        XCTAssertTrue(becameEligible(arm.events))
+
+        let stillStuck = tracker.register(outcome: .missingTarget, identity: identityA)
+        XCTAssertEqual(stillStuck.count, 3)
+        XCTAssertTrue(stillStuck.eligible)
+        // No second eligible event: already eligible before this call.
+        XCTAssertFalse(becameEligible(stillStuck.events))
+        XCTAssertEqual(increments(stillStuck.events), [.missingTarget])
+    }
+
+    // Reset events carry the post-reset count (0); increment events carry the
+    // incremented count. Confirms the emitted counts are exact per R-6.8.
+    func testEventCountsAreExact() {
+        var tracker = AcceptedSessionRecoveryTracker(failureThreshold: 3)
+        let inc = tracker.register(outcome: .forwardProgressFailure, identity: identityA)
+        XCTAssertEqual(inc.events, [.increment(reason: .recordedFailure, count: 1)])
+
+        let reset = tracker.register(outcome: .forwardProgress, identity: identityA)
+        XCTAssertEqual(reset.events, [.reset(reason: .forwardProgress, count: 0)])
+    }
+
+    // LOW regression: with failureThreshold == 1, a NEW identity that arms within
+    // the same register call (identity-change reset then increment) MUST still emit
+    // a becoming-eligible event. Prior-eligibility is measured after the reset.
+    func testThresholdOneNewIdentityStillEmitsEligible() {
+        var tracker = AcceptedSessionRecoveryTracker(failureThreshold: 1)
+        let first = tracker.register(outcome: .missingTarget, identity: identityA)
+        XCTAssertTrue(first.eligible)
+        XCTAssertTrue(becameEligible(first.events))
+
+        // Different identity: reset (was eligible on A) then increment on B, which
+        // re-arms in the same call. The eligible event must fire again for B.
+        let second = tracker.register(outcome: .missingTarget, identity: identityC)
+        XCTAssertEqual(second.count, 1)
+        XCTAssertTrue(second.eligible)
+        XCTAssertEqual(resets(second.events), [.identityChanged])
+        XCTAssertTrue(becameEligible(second.events))
+    }
+
+    // The default threshold is 3 per the SPEC.
+    func testDefaultThresholdIsThree() {
+        XCTAssertEqual(AcceptedSessionRecoveryTracker.defaultFailureThreshold, 3)
+        var tracker = AcceptedSessionRecoveryTracker()
+        _ = tracker.register(outcome: .missingTarget, identity: identityA)
+        _ = tracker.register(outcome: .missingTarget, identity: identityA)
+        XCTAssertFalse(tracker.isEligible)
+        _ = tracker.register(outcome: .missingTarget, identity: identityA)
+        XCTAssertTrue(tracker.isEligible)
+    }
+}

--- a/phase3-binary/Tests/macprovider-cliTests/AutoUpdateTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/AutoUpdateTests.swift
@@ -2140,6 +2140,257 @@ final class AutoUpdateTests: XCTestCase {
         XCTAssertEqual(marker.targetCompatibilitySetSHA256, manifest.envelopeSHA256)
     }
 
+    // SPEC-020-R005 round-6 HIGH: the swap-boundary gate is the authoritative
+    // precedence check. When it returns .abort at the swap boundary, the payload is
+    // NOT activated (binary unchanged) and the pending marker is unwound — proving
+    // the gate sits AT the swap and aborts the terminal action itself.
+    func testSwapBoundaryGateAbortPreventsActivation() async throws {
+        let fixture = try TempHome()
+        let manifestSigningKey = P256.Signing.PrivateKey()
+        let manifestPublicKey = manifestSigningKey.publicKey.pemRepresentation
+        let store = AutoUpdateMarkerStore(
+            homeDirectory: fixture.url,
+            compatibilityManifestPublicKeyPEM: manifestPublicKey
+        )
+        try store.ensureTrustedRoot()
+        let binaryDirectory = fixture.url.appendingPathComponent("bin", isDirectory: true)
+        let payload = fixture.url.appendingPathComponent("payload", isDirectory: true)
+        try FileManager.default.createDirectory(at: binaryDirectory, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o700])
+        try FileManager.default.createDirectory(at: payload, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o700])
+        let binary = binaryDirectory.appendingPathComponent("macprovider-cli")
+        let newBinary = payload.appendingPathComponent("macprovider-cli")
+        try Data("old-binary".utf8).write(to: binary)
+        try Data("new-binary".utf8).write(to: newBinary)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: binary.path)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: newBinary.path)
+        try writeOwnedReleaseResources(in: binaryDirectory, prefix: "old")
+        try writeOwnedReleaseResources(in: payload, prefix: "new")
+        _ = try CompatibilityManifestFixture(
+            root: binaryDirectory,
+            privateKey: manifestSigningKey,
+            version: "1.8.48",
+            providerCLIVersion: "1.8.48",
+            malibuAppVersion: "1.8.43",
+            commit: "1111111111111111111111111111111111111111",
+            populateResources: false
+        )
+        let manifestFixture = try CompatibilityManifestFixture(
+            root: payload,
+            privateKey: manifestSigningKey,
+            version: "1.8.50",
+            providerCLIVersion: "1.8.50",
+            malibuAppVersion: "1.8.43",
+            commit: "2222222222222222222222222222222222222222",
+            populateResources: false
+        )
+        let manifest = try CompatibilitySetManifest.loadValidated(
+            from: payload,
+            expectedProviderVersion: "1.8.50",
+            publicKeyPEM: manifestPublicKey
+        )
+        XCTAssertEqual(manifest.compatibilitySetID, manifestFixture.compatibilitySetID)
+        let prepared = PreparedSelfUpdate(
+            tempDir: fixture.url,
+            newBinary: newBinary,
+            stagedMalibuApp: nil,
+            signedPolicy: nil,
+            compatibilityManifest: manifest,
+            artifactIndexSHA256: String(repeating: "a", count: 64)
+        )
+        let head = SignedReleaseDiscoveryHead(
+            releaseSequence: 12,
+            targetVersion: "1.8.50",
+            targetCompatibilitySetID: manifest.compatibilitySetID,
+            targetArtifactIndexSHA256: prepared.artifactIndexSHA256,
+            signedPolicyMinimum: nil,
+            signedPolicyRevoked: [],
+            issuedAt: Date().addingTimeInterval(-30),
+            expiresAt: Date().addingTimeInterval(300),
+            digest: String(repeating: "b", count: 64)
+        )
+        let status = ProviderStatus(
+            modelID: "mlx-community/Test-Model",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: nil, maxConcurrencyOverride: nil)
+        )
+        let updater = AutoUpdater(
+            config: .defaults(configPath: fixture.url.appendingPathComponent("config.yaml").path),
+            currentVersion: "1.8.48",
+            providerStatus: status,
+            markerStore: store,
+            trustProvider: {
+                // Irrelevant here: the .abort gate throws before any trust check.
+                AutoUpdateTrustState(
+                    v2Accepted: false, tier: nil, encryptedLegValid: false,
+                    attestationRequired: false, attestationSatisfied: false,
+                    tokenConfigured: true, tokenValidated: false,
+                    bearerlessDuplicate: false, connected: false,
+                    stableReason: "coordinator_disconnected"
+                )
+            },
+            drain: { _ in true },
+            sendReady: {},
+            restartLaunchd: {},
+            fenceReloadJobs: {},
+            currentBinaryURL: { binary },
+            rollbackObserverAvailable: { true },
+            launchdProviderAvailable: { true }
+        )
+
+        do {
+            try await updater.preserveMarkerAndSwapForTest(
+                updateID: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+                target: "1.8.50",
+                prepared: prepared,
+                authorityMode: "signed_release",
+                discoveryHead: head,
+                swapBoundaryGate: { .abort(reason: "accepted_session_recovery_superseded_by_primary") }
+            )
+            XCTFail("expected the swap-boundary gate to abort the swap")
+        } catch let abort as AutoUpdateSwapPrecedenceAborted {
+            XCTAssertEqual(abort.reason, "accepted_session_recovery_superseded_by_primary")
+        }
+
+        // (1) The payload was NOT activated — the terminal swap did not run.
+        XCTAssertEqual(try String(contentsOf: binary), "old-binary")
+        XCTAssertEqual(try String(contentsOf: newBinary), "new-binary")
+        // (2) round-7 HIGH: NO durable pending marker remains — a pre-activation
+        // abort fully rolls back, so it cannot lock out the primary rail.
+        XCTAssertNil(try store.readPending())
+        // (3) The lock is released: a subsequent update attempt acquires the lock
+        // and does NOT hit transactionPending. Prove it via a real re-run that now
+        // proceeds and activates.
+        try await updater.preserveMarkerAndSwapForTest(
+            updateID: "bbbbbbbb-cccc-4ddd-8eee-ffffffffffff",
+            target: "1.8.50",
+            prepared: prepared,
+            authorityMode: "signed_release",
+            discoveryHead: head,
+            swapBoundaryGate: { .proceed }
+        )
+        XCTAssertEqual(try String(contentsOf: binary), "new-binary")
+    }
+
+    // SPEC-020-R005 round-7 HIGH (discrimination, the other direction): a genuine
+    // post-writePending FAILURE that is NOT a precedence abort still PRESERVES the
+    // durable pending marker for CLI startup recovery — the clean rollback must not
+    // be broadened to arbitrary thrown errors. Here `.ensureTrust` with lost trust
+    // throws trustStateLost at the same swap-boundary position as the abort.
+    func testGenuinePostWritePendingFailurePreservesPendingMarker() async throws {
+        let fixture = try TempHome()
+        let manifestSigningKey = P256.Signing.PrivateKey()
+        let manifestPublicKey = manifestSigningKey.publicKey.pemRepresentation
+        let store = AutoUpdateMarkerStore(
+            homeDirectory: fixture.url,
+            compatibilityManifestPublicKeyPEM: manifestPublicKey
+        )
+        try store.ensureTrustedRoot()
+        let binaryDirectory = fixture.url.appendingPathComponent("bin", isDirectory: true)
+        let payload = fixture.url.appendingPathComponent("payload", isDirectory: true)
+        try FileManager.default.createDirectory(at: binaryDirectory, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o700])
+        try FileManager.default.createDirectory(at: payload, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o700])
+        let binary = binaryDirectory.appendingPathComponent("macprovider-cli")
+        let newBinary = payload.appendingPathComponent("macprovider-cli")
+        try Data("old-binary".utf8).write(to: binary)
+        try Data("new-binary".utf8).write(to: newBinary)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: binary.path)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: newBinary.path)
+        try writeOwnedReleaseResources(in: binaryDirectory, prefix: "old")
+        try writeOwnedReleaseResources(in: payload, prefix: "new")
+        _ = try CompatibilityManifestFixture(
+            root: binaryDirectory,
+            privateKey: manifestSigningKey,
+            version: "1.8.48",
+            providerCLIVersion: "1.8.48",
+            malibuAppVersion: "1.8.43",
+            commit: "1111111111111111111111111111111111111111",
+            populateResources: false
+        )
+        _ = try CompatibilityManifestFixture(
+            root: payload,
+            privateKey: manifestSigningKey,
+            version: "1.8.50",
+            providerCLIVersion: "1.8.50",
+            malibuAppVersion: "1.8.43",
+            commit: "2222222222222222222222222222222222222222",
+            populateResources: false
+        )
+        let manifest = try CompatibilitySetManifest.loadValidated(
+            from: payload,
+            expectedProviderVersion: "1.8.50",
+            publicKeyPEM: manifestPublicKey
+        )
+        let prepared = PreparedSelfUpdate(
+            tempDir: fixture.url,
+            newBinary: newBinary,
+            stagedMalibuApp: nil,
+            signedPolicy: nil,
+            compatibilityManifest: manifest,
+            artifactIndexSHA256: String(repeating: "a", count: 64)
+        )
+        let head = SignedReleaseDiscoveryHead(
+            releaseSequence: 12,
+            targetVersion: "1.8.50",
+            targetCompatibilitySetID: manifest.compatibilitySetID,
+            targetArtifactIndexSHA256: prepared.artifactIndexSHA256,
+            signedPolicyMinimum: nil,
+            signedPolicyRevoked: [],
+            issuedAt: Date().addingTimeInterval(-30),
+            expiresAt: Date().addingTimeInterval(300),
+            digest: String(repeating: "b", count: 64)
+        )
+        let status = ProviderStatus(
+            modelID: "mlx-community/Test-Model",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: nil, maxConcurrencyOverride: nil)
+        )
+        let updater = AutoUpdater(
+            config: .defaults(configPath: fixture.url.appendingPathComponent("config.yaml").path),
+            currentVersion: "1.8.48",
+            providerStatus: status,
+            markerStore: store,
+            trustProvider: {
+                // Lost trust: `.ensureTrust` will throw trustStateLost at the swap
+                // boundary, a NON-abort error after writePending.
+                AutoUpdateTrustState(
+                    v2Accepted: false, tier: nil, encryptedLegValid: false,
+                    attestationRequired: false, attestationSatisfied: false,
+                    tokenConfigured: true, tokenValidated: false,
+                    bearerlessDuplicate: false, connected: false,
+                    stableReason: "attestation_degraded"
+                )
+            },
+            drain: { _ in true },
+            sendReady: {},
+            restartLaunchd: {},
+            fenceReloadJobs: {},
+            currentBinaryURL: { binary },
+            rollbackObserverAvailable: { true },
+            launchdProviderAvailable: { true }
+        )
+
+        do {
+            try await updater.preserveMarkerAndSwapForTest(
+                updateID: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+                target: "1.8.50",
+                prepared: prepared,
+                authorityMode: "signed_release",
+                discoveryHead: head,
+                swapBoundaryGate: { .ensureTrust }
+            )
+            XCTFail("expected ensureTrust to abort on lost trust")
+        } catch let error as AutoUpdateError {
+            guard case .trustStateLost = error else {
+                return XCTFail("expected trustStateLost, got \(error)")
+            }
+        }
+
+        // Binary unchanged, but the durable pending marker IS preserved for CLI
+        // startup recovery (the genuine-failure path is unchanged).
+        XCTAssertEqual(try String(contentsOf: binary), "old-binary")
+        XCTAssertNotNil(try store.readPending())
+    }
+
     func testAutoUpdaterOwnsMutationLockBeforeFencingReloadJobs() throws {
         let fixture = try TempHome()
         let store = AutoUpdateMarkerStore(homeDirectory: fixture.url)
@@ -2843,6 +3094,261 @@ final class AutoUpdateTests: XCTestCase {
         let release = try await update.resolveReleaseByTags(normalizedTarget: "1.7.0")
 
         XCTAssertEqual(release.tagName, "1.7.0")
+    }
+
+    // MARK: - SPEC-020-R005 handleCoordinatorRecommendation outcome mapping
+
+    private func r005PinnedTrust() -> AutoUpdateTrustState {
+        AutoUpdateTrustState(
+            v2Accepted: true,
+            tier: "pinned",
+            encryptedLegValid: true,
+            attestationRequired: false,
+            attestationSatisfied: true,
+            tokenConfigured: true,
+            tokenValidated: true,
+            bearerlessDuplicate: false,
+            connected: true
+        )
+    }
+
+    private func r005Status() -> ProviderStatus {
+        ProviderStatus(
+            modelID: "mlx-community/Test-Model",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: nil, maxConcurrencyOverride: nil)
+        )
+    }
+
+    // The live production state: the coordinator advertises a recommended binary
+    // version with no compatibility-set target. The recommendation resolves a
+    // release but has no installable compatibility-set target -> .missingTarget.
+    func testHandleCoordinatorRecommendationReturnsMissingTargetWhenNoCompatSet() async throws {
+        let fixture = try TempHome()
+        let store = AutoUpdateMarkerStore(homeDirectory: fixture.url)
+        try store.ensureTrustedRoot()
+        let binaryDir = fixture.url.appendingPathComponent("bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: binaryDir, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700])
+        let binary = binaryDir.appendingPathComponent("macprovider-cli")
+        try Data("old-binary".utf8).write(to: binary)
+        await AutoUpdateEventStore.shared.clear()
+        SessionAutoupdateGate.shared.resetForTest()
+        defer { SessionAutoupdateGate.shared.resetForTest() }
+
+        let latest = "https://api.github.com/repos/Augustas11/macprovider/releases/latest"
+        let vTag = URL(string: "https://api.github.com/repos/Augustas11/macprovider/releases/tags/v1.7.0")!
+        AutoUpdateMockURLProtocol.responses = [
+            vTag: (200, Data(#"{"tag_name":"1.7.0","assets":[]}"#.utf8)),
+        ]
+        defer { AutoUpdateMockURLProtocol.responses = [:] }
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [AutoUpdateMockURLProtocol.self]
+
+        let updater = AutoUpdater(
+            config: .defaults(configPath: fixture.url.appendingPathComponent("config.yaml").path),
+            currentVersion: "1.6.0",
+            providerStatus: r005Status(),
+            expectedCompatibilitySetID: nil,
+            releasesAPIURL: latest,
+            markerStore: store,
+            session: URLSession(configuration: configuration),
+            trustProvider: { self.r005PinnedTrust() },
+            drain: { _ in true },
+            sendReady: {},
+            restartLaunchd: {},
+            fenceReloadJobs: {},
+            currentBinaryURL: { binary },
+            rollbackObserverAvailable: { true },
+            launchdProviderAvailable: { true }
+        )
+
+        let outcome = await updater.handleCoordinatorRecommendation("1.7.0")
+
+        XCTAssertEqual(outcome, .missingTarget)
+        let event = await AutoUpdateEventStore.shared.lastWireObject()
+        XCTAssertEqual(event?["reason"] as? String, "coordinator_compatibility_target_missing")
+    }
+
+    func testHandleCoordinatorRecommendationReturnsNotAttemptedOnTargetNotNewer() async throws {
+        let fixture = try TempHome()
+        let store = AutoUpdateMarkerStore(homeDirectory: fixture.url)
+        SessionAutoupdateGate.shared.resetForTest()
+        defer { SessionAutoupdateGate.shared.resetForTest() }
+        let updater = AutoUpdater(
+            config: .defaults(configPath: fixture.url.appendingPathComponent("config.yaml").path),
+            currentVersion: "1.8.0",
+            providerStatus: r005Status(),
+            markerStore: store,
+            trustProvider: { self.r005PinnedTrust() },
+            drain: { _ in true },
+            sendReady: {},
+            restartLaunchd: {},
+            fenceReloadJobs: {},
+            currentBinaryURL: { nil },
+            rollbackObserverAvailable: { true },
+            launchdProviderAvailable: { true }
+        )
+
+        let outcome = await updater.handleCoordinatorRecommendation("1.7.0")
+        XCTAssertEqual(outcome, .notAttempted)
+    }
+
+    func testHandleCoordinatorRecommendationReturnsNotAttemptedOnTrustSkip() async throws {
+        let fixture = try TempHome()
+        let store = AutoUpdateMarkerStore(homeDirectory: fixture.url)
+        SessionAutoupdateGate.shared.resetForTest()
+        defer { SessionAutoupdateGate.shared.resetForTest() }
+        let updater = AutoUpdater(
+            config: .defaults(configPath: fixture.url.appendingPathComponent("config.yaml").path),
+            currentVersion: "1.6.0",
+            providerStatus: r005Status(),
+            markerStore: store,
+            trustProvider: {
+                AutoUpdateTrustState(
+                    v2Accepted: false,
+                    tier: nil,
+                    encryptedLegValid: false,
+                    attestationRequired: false,
+                    attestationSatisfied: false,
+                    tokenConfigured: true,
+                    tokenValidated: false,
+                    bearerlessDuplicate: false,
+                    connected: false,
+                    stableReason: "coordinator_disconnected"
+                )
+            },
+            drain: { _ in true },
+            sendReady: {},
+            restartLaunchd: {},
+            fenceReloadJobs: {},
+            currentBinaryURL: { nil },
+            rollbackObserverAvailable: { true },
+            launchdProviderAvailable: { true }
+        )
+
+        let outcome = await updater.handleCoordinatorRecommendation("1.7.0")
+        XCTAssertEqual(outcome, .notAttempted)
+    }
+
+    func testHandleCoordinatorRecommendationReturnsForwardProgressFailureOnUnsupportedTopology() async throws {
+        let fixture = try TempHome()
+        let store = AutoUpdateMarkerStore(homeDirectory: fixture.url)
+        SessionAutoupdateGate.shared.resetForTest()
+        defer { SessionAutoupdateGate.shared.resetForTest() }
+        let updater = AutoUpdater(
+            config: .defaults(configPath: fixture.url.appendingPathComponent("config.yaml").path),
+            currentVersion: "1.6.0",
+            providerStatus: r005Status(),
+            markerStore: store,
+            trustProvider: { self.r005PinnedTrust() },
+            drain: { _ in true },
+            sendReady: {},
+            restartLaunchd: {},
+            fenceReloadJobs: {},
+            currentBinaryURL: { nil },
+            rollbackObserverAvailable: { true },
+            launchdProviderAvailable: { false }
+        )
+
+        let outcome = await updater.handleCoordinatorRecommendation("1.7.0")
+        XCTAssertEqual(outcome, .forwardProgressFailure)
+    }
+
+    func testHandleCoordinatorRecommendationReturnsCooldownActive() async throws {
+        let fixture = try TempHome()
+        let store = AutoUpdateMarkerStore(homeDirectory: fixture.url)
+        try store.ensureTrustedRoot()
+        store.recordCooldown(target: "1.7.0", failureClass: .other)
+        SessionAutoupdateGate.shared.resetForTest()
+        defer { SessionAutoupdateGate.shared.resetForTest() }
+        let updater = AutoUpdater(
+            config: .defaults(configPath: fixture.url.appendingPathComponent("config.yaml").path),
+            currentVersion: "1.6.0",
+            providerStatus: r005Status(),
+            markerStore: store,
+            trustProvider: { self.r005PinnedTrust() },
+            drain: { _ in true },
+            sendReady: {},
+            restartLaunchd: {},
+            fenceReloadJobs: {},
+            currentBinaryURL: { nil },
+            rollbackObserverAvailable: { true },
+            launchdProviderAvailable: { true }
+        )
+
+        let outcome = await updater.handleCoordinatorRecommendation("1.7.0")
+        XCTAssertEqual(outcome, .cooldownActive)
+    }
+
+    // MEDIUM-2: target_revoked_or_below_minimum records a cooldown/failure, so it
+    // is a recorded forward-progress failure cycle and MUST increment the counter.
+    func testHandleCoordinatorRecommendationReturnsForwardProgressFailureOnBelowMinimum() async throws {
+        let fixture = try TempHome()
+        let store = AutoUpdateMarkerStore(homeDirectory: fixture.url)
+        try store.ensureTrustedRoot()
+        try await store.updateSignedPolicy(minimum: "1.8.0", revoked: [])
+        SessionAutoupdateGate.shared.resetForTest()
+        defer { SessionAutoupdateGate.shared.resetForTest() }
+        let updater = AutoUpdater(
+            config: .defaults(configPath: fixture.url.appendingPathComponent("config.yaml").path),
+            currentVersion: "1.6.0",
+            providerStatus: r005Status(),
+            markerStore: store,
+            trustProvider: { self.r005PinnedTrust() },
+            drain: { _ in true },
+            sendReady: {},
+            restartLaunchd: {},
+            fenceReloadJobs: {},
+            currentBinaryURL: { nil },
+            rollbackObserverAvailable: { true },
+            launchdProviderAvailable: { true }
+        )
+
+        // Target 1.7.0 is below the persisted minimum 1.8.0.
+        let outcome = await updater.handleCoordinatorRecommendation("1.7.0")
+        XCTAssertEqual(outcome, .forwardProgressFailure)
+    }
+
+    // SPEC-020-R005 round-4 MEDIUM-2 / R-6.8: an R005-triggered signed-recovery
+    // invocation that ends on a NON-detection terminal path still carries the R005
+    // attribution on the terminal event (the coordinator only sees the last event).
+    func testR005AttributionSurvivesOnNonDetectionTerminalEvent() async throws {
+        let fixture = try TempHome()
+        let store = AutoUpdateMarkerStore(homeDirectory: fixture.url)
+        await AutoUpdateEventStore.shared.clear()
+        SessionAutoupdateGate.shared.resetForTest()
+        defer { SessionAutoupdateGate.shared.resetForTest() }
+        var config = AppConfig.defaults(configPath: fixture.url.appendingPathComponent("config.yaml").path)
+        config.autoUpdateEnabled = false
+        let updater = AutoUpdater(
+            config: config,
+            currentVersion: "1.6.0",
+            providerStatus: r005Status(),
+            markerStore: store,
+            trustProvider: { self.r005PinnedTrust() },
+            drain: { _ in true },
+            sendReady: {},
+            restartLaunchd: {},
+            fenceReloadJobs: {},
+            currentBinaryURL: { nil },
+            rollbackObserverAvailable: { true },
+            launchdProviderAvailable: { true }
+        )
+        let attribution = [
+            "accepted_session_recovery": "true",
+            "recommendation_identity": "99.9.9|<none>",
+            "consecutive_failure_count": "3",
+        ]
+
+        // autoupdate disabled => terminal event is `autoupdate_disabled` (a non-
+        // detection path that previously dropped the R005 marker).
+        await updater.handleSignedReleaseDiscovery(attribution: attribution)
+
+        let event = await AutoUpdateEventStore.shared.lastWireObject()
+        XCTAssertEqual(event?["reason"] as? String, "autoupdate_disabled")
+        let meta = event?["extra_metadata"] as? [String: String]
+        XCTAssertEqual(meta?["accepted_session_recovery"], "true")
+        XCTAssertEqual(meta?["consecutive_failure_count"], "3")
     }
 
     private func signedDiscoveryPayload(

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -510,6 +510,684 @@ final class CoordinatorClientTests: XCTestCase {
         XCTAssertEqual(snapshot.activeRequestIDCount, 0)
     }
 
+    // SPEC-020-R005 (c): a persistently missing-target accepted session accumulates
+    // the consecutive-failure counter across periodic PURE-OBSERVATION ticks (no
+    // handleCoordinatorRecommendation, no mutation lock) and becomes eligible at the
+    // threshold, then invokes the signed rail as an accepted-session recovery.
+    func testAcceptedSessionMissingTargetReachesEligibilityAcrossTicks() async throws {
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let client = try await makeClient(status: status, recorder: CoordinatorFrameRecorder())
+        // Newer version + no compatibility-set target => pure observation classifies
+        // .missingTarget without touching the installer.
+        await client.configureAcceptedRecoveryForTest(accepted: true, recommendation: "v99.9.9", compatibilitySetID: nil)
+        await client.setAutoupdateTrustOverrideForTest { CoordinatorClientTests.r005EligibleTrust() }
+        await client.stubSignedRecoveryInvocationForTest()
+
+        let base = Date()
+        await client.reobserveAcceptedSessionRecoveryForTest(now: base)
+        var count = await client.acceptedSessionRecoveryFailureCountForTest()
+        var eligible = await client.acceptedSessionRecoveryEligibleForTest()
+        XCTAssertEqual(count, 1)
+        XCTAssertFalse(eligible)
+
+        await client.reobserveAcceptedSessionRecoveryForTest(now: base.addingTimeInterval(400))
+        count = await client.acceptedSessionRecoveryFailureCountForTest()
+        eligible = await client.acceptedSessionRecoveryEligibleForTest()
+        var invocations = await client.signedRecoveryInvocationCountForTest()
+        XCTAssertEqual(count, 2)
+        XCTAssertFalse(eligible)
+        XCTAssertEqual(invocations, 0)
+
+        await client.reobserveAcceptedSessionRecoveryForTest(now: base.addingTimeInterval(800))
+        count = await client.acceptedSessionRecoveryFailureCountForTest()
+        eligible = await client.acceptedSessionRecoveryEligibleForTest()
+        invocations = await client.signedRecoveryInvocationCountForTest()
+        let lastWasAccepted = await client.lastSignedRecoveryWasAcceptedRecoveryForTest()
+        XCTAssertEqual(count, 3)
+        XCTAssertTrue(eligible)
+        XCTAssertGreaterThanOrEqual(invocations, 1)
+        XCTAssertEqual(lastWasAccepted, true)
+    }
+
+    // SPEC-020-R005: a recorded cooldown for the recommended target is also a pure
+    // observable stuck-signal and accumulates across ticks.
+    func testAcceptedSessionCooldownObservationAccumulates() async throws {
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        // Isolate the marker store to a per-test home: this is the only accepted-recovery
+        // test that depends on a PERSISTED cooldown surviving between calls. The default
+        // shared marker store points at the real global cooldowns file, which other tests
+        // in the full suite overwrite/clear — polluting the persisted cooldown and making
+        // the observation return nil (count 0) under full-suite ordering. Create the
+        // autoupdate root explicitly: recordCooldown does `try? atomicWrite`, which
+        // silently no-ops if the directory is absent (a fresh temp home has no cooldown
+        // written → activeCooldown nil → count 0), so the dir must exist for the
+        // persisted cooldown to survive.
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("coordinator-cooldown-observe-\(UUID().uuidString)", isDirectory: true)
+        let autoupdateRoot = home.appendingPathComponent(".local/share/macprovider/autoupdate", isDirectory: true)
+        try FileManager.default.createDirectory(at: autoupdateRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: home) }
+        let markerStore = AutoUpdateMarkerStore(homeDirectory: home)
+        let client = try await makeClient(
+            status: status,
+            recorder: CoordinatorFrameRecorder(),
+            autoupdateMarkerStore: markerStore
+        )
+        // Compatibility-set target present (so not missing-target), but a recorded
+        // cooldown keeps it unusable => .cooldownActive observation.
+        await client.configureAcceptedRecoveryForTest(accepted: true, recommendation: "v99.9.9", compatibilitySetID: "set-x")
+        await client.setRecordedCooldownForTest(target: "99.9.9", failureClass: .other)
+        await client.stubSignedRecoveryInvocationForTest()
+
+        let base = Date()
+        await client.reobserveAcceptedSessionRecoveryForTest(now: base)
+        await client.reobserveAcceptedSessionRecoveryForTest(now: base.addingTimeInterval(400))
+        await client.reobserveAcceptedSessionRecoveryForTest(now: base.addingTimeInterval(800))
+        let count = await client.acceptedSessionRecoveryFailureCountForTest()
+        let eligible = await client.acceptedSessionRecoveryEligibleForTest()
+        XCTAssertEqual(count, 3)
+        XCTAssertTrue(eligible)
+    }
+
+    // SPEC-020-R005 round-8 HIGH (the exact regression): a has-compat-set target that
+    // repeatedly fails must reach threshold across throttled re-observation ticks even
+    // after its single ~300s cooldown has EXPIRED — the stuck signal is "attempted this
+    // session and not progressed", not a momentary cooldown. Primary attempt records
+    // count=1; the cooldown then expires; each later tick still increments to arm.
+    func testRepeatedlyUnusableCompatSetTargetReachesThresholdAfterCooldownExpiry() async throws {
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let client = try await makeClient(status: status, recorder: CoordinatorFrameRecorder())
+        await client.configureAcceptedRecoveryForTest(accepted: true, recommendation: "v99.9.9", compatibilitySetID: "set-x")
+        await client.stubSignedRecoveryInvocationForTest()
+
+        // Primary attempt this session: the target is recorded as attempted and the
+        // failure registers count=1. NO active cooldown is present at re-observation
+        // time (it has expired) — the observation must rely on the attempted signal.
+        await client.markTargetAttemptedForTest("99.9.9")
+        await client.applyPrimaryRecommendationOutcomeForTest(.forwardProgressFailure, normalizedVersion: "99.9.9")
+        var count = await client.acceptedSessionRecoveryFailureCountForTest()
+        let eligibleEarly = await client.acceptedSessionRecoveryEligibleForTest()
+        XCTAssertEqual(count, 1)
+        XCTAssertFalse(eligibleEarly)
+
+        // Successive throttled ticks (cooldown long expired) still increment to arm.
+        let base = Date()
+        await client.reobserveAcceptedSessionRecoveryForTest(now: base)
+        count = await client.acceptedSessionRecoveryFailureCountForTest()
+        XCTAssertEqual(count, 2)
+        await client.reobserveAcceptedSessionRecoveryForTest(now: base.addingTimeInterval(400))
+        count = await client.acceptedSessionRecoveryFailureCountForTest()
+        let eligible = await client.acceptedSessionRecoveryEligibleForTest()
+        XCTAssertEqual(count, 3)
+        XCTAssertTrue(eligible)
+    }
+
+    // SPEC-020-R005 round-8: a has-compat-set target that makes forward progress after
+    // one failure does NOT keep counting — forward progress resets the tracker and
+    // drops the cached recommendation, so the attempted signal is no longer observed.
+    func testCompatSetTargetForwardProgressStopsAttemptedCounting() async throws {
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let client = try await makeClient(status: status, recorder: CoordinatorFrameRecorder())
+        await client.configureAcceptedRecoveryForTest(accepted: true, recommendation: "v99.9.9", compatibilitySetID: "set-x")
+        await client.stubSignedRecoveryInvocationForTest()
+
+        await client.markTargetAttemptedForTest("99.9.9")
+        await client.applyPrimaryRecommendationOutcomeForTest(.forwardProgressFailure, normalizedVersion: "99.9.9")
+        var interimCount = await client.acceptedSessionRecoveryFailureCountForTest()
+        XCTAssertEqual(interimCount, 1)
+
+        // Forward progress: reset + cache cleared.
+        await client.applyPrimaryRecommendationOutcomeForTest(.forwardProgress, normalizedVersion: "99.9.9")
+        interimCount = await client.acceptedSessionRecoveryFailureCountForTest()
+        XCTAssertEqual(interimCount, 0)
+
+        // Ticks find no cached recommendation (even though the target is still marked
+        // attempted) and do not re-arm.
+        let base = Date()
+        await client.reobserveAcceptedSessionRecoveryForTest(now: base)
+        await client.reobserveAcceptedSessionRecoveryForTest(now: base.addingTimeInterval(400))
+        await client.reobserveAcceptedSessionRecoveryForTest(now: base.addingTimeInterval(800))
+        let count = await client.acceptedSessionRecoveryFailureCountForTest()
+        let eligible = await client.acceptedSessionRecoveryEligibleForTest()
+        XCTAssertEqual(count, 0)
+        XCTAssertFalse(eligible)
+    }
+
+    static func r005EligibleTrust() -> AutoUpdateTrustState {
+        AutoUpdateTrustState(
+            v2Accepted: true,
+            tier: "pinned",
+            encryptedLegValid: true,
+            attestationRequired: false,
+            attestationSatisfied: true,
+            tokenConfigured: true,
+            tokenValidated: true,
+            bearerlessDuplicate: false,
+            connected: true
+        )
+    }
+
+    static func r005IneligibleTrust() -> AutoUpdateTrustState {
+        AutoUpdateTrustState(
+            v2Accepted: false,
+            tier: nil,
+            encryptedLegValid: false,
+            attestationRequired: false,
+            attestationSatisfied: false,
+            tokenConfigured: true,
+            tokenValidated: false,
+            bearerlessDuplicate: false,
+            connected: false,
+            stableReason: "attestation_degraded"
+        )
+    }
+
+    private func primeAcceptedRecoveryEligible(_ client: CoordinatorClient, normalizedVersion: String) async {
+        let compat = await client.recommendedCompatibilitySetIDForTest()
+        let gen = await client.recommendationGenerationForTest()
+        for _ in 0 ..< 3 {
+            await client.registerRecommendationOutcomeForTest(
+                .forwardProgressFailure,
+                normalizedVersion: normalizedVersion,
+                capturedCompatibilitySetID: compat,
+                capturedGeneration: gen
+            )
+        }
+    }
+
+    // SPEC-020-R005 round-4 HIGH-2: an outcome computed against identity A must NOT
+    // mutate the tracker if the live recommendation context changed (to B, or a new
+    // generation) before the outcome resolves.
+    func testStaleRecommendationOutcomeIsDiscarded() async throws {
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let client = try await makeClient(status: status, recorder: CoordinatorFrameRecorder())
+        await client.configureAcceptedRecoveryForTest(accepted: true, recommendation: "v99.9.9", compatibilitySetID: "set-A")
+
+        // Capture identity A's context, then the coordinator payload changes to B.
+        let capturedCompat = await client.recommendedCompatibilitySetIDForTest()
+        let capturedGen = await client.recommendationGenerationForTest()
+        await client.mutateRecommendedCompatibilitySetIDForTest("set-B")
+
+        // A stale A-outcome must be discarded — neither A nor B counter is touched.
+        let applied = await client.registerRecommendationOutcomeForTest(
+            .forwardProgressFailure,
+            normalizedVersion: "99.9.9",
+            capturedCompatibilitySetID: capturedCompat,
+            capturedGeneration: capturedGen
+        )
+        XCTAssertFalse(applied)
+        var count = await client.acceptedSessionRecoveryFailureCountForTest()
+        XCTAssertEqual(count, 0)
+
+        // A fresh B-outcome (matching live context) IS applied.
+        let compatB = await client.recommendedCompatibilitySetIDForTest()
+        let genB = await client.recommendationGenerationForTest()
+        let appliedB = await client.registerRecommendationOutcomeForTest(
+            .forwardProgressFailure,
+            normalizedVersion: "99.9.9",
+            capturedCompatibilitySetID: compatB,
+            capturedGeneration: genB
+        )
+        XCTAssertTrue(appliedB)
+        count = await client.acceptedSessionRecoveryFailureCountForTest()
+        XCTAssertEqual(count, 1)
+    }
+
+    // SPEC-020-R005 round-4 HIGH-1(a): the accepted-session signed rail is NOT
+    // invoked when current autoupdate trust is lost, even at threshold eligibility.
+    func testAcceptedRecoveryTrustLostBlocksSignedRailPreInvocation() async throws {
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let client = try await makeClient(status: status, recorder: CoordinatorFrameRecorder())
+        await client.configureAcceptedRecoveryForTest(accepted: true, recommendation: "v99.9.9", compatibilitySetID: nil)
+        await client.stubSignedRecoveryInvocationForTest()
+        await primeAcceptedRecoveryEligible(client, normalizedVersion: "99.9.9")
+        let eligible = await client.acceptedSessionRecoveryEligibleForTest()
+        XCTAssertTrue(eligible)
+
+        // Trust lost => no invocation despite eligibility.
+        await client.setAutoupdateTrustOverrideForTest { CoordinatorClientTests.r005IneligibleTrust() }
+        await client.runSignedRecoveryDiscoveryForTest(now: Date())
+        var invocations = await client.signedRecoveryInvocationCountForTest()
+        XCTAssertEqual(invocations, 0)
+
+        // Trust restored => the accepted-session recovery invokes.
+        await client.setAutoupdateTrustOverrideForTest { CoordinatorClientTests.r005EligibleTrust() }
+        await client.runSignedRecoveryDiscoveryForTest(now: Date().addingTimeInterval(1000))
+        invocations = await client.signedRecoveryInvocationCountForTest()
+        let lastWasAccepted = await client.lastSignedRecoveryWasAcceptedRecoveryForTest()
+        XCTAssertEqual(invocations, 1)
+        XCTAssertEqual(lastWasAccepted, true)
+    }
+
+    // SPEC-020-R005 round-4 HIGH-1(a)+(b): the pre-swap guard aborts on trust loss
+    // and on primary-rail supersession (tracker no longer eligible).
+    func testAcceptedRecoveryPreSwapGuardAbortsOnTrustLossAndSupersession() async throws {
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let client = try await makeClient(status: status, recorder: CoordinatorFrameRecorder())
+        await client.configureAcceptedRecoveryForTest(accepted: true, recommendation: "v99.9.9", compatibilitySetID: nil)
+        await primeAcceptedRecoveryEligible(client, normalizedVersion: "99.9.9")
+
+        // Trust eligible + tracker eligible => proceed.
+        await client.setAutoupdateTrustOverrideForTest { CoordinatorClientTests.r005EligibleTrust() }
+        var reason = await client.acceptedRecoveryPreSwapAbortReasonForTest()
+        XCTAssertNil(reason)
+
+        // Trust lost => abort.
+        await client.setAutoupdateTrustOverrideForTest { CoordinatorClientTests.r005IneligibleTrust() }
+        reason = await client.acceptedRecoveryPreSwapAbortReasonForTest()
+        XCTAssertEqual(reason, "trust_state_lost")
+
+        // Trust restored but primary rail made forward progress (tracker reset) =>
+        // abort as superseded.
+        await client.setAutoupdateTrustOverrideForTest { CoordinatorClientTests.r005EligibleTrust() }
+        await client.applyPrimaryRecommendationOutcomeForTest(.forwardProgress, normalizedVersion: "99.9.9")
+        reason = await client.acceptedRecoveryPreSwapAbortReasonForTest()
+        XCTAssertEqual(reason, "accepted_session_recovery_superseded_by_primary")
+    }
+
+    // SPEC-020-R005 round-5 HIGH: the pre-swap guard aborts on a recommendation-
+    // context change (generation/identity) even while the tracker is still NOMINALLY
+    // eligible for the OLD identity — eligibility lags a generation change by one
+    // outcome registration, so the guard must not rely on tracker.isEligible alone.
+    func testPreSwapGuardAbortsOnGenerationChangeDespiteStaleEligibility() async throws {
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let client = try await makeClient(status: status, recorder: CoordinatorFrameRecorder())
+        await client.configureAcceptedRecoveryForTest(accepted: true, recommendation: "v99.9.9", compatibilitySetID: nil)
+        await primeAcceptedRecoveryEligible(client, normalizedVersion: "99.9.9")
+        await client.setAutoupdateTrustOverrideForTest { CoordinatorClientTests.r005EligibleTrust() }
+
+        // Capture the context at invocation (generation N, identity A).
+        let capturedGen = await client.recommendationGenerationForTest()
+        let capturedIdentityOpt = await client.acceptedSessionRecoveryIdentityForTest()
+        let capturedIdentity = try XCTUnwrap(capturedIdentityOpt)
+
+        // The coordinator context changes (reconnect / new recommendation B): the
+        // generation bumps but the tracker is still eligible for identity A.
+        await client.mutateRecommendedCompatibilitySetIDForTest("set-B")
+        let stillEligibleForA = await client.acceptedSessionRecoveryEligibleForTest()
+        XCTAssertTrue(stillEligibleForA)
+
+        // The guard, aware of the captured generation, aborts as superseded.
+        let reason = await client.acceptedRecoveryPreSwapAbortReasonForTest(
+            capturedGeneration: capturedGen,
+            capturedIdentity: capturedIdentity
+        )
+        XCTAssertEqual(reason, "accepted_session_recovery_superseded_by_primary")
+    }
+
+    // SPEC-020-R005 round-6 HIGH (the terminal fix): model the real temporal
+    // sequence — the pre-drain early-out passes, the coordinator then accepts a new
+    // recommendation DURING the drain await (generation bumps), and the authoritative
+    // SWAP-BOUNDARY gate (evaluated after drain, at the swap) aborts as superseded
+    // even though the tracker is still nominally eligible for the old identity.
+    func testSwapBoundaryGateAbortsAfterMidDrainGenerationBump() async throws {
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let client = try await makeClient(status: status, recorder: CoordinatorFrameRecorder())
+        await client.configureAcceptedRecoveryForTest(accepted: true, recommendation: "v99.9.9", compatibilitySetID: nil)
+        await primeAcceptedRecoveryEligible(client, normalizedVersion: "99.9.9")
+        await client.setAutoupdateTrustOverrideForTest { CoordinatorClientTests.r005EligibleTrust() }
+
+        // Invocation: capture (generation N, identity A).
+        let capturedGen = await client.recommendationGenerationForTest()
+        let capturedIdentityOpt = await client.acceptedSessionRecoveryIdentityForTest()
+        let capturedIdentity = try XCTUnwrap(capturedIdentityOpt)
+
+        // Pre-drain early-out passes (nothing has changed yet).
+        let preDrain = await client.acceptedRecoveryPreSwapAbortReasonForTest(
+            capturedGeneration: capturedGen,
+            capturedIdentity: capturedIdentity
+        )
+        XCTAssertNil(preDrain)
+        var decision = await client.acceptedRecoverySwapBoundaryDecisionForTest(
+            capturedGeneration: capturedGen,
+            capturedIdentity: capturedIdentity
+        )
+        XCTAssertEqual(decision, .proceed)
+
+        // DURING the drain await, the coordinator accepts a new installable
+        // recommendation B: the generation bumps; the tracker still reads eligible
+        // for A (eligibility lags a generation by one outcome registration).
+        await client.mutateRecommendedCompatibilitySetIDForTest("set-B")
+        let stillEligibleForA = await client.acceptedSessionRecoveryEligibleForTest()
+        XCTAssertTrue(stillEligibleForA)
+
+        // The swap-boundary gate (evaluated after drain) aborts as superseded — the
+        // signed rail will not swap under signed_release while the primary rail is
+        // again viable.
+        decision = await client.acceptedRecoverySwapBoundaryDecisionForTest(
+            capturedGeneration: capturedGen,
+            capturedIdentity: capturedIdentity
+        )
+        XCTAssertEqual(decision, .abort(reason: "accepted_session_recovery_superseded_by_primary"))
+    }
+
+    // SPEC-020-R005 round-6 MEDIUM: re-observation must NOT count a stale cooldown
+    // for a recommendation that is not newer than the running binary (a no-op
+    // target, never an R005 stuck signal).
+    func testNotNewerRecommendationWithCooldownDoesNotArmRecovery() async throws {
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let client = try await makeClient(status: status, recorder: CoordinatorFrameRecorder())
+        // The recommended version equals the running binary version (not newer), and
+        // it has an active cooldown from a prior failure.
+        let running = CoordinatorClient.binaryVersion
+        await client.configureAcceptedRecoveryForTest(accepted: true, recommendation: running, compatibilitySetID: "set-x")
+        await client.setRecordedCooldownForTest(target: running, failureClass: .other)
+        // Even marked attempted, a not-newer target must never count (the newer guard
+        // precedes the attempted signal — round-6 MEDIUM stays fixed under round-8).
+        await client.markTargetAttemptedForTest(running)
+        await client.stubSignedRecoveryInvocationForTest()
+
+        let base = Date()
+        await client.reobserveAcceptedSessionRecoveryForTest(now: base)
+        await client.reobserveAcceptedSessionRecoveryForTest(now: base.addingTimeInterval(400))
+        await client.reobserveAcceptedSessionRecoveryForTest(now: base.addingTimeInterval(800))
+        let count = await client.acceptedSessionRecoveryFailureCountForTest()
+        let eligible = await client.acceptedSessionRecoveryEligibleForTest()
+        let invocations = await client.signedRecoveryInvocationCountForTest()
+        XCTAssertEqual(count, 0)
+        XCTAssertFalse(eligible)
+        XCTAssertEqual(invocations, 0)
+    }
+
+    // SPEC-020-R005 round-5 MEDIUM: an accepted→disconnected transition after
+    // invocation (no trust degradation) must NOT be blocked by the swap-boundary
+    // gate. The gate permits the fallback: while accepted it proceeds, and after the
+    // session drops it STILL proceeds (the disconnected R001 rail's swap does not
+    // gate on coordinator-session trust).
+    func testAcceptedToDisconnectedFallbackNotBlockedByTrustAtSwap() async throws {
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let client = try await makeClient(status: status, recorder: CoordinatorFrameRecorder())
+        await client.configureAcceptedRecoveryForTest(accepted: true, recommendation: "v99.9.9", compatibilitySetID: nil)
+        await primeAcceptedRecoveryEligible(client, normalizedVersion: "99.9.9")
+        await client.setAutoupdateTrustOverrideForTest { CoordinatorClientTests.r005EligibleTrust() }
+
+        let capturedGen = await client.recommendationGenerationForTest()
+        let capturedIdentityOpt = await client.acceptedSessionRecoveryIdentityForTest()
+        let capturedIdentity = try XCTUnwrap(capturedIdentityOpt)
+
+        // While still accepted: the swap-boundary gate proceeds.
+        var decision = await client.acceptedRecoverySwapBoundaryDecisionForTest(
+            capturedGeneration: capturedGen,
+            capturedIdentity: capturedIdentity
+        )
+        XCTAssertEqual(decision, .proceed)
+
+        // Session drops (no attestation/token degradation): the swap-boundary gate
+        // STILL proceeds — the disconnected R001 rail is not blocked.
+        await client.configureAcceptedRecoveryForTest(accepted: false, recommendation: nil, compatibilitySetID: nil)
+        decision = await client.acceptedRecoverySwapBoundaryDecisionForTest(
+            capturedGeneration: capturedGen,
+            capturedIdentity: capturedIdentity
+        )
+        XCTAssertEqual(decision, .proceed)
+    }
+
+    // SPEC-020-R005 (a) / re-audit HIGH-1: re-observation does NOT run and does NOT
+    // count while the primary coordinator rail is in flight for the same identity.
+    func testReobservationSkipsWhilePrimaryRailInFlight() async throws {
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let client = try await makeClient(status: status, recorder: CoordinatorFrameRecorder())
+        await client.configureAcceptedRecoveryForTest(accepted: true, recommendation: "v99.9.9", compatibilitySetID: nil)
+        await client.stubSignedRecoveryInvocationForTest()
+
+        // Primary rail owns this identity: the tick must be a complete no-op.
+        await client.setCoordinatorRecommendationInFlightForTest("99.9.9")
+        await client.reobserveAcceptedSessionRecoveryForTest(now: Date())
+        var count = await client.acceptedSessionRecoveryFailureCountForTest()
+        XCTAssertEqual(count, 0)
+
+        // Once the primary rail releases the identity, observation resumes.
+        await client.setCoordinatorRecommendationInFlightForTest(nil)
+        await client.reobserveAcceptedSessionRecoveryForTest(now: Date().addingTimeInterval(400))
+        count = await client.acceptedSessionRecoveryFailureCountForTest()
+        XCTAssertEqual(count, 1)
+    }
+
+    // SPEC-020-R005 (b) / re-audit HIGH-2 / AC-V0.1-R005-3: after the primary rail
+    // reaches forward progress, the resolved recommendation is dropped, so later
+    // heartbeat ticks do NOT re-arm eligibility until a NEW recommendation arrives.
+    func testForwardProgressClearsRecommendationAndPreventsReArm() async throws {
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let client = try await makeClient(status: status, recorder: CoordinatorFrameRecorder())
+        await client.configureAcceptedRecoveryForTest(accepted: true, recommendation: "v99.9.9", compatibilitySetID: nil)
+        await client.stubSignedRecoveryInvocationForTest()
+
+        let base = Date()
+        await client.reobserveAcceptedSessionRecoveryForTest(now: base)
+        await client.reobserveAcceptedSessionRecoveryForTest(now: base.addingTimeInterval(400))
+        var count = await client.acceptedSessionRecoveryFailureCountForTest()
+        XCTAssertEqual(count, 2)
+
+        // Primary rail makes forward progress: counter resets AND the cached
+        // recommendation is dropped.
+        await client.applyPrimaryRecommendationOutcomeForTest(.forwardProgress, normalizedVersion: "99.9.9")
+        count = await client.acceptedSessionRecoveryFailureCountForTest()
+        let cached = await client.currentCoordinatorRecommendationForTest()
+        XCTAssertEqual(count, 0)
+        XCTAssertNil(cached)
+
+        // Subsequent ticks find no recommendation and do not re-arm.
+        await client.reobserveAcceptedSessionRecoveryForTest(now: base.addingTimeInterval(1200))
+        await client.reobserveAcceptedSessionRecoveryForTest(now: base.addingTimeInterval(1600))
+        await client.reobserveAcceptedSessionRecoveryForTest(now: base.addingTimeInterval(2000))
+        count = await client.acceptedSessionRecoveryFailureCountForTest()
+        let eligible = await client.acceptedSessionRecoveryEligibleForTest()
+        let invocations = await client.signedRecoveryInvocationCountForTest()
+        XCTAssertEqual(count, 0)
+        XCTAssertFalse(eligible)
+        XCTAssertEqual(invocations, 0)
+    }
+
+    // SPEC-020-R005 / AC-V0.1-R005-4: an accepted-session recovery drains via the
+    // coordinator-aware path (state_update draining + drain_status frames) so the
+    // coordinator stops routing buyers.
+    func testAcceptedSessionRecoveryDrainsViaCoordinatorAwarePath() async throws {
+        let recorder = CoordinatorFrameRecorder()
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let client = try await makeClient(status: status, recorder: recorder)
+        // Live accepted session at drain time => coordinator-aware drain.
+        await client.configureAcceptedRecoveryForTest(accepted: true, recommendation: nil, compatibilitySetID: nil)
+
+        let drained = await client.signedRecoveryDrainForTest(target: "1.9.0")
+        XCTAssertTrue(drained)
+        let frames = await recorder.frames
+        XCTAssertTrue(frames.contains { ($0["type"] as? String) == "drain_status" }, "expected drain_status frame")
+        XCTAssertTrue(
+            frames.contains {
+                ($0["type"] as? String) == "state_update" && ($0["state"] as? String) == "draining"
+            },
+            "expected state_update draining frame"
+        )
+    }
+
+    func testDisconnectedRecoveryDrainSendsNoCoordinatorFrames() async throws {
+        let recorder = CoordinatorFrameRecorder()
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        // No accepted session (default) => local drain, no coordinator frames.
+        let client = try await makeClient(status: status, recorder: recorder)
+
+        let drained = await client.signedRecoveryDrainForTest(target: "1.9.0")
+        XCTAssertTrue(drained)
+        let frames = await recorder.frames
+        XCTAssertFalse(frames.contains { ($0["type"] as? String) == "drain_status" })
+        XCTAssertFalse(frames.contains { ($0["type"] as? String) == "state_update" })
+    }
+
+    // SPEC-020-R005 (d) / MEDIUM: if the accepted session drops before drain (the
+    // coordinator-aware send throws), the drain falls back to the local drain and
+    // still completes rather than failing.
+    func testAcceptedSessionRecoveryDrainFallsBackToLocalWhenSendFails() async throws {
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let client = try await makeClient(
+            status: status,
+            recorder: CoordinatorFrameRecorder(),
+            sendOverride: { _ in throw CoordinatorClientTestError.sendStateUpdateFailed }
+        )
+        // Accepted at entry, but every coordinator send fails (session dropped).
+        await client.configureAcceptedRecoveryForTest(accepted: true, recommendation: nil, compatibilitySetID: nil)
+
+        let drained = await client.signedRecoveryDrainForTest(target: "1.9.0")
+        XCTAssertTrue(drained)
+        let snapshot = await status.snapshot()
+        XCTAssertEqual(snapshot.activeRequestIDCount, 0)
+    }
+
+    // SPEC-020-R005 round-3 MEDIUM / AC-V0.1-R005-4: when the coordinator-aware
+    // drain has already emitted state_update(draining) but a subsequent drain_status
+    // send throws, the recovery must NOT silently local-drain. It must reconcile the
+    // coordinator view by sending a terminal ready frame and abort the drain cycle.
+    func testAcceptedSessionRecoveryReconcilesCoordinatorAfterPartialDrain() async throws {
+        let recorder = CoordinatorFrameRecorder()
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        // state_update frames succeed (coordinator-visible side effect fires), but
+        // drain_status frames throw — simulating a socket that fails mid-drain after
+        // the draining frame was already delivered.
+        let client = try await makeClient(
+            status: status,
+            recorder: recorder,
+            sendOverride: { frame in
+                if (frame["type"] as? String) == "drain_status" {
+                    throw CoordinatorClientTestError.sendStateUpdateFailed
+                }
+                await recorder.append(frame)
+            }
+        )
+        await client.configureAcceptedRecoveryForTest(accepted: true, recommendation: nil, compatibilitySetID: nil)
+
+        let drained = await client.signedRecoveryDrainForTest(target: "1.9.0")
+        // Drain aborted (not completed) rather than proceeding to swap.
+        XCTAssertFalse(drained)
+        let frames = await recorder.frames
+        // Coordinator saw the draining frame ...
+        XCTAssertTrue(
+            frames.contains {
+                ($0["type"] as? String) == "state_update" && ($0["state"] as? String) == "draining"
+            },
+            "expected the draining side effect to have fired"
+        )
+        // ... and then a terminal ready frame reconciling the stale draining view.
+        XCTAssertTrue(
+            frames.contains {
+                ($0["type"] as? String) == "state_update" && ($0["state"] as? String) == "ready"
+            },
+            "expected a terminal ready frame to reconcile the coordinator drain view"
+        )
+    }
+
+    // SPEC-020-R005 round-4 MEDIUM-1: once a coordinator-visible drain side effect
+    // fired, a transient failure of the compensating ready send must still ABORT the
+    // cycle — never fall through to a local drain + swap while the coordinator may
+    // still hold the stale draining view.
+    func testAcceptedSessionRecoveryAbortsWhenReadyReconcileAlsoFails() async throws {
+        let recorder = CoordinatorFrameRecorder()
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        // The draining state_update succeeds (side effect fires); every other send —
+        // including the compensating ready state_update and all drain_status — throws.
+        let client = try await makeClient(
+            status: status,
+            recorder: recorder,
+            sendOverride: { frame in
+                if (frame["type"] as? String) == "state_update",
+                   (frame["state"] as? String) == "draining" {
+                    await recorder.append(frame)
+                    return
+                }
+                throw CoordinatorClientTestError.sendStateUpdateFailed
+            }
+        )
+        await client.configureAcceptedRecoveryForTest(accepted: true, recommendation: nil, compatibilitySetID: nil)
+
+        let drained = await client.signedRecoveryDrainForTest(target: "1.9.0")
+        // Aborted (no swap), even though the ready reconcile could not be delivered.
+        XCTAssertFalse(drained)
+        let frames = await recorder.frames
+        XCTAssertTrue(
+            frames.contains {
+                ($0["type"] as? String) == "state_update" && ($0["state"] as? String) == "draining"
+            },
+            "expected the draining side effect to have fired"
+        )
+        // The ready reconcile threw, so no ready frame is recorded — but the cycle
+        // still aborted rather than local-draining.
+        XCTAssertFalse(
+            frames.contains {
+                ($0["type"] as? String) == "state_update" && ($0["state"] as? String) == "ready"
+            }
+        )
+    }
+
     func testPostDrainReconnectLoopReentersConnectPath() async throws {
         let recorder = CoordinatorFrameRecorder()
         let attempts = ReconnectAttemptRecorder()
@@ -5777,6 +6455,7 @@ private actor CoordinatorFrameRecorder {
         frames.append(frame)
     }
 }
+
 
 private actor ReconnectAttemptRecorder {
     private var count = 0


### PR DESCRIPTION
## Summary

Implements **SPEC-020-R005** (v0.1.14) — accepted-but-stuck session recovery. Today the
signed-recovery poll is hard-gated on `!coordinatorSessionAccepted`, so an admitted provider
whose coordinator-recommended autoupdate never makes forward progress (the coordinator
advertises `recommended_binary_version` with no `recommended_compatibility_set_id` — the live
production state — or the target is repeatedly unusable) can never self-heal while still
serving. That's exactly the stuck-but-connected fleet in #1235.

R005 makes such a session eligible to invoke the existing signed-recovery rail after
`accepted_session_recovery_failure_threshold` (default 3) consecutive forward-progress
failures for the current recommendation, resetting on forward progress or recommendation
identity change.

## How

- `AutoUpdater.handleCoordinatorRecommendation` returns a `RecommendationOutcome`
  (notAttempted / missingTarget / cooldownActive / forwardProgressFailure / forwardProgress);
  `forwardProgress` is set only after the compatibility-set match gate.
- New actor-owned `AcceptedSessionRecoveryTracker` counts consecutive failures per **normalized**
  recommendation identity (version|compatSetID); increments on missingTarget/cooldownActive/
  forwardProgressFailure, resets on forwardProgress or identity change; emits R-6.8 events
  (increment / reset / becoming-eligible) with the normalized identity + count.
- A bounded, single-in-flight, throttled (300s+jitter) **re-observation** path on the heartbeat
  tick lets a persistently-stuck accepted session accumulate to the threshold without ever
  triggering a duplicate install (`already_attempted` untouched; observational only).
- `runSignedRecoveryDiscoveryIfDue` fires when `!accepted` OR (`accepted` AND tracker eligible);
  accepted invocations use the **coordinator-aware drain** (state_update/drain_status) so buyers
  are not routed to a draining provider, keep `source: github_poll` (R-6.4), and preserve
  signed-release swap authority. Disconnected rail keeps local drain. Both rails share the
  single mutation lock (no concurrent/double install).
- **Trust + primary-rail precedence is enforced at the swap boundary itself.**
  `preserveMarkerAndSwap` takes a `swapBoundaryGate: () async -> AutoUpdateSwapBoundaryDecision`
  (`.proceed` / `.ensureTrust` / `.abort(reason:)`) evaluated inside the swap critical section
  immediately before `activateReleasePayload`, with **no await between the decision and the
  swap**. The accepted-session rail's gate re-runs the full precedence decision
  (trust eligible + `coordinatorSessionAccepted` + generation == captured + identity == captured
  + tracker eligible) and `.abort(reason: accepted_session_recovery_superseded_by_primary |
  trust_state_lost)` if any check fails — so if the coordinator rail becomes viable again *during
  the drain await*, the signed swap is abandoned rather than racing the now-current primary rail
  (AC-V0.1-R005-3/4). Primary rail passes `{ .ensureTrust }` (unchanged trust-loss/rollback
  path); non-accepted signed rail passes `{ .proceed }` (unchanged).
- Recommendation outcomes are bound to a **captured recommendation identity + generation**
  taken before the evaluating await; a stale outcome (identity/generation changed across the
  await, e.g. a reconnect) is discarded and never mutates the tracker. Heartbeat re-observation
  only counts a recommendation that is strictly newer than the running binary
  (`compareSemver(binaryVersion, target) == .orderedAscending`), so a not-newer/no-op target's
  stale cooldown can never arm recovery.

## Testing

- `cd phase3-binary && swift test --filter 'AcceptedSessionRecoveryTrackerTests|AutoUpdateTests|CoordinatorClientTests'` → **270 passed, 0 failures**. Debug + `-c release` both build clean.
- Covers AC-V0.1-R005-1..4: threshold-not-transience (across heartbeat ticks), target-missing
  persistence + reset, forward-progress/identity reset resumes the coordinator rail, additive/
  serialized/coordinator-aware-drain attribution, plus the swap-boundary precedence tests
  (mid-drain generation bump aborts the swap; `.abort` gate prevents activation; not-newer
  recommendation with an active cooldown does not arm recovery; accepted→disconnected fallback
  is not spuriously blocked).

## Audit

3-lane codex (code / security / architecture) over the full combined diff, run to convergence —
several rounds on this genuinely re-entrancy-sensitive path, each fix re-audited across all three
lanes. Findings raised and resolved: trust-loss precedence not re-checked on the accepted-session
signed rail; recommendation-outcome registration bound to the live (not captured) identity across
an await; coordinator-aware drain able to local-drain + swap after a coordinator-visible side
effect; R-6.8 attribution missing on non-detection terminal events; the precedence guard running
one suspension-point (drain) before the actual swap; and re-observation counting a not-newer
target's stale cooldown. The terminal fix relocates the authoritative trust + generation +
identity + eligibility decision into the swap critical section itself. Final re-audit: 0 Critical /
0 High / 0 Medium across all three lanes.

Closes child A″ of #1235 (SPEC-020-R005 conformant).

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "issue": "https://github.com/Augustas11/macprovider/issues/1235",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R005"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "cd phase3-binary && swift test --filter AcceptedSessionRecoveryTrackerTests",
    "cd phase3-binary && swift test --filter AutoUpdateTests",
    "cd phase3-binary && swift test --filter CoordinatorClientTests"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
