### PR TITLE
Add BYOM offer dry-run CLI

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/BYOMDiscovery.swift
+++ b/phase3-binary/Sources/macprovider-cli/BYOMDiscovery.swift
@@ -18,6 +18,11 @@ enum BYOMDiscoveryWarning: String, Codable, Sendable {
     case namespacePermissionInvalid = "namespace_permission_invalid"
 }
 
+enum BYOMDiscoveryNamespaceMode: Sendable {
+    case readOrCreate
+    case readOnly
+}
+
 struct BYOMDiscoveryWire: Codable, Equatable, Sendable {
     struct Adapter: Codable, Equatable, Sendable {
         let runtimeSource: String
@@ -546,6 +551,87 @@ struct BYOMEvaluationWire: Codable, Equatable, Sendable {
     }
 }
 
+struct BYOMOfferDryRunWire: Codable, Equatable, Sendable {
+    let schema: String
+    let generatedAt: String
+    let cliVersion: String
+    let candidateID: String
+    let servedModelRef: String
+    let catalogModelKey: String?
+    let wouldSubmit: Bool
+    let likelyAdmissionState: String
+    let likelyAdmissionStateSource: String
+    let providerGuidance: BYOMDiscoveryWire.Guidance
+    let reasonCode: String?
+    let warnings: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case schema
+        case generatedAt = "generated_at"
+        case cliVersion = "cli_version"
+        case candidateID = "candidate_id"
+        case servedModelRef = "served_model_ref"
+        case catalogModelKey = "catalog_model_key"
+        case wouldSubmit = "would_submit"
+        case likelyAdmissionState = "likely_admission_state"
+        case likelyAdmissionStateSource = "likely_admission_state_source"
+        case providerGuidance = "provider_guidance"
+        case reasonCode = "reason_code"
+        case warnings
+    }
+
+    init(
+        generatedAt: String = ModelSwitchingWireCodec.timestamp(),
+        cliVersion: String = CoordinatorClient.binaryVersion,
+        candidateID: String,
+        servedModelRef: String,
+        catalogModelKey: String?,
+        wouldSubmit: Bool,
+        likelyAdmissionState: String,
+        likelyAdmissionStateSource: String,
+        providerGuidance: BYOMDiscoveryWire.Guidance,
+        reasonCode: String?,
+        warnings: [String]
+    ) {
+        schema = "model_admission_offer_dry_run.v1"
+        self.generatedAt = generatedAt
+        self.cliVersion = cliVersion
+        self.candidateID = candidateID
+        self.servedModelRef = servedModelRef
+        self.catalogModelKey = catalogModelKey
+        self.wouldSubmit = wouldSubmit
+        self.likelyAdmissionState = likelyAdmissionState
+        self.likelyAdmissionStateSource = likelyAdmissionStateSource
+        self.providerGuidance = providerGuidance
+        self.reasonCode = reasonCode
+        self.warnings = warnings
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(schema, forKey: .schema)
+        try container.encode(generatedAt, forKey: .generatedAt)
+        try container.encode(cliVersion, forKey: .cliVersion)
+        try container.encode(candidateID, forKey: .candidateID)
+        try container.encode(servedModelRef, forKey: .servedModelRef)
+        if let catalogModelKey {
+            try container.encode(catalogModelKey, forKey: .catalogModelKey)
+        } else {
+            try container.encodeNil(forKey: .catalogModelKey)
+        }
+        try container.encode(wouldSubmit, forKey: .wouldSubmit)
+        try container.encode(likelyAdmissionState, forKey: .likelyAdmissionState)
+        try container.encode(likelyAdmissionStateSource, forKey: .likelyAdmissionStateSource)
+        try container.encode(providerGuidance, forKey: .providerGuidance)
+        if let reasonCode {
+            try container.encode(reasonCode, forKey: .reasonCode)
+        } else {
+            try container.encodeNil(forKey: .reasonCode)
+        }
+        try container.encode(warnings, forKey: .warnings)
+    }
+}
+
 struct BYOMDiscoveryEnvironment: Sendable {
     let namespaceURL: URL
     let mlxCacheRoot: URL
@@ -697,20 +783,28 @@ struct BYOMDiscoveryRunner {
     private let environment: BYOMDiscoveryEnvironment
     private let fileManager: FileManager
     private let httpClient: any BYOMDiscoveryHTTPClient
+    private let namespaceMode: BYOMDiscoveryNamespaceMode
 
     init(
         environment: BYOMDiscoveryEnvironment,
         fileManager: FileManager = .default,
-        httpClient: any BYOMDiscoveryHTTPClient = BYOMURLSessionHTTPClient()
+        httpClient: any BYOMDiscoveryHTTPClient = BYOMURLSessionHTTPClient(),
+        namespaceMode: BYOMDiscoveryNamespaceMode = .readOrCreate
     ) {
         self.environment = environment
         self.fileManager = fileManager
         self.httpClient = httpClient
+        self.namespaceMode = namespaceMode
     }
 
     func discover() async -> BYOMDiscoveryWire {
-        let namespace = BYOMDiscoveryNamespaceStore(fileManager: fileManager)
-            .readOrCreateNamespace(at: environment.namespaceURL)
+        let namespaceStore = BYOMDiscoveryNamespaceStore(fileManager: fileManager)
+        let namespace: BYOMDiscoveryNamespaceStore.Result = switch namespaceMode {
+        case .readOrCreate:
+            namespaceStore.readOrCreateNamespace(at: environment.namespaceURL)
+        case .readOnly:
+            namespaceStore.readNamespace(at: environment.namespaceURL)
+        }
         let catalog = BYOMCatalogMatcher()
         var adapters: [BYOMDiscoveryWire.Adapter] = []
         var candidates: [BYOMDiscoveryWire.Candidate] = []
@@ -1227,6 +1321,179 @@ struct BYOMEvaluationRunner: Sendable {
     }
 }
 
+struct BYOMOfferDryRunRunner: Sendable {
+    private let target: String
+    private let environment: BYOMDiscoveryEnvironment
+    private let httpClient: any BYOMDiscoveryHTTPClient
+
+    init(
+        target: String,
+        environment: BYOMDiscoveryEnvironment,
+        httpClient: any BYOMDiscoveryHTTPClient = BYOMURLSessionHTTPClient()
+    ) {
+        self.target = target
+        self.environment = environment
+        self.httpClient = httpClient
+    }
+
+    func dryRun() async -> BYOMOfferDryRunWire {
+        let discovery = await BYOMDiscoveryRunner(
+            environment: environment,
+            httpClient: httpClient,
+            namespaceMode: .readOnly
+        ).discover()
+        guard let candidate = selectLocalOfferCandidate(from: discovery.candidates) else {
+            let reason = "candidate_not_found"
+            let warnings = discovery.warnings.sorted()
+            return BYOMOfferDryRunWire(
+                candidateID: "unknown",
+                servedModelRef: "unknown",
+                catalogModelKey: nil,
+                wouldSubmit: false,
+                likelyAdmissionState: "local_only",
+                likelyAdmissionStateSource: "local_default",
+                providerGuidance: dryRunGuidance(
+                    wouldSubmit: false,
+                    catalogModelKey: nil,
+                    reasonCode: reason,
+                    warnings: warnings
+                ),
+                reasonCode: reason,
+                warnings: warnings
+            )
+        }
+
+        let warnings = candidate.warningCodes.sorted()
+        let reason = reasonCode(for: candidate, warnings: Set(warnings))
+        let wouldSubmit = canSubmitLocalDryRun(candidate: candidate, reasonCode: reason)
+        return BYOMOfferDryRunWire(
+            candidateID: candidate.candidateID,
+            servedModelRef: candidate.servedModelRef,
+            catalogModelKey: candidate.catalogModelKey,
+            wouldSubmit: wouldSubmit,
+            likelyAdmissionState: localDefaultAdmissionState(candidate.admissionState),
+            likelyAdmissionStateSource: "local_default",
+            providerGuidance: dryRunGuidance(
+                wouldSubmit: wouldSubmit,
+                catalogModelKey: candidate.catalogModelKey,
+                reasonCode: reason,
+                warnings: warnings
+            ),
+            reasonCode: reason,
+            warnings: warnings
+        )
+    }
+
+    private func selectLocalOfferCandidate(from candidates: [BYOMDiscoveryWire.Candidate]) -> BYOMDiscoveryWire.Candidate? {
+        let normalizedTarget = BYOMCandidateIdentity.normalizedServedModelRef(target)
+        return candidates.first {
+            $0.candidateID == target
+                || BYOMCandidateIdentity.normalizedServedModelRef($0.servedModelRef) == normalizedTarget
+                || BYOMCandidateIdentity.normalizedServedModelRef($0.displayName) == normalizedTarget
+        }
+    }
+
+    private func canSubmitLocalDryRun(candidate: BYOMDiscoveryWire.Candidate, reasonCode: String?) -> Bool {
+        guard candidate.candidateID.hasPrefix("byom_"),
+              !candidate.candidateID.hasPrefix("byom_unstable_"),
+              candidate.admissionStateSource == "local_default",
+              candidate.admissionState == "offerable",
+              candidate.readinessState == "ready",
+              candidate.fitState != "does_not_fit" else {
+            return false
+        }
+        return !Set(candidate.warningCodes).contains(BYOMDiscoveryWarning.candidateIDUnstable.rawValue)
+            && !Set(candidate.warningCodes).contains(BYOMDiscoveryWarning.namespacePermissionInvalid.rawValue)
+            && reasonCode != BYOMDiscoveryWarning.evaluationRequired.rawValue
+            && reasonCode != BYOMDiscoveryWarning.requiresPreparation.rawValue
+    }
+
+    private func localDefaultAdmissionState(_ state: String) -> String {
+        switch state {
+        case "offerable", "not_offered":
+            return state
+        default:
+            return "local_only"
+        }
+    }
+
+    private func reasonCode(for candidate: BYOMDiscoveryWire.Candidate, warnings: Set<String>) -> String? {
+        let blockingReasons = [
+            BYOMDiscoveryWarning.candidateIDUnstable.rawValue,
+            BYOMDiscoveryWarning.namespacePermissionInvalid.rawValue,
+            BYOMDiscoveryWarning.adapterRejectedNonLoopback.rawValue,
+            BYOMDiscoveryWarning.adapterMalformedResponse.rawValue,
+            BYOMDiscoveryWarning.adapterResponseTruncated.rawValue,
+            BYOMDiscoveryWarning.requiresPreparation.rawValue,
+            BYOMDiscoveryWarning.evaluationRequired.rawValue,
+        ]
+        if let blocker = blockingReasons.first(where: warnings.contains) {
+            return blocker
+        }
+        if candidate.catalogModelKey == nil {
+            return "no_trusted_catalog_match"
+        }
+        if warnings.contains(BYOMDiscoveryWarning.catalogMatchUnverified.rawValue) {
+            return "catalog_binding_unverified"
+        }
+        if warnings.contains(BYOMDiscoveryWarning.evaluationRequired.rawValue) {
+            return BYOMDiscoveryWarning.evaluationRequired.rawValue
+        }
+        return nil
+    }
+
+    private func dryRunGuidance(
+        wouldSubmit: Bool,
+        catalogModelKey: String?,
+        reasonCode: String?,
+        warnings: [String]
+    ) -> BYOMDiscoveryWire.Guidance {
+        if wouldSubmit {
+            if catalogModelKey == nil {
+                return BYOMDiscoveryWire.Guidance(
+                    stateLabelKey: "byom.offer_dry_run.would_submit",
+                    stateMeaningKey: "byom.offer_dry_run.no_earning_path_v0_1",
+                    nextAction: "submit_offer",
+                    transitionReasonCode: reasonCode,
+                    earningPathClass: "no_earning_path_in_v0_1"
+                )
+            }
+            return BYOMDiscoveryWire.Guidance(
+                stateLabelKey: "byom.offer_dry_run.would_submit",
+                stateMeaningKey: "byom.offer_dry_run.catalog_path_missing_trusted_binding",
+                nextAction: "submit_offer",
+                transitionReasonCode: reasonCode,
+                earningPathClass: "not_earning_yet_catalog_or_receipt_path_exists"
+            )
+        }
+        if reasonCode == BYOMDiscoveryWarning.evaluationRequired.rawValue {
+            if catalogModelKey == nil {
+                return BYOMDiscoveryWire.Guidance(
+                    stateLabelKey: "byom.offer_dry_run.blocked",
+                    stateMeaningKey: "byom.offer_dry_run.no_earning_path_v0_1",
+                    nextAction: "evaluate",
+                    transitionReasonCode: reasonCode,
+                    earningPathClass: "no_earning_path_in_v0_1"
+                )
+            }
+            return BYOMDiscoveryWire.Guidance(
+                stateLabelKey: "byom.offer_dry_run.blocked",
+                stateMeaningKey: "byom.offer_dry_run.catalog_path_missing_trusted_binding",
+                nextAction: "evaluate",
+                transitionReasonCode: reasonCode,
+                earningPathClass: "not_earning_yet_catalog_or_receipt_path_exists"
+            )
+        }
+        return BYOMDiscoveryWire.Guidance(
+            stateLabelKey: "byom.offer_dry_run.blocked",
+            stateMeaningKey: "byom.offer_dry_run.not_submitted_not_earning",
+            nextAction: "fix_local_blocker",
+            transitionReasonCode: reasonCode ?? warnings.sorted().first,
+            earningPathClass: "local_inventory_only"
+        )
+    }
+}
+
 struct BYOMDiscoveryNamespaceStore {
     struct Result: Sendable {
         let bytes: Data?
@@ -1264,6 +1531,25 @@ struct BYOMDiscoveryNamespaceStore {
                 return Result(bytes: nil, warnings: [.candidateIDUnstable])
             }
             try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+            return Result(bytes: data, warnings: [])
+        } catch {
+            return Result(bytes: nil, warnings: [.candidateIDUnstable])
+        }
+    }
+
+    func readNamespace(at url: URL) -> Result {
+        do {
+            let parent = url.deletingLastPathComponent()
+            guard fileManager.fileExists(atPath: url.path) else {
+                return Result(bytes: nil, warnings: [.candidateIDUnstable])
+            }
+            guard namespaceDirectoryPermissionsArePrivate(parent), namespaceFilePermissionsArePrivate(url) else {
+                return Result(bytes: nil, warnings: [.namespacePermissionInvalid, .candidateIDUnstable])
+            }
+            let data = try Data(contentsOf: url)
+            guard data.count == 32 else {
+                return Result(bytes: nil, warnings: [.namespacePermissionInvalid, .candidateIDUnstable])
+            }
             return Result(bytes: data, warnings: [])
         } catch {
             return Result(bytes: nil, warnings: [.candidateIDUnstable])

--- a/phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift
@@ -11,6 +11,7 @@ struct ModelsCommand: AsyncParsableCommand {
             ModelsListCommand.self,
             ModelsDiscoverCommand.self,
             ModelsEvaluateCommand.self,
+            ModelsOfferCommand.self,
             ModelsSwitchCommand.self,
             ModelsStatusCommand.self,
             ModelsBrowseCommand.self,
@@ -95,6 +96,51 @@ struct ModelsEvaluateCommand: AsyncParsableCommand {
         let document = await BYOMEvaluationRunner(target: candidate, environment: environment).evaluate()
         for warning in document.warnings.sorted() {
             writeStderr("models evaluate warning: \(warning)")
+        }
+        try ModelSwitchingWireCodec.printJSON(document)
+    }
+}
+
+struct ModelsOfferCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "offer",
+        abstract: "Dry-run a provider-local BYOM admission offer."
+    )
+
+    @Argument(help: "Candidate id, served model reference, or display name from models discover --json.")
+    var candidate: String
+
+    @Flag(help: "Explain the offer package without submitting coordinator state.")
+    var dryRun = false
+
+    @Flag(name: .customLong("json"), help: "Emit the strict model_admission_offer_dry_run.v1 JSON contract.")
+    var emitJSON = false
+
+    @Option(help: ArgumentHelp("CLI-owned local discovery namespace path.", visibility: .hidden))
+    var localDiscoveryNamespacePath: String?
+
+    @Option(help: "HuggingFace cache root to inspect read-only. Defaults to HF_HUB_CACHE, HF_HOME/hub, or ~/.cache/huggingface/hub.")
+    var mlxCacheDir: String?
+
+    @Option(help: "Ollama-compatible loopback origin to query. Must be http://127.0.0.0/8:<port> or http://[::1]:<port>.")
+    var ollamaOrigin: String = "http://127.0.0.1:11434"
+
+    @Flag(help: "Skip the Ollama-compatible loopback adapter during candidate lookup.")
+    var skipOllama = false
+
+    func run() async throws {
+        guard dryRun, emitJSON else {
+            writeStderr("models offer is dry-run JSON-only in this release; pass --dry-run --json")
+            throw ExitCode(2)
+        }
+        let environment = BYOMDiscoveryEnvironment.production(
+            namespacePath: localDiscoveryNamespacePath,
+            mlxCacheDir: mlxCacheDir,
+            ollamaOrigin: skipOllama ? nil : ollamaOrigin
+        )
+        let document = await BYOMOfferDryRunRunner(target: candidate, environment: environment).dryRun()
+        for warning in document.warnings.sorted() {
+            writeStderr("models offer warning: \(warning)")
         }
         try ModelSwitchingWireCodec.printJSON(document)
     }

--- a/phase3-binary/Tests/macprovider-cliTests/BYOMOfferDryRunTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/BYOMOfferDryRunTests.swift
@@ -1,0 +1,299 @@
+import ArgumentParser
+import Darwin
+import Foundation
+import XCTest
+@testable import macprovider_cli
+
+final class BYOMOfferDryRunTests: XCTestCase {
+    func testOfferCommandRequiresDryRunJSONFlags() async throws {
+        let command = try ModelsOfferCommand.parse(["ollama:tiny-offer-1b-q4", "--dry-run", "--skip-ollama"])
+        let capture = await captureBYOMOfferOutput {
+            try await command.run()
+        }
+
+        XCTAssertTrue(capture.stdout.isEmpty)
+        XCTAssertTrue(capture.stderr.contains("dry-run JSON-only"))
+        XCTAssertEqual((capture.error as? ExitCode), ExitCode(2))
+    }
+
+    func testOfferDryRunCommandEmitsUnknownWithoutReflectingUnsafeTarget() async throws {
+        let root = try temporaryBYOMOfferDirectory("byom-offer-command")
+        let unsafeTarget = "http://192.168.1.10:11434/private-model?api_key=secret"
+        let command = try ModelsOfferCommand.parse([
+            unsafeTarget,
+            "--dry-run",
+            "--json",
+            "--skip-ollama",
+            "--local-discovery-namespace-path", root.appendingPathComponent("ns").path,
+            "--mlx-cache-dir", root.appendingPathComponent("hf", isDirectory: true).path,
+        ])
+        let capture = await captureBYOMOfferOutput {
+            try await command.run()
+        }
+
+        XCTAssertNil(capture.error)
+        let object = try jsonObject(capture.stdout)
+        XCTAssertEqual(object["schema"] as? String, "model_admission_offer_dry_run.v1")
+        XCTAssertEqual(object["candidate_id"] as? String, "unknown")
+        XCTAssertEqual(object["served_model_ref"] as? String, "unknown")
+        XCTAssertEqual(object["would_submit"] as? Bool, false)
+        XCTAssertFalse((capture.stdout + capture.stderr).contains(unsafeTarget))
+        XCTAssertFalse((capture.stdout + capture.stderr).contains("api_key"))
+    }
+
+    func testOfferDryRunUnknownCandidatePreservesDiscoveryWarnings() async throws {
+        let root = try temporaryBYOMOfferDirectory("byom-offer-unknown-warnings")
+
+        let document = await BYOMOfferDryRunRunner(
+            target: "missing-model",
+            environment: BYOMDiscoveryEnvironment(
+                namespaceURL: root.appendingPathComponent("ns"),
+                mlxCacheRoot: root.appendingPathComponent("hf", isDirectory: true),
+                ollamaOrigin: "http://192.168.1.10:11434"
+            ),
+            httpClient: BYOMOfferStubHTTPClient(tagsBody: #"{"models":[]}"#)
+        ).dryRun()
+
+        XCTAssertEqual(document.candidateID, "unknown")
+        XCTAssertEqual(document.servedModelRef, "unknown")
+        XCTAssertEqual(document.reasonCode, "candidate_not_found")
+        XCTAssertEqual(document.wouldSubmit, false)
+        XCTAssertTrue(document.warnings.contains("candidate_id_unstable"))
+        XCTAssertTrue(document.warnings.contains("adapter_rejected_non_loopback"))
+        XCTAssertTrue(document.warnings.contains("adapter_unavailable"))
+        XCTAssertEqual(document.providerGuidance.transitionReasonCode, "candidate_not_found")
+    }
+
+    func testOfferDryRunForNonCatalogCandidateDoesNotSubmitAndHasNoEarningPath() async throws {
+        let root = try temporaryBYOMOfferDirectory("byom-offer-noncatalog")
+        let namespace = root.appendingPathComponent("ns")
+        try writeBYOMOfferNamespace(at: namespace)
+        let client = BYOMOfferStubHTTPClient(tagsBody: #"{"models":[{"name":"tiny-offer-1b-q4"}]}"#)
+
+        let document = await BYOMOfferDryRunRunner(
+            target: "ollama:tiny-offer-1b-q4",
+            environment: BYOMDiscoveryEnvironment(
+                namespaceURL: namespace,
+                mlxCacheRoot: root.appendingPathComponent("hf", isDirectory: true),
+                ollamaOrigin: "http://127.0.0.1:11434"
+            ),
+            httpClient: client
+        ).dryRun()
+
+        XCTAssertEqual(document.schema, "model_admission_offer_dry_run.v1")
+        XCTAssertEqual(document.servedModelRef, "ollama:tiny-offer-1b-q4")
+        XCTAssertNil(document.catalogModelKey)
+        XCTAssertEqual(document.wouldSubmit, false)
+        XCTAssertEqual(document.likelyAdmissionState, "offerable")
+        XCTAssertEqual(document.likelyAdmissionStateSource, "local_default")
+        XCTAssertEqual(document.reasonCode, "evaluation_required")
+        XCTAssertEqual(document.providerGuidance.nextAction, "evaluate")
+        XCTAssertEqual(document.providerGuidance.stateMeaningKey, "byom.offer_dry_run.no_earning_path_v0_1")
+        XCTAssertEqual(document.providerGuidance.earningPathClass, "no_earning_path_in_v0_1")
+        XCTAssertEqual(client.getCount, 1)
+        XCTAssertEqual(client.postCount, 0)
+
+        let encoded = try ModelSwitchingWireCodec.encode(document)
+        XCTAssertFalse(encoded.contains("prompt_rate"))
+        XCTAssertFalse(encoded.contains("completion_rate"))
+        XCTAssertFalse(encoded.contains("provider_share"))
+        XCTAssertFalse(encoded.contains("payout"))
+        XCTAssertFalse(encoded.contains("usd_per"))
+    }
+
+    func testOfferDryRunForCatalogCandidateReportsMissingTrustedBindingWithoutRates() async throws {
+        let root = try temporaryBYOMOfferDirectory("byom-offer-catalog")
+        let namespace = root.appendingPathComponent("ns")
+        try writeBYOMOfferNamespace(at: namespace)
+        let client = BYOMOfferStubHTTPClient(tagsBody: #"{"models":[{"name":"qwen3-8b"}]}"#)
+
+        let document = await BYOMOfferDryRunRunner(
+            target: "ollama:qwen3-8b",
+            environment: BYOMDiscoveryEnvironment(
+                namespaceURL: namespace,
+                mlxCacheRoot: root.appendingPathComponent("hf", isDirectory: true),
+                ollamaOrigin: "http://127.0.0.1:11434"
+            ),
+            httpClient: client
+        ).dryRun()
+
+        XCTAssertEqual(document.wouldSubmit, false)
+        XCTAssertEqual(document.catalogModelKey, "qwen3-8b")
+        XCTAssertEqual(document.reasonCode, "evaluation_required")
+        XCTAssertTrue(document.warnings.contains("catalog_match_unverified"))
+        XCTAssertTrue(document.warnings.contains("evaluation_required"))
+        XCTAssertEqual(document.providerGuidance.nextAction, "evaluate")
+        XCTAssertEqual(document.providerGuidance.earningPathClass, "not_earning_yet_catalog_or_receipt_path_exists")
+        XCTAssertEqual(document.providerGuidance.stateMeaningKey, "byom.offer_dry_run.catalog_path_missing_trusted_binding")
+        XCTAssertEqual(client.postCount, 0)
+
+        let encoded = try ModelSwitchingWireCodec.encode(document)
+        XCTAssertFalse(encoded.contains("prompt_rate"))
+        XCTAssertFalse(encoded.contains("completion_rate"))
+        XCTAssertFalse(encoded.contains("provider_share"))
+        XCTAssertFalse(encoded.contains("settlement_capable"))
+        XCTAssertFalse(encoded.contains("catalog_priced"))
+    }
+
+    func testOfferDryRunBlocksInvalidNamespaceWithoutSubmitting() async throws {
+        let root = try temporaryBYOMOfferDirectory("byom-offer-namespace")
+        let cache = root.appendingPathComponent("hf", isDirectory: true)
+        let namespace = root.appendingPathComponent("ns")
+        try Data(repeating: 0x11, count: 32).write(to: namespace)
+        try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: namespace.path)
+        try createBYOMOfferMLXSnapshot(cacheRoot: cache, modelID: "mlx-community/Tiny-1B-4bit")
+        let before = try recursiveBYOMOfferPaths(cache)
+
+        let document = await BYOMOfferDryRunRunner(
+            target: "mlx-community/Tiny-1B-4bit",
+            environment: BYOMDiscoveryEnvironment(namespaceURL: namespace, mlxCacheRoot: cache, ollamaOrigin: nil),
+            httpClient: BYOMOfferStubHTTPClient(tagsBody: #"{"models":[]}"#)
+        ).dryRun()
+
+        XCTAssertEqual(document.wouldSubmit, false)
+        XCTAssertEqual(document.likelyAdmissionState, "local_only")
+        XCTAssertEqual(document.reasonCode, "candidate_id_unstable")
+        XCTAssertTrue(document.candidateID.hasPrefix("byom_unstable_"))
+        XCTAssertTrue(document.warnings.contains("candidate_id_unstable"))
+        XCTAssertTrue(document.warnings.contains("namespace_permission_invalid"))
+        XCTAssertEqual(document.providerGuidance.nextAction, "fix_local_blocker")
+        XCTAssertEqual(document.providerGuidance.earningPathClass, "local_inventory_only")
+        let after = try recursiveBYOMOfferPaths(cache)
+        XCTAssertEqual(before, after)
+    }
+
+    func testOfferDryRunDoesNotCreateMissingNamespace() async throws {
+        let root = try temporaryBYOMOfferDirectory("byom-offer-readonly-namespace")
+        let cache = root.appendingPathComponent("hf", isDirectory: true)
+        let namespace = root.appendingPathComponent("ns")
+        try createBYOMOfferMLXSnapshot(cacheRoot: cache, modelID: "mlx-community/Tiny-1B-4bit")
+
+        let document = await BYOMOfferDryRunRunner(
+            target: "mlx-community/Tiny-1B-4bit",
+            environment: BYOMDiscoveryEnvironment(namespaceURL: namespace, mlxCacheRoot: cache, ollamaOrigin: nil),
+            httpClient: BYOMOfferStubHTTPClient(tagsBody: #"{"models":[]}"#)
+        ).dryRun()
+
+        XCTAssertEqual(document.wouldSubmit, false)
+        XCTAssertEqual(document.reasonCode, "candidate_id_unstable")
+        XCTAssertTrue(document.candidateID.hasPrefix("byom_unstable_"))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: namespace.path))
+    }
+
+    private func temporaryBYOMOfferDirectory(_ name: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(name)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: url.path)
+        return url
+    }
+
+    private func writeBYOMOfferNamespace(at url: URL) throws {
+        let parent = url.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: parent.path)
+        try Data(repeating: 0x22, count: 32).write(to: url)
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+    }
+
+    private func createBYOMOfferMLXSnapshot(cacheRoot: URL, modelID: String) throws {
+        let repo = cacheRoot
+            .appendingPathComponent("models--" + modelID.replacingOccurrences(of: "/", with: "--"), isDirectory: true)
+            .appendingPathComponent("snapshots", isDirectory: true)
+            .appendingPathComponent("0123456789abcdef0123456789abcdef01234567", isDirectory: true)
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        try Data(#"{"max_position_embeddings":2048}"#.utf8).write(to: repo.appendingPathComponent("config.json"))
+        try Data(repeating: 0x7a, count: 128).write(to: repo.appendingPathComponent("model.safetensors"))
+    }
+
+    private func recursiveBYOMOfferPaths(_ root: URL) throws -> [String] {
+        guard let enumerator = FileManager.default.enumerator(at: root, includingPropertiesForKeys: [.isRegularFileKey]) else {
+            return []
+        }
+        var result: [String] = []
+        for case let url as URL in enumerator {
+            result.append(String(url.path.dropFirst(root.path.count + 1)))
+        }
+        return result.sorted()
+    }
+
+    private func jsonObject(_ stdout: String) throws -> [String: Any] {
+        let line = try XCTUnwrap(stdout.split(whereSeparator: \.isNewline).first { line in
+            line.trimmingCharacters(in: .whitespaces).hasPrefix("{")
+        })
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any])
+    }
+}
+
+private final class BYOMOfferStubHTTPClient: BYOMDiscoveryHTTPClient, @unchecked Sendable {
+    private let lock = NSLock()
+    private let tagsBody: String
+    private var gets = 0
+    private var posts = 0
+
+    var getCount: Int {
+        lock.withLock { gets }
+    }
+
+    var postCount: Int {
+        lock.withLock { posts }
+    }
+
+    init(tagsBody: String) {
+        self.tagsBody = tagsBody
+    }
+
+    func get(_ url: URL, maxHeaderBytes: Int, maxBodyBytes: Int) async throws -> BYOMHTTPResponse {
+        lock.withLock {
+            gets += 1
+        }
+        return BYOMHTTPResponse(statusCode: 200, headers: [("content-type", "application/json")], body: Data(tagsBody.utf8))
+    }
+
+    func post(_ url: URL, jsonBody: Data, maxHeaderBytes: Int, maxBodyBytes: Int) async throws -> BYOMHTTPResponse {
+        lock.withLock {
+            posts += 1
+        }
+        return BYOMHTTPResponse(statusCode: 500, headers: [], body: Data())
+    }
+}
+
+private struct BYOMOfferCapturedOutput {
+    let stdout: String
+    let stderr: String
+    let error: Error?
+}
+
+private func captureBYOMOfferOutput(_ body: () async throws -> Void) async -> BYOMOfferCapturedOutput {
+    let stdoutPipe = Pipe()
+    let stderrPipe = Pipe()
+    let savedStdout = dup(STDOUT_FILENO)
+    let savedStderr = dup(STDERR_FILENO)
+    dup2(stdoutPipe.fileHandleForWriting.fileDescriptor, STDOUT_FILENO)
+    dup2(stderrPipe.fileHandleForWriting.fileDescriptor, STDERR_FILENO)
+
+    let error: Error?
+    do {
+        try await body()
+        error = nil
+    } catch let caught {
+        error = caught
+    }
+
+    fflush(stdout)
+    fflush(stderr)
+    dup2(savedStdout, STDOUT_FILENO)
+    dup2(savedStderr, STDERR_FILENO)
+    close(savedStdout)
+    close(savedStderr)
+    stdoutPipe.fileHandleForWriting.closeFile()
+    stderrPipe.fileHandleForWriting.closeFile()
+
+    let stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+    let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+    return BYOMOfferCapturedOutput(
+        stdout: String(decoding: stdoutData, as: UTF8.self),
+        stderr: String(decoding: stderrData, as: UTF8.self),
+        error: error
+    )
+}


### PR DESCRIPTION
## Summary

- Adds `macprovider-cli models offer <candidate> --dry-run --json`.
- Emits the closed `model_admission_offer_dry_run.v1` envelope without submitting coordinator state.
- Keeps dry-run discovery namespace access read-only, preserves redacted discovery warnings for unknown candidates, and blocks unevaluated candidates to `next_action: evaluate`.
- Keeps rate, payout, settlement, routing, and buyer-visibility economics absent before trusted admission/economics evidence exists.

## Issues

Refs #1240.
Closes #1252.

Depends on #1262 / #1251 and #1260 / #1250.

Gate references: #1243, #1244, #1246, #1247, #1248.
#1245 remains open for later live external-runtime proof.

## Specs

- `SPEC-047-R002`: offer dry-run command and schema, no state submission.
- `SPEC-047-R003`: non-settlement BYOM states remain non-routable and non-earning.
- `SPEC-047-R004`: no provider payout rates or catalog economics before trusted economics are permitted.
- `SPEC-046-R003`: reuses provider guidance shape and closed action/economics classes.
- `SPEC-046-R006`: dry-run remains read-only for local discovery namespace state.
- `SPEC-046-R007`: redacts target/endpoint material and keeps warning output code-based.

## Tests

- `cd phase3-binary && swift test --filter macprovider_cliTests.BYOMOfferDryRunTests`
- `cd phase3-binary && swift test --filter macprovider_cliTests.BYOMDiscoveryTests`
- `cd phase3-binary && swift test --filter macprovider_cliTests.BYOMEvaluationTests`
- `cd phase3-binary && swift test --filter macprovider_cliTests`
- `git diff --cached --check`

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": [
    "SPEC-047",
    "SPEC-046"
  ],
  "requirements": [
    "SPEC-047-R002",
    "SPEC-047-R003",
    "SPEC-047-R004",
    "SPEC-046-R003",
    "SPEC-046-R006",
    "SPEC-046-R007"
  ],
  "authority_domains": [
    "network-model-admission",
    "provider-byom-discovery"
  ],
  "arbitration": [
    "DECISION_REQUIRED"
  ],
  "tests": [
    "cd phase3-binary && swift test --filter macprovider_cliTests.BYOMOfferDryRunTests",
    "cd phase3-binary && swift test --filter macprovider_cliTests.BYOMDiscoveryTests",
    "cd phase3-binary && swift test --filter macprovider_cliTests.BYOMEvaluationTests",
    "cd phase3-binary && swift test --filter macprovider_cliTests",
    "git diff --cached --check"
  ],
  "journeys": [
    "not-required"
  ],
  "issue": "https://github.com/Augustas11/macprovider/issues/1240"
}
SPEC-GOVERNANCE-DECLARATION-END
