### PR TITLE
Add coordinator-backed BYOM offer submission

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/BYOMDiscovery.swift
+++ b/phase3-binary/Sources/macprovider-cli/BYOMDiscovery.swift
@@ -632,6 +632,727 @@ struct BYOMOfferDryRunWire: Codable, Equatable, Sendable {
     }
 }
 
+struct BYOMAdmissionStatusWire: Codable, Equatable, Sendable {
+    let schema: String
+    let generatedAt: String
+    let cliVersion: String
+    let providerID: String
+    let candidateID: String
+    let servedModelRef: String
+    let catalogModelKey: String?
+    let admissionState: String
+    let admissionStateSource: String
+    let coordinatorEventID: String?
+    let stateObservedAt: String?
+    let providerGuidance: BYOMDiscoveryWire.Guidance
+    let allowedNextStates: [String]
+    let warnings: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case schema
+        case generatedAt = "generated_at"
+        case cliVersion = "cli_version"
+        case providerID = "provider_id"
+        case candidateID = "candidate_id"
+        case servedModelRef = "served_model_ref"
+        case catalogModelKey = "catalog_model_key"
+        case admissionState = "admission_state"
+        case admissionStateSource = "admission_state_source"
+        case coordinatorEventID = "coordinator_event_id"
+        case stateObservedAt = "state_observed_at"
+        case providerGuidance = "provider_guidance"
+        case allowedNextStates = "allowed_next_states"
+        case warnings
+    }
+}
+
+extension BYOMAdmissionStatusWire {
+    private static let topLevelKeys: Set<String> = [
+        "schema",
+        "generated_at",
+        "cli_version",
+        "provider_id",
+        "candidate_id",
+        "served_model_ref",
+        "catalog_model_key",
+        "admission_state",
+        "admission_state_source",
+        "coordinator_event_id",
+        "state_observed_at",
+        "provider_guidance",
+        "allowed_next_states",
+        "warnings",
+    ]
+    private static let guidanceKeys: Set<String> = [
+        "state_label_key",
+        "state_meaning_key",
+        "next_action",
+        "transition_reason_code",
+        "earning_path_class",
+    ]
+    private static let localDefaultStates: Set<String> = ["local_only", "not_offered", "offerable"]
+    private static let coordinatorStates: Set<String> = [
+        "not_offered",
+        "offer_submitted",
+        "offer_rejected",
+        "sandbox_probe_only",
+        "network_visible_unpriced",
+        "network_admitted_unsettled",
+        "catalog_priced",
+        "settlement_capable",
+        "withdrawn",
+        "revoked",
+    ]
+    private static let nextActions: Set<String> = [
+        "fix_local_blocker",
+        "evaluate",
+        "offer_dry_run",
+        "submit_offer",
+        "revise_and_reoffer",
+        "check_status",
+        "withdraw",
+        "wait_for_coordinator",
+        "maintain_runtime",
+        "none",
+    ]
+    private static let earningPathClasses: Set<String> = [
+        "local_inventory_only",
+        "not_earning_yet_catalog_or_receipt_path_exists",
+        "no_earning_path_in_v0_1",
+        "settlement_capable",
+    ]
+    private static let reasonRequiredStates: Set<String> = [
+        "offer_rejected",
+        "withdrawn",
+        "revoked",
+    ]
+
+    static func decodeStrictStatus(
+        from data: Data,
+        expectedProviderID: String? = nil,
+        expectedCandidateID: String? = nil
+    ) throws -> BYOMAdmissionStatusWire {
+        guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              Set(object.keys) == topLevelKeys,
+              let guidance = object["provider_guidance"] as? [String: Any],
+              Set(guidance.keys) == guidanceKeys else {
+            throw BYOMModelAdmissionError.invalidStatusSchema
+        }
+        let status = try JSONDecoder().decode(BYOMAdmissionStatusWire.self, from: data)
+        try validate(status, expectedProviderID: expectedProviderID, expectedCandidateID: expectedCandidateID)
+        return status
+    }
+
+    private static func validate(
+        _ status: BYOMAdmissionStatusWire,
+        expectedProviderID: String?,
+        expectedCandidateID: String?
+    ) throws {
+        guard status.schema == "model_admission_status.v1",
+              status.admissionStateSource == "local_default" || status.admissionStateSource == "coordinator",
+              nextActions.contains(status.providerGuidance.nextAction),
+              earningPathClasses.contains(status.providerGuidance.earningPathClass) else {
+            throw BYOMModelAdmissionError.invalidStatusSchema
+        }
+        if let expectedProviderID, status.providerID != expectedProviderID {
+            throw BYOMModelAdmissionError.invalidStatusSchema
+        }
+        if let expectedCandidateID, status.candidateID != expectedCandidateID {
+            throw BYOMModelAdmissionError.invalidStatusSchema
+        }
+        if status.admissionStateSource == "local_default" {
+            guard localDefaultStates.contains(status.admissionState),
+                  status.allowedNextStates.isEmpty else {
+                throw BYOMModelAdmissionError.invalidStatusSchema
+            }
+            return
+        }
+        guard coordinatorStates.contains(status.admissionState) else {
+            throw BYOMModelAdmissionError.invalidStatusSchema
+        }
+        let allowed = Set(Self.allowedNextStates(for: status.admissionState))
+        guard status.allowedNextStates.allSatisfy({ allowed.contains($0) }) else {
+            throw BYOMModelAdmissionError.invalidStatusSchema
+        }
+        if reasonRequiredStates.contains(status.admissionState),
+           status.providerGuidance.transitionReasonCode?.isEmpty ?? true {
+            throw BYOMModelAdmissionError.invalidStatusSchema
+        }
+        guard Self.guidanceMatches(status) else {
+            throw BYOMModelAdmissionError.invalidStatusSchema
+        }
+    }
+
+    private static func allowedNextStates(for state: String) -> [String] {
+        switch state {
+        case "not_offered", "withdrawn", "revoked":
+            return ["offer_submitted"]
+        case "offer_rejected":
+            return ["offer_submitted", "revoked"]
+        case "offer_submitted":
+            return ["offer_rejected", "sandbox_probe_only", "network_visible_unpriced", "network_admitted_unsettled", "catalog_priced", "withdrawn", "revoked"]
+        case "sandbox_probe_only":
+            return ["network_visible_unpriced", "network_admitted_unsettled", "catalog_priced", "withdrawn", "revoked"]
+        case "network_visible_unpriced":
+            return ["network_admitted_unsettled", "catalog_priced", "withdrawn", "revoked"]
+        case "network_admitted_unsettled":
+            return ["catalog_priced", "settlement_capable", "withdrawn", "revoked"]
+        case "catalog_priced":
+            return ["network_admitted_unsettled", "settlement_capable", "withdrawn", "revoked"]
+        case "settlement_capable":
+            return ["network_admitted_unsettled", "catalog_priced", "withdrawn", "revoked"]
+        default:
+            return []
+        }
+    }
+
+    private static func guidanceMatches(_ status: BYOMAdmissionStatusWire) -> Bool {
+        let guidance = status.providerGuidance
+        switch status.admissionState {
+        case "not_offered":
+            return guidance.nextAction == "submit_offer" &&
+                guidance.earningPathClass == "local_inventory_only"
+        case "offer_submitted":
+            return guidance.nextAction == "wait_for_coordinator" &&
+                (guidance.earningPathClass == "no_earning_path_in_v0_1" ||
+                 guidance.earningPathClass == "not_earning_yet_catalog_or_receipt_path_exists")
+        case "offer_rejected":
+            return guidance.nextAction == "revise_and_reoffer" &&
+                guidance.earningPathClass == "no_earning_path_in_v0_1"
+        case "sandbox_probe_only", "network_visible_unpriced", "network_admitted_unsettled", "catalog_priced":
+            return guidance.nextAction == "withdraw" &&
+                guidance.earningPathClass == "not_earning_yet_catalog_or_receipt_path_exists"
+        case "settlement_capable":
+            return guidance.nextAction == "maintain_runtime" &&
+                guidance.earningPathClass == "settlement_capable"
+        case "withdrawn", "revoked":
+            return guidance.nextAction == "submit_offer" &&
+                guidance.earningPathClass == "no_earning_path_in_v0_1"
+        default:
+            return false
+        }
+    }
+}
+
+struct BYOMOfferSubmitRequestWire: Codable, Equatable, Sendable {
+    let schema: String
+    let signatureDomain: String
+    let providerID: String
+    let candidateID: String
+    let runtimeSource: String
+    let servedModelRef: String
+    let catalogModelKey: String
+    let discoveryDigestSHA256: String
+    let evaluationDigestSHA256: String
+    let artifactHashes: [String: String]
+    let advisoryCapabilities: AdvisoryCapabilities
+    let fitEvidenceSource: String
+    let localReadiness: String
+    let requestedDisclosureClass: String
+    let timestamp: String
+    let nonce: String
+    let idempotencyKey: String
+    let signingKeyDigest: String
+    let signatureAlgorithm: String
+    var providerSignature: String
+    let cliVersion: String
+
+    enum CodingKeys: String, CodingKey {
+        case schema
+        case signatureDomain = "signature_domain"
+        case providerID = "provider_id"
+        case candidateID = "candidate_id"
+        case runtimeSource = "runtime_source"
+        case servedModelRef = "served_model_ref"
+        case catalogModelKey = "catalog_model_key"
+        case discoveryDigestSHA256 = "discovery_digest_sha256"
+        case evaluationDigestSHA256 = "evaluation_digest_sha256"
+        case artifactHashes = "artifact_hashes"
+        case advisoryCapabilities = "advisory_capabilities"
+        case fitEvidenceSource = "fit_evidence_source"
+        case localReadiness = "local_readiness"
+        case requestedDisclosureClass = "requested_disclosure_class"
+        case timestamp
+        case nonce
+        case idempotencyKey = "idempotency_key"
+        case signingKeyDigest = "signing_key_digest"
+        case signatureAlgorithm = "signature_algorithm"
+        case providerSignature = "provider_signature"
+        case cliVersion = "cli_version"
+    }
+
+    struct AdvisoryCapabilities: Codable, Equatable, Sendable {
+        let chatCompletions: Bool?
+        let streaming: Bool?
+        let toolCallPassthrough: Bool?
+        let structuredOutputPassthrough: Bool?
+        let jsonMode: Bool?
+        let usageReporting: Bool?
+        let maxContextTokens: Int?
+        let quantization: String?
+        let family: String?
+        let runtimeVersion: String?
+
+        enum CodingKeys: String, CodingKey {
+            case chatCompletions = "chat_completions"
+            case streaming
+            case toolCallPassthrough = "tool_call_passthrough"
+            case structuredOutputPassthrough = "structured_output_passthrough"
+            case jsonMode = "json_mode"
+            case usageReporting = "usage_reporting"
+            case maxContextTokens = "max_context_tokens"
+            case quantization
+            case family
+            case runtimeVersion = "runtime_version"
+        }
+    }
+
+    func canonicalValue() -> RFC8785JCS.Value {
+        .object([
+            "signature_domain": .string(signatureDomain),
+            "provider_id": .string(providerID),
+            "candidate_id": .string(candidateID),
+            "runtime_source": .string(runtimeSource),
+            "served_model_ref": .string(servedModelRef),
+            "catalog_model_key": .string(catalogModelKey),
+            "discovery_digest_sha256": .string(discoveryDigestSHA256),
+            "evaluation_digest_sha256": .string(evaluationDigestSHA256),
+            "artifact_hashes": .object(artifactHashes.mapValues(RFC8785JCS.Value.string)),
+            "advisory_capabilities": advisoryCapabilities.canonicalValue(),
+            "fit_evidence_source": .string(fitEvidenceSource),
+            "local_readiness": .string(localReadiness),
+            "requested_disclosure_class": .string(requestedDisclosureClass),
+            "timestamp": .string(timestamp),
+            "nonce": .string(nonce),
+            "idempotency_key": .string(idempotencyKey),
+            "signing_key_digest": .string(signingKeyDigest),
+            "cli_version": .string(cliVersion),
+        ])
+    }
+}
+
+extension BYOMOfferSubmitRequestWire.AdvisoryCapabilities {
+    init(_ capabilities: BYOMDiscoveryWire.Capabilities) {
+        self.init(
+            chatCompletions: capabilities.chatCompletions,
+            streaming: capabilities.streaming,
+            toolCallPassthrough: capabilities.toolCallPassthrough,
+            structuredOutputPassthrough: capabilities.structuredOutputPassthrough,
+            jsonMode: capabilities.jsonMode,
+            usageReporting: capabilities.usageReporting,
+            maxContextTokens: capabilities.maxContextTokens,
+            quantization: capabilities.quantization,
+            family: capabilities.family,
+            runtimeVersion: capabilities.runtimeVersion
+        )
+    }
+
+    func canonicalValue() -> RFC8785JCS.Value {
+        .object([
+            "chat_completions": chatCompletions.map(RFC8785JCS.Value.bool) ?? .null,
+            "streaming": streaming.map(RFC8785JCS.Value.bool) ?? .null,
+            "tool_call_passthrough": toolCallPassthrough.map(RFC8785JCS.Value.bool) ?? .null,
+            "structured_output_passthrough": structuredOutputPassthrough.map(RFC8785JCS.Value.bool) ?? .null,
+            "json_mode": jsonMode.map(RFC8785JCS.Value.bool) ?? .null,
+            "usage_reporting": usageReporting.map(RFC8785JCS.Value.bool) ?? .null,
+            "max_context_tokens": maxContextTokens.map(RFC8785JCS.Value.int) ?? .null,
+            "quantization": quantization.map(RFC8785JCS.Value.string) ?? .null,
+            "family": family.map(RFC8785JCS.Value.string) ?? .null,
+            "runtime_version": runtimeVersion.map(RFC8785JCS.Value.string) ?? .null,
+        ])
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try encodeNullable(chatCompletions, forKey: .chatCompletions, into: &container)
+        try encodeNullable(streaming, forKey: .streaming, into: &container)
+        try encodeNullable(toolCallPassthrough, forKey: .toolCallPassthrough, into: &container)
+        try encodeNullable(structuredOutputPassthrough, forKey: .structuredOutputPassthrough, into: &container)
+        try encodeNullable(jsonMode, forKey: .jsonMode, into: &container)
+        try encodeNullable(usageReporting, forKey: .usageReporting, into: &container)
+        try encodeNullable(maxContextTokens, forKey: .maxContextTokens, into: &container)
+        try encodeNullable(quantization, forKey: .quantization, into: &container)
+        try encodeNullable(family, forKey: .family, into: &container)
+        try encodeNullable(runtimeVersion, forKey: .runtimeVersion, into: &container)
+    }
+
+    private func encodeNullable<T: Encodable>(
+        _ value: T?,
+        forKey key: CodingKeys,
+        into container: inout KeyedEncodingContainer<CodingKeys>
+    ) throws {
+        if let value {
+            try container.encode(value, forKey: key)
+        } else {
+            try container.encodeNil(forKey: key)
+        }
+    }
+}
+
+enum BYOMModelAdmissionError: Error, Equatable, CustomStringConvertible {
+    case missingProviderID
+    case missingCoordinatorURL
+    case missingBearer(providerID: String)
+    case missingAdmissionIdentity(providerID: String)
+    case candidateNotFound
+    case candidateUnstable
+    case candidateNotOfferable
+    case invalidEvaluationDigest
+    case invalidCoordinatorURL
+    case httpStatus(Int)
+    case invalidStatusSchema
+
+    var description: String {
+        switch self {
+        case .missingProviderID:
+            return "models offer requires provider_id from --provider-id, config, or MACPROVIDER_PROVIDER_ID"
+        case .missingCoordinatorURL:
+            return "models offer requires coordinator_url from --coordinator-url, config, or MACPROVIDER_COORDINATOR_URL"
+        case .missingBearer(let providerID):
+            return "provider bearer token is missing for \(providerID); run macprovider-cli credentials import first"
+        case .missingAdmissionIdentity(let providerID):
+            return "provider admission signing identity is missing for \(providerID); start provider enrollment before offering BYOM models"
+        case .candidateNotFound:
+            return "BYOM candidate was not found in local discovery"
+        case .candidateUnstable:
+            return "BYOM candidate id is unstable; run models discover --json to initialize the local namespace"
+        case .candidateNotOfferable:
+            return "BYOM candidate is not offerable; run models evaluate and models offer --dry-run --json before submitting"
+        case .invalidEvaluationDigest:
+            return "evaluation digest must be a 64-character lowercase SHA-256 hex value"
+        case .invalidCoordinatorURL:
+            return "invalid coordinator URL; use wss:// or https://"
+        case .httpStatus(let status):
+            return "coordinator model admission request failed with HTTP \(status)"
+        case .invalidStatusSchema:
+            return "coordinator returned an invalid model admission status schema"
+        }
+    }
+}
+
+struct BYOMOfferSubmissionPackage: Equatable, Sendable {
+    let request: BYOMOfferSubmitRequestWire
+    let encodedRequest: Data
+    let payloadDigestSHA256: String
+}
+
+struct BYOMOfferSubmissionBuilder {
+    private static let stableCandidatePattern = #"^byom_[a-z2-7]{52}$"#
+
+    static func makePackage(
+        providerID: String,
+        candidate: BYOMDiscoveryWire.Candidate,
+        admissionIdentity: Curve25519.Signing.PrivateKey,
+        evaluationDigestSHA256: String?,
+        requestedDisclosureClass: String,
+        now: Date = Date(),
+        nonce: String = UUID().uuidString.lowercased(),
+        idempotencyKey: String = UUID().uuidString.lowercased(),
+        cliVersion: String = CoordinatorClient.binaryVersion
+    ) throws -> BYOMOfferSubmissionPackage {
+        guard candidate.candidateID.range(of: stableCandidatePattern, options: .regularExpression) != nil,
+              !candidate.warningCodes.contains(BYOMDiscoveryWarning.candidateIDUnstable.rawValue),
+              !candidate.warningCodes.contains(BYOMDiscoveryWarning.namespacePermissionInvalid.rawValue) else {
+            throw BYOMModelAdmissionError.candidateUnstable
+        }
+        let evaluationDigest = evaluationDigestSHA256?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if !evaluationDigest.isEmpty, !Self.isLowercaseSHA256(evaluationDigest) {
+            throw BYOMModelAdmissionError.invalidEvaluationDigest
+        }
+        guard Self.canSubmit(candidate: candidate, evaluationDigestSHA256: evaluationDigest) else {
+            throw BYOMModelAdmissionError.candidateNotOfferable
+        }
+        let publicKey = admissionIdentity.publicKey.rawRepresentation
+        let signingKeyDigest = Self.sha256Hex(publicKey)
+        var request = BYOMOfferSubmitRequestWire(
+            schema: "model_admission_offer_submit.v1",
+            signatureDomain: "macprovider.model_admission.offer.v1",
+            providerID: providerID,
+            candidateID: candidate.candidateID,
+            runtimeSource: candidate.runtimeSource,
+            servedModelRef: candidate.servedModelRef,
+            catalogModelKey: candidate.catalogModelKey ?? "",
+            discoveryDigestSHA256: try discoveryDigest(candidate),
+            evaluationDigestSHA256: evaluationDigest,
+            artifactHashes: [:],
+            advisoryCapabilities: BYOMOfferSubmitRequestWire.AdvisoryCapabilities(candidate.capabilities),
+            fitEvidenceSource: "local_discovery",
+            localReadiness: candidate.readinessState,
+            requestedDisclosureClass: requestedDisclosureClass,
+            timestamp: ModelSwitchingWireCodec.timestamp(now),
+            nonce: nonce,
+            idempotencyKey: idempotencyKey,
+            signingKeyDigest: signingKeyDigest,
+            signatureAlgorithm: "ed25519",
+            providerSignature: "",
+            cliVersion: cliVersion
+        )
+        let canonical = try RFC8785JCS.canonicalString(request.canonicalValue())
+        let canonicalData = Data(canonical.utf8)
+        let signatureData = try admissionIdentity.signature(for: canonicalData)
+        request.providerSignature = signatureData.base64EncodedString()
+        return BYOMOfferSubmissionPackage(
+            request: request,
+            encodedRequest: Data(try ModelSwitchingWireCodec.encode(request).utf8),
+            payloadDigestSHA256: Self.sha256Hex(canonicalData)
+        )
+    }
+
+    static func discoveryDigest(_ candidate: BYOMDiscoveryWire.Candidate) throws -> String {
+        try RFC8785JCS.sha256Hex(of: .object([
+            "candidate_id": .string(candidate.candidateID),
+            "runtime_source": .string(candidate.runtimeSource),
+            "served_model_ref": .string(candidate.servedModelRef),
+            "catalog_model_key": candidate.catalogModelKey.map(RFC8785JCS.Value.string) ?? .null,
+            "identity_state": .string(candidate.identityState),
+            "readiness_state": .string(candidate.readinessState),
+            "fit_state": .string(candidate.fitState),
+            "evaluation_state": .string(candidate.evaluationState),
+            "admission_state": .string(candidate.admissionState),
+            "warning_codes": .array(candidate.warningCodes.sorted().map(RFC8785JCS.Value.string)),
+        ]))
+    }
+
+    private static func sha256Hex(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func isLowercaseSHA256(_ value: String) -> Bool {
+        value.range(of: #"^[0-9a-f]{64}$"#, options: .regularExpression) != nil
+    }
+
+    private static func canSubmit(candidate: BYOMDiscoveryWire.Candidate, evaluationDigestSHA256: String) -> Bool {
+        guard candidate.admissionStateSource == "local_default",
+              candidate.admissionState == "offerable",
+              candidate.readinessState == "ready",
+              candidate.fitState != "does_not_fit" else {
+            return false
+        }
+        let warnings = Set(candidate.warningCodes)
+        if warnings.contains(BYOMDiscoveryWarning.adapterRejectedNonLoopback.rawValue) ||
+            warnings.contains(BYOMDiscoveryWarning.adapterMalformedResponse.rawValue) ||
+            warnings.contains(BYOMDiscoveryWarning.adapterResponseTruncated.rawValue) ||
+            warnings.contains(BYOMDiscoveryWarning.requiresPreparation.rawValue) {
+            return false
+        }
+        return !evaluationDigestSHA256.isEmpty || !warnings.contains(BYOMDiscoveryWarning.evaluationRequired.rawValue)
+    }
+}
+
+struct BYOMModelAdmissionClient: Sendable {
+    private static let maxStatusResponseBytes = 64 * 1024
+
+    let baseURL: URL
+    private let session: URLSession?
+
+    init(coordinatorURL: String?, session: URLSession? = nil) throws {
+        guard let baseURL = Self.httpBaseURL(from: coordinatorURL) else {
+            throw BYOMModelAdmissionError.invalidCoordinatorURL
+        }
+        self.baseURL = baseURL
+        self.session = session
+    }
+
+    init(baseURL: URL, session: URLSession? = nil) {
+        self.baseURL = baseURL
+        self.session = session
+    }
+
+    static func httpBaseURL(from coordinatorURL: String?) -> URL? {
+        guard let coordinatorURL,
+              var components = URLComponents(string: coordinatorURL.trimmingCharacters(in: .whitespacesAndNewlines)) else {
+            return nil
+        }
+        guard components.user == nil,
+              components.password == nil,
+              components.host != nil else {
+            return nil
+        }
+        switch components.scheme {
+        case "wss":
+            components.scheme = "https"
+        case "https":
+            break
+        default:
+            return nil
+        }
+        components.path = ""
+        components.query = nil
+        components.fragment = nil
+        return components.url
+    }
+
+    func submitOffer(_ package: BYOMOfferSubmissionPackage, bearerToken: String) async throws -> BYOMAdmissionStatusWire {
+        var request = URLRequest(url: baseURL.appendingPathComponent("v1/provider/model-admission/offers"))
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(bearerToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "content-type")
+        request.setValue("application/json", forHTTPHeaderField: "accept")
+        request.httpBody = package.encodedRequest
+        return try await perform(
+            request,
+            expectedProviderID: package.request.providerID,
+            expectedCandidateID: package.request.candidateID
+        )
+    }
+
+    func status(candidateID: String, providerID: String? = nil, bearerToken: String) async throws -> BYOMAdmissionStatusWire {
+        var components = URLComponents(url: baseURL.appendingPathComponent("v1/provider/model-admission/status"), resolvingAgainstBaseURL: false)
+        components?.queryItems = [URLQueryItem(name: "candidate_id", value: candidateID)]
+        guard let url = components?.url else {
+            throw BYOMModelAdmissionError.invalidCoordinatorURL
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(bearerToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "accept")
+        return try await perform(request, expectedProviderID: providerID, expectedCandidateID: candidateID)
+    }
+
+    private func perform(
+        _ request: URLRequest,
+        expectedProviderID: String?,
+        expectedCandidateID: String?
+    ) async throws -> BYOMAdmissionStatusWire {
+        let data: Data
+        let response: URLResponse
+        if let session {
+            (data, response) = try await session.data(for: request)
+        } else {
+            let ephemeral = URLSession(configuration: .ephemeral, delegate: NoRedirectURLSessionDelegate(), delegateQueue: nil)
+            defer { ephemeral.finishTasksAndInvalidate() }
+            (data, response) = try await ephemeral.data(for: request)
+        }
+        guard let http = response as? HTTPURLResponse else {
+            throw BYOMModelAdmissionError.invalidStatusSchema
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            throw BYOMModelAdmissionError.httpStatus(http.statusCode)
+        }
+        guard data.count <= Self.maxStatusResponseBytes else {
+            throw BYOMModelAdmissionError.invalidStatusSchema
+        }
+        let status = try BYOMAdmissionStatusWire.decodeStrictStatus(
+            from: data,
+            expectedProviderID: expectedProviderID,
+            expectedCandidateID: expectedCandidateID
+        )
+        guard status.admissionStateSource == "coordinator" else {
+            throw BYOMModelAdmissionError.invalidStatusSchema
+        }
+        return status
+    }
+}
+
+struct BYOMModelAdmissionRuntime: Sendable {
+    let environment: BYOMDiscoveryEnvironment
+    let credentialStore: any ProviderCredentialStoring
+    let identityStore: any ProviderIdentityKeyStoring
+    let client: BYOMModelAdmissionClient
+    let httpClient: any BYOMDiscoveryHTTPClient
+
+    init(
+        environment: BYOMDiscoveryEnvironment,
+        credentialStore: any ProviderCredentialStoring = KeychainProviderCredentialStore(),
+        identityStore: any ProviderIdentityKeyStoring = KeychainReceiptKeyStore(),
+        client: BYOMModelAdmissionClient,
+        httpClient: any BYOMDiscoveryHTTPClient = BYOMURLSessionHTTPClient()
+    ) {
+        self.environment = environment
+        self.credentialStore = credentialStore
+        self.identityStore = identityStore
+        self.client = client
+        self.httpClient = httpClient
+    }
+
+    func submitOffer(
+        providerID: String,
+        target: String,
+        evaluationDigestSHA256: String?,
+        requestedDisclosureClass: String
+    ) async throws -> BYOMAdmissionStatusWire {
+        let discovery = await BYOMDiscoveryRunner(
+            environment: environment,
+            httpClient: httpClient,
+            namespaceMode: .readOnly
+        ).discover()
+        guard let candidate = Self.selectCandidate(target: target, candidates: discovery.candidates) else {
+            throw BYOMModelAdmissionError.candidateNotFound
+        }
+        guard let bearer = try credentialStore.load(providerID: providerID) else {
+            throw BYOMModelAdmissionError.missingBearer(providerID: providerID)
+        }
+        guard let identity = try identityStore.loadAdmissionIdentity(providerId: providerID) else {
+            throw BYOMModelAdmissionError.missingAdmissionIdentity(providerID: providerID)
+        }
+        let package = try BYOMOfferSubmissionBuilder.makePackage(
+            providerID: providerID,
+            candidate: candidate,
+            admissionIdentity: identity,
+            evaluationDigestSHA256: evaluationDigestSHA256,
+            requestedDisclosureClass: requestedDisclosureClass
+        )
+        return try await client.submitOffer(package, bearerToken: bearer)
+    }
+
+    func status(providerID: String, target: String) async throws -> BYOMAdmissionStatusWire {
+        let candidate = await resolveCandidate(target)
+        let candidateID = candidate?.candidateID ?? target.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let bearer = try credentialStore.load(providerID: providerID) else {
+            throw BYOMModelAdmissionError.missingBearer(providerID: providerID)
+        }
+        let status = try await client.status(candidateID: candidateID, providerID: providerID, bearerToken: bearer)
+        return status.withLocalCandidateIdentityIfCoordinatorHasNoOffer(candidate)
+    }
+
+    private func resolveCandidate(_ target: String) async -> BYOMDiscoveryWire.Candidate? {
+        let discovery = await BYOMDiscoveryRunner(
+            environment: environment,
+            httpClient: httpClient,
+            namespaceMode: .readOnly
+        ).discover()
+        return Self.selectCandidate(target: target, candidates: discovery.candidates)
+    }
+
+    static func selectCandidate(target: String, candidates: [BYOMDiscoveryWire.Candidate]) -> BYOMDiscoveryWire.Candidate? {
+        let trimmed = target.trimmingCharacters(in: .whitespacesAndNewlines)
+        return candidates.first { candidate in
+            candidate.candidateID == trimmed ||
+                candidate.servedModelRef == trimmed ||
+                candidate.displayName == trimmed
+        }
+    }
+}
+
+private extension BYOMAdmissionStatusWire {
+    func withLocalCandidateIdentityIfCoordinatorHasNoOffer(_ candidate: BYOMDiscoveryWire.Candidate?) -> BYOMAdmissionStatusWire {
+        guard let candidate,
+              candidate.candidateID == candidateID,
+              admissionStateSource == "coordinator",
+              admissionState == "not_offered",
+              servedModelRef.isEmpty
+        else {
+            return self
+        }
+        return BYOMAdmissionStatusWire(
+            schema: schema,
+            generatedAt: generatedAt,
+            cliVersion: cliVersion,
+            providerID: providerID,
+            candidateID: candidateID,
+            servedModelRef: candidate.servedModelRef,
+            catalogModelKey: catalogModelKey ?? candidate.catalogModelKey,
+            admissionState: admissionState,
+            admissionStateSource: admissionStateSource,
+            coordinatorEventID: coordinatorEventID,
+            stateObservedAt: stateObservedAt,
+            providerGuidance: providerGuidance,
+            allowedNextStates: allowedNextStates,
+            warnings: warnings
+        )
+    }
+}
+
 struct BYOMDiscoveryEnvironment: Sendable {
     let namespaceURL: URL
     let mlxCacheRoot: URL

--- a/phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift
@@ -12,6 +12,7 @@ struct ModelsCommand: AsyncParsableCommand {
             ModelsDiscoverCommand.self,
             ModelsEvaluateCommand.self,
             ModelsOfferCommand.self,
+            ModelsAdmissionCommand.self,
             ModelsSwitchCommand.self,
             ModelsStatusCommand.self,
             ModelsBrowseCommand.self,
@@ -104,7 +105,7 @@ struct ModelsEvaluateCommand: AsyncParsableCommand {
 struct ModelsOfferCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "offer",
-        abstract: "Dry-run a provider-local BYOM admission offer."
+        abstract: "Dry-run or submit a provider-local BYOM admission offer."
     )
 
     @Argument(help: "Candidate id, served model reference, or display name from models discover --json.")
@@ -115,6 +116,24 @@ struct ModelsOfferCommand: AsyncParsableCommand {
 
     @Flag(name: .customLong("json"), help: "Emit the strict model_admission_offer_dry_run.v1 JSON contract.")
     var emitJSON = false
+
+    @Flag(help: "Confirm coordinator state mutation for a non-earning BYOM offer submission.")
+    var yes = false
+
+    @Option(help: "YAML config path. Overrides MACPROVIDER_CONFIG.")
+    var config: String?
+
+    @Option(help: "Coordinator WebSocket/HTTPS URL. Overrides MACPROVIDER_COORDINATOR_URL and config file coordinator_url.")
+    var coordinatorURL: String?
+
+    @Option(help: "Stable provider identifier. Overrides MACPROVIDER_PROVIDER_ID and config file provider_id.")
+    var providerID: String?
+
+    @Option(help: "Optional 64-character lowercase SHA-256 digest of a local evaluation document.")
+    var evaluationDigestSHA256: String?
+
+    @Option(help: "Requested non-earning disclosure class for coordinator admission.")
+    var requestedDisclosureClass: String = "non_earning_provider_asserted"
 
     @Option(help: ArgumentHelp("CLI-owned local discovery namespace path.", visibility: .hidden))
     var localDiscoveryNamespacePath: String?
@@ -129,8 +148,12 @@ struct ModelsOfferCommand: AsyncParsableCommand {
     var skipOllama = false
 
     func run() async throws {
-        guard dryRun, emitJSON else {
-            writeStderr("models offer is dry-run JSON-only in this release; pass --dry-run --json")
+        guard emitJSON else {
+            if dryRun {
+                writeStderr("models offer is dry-run JSON-only in this release; pass --json")
+            } else {
+                writeStderr("models offer submission is JSON-only in this release; pass --json")
+            }
             throw ExitCode(2)
         }
         let environment = BYOMDiscoveryEnvironment.production(
@@ -138,12 +161,129 @@ struct ModelsOfferCommand: AsyncParsableCommand {
             mlxCacheDir: mlxCacheDir,
             ollamaOrigin: skipOllama ? nil : ollamaOrigin
         )
-        let document = await BYOMOfferDryRunRunner(target: candidate, environment: environment).dryRun()
-        for warning in document.warnings.sorted() {
-            writeStderr("models offer warning: \(warning)")
+        if dryRun {
+            let document = await BYOMOfferDryRunRunner(target: candidate, environment: environment).dryRun()
+            for warning in document.warnings.sorted() {
+                writeStderr("models offer warning: \(warning)")
+            }
+            try ModelSwitchingWireCodec.printJSON(document)
+            return
         }
-        try ModelSwitchingWireCodec.printJSON(document)
+        guard yes else {
+            writeStderr("models offer submission mutates coordinator admission state; pass --yes --json after reviewing models offer --dry-run --json")
+            throw ExitCode(2)
+        }
+        do {
+            let resolved = try loadModelAdmissionConfig(
+                config: config,
+                coordinatorURL: coordinatorURL,
+                providerID: providerID
+            )
+            let client = try BYOMModelAdmissionClient(coordinatorURL: resolved.coordinatorURL)
+            let runtime = BYOMModelAdmissionRuntime(environment: environment, client: client)
+            let status = try await runtime.submitOffer(
+                providerID: resolved.providerID,
+                target: candidate,
+                evaluationDigestSHA256: evaluationDigestSHA256,
+                requestedDisclosureClass: requestedDisclosureClass
+            )
+            try ModelSwitchingWireCodec.printJSON(status)
+        } catch let error as BYOMModelAdmissionError {
+            writeStderr(error.description)
+            throw ExitCode(2)
+        }
     }
+}
+
+struct ModelsAdmissionCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "admission",
+        abstract: "Read BYOM model admission state.",
+        subcommands: [
+            ModelsAdmissionStatusCommand.self,
+        ]
+    )
+}
+
+struct ModelsAdmissionStatusCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "status",
+        abstract: "Read coordinator-backed BYOM admission status."
+    )
+
+    @Argument(help: "Candidate id, served model reference, or display name from models discover --json.")
+    var candidate: String
+
+    @Flag(name: .customLong("json"), help: "Emit the strict model_admission_status.v1 JSON contract.")
+    var emitJSON = false
+
+    @Option(help: "YAML config path. Overrides MACPROVIDER_CONFIG.")
+    var config: String?
+
+    @Option(help: "Coordinator WebSocket/HTTPS URL. Overrides MACPROVIDER_COORDINATOR_URL and config file coordinator_url.")
+    var coordinatorURL: String?
+
+    @Option(help: "Stable provider identifier. Overrides MACPROVIDER_PROVIDER_ID and config file provider_id.")
+    var providerID: String?
+
+    @Option(help: ArgumentHelp("CLI-owned local discovery namespace path.", visibility: .hidden))
+    var localDiscoveryNamespacePath: String?
+
+    @Option(help: "HuggingFace cache root to inspect read-only. Defaults to HF_HUB_CACHE, HF_HOME/hub, or ~/.cache/huggingface/hub.")
+    var mlxCacheDir: String?
+
+    @Option(help: "Ollama-compatible loopback origin to query. Must be http://127.0.0.0/8:<port> or http://[::1]:<port>.")
+    var ollamaOrigin: String = "http://127.0.0.1:11434"
+
+    @Flag(help: "Skip the Ollama-compatible loopback adapter during candidate lookup.")
+    var skipOllama = false
+
+    func run() async throws {
+        guard emitJSON else {
+            writeStderr("models admission status is JSON-only in this release; pass --json")
+            throw ExitCode(2)
+        }
+        do {
+            let resolved = try loadModelAdmissionConfig(
+                config: config,
+                coordinatorURL: coordinatorURL,
+                providerID: providerID
+            )
+            let environment = BYOMDiscoveryEnvironment.production(
+                namespacePath: localDiscoveryNamespacePath,
+                mlxCacheDir: mlxCacheDir,
+                ollamaOrigin: skipOllama ? nil : ollamaOrigin
+            )
+            let client = try BYOMModelAdmissionClient(coordinatorURL: resolved.coordinatorURL)
+            let runtime = BYOMModelAdmissionRuntime(environment: environment, client: client)
+            let status = try await runtime.status(providerID: resolved.providerID, target: candidate)
+            try ModelSwitchingWireCodec.printJSON(status)
+        } catch let error as BYOMModelAdmissionError {
+            writeStderr(error.description)
+            throw ExitCode(2)
+        }
+    }
+}
+
+private func loadModelAdmissionConfig(
+    config: String?,
+    coordinatorURL: String?,
+    providerID: String?
+) throws -> (coordinatorURL: String, providerID: String) {
+    let resolved = try ConfigLoader.load(cli: CLIOverrides(
+        coordinatorURL: coordinatorURL,
+        providerID: providerID,
+        configPath: config
+    ))
+    guard let providerID = resolved.providerID?.trimmingCharacters(in: .whitespacesAndNewlines),
+          !providerID.isEmpty else {
+        throw BYOMModelAdmissionError.missingProviderID
+    }
+    guard let coordinatorURL = resolved.coordinatorURL?.trimmingCharacters(in: .whitespacesAndNewlines),
+          !coordinatorURL.isEmpty else {
+        throw BYOMModelAdmissionError.missingCoordinatorURL
+    }
+    return (coordinatorURL, providerID)
 }
 
 struct ModelsListCommand: AsyncParsableCommand {

--- a/phase3-binary/Tests/macprovider-cliTests/BYOMAdmissionTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/BYOMAdmissionTests.swift
@@ -1,0 +1,558 @@
+import ArgumentParser
+import CryptoKit
+import Darwin
+import Foundation
+import XCTest
+@testable import macprovider_cli
+
+final class BYOMAdmissionTests: XCTestCase {
+    override func tearDown() {
+        BYOMAdmissionMockURLProtocol.requestHandler = nil
+        super.tearDown()
+    }
+
+    func testOfferCommandRequiresExplicitYesForCoordinatorMutation() async throws {
+        let command = try ModelsOfferCommand.parse([
+            "ollama:tiny-offer-1b-q4",
+            "--json",
+            "--skip-ollama",
+            "--coordinator-url", "wss://coordinator.example/ws/provider",
+            "--provider-id", "provider-byom-a",
+        ])
+        let capture = await captureBYOMAdmissionOutput {
+            try await command.run()
+        }
+
+        XCTAssertFalse(command.yes)
+        XCTAssertEqual((capture.error as? ExitCode), ExitCode(2))
+    }
+
+    func testOfferSubmissionPackageBindsAdmissionIdentityAndCandidate() throws {
+        let identity = Curve25519.Signing.PrivateKey()
+        let candidate = byomAdmissionCandidate(
+            candidateID: stableBYOMAdmissionCandidateID("a"),
+            servedModelRef: "ollama:qwen3-8b",
+            catalogModelKey: "qwen3-8b"
+        )
+
+        let package = try BYOMOfferSubmissionBuilder.makePackage(
+            providerID: "provider-byom-a",
+            candidate: candidate,
+            admissionIdentity: identity,
+            evaluationDigestSHA256: String(repeating: "b", count: 64),
+            requestedDisclosureClass: "non_earning_provider_asserted",
+            now: Date(timeIntervalSince1970: 1_800_000_000),
+            nonce: "nonce_test",
+            idempotencyKey: "request_test",
+            cliVersion: "test"
+        )
+
+        XCTAssertEqual(package.request.schema, "model_admission_offer_submit.v1")
+        XCTAssertEqual(package.request.signatureDomain, "macprovider.model_admission.offer.v1")
+        XCTAssertEqual(package.request.providerID, "provider-byom-a")
+        XCTAssertEqual(package.request.candidateID, stableBYOMAdmissionCandidateID("a"))
+        XCTAssertEqual(package.request.catalogModelKey, "qwen3-8b")
+        XCTAssertEqual(package.request.signatureAlgorithm, "ed25519")
+        XCTAssertFalse(String(decoding: package.encodedRequest, as: UTF8.self).contains("endpoint"))
+        XCTAssertFalse(String(decoding: package.encodedRequest, as: UTF8.self).contains("payout"))
+
+        let canonical = try RFC8785JCS.canonicalString(package.request.canonicalValue())
+        let signature = try XCTUnwrap(Data(base64Encoded: package.request.providerSignature))
+        XCTAssertTrue(identity.publicKey.isValidSignature(signature, for: Data(canonical.utf8)))
+    }
+
+    func testOfferSubmissionRunnerPostsPackageAndPreservesNonEarningStatus() async throws {
+        let root = try temporaryBYOMAdmissionDirectory("byom-admission-submit")
+        let namespace = root.appendingPathComponent("ns")
+        let cache = root.appendingPathComponent("hf", isDirectory: true)
+        try writeBYOMAdmissionNamespace(at: namespace)
+        try createBYOMAdmissionMLXSnapshot(cacheRoot: cache, modelID: "mlx-community/Tiny-1B-4bit")
+
+        let identity = Curve25519.Signing.PrivateKey()
+        let credentialStore = BYOMAdmissionCredentialStore(token: "provider-token-test")
+        let identityStore = BYOMAdmissionIdentityStore(identity: identity)
+        let session = makeBYOMAdmissionSession { request in
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer provider-token-test")
+            XCTAssertEqual(request.httpMethod, "POST")
+            let body = try XCTUnwrap(byomAdmissionRequestBody(request))
+            let object = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            XCTAssertEqual(object["schema"] as? String, "model_admission_offer_submit.v1")
+            XCTAssertEqual(object["signature_domain"] as? String, "macprovider.model_admission.offer.v1")
+            XCTAssertEqual(object["provider_id"] as? String, "provider-byom-a")
+            XCTAssertEqual(object["served_model_ref"] as? String, "mlx-community/Tiny-1B-4bit")
+            XCTAssertEqual(object["runtime_source"] as? String, "mlx_cache")
+            XCTAssertEqual(object["signature_algorithm"] as? String, "ed25519")
+            XCTAssertNotNil(object["provider_signature"] as? String)
+            XCTAssertNotNil(object["signing_key_digest"] as? String)
+            let candidateID = try XCTUnwrap(object["candidate_id"] as? String)
+            return BYOMAdmissionMockHTTPResponse(
+                statusCode: 200,
+                body: """
+                {"admission_state":"offer_submitted","admission_state_source":"coordinator","allowed_next_states":["offer_rejected","sandbox_probe_only","network_visible_unpriced","network_admitted_unsettled","catalog_priced","withdrawn","revoked"],"candidate_id":"\(candidateID)","catalog_model_key":null,"cli_version":"test","coordinator_event_id":"event_test","generated_at":"2027-01-15T08:00:00Z","provider_guidance":{"earning_path_class":"no_earning_path_in_v0_1","next_action":"wait_for_coordinator","state_label_key":"byom.admission.offer_submitted","state_meaning_key":"byom.admission.not_earning","transition_reason_code":null},"provider_id":"provider-byom-a","schema":"model_admission_status.v1","served_model_ref":"mlx-community/Tiny-1B-4bit","state_observed_at":"2027-01-15T08:00:00Z","warnings":[]}
+                """
+            )
+        }
+        let runtime = BYOMModelAdmissionRuntime(
+            environment: BYOMDiscoveryEnvironment(namespaceURL: namespace, mlxCacheRoot: cache, ollamaOrigin: nil),
+            credentialStore: credentialStore,
+            identityStore: identityStore,
+            client: BYOMModelAdmissionClient(baseURL: URL(string: "https://coordinator.test")!, session: session),
+            httpClient: BYOMAdmissionDiscoveryHTTPClient()
+        )
+
+        let status = try await runtime.submitOffer(
+            providerID: "provider-byom-a",
+            target: "mlx-community/Tiny-1B-4bit",
+            evaluationDigestSHA256: String(repeating: "b", count: 64),
+            requestedDisclosureClass: "non_earning_provider_asserted"
+        )
+
+        XCTAssertEqual(status.schema, "model_admission_status.v1")
+        XCTAssertEqual(status.admissionState, "offer_submitted")
+        XCTAssertEqual(status.providerGuidance.nextAction, "wait_for_coordinator")
+        XCTAssertEqual(status.allowedNextStates.first, "offer_rejected")
+    }
+
+    func testAdmissionStatusClientReadsCandidateStatus() async throws {
+        let session = makeBYOMAdmissionSession { request in
+            XCTAssertEqual(request.httpMethod, "GET")
+            XCTAssertEqual(request.url?.query, "candidate_id=\(stableBYOMAdmissionCandidateID("c"))")
+            return BYOMAdmissionMockHTTPResponse(
+                statusCode: 200,
+                body: """
+                {"admission_state":"not_offered","admission_state_source":"coordinator","allowed_next_states":["offer_submitted"],"candidate_id":"\(stableBYOMAdmissionCandidateID("c"))","catalog_model_key":null,"cli_version":"test","coordinator_event_id":null,"generated_at":"2027-01-15T08:00:00Z","provider_guidance":{"earning_path_class":"local_inventory_only","next_action":"submit_offer","state_label_key":"byom.admission.not_offered","state_meaning_key":"byom.admission.not_offered","transition_reason_code":null},"provider_id":"provider-byom-a","schema":"model_admission_status.v1","served_model_ref":"","state_observed_at":"2027-01-15T08:00:00Z","warnings":[]}
+                """
+            )
+        }
+        let client = BYOMModelAdmissionClient(baseURL: URL(string: "https://coordinator.test")!, session: session)
+        let status = try await client.status(candidateID: stableBYOMAdmissionCandidateID("c"), bearerToken: "token")
+
+        XCTAssertEqual(status.admissionState, "not_offered")
+        XCTAssertEqual(status.providerGuidance.nextAction, "submit_offer")
+        XCTAssertEqual(status.allowedNextStates, ["offer_submitted"])
+    }
+
+    func testAdmissionRuntimeStatusPreservesLocalIdentityForNotOfferedCandidate() async throws {
+        let root = try temporaryBYOMAdmissionDirectory("byom-admission-status")
+        let namespace = root.appendingPathComponent("ns")
+        let cache = root.appendingPathComponent("hf", isDirectory: true)
+        try writeBYOMAdmissionNamespace(at: namespace)
+        try createBYOMAdmissionMLXSnapshot(cacheRoot: cache, modelID: "mlx-community/Tiny-1B-4bit")
+        let credentialStore = BYOMAdmissionCredentialStore(token: "provider-token-test")
+        let identityStore = BYOMAdmissionIdentityStore(identity: Curve25519.Signing.PrivateKey())
+        let session = makeBYOMAdmissionSession { request in
+            XCTAssertEqual(request.httpMethod, "GET")
+            let queryItems = URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)?.queryItems
+            let candidateID = try XCTUnwrap(queryItems?.first(where: { $0.name == "candidate_id" })?.value)
+            return BYOMAdmissionMockHTTPResponse(
+                statusCode: 200,
+                body: """
+                {"admission_state":"not_offered","admission_state_source":"coordinator","allowed_next_states":["offer_submitted"],"candidate_id":"\(candidateID)","catalog_model_key":null,"cli_version":"test","coordinator_event_id":null,"generated_at":"2027-01-15T08:00:00Z","provider_guidance":{"earning_path_class":"local_inventory_only","next_action":"submit_offer","state_label_key":"byom.admission.not_offered","state_meaning_key":"byom.admission.not_offered","transition_reason_code":null},"provider_id":"provider-byom-a","schema":"model_admission_status.v1","served_model_ref":"","state_observed_at":"2027-01-15T08:00:00Z","warnings":[]}
+                """
+            )
+        }
+        let runtime = BYOMModelAdmissionRuntime(
+            environment: BYOMDiscoveryEnvironment(namespaceURL: namespace, mlxCacheRoot: cache, ollamaOrigin: nil),
+            credentialStore: credentialStore,
+            identityStore: identityStore,
+            client: BYOMModelAdmissionClient(baseURL: URL(string: "https://coordinator.test")!, session: session),
+            httpClient: BYOMAdmissionDiscoveryHTTPClient()
+        )
+
+        let status = try await runtime.status(providerID: "provider-byom-a", target: "mlx-community/Tiny-1B-4bit")
+
+        XCTAssertTrue(status.candidateID.hasPrefix("byom_"))
+        XCTAssertEqual(status.candidateID.count, 57)
+        XCTAssertEqual(status.servedModelRef, "mlx-community/Tiny-1B-4bit")
+        XCTAssertEqual(status.admissionState, "not_offered")
+        XCTAssertEqual(status.admissionStateSource, "coordinator")
+    }
+
+    func testAdmissionStatusClientAcceptsCatalogPricedSettlementTransition() async throws {
+        let session = makeBYOMAdmissionSession { _ in
+            BYOMAdmissionMockHTTPResponse(
+                statusCode: 200,
+                body: """
+                {"admission_state":"catalog_priced","admission_state_source":"coordinator","allowed_next_states":["network_admitted_unsettled","settlement_capable","withdrawn","revoked"],"candidate_id":"\(stableBYOMAdmissionCandidateID("l"))","catalog_model_key":"qwen3-8b","cli_version":"test","coordinator_event_id":"event_test","generated_at":"2027-01-15T08:00:00Z","provider_guidance":{"earning_path_class":"not_earning_yet_catalog_or_receipt_path_exists","next_action":"withdraw","state_label_key":"byom.admission.catalog_priced","state_meaning_key":"byom.admission.catalog_priced","transition_reason_code":null},"provider_id":"provider-byom-a","schema":"model_admission_status.v1","served_model_ref":"ollama:qwen3:8b","state_observed_at":"2027-01-15T08:00:00Z","warnings":[]}
+                """
+            )
+        }
+        let client = BYOMModelAdmissionClient(baseURL: URL(string: "https://coordinator.test")!, session: session)
+        let status = try await client.status(candidateID: stableBYOMAdmissionCandidateID("l"), bearerToken: "token")
+
+        XCTAssertEqual(status.admissionState, "catalog_priced")
+        XCTAssertEqual(status.allowedNextStates, ["network_admitted_unsettled", "settlement_capable", "withdrawn", "revoked"])
+    }
+
+    func testAdmissionClientRejectsCredentialedURLAndOversizedStatus() async throws {
+        XCTAssertThrowsError(try BYOMModelAdmissionClient(coordinatorURL: "wss://user:pass@coordinator.test/ws/provider")) { error in
+            XCTAssertEqual(error as? BYOMModelAdmissionError, .invalidCoordinatorURL)
+        }
+        let session = makeBYOMAdmissionSession { _ in
+            BYOMAdmissionMockHTTPResponse(statusCode: 200, body: String(repeating: " ", count: 64 * 1024 + 1))
+        }
+        let client = BYOMModelAdmissionClient(baseURL: URL(string: "https://coordinator.test")!, session: session)
+        do {
+            _ = try await client.status(candidateID: stableBYOMAdmissionCandidateID("d"), bearerToken: "token")
+            XCTFail("oversized status responses must fail closed")
+        } catch let error as BYOMModelAdmissionError {
+            XCTAssertEqual(error, .invalidStatusSchema)
+        }
+    }
+
+    func testOfferPackageRejectsUnstableCandidateAndBadEvaluationDigest() throws {
+        let identity = Curve25519.Signing.PrivateKey()
+        let unstable = byomAdmissionCandidate(
+            candidateID: "byom_unstable_123",
+            servedModelRef: "ollama:qwen3-8b",
+            warningCodes: ["candidate_id_unstable"]
+        )
+        XCTAssertThrowsError(try BYOMOfferSubmissionBuilder.makePackage(
+            providerID: "provider-byom-a",
+            candidate: unstable,
+            admissionIdentity: identity,
+            evaluationDigestSHA256: nil,
+            requestedDisclosureClass: "non_earning_provider_asserted"
+        )) { error in
+            XCTAssertEqual(error as? BYOMModelAdmissionError, .candidateUnstable)
+        }
+
+        let stable = byomAdmissionCandidate(candidateID: stableBYOMAdmissionCandidateID("e"), servedModelRef: "ollama:qwen3-8b")
+        XCTAssertThrowsError(try BYOMOfferSubmissionBuilder.makePackage(
+            providerID: "provider-byom-a",
+            candidate: stable,
+            admissionIdentity: identity,
+            evaluationDigestSHA256: "ABC",
+            requestedDisclosureClass: "non_earning_provider_asserted"
+        )) { error in
+            XCTAssertEqual(error as? BYOMModelAdmissionError, .invalidEvaluationDigest)
+        }
+    }
+
+    func testOfferPackageRequiresEvaluationDigestWhenDiscoveryStillRequiresEvaluation() throws {
+        let identity = Curve25519.Signing.PrivateKey()
+        let candidate = byomAdmissionCandidate(
+            candidateID: stableBYOMAdmissionCandidateID("f"),
+            servedModelRef: "ollama:qwen3-8b",
+            warningCodes: ["evaluation_required"]
+        )
+        XCTAssertThrowsError(try BYOMOfferSubmissionBuilder.makePackage(
+            providerID: "provider-byom-a",
+            candidate: candidate,
+            admissionIdentity: identity,
+            evaluationDigestSHA256: nil,
+            requestedDisclosureClass: "non_earning_provider_asserted"
+        )) { error in
+            XCTAssertEqual(error as? BYOMModelAdmissionError, .candidateNotOfferable)
+        }
+        XCTAssertNoThrow(try BYOMOfferSubmissionBuilder.makePackage(
+            providerID: "provider-byom-a",
+            candidate: candidate,
+            admissionIdentity: identity,
+            evaluationDigestSHA256: String(repeating: "b", count: 64),
+            requestedDisclosureClass: "non_earning_provider_asserted"
+        ))
+    }
+
+    func testAdmissionClientRejectsNonClosedOrInvalidStatusEnvelope() async throws {
+        let invalidBodies = [
+            """
+            {"admission_state":"not_offered","admission_state_source":"coordinator","allowed_next_states":["offer_submitted"],"candidate_id":"\(stableBYOMAdmissionCandidateID("g"))","catalog_model_key":null,"cli_version":"test","coordinator_event_id":null,"generated_at":"2027-01-15T08:00:00Z","provider_guidance":{"earning_path_class":"local_inventory_only","next_action":"submit_offer","state_label_key":"byom.admission.not_offered","state_meaning_key":"byom.admission.not_offered","transition_reason_code":null},"provider_id":"provider-byom-a","schema":"model_admission_status.v1","served_model_ref":"","state_observed_at":"2027-01-15T08:00:00Z","warnings":[],"unexpected":true}
+            """,
+            """
+            {"admission_state":"offer_submitted","admission_state_source":"coordinator","allowed_next_states":["settlement_capable"],"candidate_id":"\(stableBYOMAdmissionCandidateID("h"))","catalog_model_key":null,"cli_version":"test","coordinator_event_id":"event_test","generated_at":"2027-01-15T08:00:00Z","provider_guidance":{"earning_path_class":"no_earning_path_in_v0_1","next_action":"wait_for_coordinator","state_label_key":"byom.admission.offer_submitted","state_meaning_key":"byom.admission.not_earning","transition_reason_code":null},"provider_id":"provider-byom-a","schema":"model_admission_status.v1","served_model_ref":"ollama:qwen3-8b","state_observed_at":"2027-01-15T08:00:00Z","warnings":[]}
+            """,
+            """
+            {"admission_state":"revoked","admission_state_source":"coordinator","allowed_next_states":["offer_submitted"],"candidate_id":"\(stableBYOMAdmissionCandidateID("i"))","catalog_model_key":null,"cli_version":"test","coordinator_event_id":"event_test","generated_at":"2027-01-15T08:00:00Z","provider_guidance":{"earning_path_class":"no_earning_path_in_v0_1","next_action":"submit_offer","state_label_key":"byom.admission.revoked","state_meaning_key":"byom.admission.not_earning","transition_reason_code":null},"provider_id":"provider-byom-a","schema":"model_admission_status.v1","served_model_ref":"ollama:qwen3-8b","state_observed_at":"2027-01-15T08:00:00Z","warnings":[]}
+            """,
+            """
+            {"admission_state":"catalog_priced","admission_state_source":"coordinator","allowed_next_states":["catalog_priced"],"candidate_id":"\(stableBYOMAdmissionCandidateID("l"))","catalog_model_key":"qwen3-8b","cli_version":"test","coordinator_event_id":"event_test","generated_at":"2027-01-15T08:00:00Z","provider_guidance":{"earning_path_class":"not_earning_yet_catalog_or_receipt_path_exists","next_action":"maintain_runtime","state_label_key":"byom.admission.catalog_priced","state_meaning_key":"byom.admission.catalog_priced","transition_reason_code":null},"provider_id":"provider-byom-a","schema":"model_admission_status.v1","served_model_ref":"ollama:qwen3:8b","state_observed_at":"2027-01-15T08:00:00Z","warnings":[]}
+            """,
+            """
+            {"admission_state":"offer_submitted","admission_state_source":"coordinator","allowed_next_states":["offer_rejected","sandbox_probe_only","network_visible_unpriced","network_admitted_unsettled","catalog_priced","withdrawn","revoked"],"candidate_id":"\(stableBYOMAdmissionCandidateID("m"))","catalog_model_key":null,"cli_version":"test","coordinator_event_id":"event_test","generated_at":"2027-01-15T08:00:00Z","provider_guidance":{"earning_path_class":"settlement_capable","next_action":"wait_for_coordinator","state_label_key":"byom.admission.offer_submitted","state_meaning_key":"byom.admission.not_earning","transition_reason_code":null},"provider_id":"provider-byom-a","schema":"model_admission_status.v1","served_model_ref":"ollama:qwen3:8b","state_observed_at":"2027-01-15T08:00:00Z","warnings":[]}
+            """,
+        ]
+        for body in invalidBodies {
+            let session = makeBYOMAdmissionSession { _ in
+                BYOMAdmissionMockHTTPResponse(statusCode: 200, body: body)
+            }
+            let client = BYOMModelAdmissionClient(baseURL: URL(string: "https://coordinator.test")!, session: session)
+            do {
+                _ = try await client.status(candidateID: stableBYOMAdmissionCandidateID("j"), bearerToken: "token")
+                XCTFail("invalid status envelope succeeded: \(body)")
+            } catch let error as BYOMModelAdmissionError {
+                XCTAssertEqual(error, .invalidStatusSchema)
+            }
+        }
+    }
+
+    func testAdmissionStatusClientRejectsMismatchedStatusIdentity() async throws {
+        let session = makeBYOMAdmissionSession { _ in
+            BYOMAdmissionMockHTTPResponse(
+                statusCode: 200,
+                body: """
+                {"admission_state":"not_offered","admission_state_source":"coordinator","allowed_next_states":["offer_submitted"],"candidate_id":"\(stableBYOMAdmissionCandidateID("n"))","catalog_model_key":null,"cli_version":"test","coordinator_event_id":null,"generated_at":"2027-01-15T08:00:00Z","provider_guidance":{"earning_path_class":"local_inventory_only","next_action":"submit_offer","state_label_key":"byom.admission.not_offered","state_meaning_key":"byom.admission.not_offered","transition_reason_code":null},"provider_id":"provider-byom-b","schema":"model_admission_status.v1","served_model_ref":"","state_observed_at":"2027-01-15T08:00:00Z","warnings":[]}
+                """
+            )
+        }
+        let client = BYOMModelAdmissionClient(baseURL: URL(string: "https://coordinator.test")!, session: session)
+
+        do {
+            _ = try await client.status(
+                candidateID: stableBYOMAdmissionCandidateID("c"),
+                providerID: "provider-byom-a",
+                bearerToken: "token"
+            )
+            XCTFail("mismatched provider/candidate status succeeded")
+        } catch let error as BYOMModelAdmissionError {
+            XCTAssertEqual(error, .invalidStatusSchema)
+        }
+    }
+
+    func testAdmissionStatusClientRejectsRemoteLocalDefaultGuidance() async throws {
+        let candidateID = stableBYOMAdmissionCandidateID("c")
+        let session = makeBYOMAdmissionSession { _ in
+            BYOMAdmissionMockHTTPResponse(
+                statusCode: 200,
+                body: """
+                {"admission_state":"offerable","admission_state_source":"local_default","allowed_next_states":[],"candidate_id":"\(candidateID)","catalog_model_key":null,"cli_version":"test","coordinator_event_id":null,"generated_at":"2027-01-15T08:00:00Z","provider_guidance":{"earning_path_class":"settlement_capable","next_action":"maintain_runtime","state_label_key":"byom.admission.offerable","state_meaning_key":"byom.admission.offerable","transition_reason_code":null},"provider_id":"provider-byom-a","schema":"model_admission_status.v1","served_model_ref":"ollama:qwen3:8b","state_observed_at":"2027-01-15T08:00:00Z","warnings":[]}
+                """
+            )
+        }
+        let client = BYOMModelAdmissionClient(baseURL: URL(string: "https://coordinator.test")!, session: session)
+
+        do {
+            _ = try await client.status(
+                candidateID: candidateID,
+                providerID: "provider-byom-a",
+                bearerToken: "token"
+            )
+            XCTFail("remote local_default status succeeded")
+        } catch let error as BYOMModelAdmissionError {
+            XCTAssertEqual(error, .invalidStatusSchema)
+        }
+    }
+
+    private func temporaryBYOMAdmissionDirectory(_ name: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(name)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: url.path)
+        return url
+    }
+
+    private func writeBYOMAdmissionNamespace(at url: URL) throws {
+        let parent = url.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: parent.path)
+        try Data(repeating: 0x33, count: 32).write(to: url)
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+    }
+
+    private func createBYOMAdmissionMLXSnapshot(cacheRoot: URL, modelID: String) throws {
+        let repo = cacheRoot
+            .appendingPathComponent("models--" + modelID.replacingOccurrences(of: "/", with: "--"), isDirectory: true)
+            .appendingPathComponent("snapshots", isDirectory: true)
+            .appendingPathComponent("0123456789abcdef0123456789abcdef01234567", isDirectory: true)
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        try Data(#"{"max_position_embeddings":2048}"#.utf8).write(to: repo.appendingPathComponent("config.json"))
+        try Data(repeating: 0x7a, count: 128).write(to: repo.appendingPathComponent("model.safetensors"))
+    }
+}
+
+private func byomAdmissionCandidate(
+    candidateID: String,
+    servedModelRef: String,
+    catalogModelKey: String? = nil,
+    warningCodes: [String] = []
+) -> BYOMDiscoveryWire.Candidate {
+    BYOMDiscoveryWire.Candidate(
+        candidateID: candidateID,
+        runtimeSource: servedModelRef.hasPrefix("ollama:") ? "ollama_loopback" : "mlx_cache",
+        displayName: servedModelRef,
+        servedModelRef: servedModelRef,
+        catalogModelKey: catalogModelKey,
+        identityState: "provider_asserted",
+        locality: "local",
+        estimatedGB: 1.0,
+        contextWindowTokens: 2048,
+        capabilities: BYOMDiscoveryWire.Capabilities(
+            chatCompletions: true,
+            streaming: nil,
+            toolCallPassthrough: nil,
+            structuredOutputPassthrough: nil,
+            jsonMode: nil,
+            usageReporting: nil,
+            maxContextTokens: 2048,
+            quantization: nil,
+            family: nil,
+            runtimeVersion: nil
+        ),
+        readinessState: "ready",
+        fitState: "fits",
+        evaluationState: "not_evaluated",
+        admissionState: "offerable",
+        admissionStateSource: "local_default",
+        providerGuidance: BYOMDiscoveryWire.Guidance(
+            stateLabelKey: "provider_models.state.not_offered",
+            stateMeaningKey: "test",
+            nextAction: "evaluate",
+            transitionReasonCode: "test",
+            earningPathClass: "local_inventory_only"
+        ),
+        warningCodes: warningCodes
+    )
+}
+
+private func stableBYOMAdmissionCandidateID(_ character: Character) -> String {
+    "byom_" + String(repeating: String(character), count: 52)
+}
+
+private struct BYOMAdmissionCredentialStore: ProviderCredentialStoring {
+    let token: String?
+
+    func load(providerID: String) throws -> String? { token }
+    func importIfAbsentOrMatches(providerID: String, token: String) throws {}
+    func replace(providerID: String, token: String) throws {}
+    func repairCorruptIfStillCorrupt(providerID: String, token: String) throws {}
+    func deleteAll() throws {}
+}
+
+private struct BYOMAdmissionIdentityStore: ProviderIdentityKeyStoring {
+    let identity: Curve25519.Signing.PrivateKey?
+
+    func loadAdmissionIdentity(providerId: String) throws -> Curve25519.Signing.PrivateKey? { identity }
+    func loadOrGenerate(providerId: String) throws -> Curve25519.Signing.PrivateKey { identity ?? Curve25519.Signing.PrivateKey() }
+    func loadCurrent(providerId: String) throws -> Curve25519.Signing.PrivateKey? { identity }
+    func storeNew(providerId: String, privateKey: Curve25519.Signing.PrivateKey) throws {}
+    func swapToCurrent(providerId: String, newKey: Curve25519.Signing.PrivateKey) throws {}
+    func loadPendingAdmissionIdentity(providerId: String) throws -> Curve25519.Signing.PrivateKey? { nil }
+    func beginAdmissionIdentityRotation(providerId: String) throws -> Curve25519.Signing.PrivateKey { Curve25519.Signing.PrivateKey() }
+    func isAdmissionIdentityRecoveryPending(providerId: String, candidatePublicKey: Data) throws -> Bool { false }
+    func beginAdmissionIdentityRecovery(providerId: String, allowExistingCurrent: Bool, afterPendingPersisted: (Curve25519.Signing.PrivateKey) throws -> Void) throws -> Curve25519.Signing.PrivateKey {
+        let key = Curve25519.Signing.PrivateKey()
+        try afterPendingPersisted(key)
+        return key
+    }
+    func loadBootstrapIdentity(providerId: String) throws -> Curve25519.Signing.PrivateKey? { identity }
+    func loadOrStoreBootstrapIdentity(providerId: String, candidate: Curve25519.Signing.PrivateKey) throws -> Curve25519.Signing.PrivateKey { identity ?? candidate }
+    func loadOrStoreAdmissionIdentity(providerId: String, candidate: Curve25519.Signing.PrivateKey) throws -> Curve25519.Signing.PrivateKey { identity ?? candidate }
+    func loadPrevious(providerId: String) throws -> Curve25519.Signing.PrivateKey? { nil }
+    func loadPreviousAdmissionIdentity(providerId: String) throws -> Curve25519.Signing.PrivateKey? { nil }
+    func loadPreviousAdmissionIdentityState(providerId: String) throws -> AdmissionIdentityPreviousKeyState? { nil }
+    func loadAdmissionIdentityRecoveryMarker(providerId: String) throws -> Data? { nil }
+    func commitAdmissionIdentityRotation(providerId: String, expectedPublicKey: Data, previousValidUntil: Date?) throws -> Curve25519.Signing.PrivateKey { identity ?? Curve25519.Signing.PrivateKey() }
+    func commitAdmissionIdentityRecovery(providerId: String, expectedPublicKey: Data) throws -> Curve25519.Signing.PrivateKey { identity ?? Curve25519.Signing.PrivateKey() }
+    func cancelAdmissionIdentityRotation(providerId: String) throws {}
+}
+
+private struct BYOMAdmissionDiscoveryHTTPClient: BYOMDiscoveryHTTPClient {
+    func get(_ url: URL, maxHeaderBytes: Int, maxBodyBytes: Int) async throws -> BYOMHTTPResponse {
+        BYOMHTTPResponse(statusCode: 200, headers: [], body: Data(#"{"models":[]}"#.utf8))
+    }
+}
+
+private struct BYOMAdmissionMockHTTPResponse {
+    let statusCode: Int
+    let body: String
+}
+
+private func makeBYOMAdmissionSession(
+    handler: @escaping @Sendable (URLRequest) throws -> BYOMAdmissionMockHTTPResponse
+) -> URLSession {
+    BYOMAdmissionMockURLProtocol.requestHandler = handler
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [BYOMAdmissionMockURLProtocol.self]
+    return URLSession(configuration: configuration, delegate: NoRedirectURLSessionDelegate(), delegateQueue: nil)
+}
+
+private func byomAdmissionRequestBody(_ request: URLRequest) -> Data? {
+    if let body = request.httpBody {
+        return body
+    }
+    guard let stream = request.httpBodyStream else {
+        return nil
+    }
+    stream.open()
+    defer { stream.close() }
+    var data = Data()
+    var buffer = [UInt8](repeating: 0, count: 4096)
+    while stream.hasBytesAvailable {
+        let count = stream.read(&buffer, maxLength: buffer.count)
+        if count <= 0 {
+            break
+        }
+        data.append(buffer, count: count)
+    }
+    return data
+}
+
+private final class BYOMAdmissionMockURLProtocol: URLProtocol {
+    static var requestHandler: (@Sendable (URLRequest) throws -> BYOMAdmissionMockHTTPResponse)?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = Self.requestHandler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        do {
+            let response = try handler(request)
+            let http = HTTPURLResponse(
+                url: request.url!,
+                statusCode: response.statusCode,
+                httpVersion: nil,
+                headerFields: ["content-type": "application/json"]
+            )!
+            client?.urlProtocol(self, didReceive: http, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: Data(response.body.utf8))
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+private struct BYOMAdmissionCapturedOutput {
+    let stdout: String
+    let stderr: String
+    let error: Error?
+}
+
+private func captureBYOMAdmissionOutput(_ body: () async throws -> Void) async -> BYOMAdmissionCapturedOutput {
+    let stdoutPipe = Pipe()
+    let stderrPipe = Pipe()
+    let savedStdout = dup(STDOUT_FILENO)
+    let savedStderr = dup(STDERR_FILENO)
+    dup2(stdoutPipe.fileHandleForWriting.fileDescriptor, STDOUT_FILENO)
+    dup2(stderrPipe.fileHandleForWriting.fileDescriptor, STDERR_FILENO)
+
+    let error: Error?
+    do {
+        try await body()
+        error = nil
+    } catch let caught {
+        error = caught
+    }
+
+    fflush(stdout)
+    fflush(stderr)
+    dup2(savedStdout, STDOUT_FILENO)
+    dup2(savedStderr, STDERR_FILENO)
+    close(savedStdout)
+    close(savedStderr)
+    stdoutPipe.fileHandleForWriting.closeFile()
+    stderrPipe.fileHandleForWriting.closeFile()
+
+    let stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+    let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+    return BYOMAdmissionCapturedOutput(
+        stdout: String(decoding: stdoutData, as: UTF8.self),
+        stderr: String(decoding: stderrData, as: UTF8.self),
+        error: error
+    )
+}

--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -253,6 +253,11 @@ func main() {
 		fmt.Fprintf(os.Stderr, "admission storage: %v\n", err)
 		os.Exit(1)
 	}
+	byomOfferStore, err := providerws.NewSQLiteModelAdmissionStore(reqLogStore.DB())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "BYOM offer storage: %v\n", err)
+		os.Exit(1)
+	}
 	connectionEventStore, err := providerevents.Open(providerevents.DefaultDBPath(cfg.Storage.DBPath))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "provider connection events storage: %v\n", err)
@@ -531,6 +536,7 @@ func main() {
 	wsOpts = append(wsOpts, providerws.WithVersion(version))
 	wsOpts = append(wsOpts, providerws.WithReferralPolicy(referralPolicy))
 	wsOpts = append(wsOpts, providerws.WithAdmissionStore(admissionStore))
+	wsOpts = append(wsOpts, providerws.WithModelAdmissionStore(byomOfferStore))
 	wsOpts = append(wsOpts, providerws.WithConnectionEventStore(connectionEventStore))
 	wsOpts = append(wsOpts, providerws.WithConnectionEventMetrics(metricsHandle))
 	if canaryStore != nil {

--- a/phase4-coordinator/internal/ws/model_admission.go
+++ b/phase4-coordinator/internal/ws/model_admission.go
@@ -1,0 +1,1099 @@
+package ws
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/billing"
+	"github.com/augstar/macprovider-coordinator/internal/config"
+	"github.com/augstar/macprovider-coordinator/internal/sqliteutil"
+)
+
+const (
+	modelAdmissionOfferSubmitSchema = "model_admission_offer_submit.v1"
+	modelAdmissionStatusSchema      = "model_admission_status.v1"
+	modelAdmissionSignedDomain      = "macprovider.model_admission.offer.v1"
+	modelAdmissionOfferSubmitted    = "offer_submitted"
+	modelAdmissionNotOffered        = "not_offered"
+	modelAdmissionActorProvider     = "provider"
+	modelAdmissionMaxBodyBytes      = 64 * 1024
+	modelAdmissionMaxEvents         = 256
+	modelAdmissionMaxCandidates     = 64
+	modelAdmissionMaxClockSkew      = 5 * time.Minute
+)
+
+var (
+	errModelAdmissionReplayConflict = errors.New("model admission replay conflict")
+	errModelAdmissionCapExceeded    = errors.New("model admission cap exceeded")
+	errModelAdmissionRateLimited    = errors.New("model admission rate limited")
+	modelAdmissionCandidatePattern  = regexp.MustCompile(`^byom_[a-z2-7]{52}$`)
+	modelAdmissionCLIVersionPattern = regexp.MustCompile(`^[0-9A-Za-z][0-9A-Za-z._+-]{0,63}$`)
+	modelAdmissionServedRefPattern  = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._:/+-]{0,255}$`)
+)
+
+type ModelAdmissionStore interface {
+	AppendModelAdmissionOffer(context.Context, ModelAdmissionEvent) (ModelAdmissionEvent, bool, error)
+	LatestModelAdmissionStatus(context.Context, string, string) (ModelAdmissionEvent, bool, error)
+}
+
+type ModelAdmissionEvent struct {
+	CoordinatorEventID       string
+	Actor                    string
+	ProviderID               string
+	CandidateID              string
+	ServedModelRef           string
+	CatalogModelKey          string
+	DiscoveryDigestSHA256    string
+	EvaluationDigestSHA256   string
+	RequestedDisclosureClass string
+	PreviousState            string
+	State                    string
+	NextState                string
+	ReasonCode               string
+	RequestID                string
+	Nonce                    string
+	PayloadDigestSHA256      string
+	SignatureDigestSHA256    string
+	CreatedAt                time.Time
+}
+
+type memoryModelAdmissionStore struct {
+	mu            sync.Mutex
+	events        []ModelAdmissionEvent
+	latest        map[string]ModelAdmissionEvent
+	requestIDs    map[string]ModelAdmissionEvent
+	nonces        map[string]ModelAdmissionEvent
+	candidates    map[string]map[string]struct{}
+	providerEvent map[string][]time.Time
+}
+
+func NewMemoryModelAdmissionStore() ModelAdmissionStore {
+	return &memoryModelAdmissionStore{
+		latest:        map[string]ModelAdmissionEvent{},
+		requestIDs:    map[string]ModelAdmissionEvent{},
+		nonces:        map[string]ModelAdmissionEvent{},
+		candidates:    map[string]map[string]struct{}{},
+		providerEvent: map[string][]time.Time{},
+	}
+}
+
+func (s *memoryModelAdmissionStore) AppendModelAdmissionOffer(_ context.Context, event ModelAdmissionEvent) (ModelAdmissionEvent, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := event.CreatedAt
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	event.CreatedAt = now.UTC()
+	if existing, ok := s.requestIDs[event.ProviderID+"|"+event.RequestID]; ok {
+		if existing.PayloadDigestSHA256 == event.PayloadDigestSHA256 {
+			return existing, true, nil
+		}
+		return ModelAdmissionEvent{}, false, errModelAdmissionReplayConflict
+	}
+	if existing, ok := s.nonces[event.ProviderID+"|"+event.Nonce]; ok {
+		if existing.PayloadDigestSHA256 == event.PayloadDigestSHA256 {
+			return existing, true, nil
+		}
+		return ModelAdmissionEvent{}, false, errModelAdmissionReplayConflict
+	}
+	window := pruneModelAdmissionWindow(s.providerEvent[event.ProviderID], now)
+	if len(window) >= modelAdmissionMaxEvents {
+		return ModelAdmissionEvent{}, false, errModelAdmissionRateLimited
+	}
+	candidateSet := s.candidates[event.ProviderID]
+	if candidateSet == nil {
+		candidateSet = map[string]struct{}{}
+		s.candidates[event.ProviderID] = candidateSet
+	}
+	if _, known := candidateSet[event.CandidateID]; !known && len(candidateSet) >= modelAdmissionMaxCandidates {
+		return ModelAdmissionEvent{}, false, errModelAdmissionCapExceeded
+	}
+	previousState := modelAdmissionNotOffered
+	if previous, ok := s.latest[event.ProviderID+"|"+event.CandidateID]; ok {
+		previousState = previous.State
+		if !sameModelAdmissionTuple(previous, event) {
+			return ModelAdmissionEvent{}, false, errModelAdmissionReplayConflict
+		}
+		if modelAdmissionRequiresRefreshedEvidence(previousState) && !modelAdmissionEvidenceRefreshed(previous, event) {
+			return ModelAdmissionEvent{}, false, errModelAdmissionReplayConflict
+		}
+	}
+	if !modelAdmissionCanSubmitOffer(previousState) {
+		return ModelAdmissionEvent{}, false, errModelAdmissionReplayConflict
+	}
+	event = prepareModelAdmissionTransition(event, previousState)
+	candidateSet[event.CandidateID] = struct{}{}
+	s.providerEvent[event.ProviderID] = append(window, now)
+	s.events = append(s.events, event)
+	s.latest[event.ProviderID+"|"+event.CandidateID] = event
+	s.requestIDs[event.ProviderID+"|"+event.RequestID] = event
+	s.nonces[event.ProviderID+"|"+event.Nonce] = event
+	return event, false, nil
+}
+
+func (s *memoryModelAdmissionStore) LatestModelAdmissionStatus(_ context.Context, providerID, candidateID string) (ModelAdmissionEvent, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	event, ok := s.latest[providerID+"|"+candidateID]
+	return event, ok, nil
+}
+
+type SQLiteModelAdmissionStore struct {
+	db *sql.DB
+}
+
+func NewSQLiteModelAdmissionStore(db *sql.DB) (*SQLiteModelAdmissionStore, error) {
+	if db == nil {
+		return nil, fmt.Errorf("db is required")
+	}
+	if _, err := db.ExecContext(context.Background(), `
+CREATE TABLE IF NOT EXISTS model_admission_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    provider_id TEXT NOT NULL,
+    candidate_id TEXT NOT NULL,
+    served_model_ref TEXT NOT NULL,
+    catalog_model_key TEXT NOT NULL,
+    discovery_digest_sha256 TEXT NOT NULL,
+    evaluation_digest_sha256 TEXT NOT NULL,
+    requested_disclosure_class TEXT NOT NULL,
+    previous_state TEXT NOT NULL,
+    state TEXT NOT NULL,
+    next_state TEXT NOT NULL,
+    actor TEXT NOT NULL,
+    coordinator_event_id TEXT NOT NULL,
+    reason_code TEXT NOT NULL,
+    request_id TEXT NOT NULL,
+    nonce TEXT NOT NULL,
+    payload_digest_sha256 TEXT NOT NULL,
+    signature_digest_sha256 TEXT NOT NULL,
+    created_at_utc TEXT NOT NULL
+)`); err != nil {
+		return nil, err
+	}
+	if _, err := db.ExecContext(context.Background(), `
+CREATE UNIQUE INDEX IF NOT EXISTS model_admission_events_provider_request_id
+ON model_admission_events(provider_id, request_id)`); err != nil {
+		return nil, err
+	}
+	if _, err := db.ExecContext(context.Background(), `
+CREATE UNIQUE INDEX IF NOT EXISTS model_admission_events_provider_nonce
+ON model_admission_events(provider_id, nonce)`); err != nil {
+		return nil, err
+	}
+	return &SQLiteModelAdmissionStore{db: db}, nil
+}
+
+func (s *SQLiteModelAdmissionStore) AppendModelAdmissionOffer(ctx context.Context, event ModelAdmissionEvent) (ModelAdmissionEvent, bool, error) {
+	now := event.CreatedAt
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	event.CreatedAt = now.UTC()
+	var stored ModelAdmissionEvent
+	var replay bool
+	err := sqliteutil.Transact(ctx, s.db, func(txCtx context.Context, conn *sql.Conn) error {
+		existing, found, err := scanModelAdmissionEvent(txCtx, conn, modelAdmissionEventSelect(`
+  FROM model_admission_events
+ WHERE provider_id = ? AND (request_id = ? OR nonce = ?)
+ ORDER BY id DESC
+ LIMIT 1`), event.ProviderID, event.RequestID, event.Nonce)
+		if err != nil {
+			return err
+		}
+		if found {
+			if existing.PayloadDigestSHA256 == event.PayloadDigestSHA256 {
+				stored = existing
+				replay = true
+				return nil
+			}
+			return errModelAdmissionReplayConflict
+		}
+		windowStart := now.Add(-time.Hour).UTC().Format(time.RFC3339Nano)
+		var eventsInWindow int
+		if err := conn.QueryRowContext(txCtx, `
+SELECT COUNT(*) FROM model_admission_events WHERE provider_id = ? AND created_at_utc >= ?`,
+			event.ProviderID, windowStart).Scan(&eventsInWindow); err != nil {
+			return err
+		}
+		if eventsInWindow >= modelAdmissionMaxEvents {
+			return errModelAdmissionRateLimited
+		}
+		var candidates int
+		if err := conn.QueryRowContext(txCtx, `
+SELECT COUNT(DISTINCT candidate_id) FROM model_admission_events WHERE provider_id = ? AND candidate_id <> ?`,
+			event.ProviderID, event.CandidateID).Scan(&candidates); err != nil {
+			return err
+		}
+		if candidates >= modelAdmissionMaxCandidates {
+			return errModelAdmissionCapExceeded
+		}
+		previousState := modelAdmissionNotOffered
+		previous, found, err := scanModelAdmissionEvent(txCtx, conn, modelAdmissionEventSelect(`
+  FROM model_admission_events
+ WHERE provider_id = ? AND candidate_id = ?
+ ORDER BY id DESC
+ LIMIT 1`), event.ProviderID, event.CandidateID)
+		if err != nil {
+			return err
+		}
+		if found {
+			previousState = previous.State
+			if !sameModelAdmissionTuple(previous, event) {
+				return errModelAdmissionReplayConflict
+			}
+			if modelAdmissionRequiresRefreshedEvidence(previousState) && !modelAdmissionEvidenceRefreshed(previous, event) {
+				return errModelAdmissionReplayConflict
+			}
+		}
+		if !modelAdmissionCanSubmitOffer(previousState) {
+			return errModelAdmissionReplayConflict
+		}
+		event = prepareModelAdmissionTransition(event, previousState)
+		if _, err := conn.ExecContext(txCtx, `
+INSERT INTO model_admission_events(
+    provider_id, candidate_id, served_model_ref, catalog_model_key,
+    discovery_digest_sha256, evaluation_digest_sha256, requested_disclosure_class,
+    previous_state, state, next_state, actor, coordinator_event_id,
+    reason_code, request_id, nonce, payload_digest_sha256,
+    signature_digest_sha256, created_at_utc
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			event.ProviderID,
+			event.CandidateID,
+			event.ServedModelRef,
+			event.CatalogModelKey,
+			event.DiscoveryDigestSHA256,
+			event.EvaluationDigestSHA256,
+			event.RequestedDisclosureClass,
+			event.PreviousState,
+			event.State,
+			event.NextState,
+			event.Actor,
+			event.CoordinatorEventID,
+			event.ReasonCode,
+			event.RequestID,
+			event.Nonce,
+			event.PayloadDigestSHA256,
+			event.SignatureDigestSHA256,
+			event.CreatedAt.Format(time.RFC3339Nano),
+		); err != nil {
+			return err
+		}
+		stored = event
+		return nil
+	})
+	return stored, replay, err
+}
+
+func (s *SQLiteModelAdmissionStore) LatestModelAdmissionStatus(ctx context.Context, providerID, candidateID string) (ModelAdmissionEvent, bool, error) {
+	return scanModelAdmissionEvent(ctx, s.db, modelAdmissionEventSelect(`
+  FROM model_admission_events
+ WHERE provider_id = ? AND candidate_id = ?
+ ORDER BY id DESC
+ LIMIT 1`), providerID, candidateID)
+}
+
+type modelAdmissionQueryer interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+func scanModelAdmissionEvent(ctx context.Context, q modelAdmissionQueryer, query string, args ...any) (ModelAdmissionEvent, bool, error) {
+	var event ModelAdmissionEvent
+	var createdAt string
+	err := q.QueryRowContext(ctx, query, args...).Scan(
+		&event.CoordinatorEventID,
+		&event.Actor,
+		&event.ProviderID,
+		&event.CandidateID,
+		&event.ServedModelRef,
+		&event.CatalogModelKey,
+		&event.DiscoveryDigestSHA256,
+		&event.EvaluationDigestSHA256,
+		&event.RequestedDisclosureClass,
+		&event.PreviousState,
+		&event.State,
+		&event.NextState,
+		&event.ReasonCode,
+		&event.RequestID,
+		&event.Nonce,
+		&event.PayloadDigestSHA256,
+		&event.SignatureDigestSHA256,
+		&createdAt,
+	)
+	if err == sql.ErrNoRows {
+		return ModelAdmissionEvent{}, false, nil
+	}
+	if err != nil {
+		return ModelAdmissionEvent{}, false, err
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, createdAt)
+	if err != nil {
+		return ModelAdmissionEvent{}, false, err
+	}
+	event.CreatedAt = parsed.UTC()
+	return event, true, nil
+}
+
+func modelAdmissionEventSelect(tail string) string {
+	return `SELECT coordinator_event_id, actor, provider_id, candidate_id, served_model_ref, catalog_model_key,
+       discovery_digest_sha256, evaluation_digest_sha256, requested_disclosure_class,
+       previous_state, state, next_state, reason_code, request_id, nonce, payload_digest_sha256,
+       signature_digest_sha256, created_at_utc` + tail
+}
+
+func modelAdmissionCanSubmitOffer(previousState string) bool {
+	switch previousState {
+	case modelAdmissionNotOffered, "offer_rejected", "withdrawn", "revoked":
+		return true
+	default:
+		return false
+	}
+}
+
+func sameModelAdmissionTuple(previous, next ModelAdmissionEvent) bool {
+	return previous.CandidateID == next.CandidateID &&
+		previous.ServedModelRef == next.ServedModelRef &&
+		previous.CatalogModelKey == next.CatalogModelKey
+}
+
+func modelAdmissionRequiresRefreshedEvidence(previousState string) bool {
+	switch previousState {
+	case "offer_rejected", "withdrawn", "revoked":
+		return true
+	default:
+		return false
+	}
+}
+
+func modelAdmissionEvidenceRefreshed(previous, next ModelAdmissionEvent) bool {
+	return previous.DiscoveryDigestSHA256 != next.DiscoveryDigestSHA256 ||
+		previous.EvaluationDigestSHA256 != next.EvaluationDigestSHA256
+}
+
+func prepareModelAdmissionTransition(event ModelAdmissionEvent, previousState string) ModelAdmissionEvent {
+	event.Actor = modelAdmissionActorProvider
+	event.PreviousState = previousState
+	event.NextState = modelAdmissionOfferSubmitted
+	sum := sha256.Sum256([]byte(strings.Join([]string{
+		event.ProviderID,
+		event.CandidateID,
+		event.RequestID,
+		event.Nonce,
+		event.PreviousState,
+		event.NextState,
+		event.PayloadDigestSHA256,
+	}, "\x00")))
+	event.CoordinatorEventID = hex.EncodeToString(sum[:])
+	return event
+}
+
+func (s *Server) handleProviderModelAdmissionOffer(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	providerID, ok := s.authenticateProviderReadOnly(w, r)
+	if !ok {
+		return
+	}
+	if !s.allowModelAdmissionAttempt(providerID) {
+		writeJSON(w, http.StatusTooManyRequests, modelAdmissionError("rate_limited", "model admission offer rejected"))
+		return
+	}
+	var body modelAdmissionOfferSubmitRequest
+	r.Body = http.MaxBytesReader(w, r.Body, modelAdmissionMaxBodyBytes+1)
+	if err := decodeStrictJSON(r.Body, &body); err != nil {
+		writeJSON(w, http.StatusBadRequest, modelAdmissionError("invalid_json", "invalid model admission offer package"))
+		return
+	}
+	event, err := s.verifyModelAdmissionOffer(r.Context(), providerID, body)
+	if err != nil {
+		status := http.StatusBadRequest
+		code := "invalid_offer"
+		switch {
+		case errors.Is(err, errModelAdmissionRateLimited):
+			status, code = http.StatusTooManyRequests, "rate_limited"
+		case errors.Is(err, errModelAdmissionCapExceeded):
+			status, code = http.StatusTooManyRequests, "candidate_cap_exceeded"
+		case errors.Is(err, errModelAdmissionReplayConflict):
+			status, code = http.StatusConflict, "replay_conflict"
+		case errors.Is(err, errModelAdmissionUnauthorized):
+			status, code = http.StatusUnauthorized, "unauthorized"
+		}
+		writeJSON(w, status, modelAdmissionError(code, "model admission offer rejected"))
+		return
+	}
+	stored, replay, err := s.modelAdmissions.AppendModelAdmissionOffer(r.Context(), event)
+	if err != nil {
+		status := http.StatusInternalServerError
+		code := "model_admission_store_error"
+		switch {
+		case errors.Is(err, errModelAdmissionRateLimited):
+			status, code = http.StatusTooManyRequests, "rate_limited"
+		case errors.Is(err, errModelAdmissionCapExceeded):
+			status, code = http.StatusTooManyRequests, "candidate_cap_exceeded"
+		case errors.Is(err, errModelAdmissionReplayConflict):
+			status, code = http.StatusConflict, "replay_conflict"
+		}
+		writeJSON(w, status, modelAdmissionError(code, "model admission offer rejected"))
+		return
+	}
+	writeJSON(w, http.StatusOK, s.modelAdmissionStatusResponseFromEvent(stored, replay))
+}
+
+func (s *Server) handleProviderModelAdmissionStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	providerID, ok := s.authenticateProviderReadOnly(w, r)
+	if !ok {
+		return
+	}
+	candidateID := strings.TrimSpace(r.URL.Query().Get("candidate_id"))
+	if !validModelAdmissionCandidateID(candidateID) {
+		writeJSON(w, http.StatusBadRequest, modelAdmissionError("invalid_candidate_id", "invalid model admission candidate_id"))
+		return
+	}
+	event, found, err := s.modelAdmissions.LatestModelAdmissionStatus(r.Context(), providerID, candidateID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, modelAdmissionError("model_admission_store_error", "model admission status lookup failed"))
+		return
+	}
+	if !found {
+		event = ModelAdmissionEvent{
+			ProviderID:  providerID,
+			CandidateID: candidateID,
+			State:       modelAdmissionNotOffered,
+			NextState:   modelAdmissionNotOffered,
+			ReasonCode:  "not_offered",
+			CreatedAt:   s.now().UTC(),
+		}
+	}
+	writeJSON(w, http.StatusOK, s.modelAdmissionStatusResponseFromEvent(event, false))
+}
+
+var errModelAdmissionUnauthorized = errors.New("model admission unauthorized")
+
+func (s *Server) authenticateProviderReadOnly(w http.ResponseWriter, r *http.Request) (string, bool) {
+	if !s.cfg.Auth.RequireProviderTokens {
+		writeJSON(w, http.StatusServiceUnavailable, modelAdmissionError("provider_tokens_not_enabled", "provider tokens not enabled"))
+		return "", false
+	}
+	if s.tokens == nil {
+		writeJSON(w, http.StatusServiceUnavailable, modelAdmissionError("provider_tokens_unavailable", "provider tokens unavailable"))
+		return "", false
+	}
+	raw := bearerToken(r.Header.Get("Authorization"))
+	if raw == "" {
+		writeJSON(w, http.StatusUnauthorized, modelAdmissionError("unauthorized", "provider bearer token required"))
+		return "", false
+	}
+	readOnlyTokens, ok := s.tokens.(computeIntegrityReadOnlyTokenValidator)
+	if !ok {
+		writeJSON(w, http.StatusServiceUnavailable, modelAdmissionError("provider_tokens_read_only_unavailable", "provider token read-only validation unavailable"))
+		return "", false
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
+	defer cancel()
+	providerID, valid, err := readOnlyTokens.ValidateTokenReadOnly(ctx, raw)
+	if err != nil || !valid {
+		writeJSON(w, http.StatusUnauthorized, modelAdmissionError("unauthorized", "provider bearer token required"))
+		return "", false
+	}
+	return providerID, true
+}
+
+func (s *Server) verifyModelAdmissionOffer(ctx context.Context, authenticatedProviderID string, body modelAdmissionOfferSubmitRequest) (ModelAdmissionEvent, error) {
+	if s.providerModelAdmissionSanctioned(authenticatedProviderID) {
+		return ModelAdmissionEvent{}, errModelAdmissionUnauthorized
+	}
+	if body.Schema != modelAdmissionOfferSubmitSchema {
+		return ModelAdmissionEvent{}, fmt.Errorf("invalid schema")
+	}
+	if body.SignatureDomain != modelAdmissionSignedDomain || body.ProviderID != authenticatedProviderID {
+		return ModelAdmissionEvent{}, errModelAdmissionUnauthorized
+	}
+	if err := validateModelAdmissionPayload(body); err != nil {
+		return ModelAdmissionEvent{}, err
+	}
+	if body.SignatureAlgorithm != "ed25519" {
+		return ModelAdmissionEvent{}, fmt.Errorf("invalid signature algorithm")
+	}
+	signature, err := base64.StdEncoding.DecodeString(body.ProviderSignature)
+	if err != nil || len(signature) != ed25519.SignatureSize {
+		return ModelAdmissionEvent{}, fmt.Errorf("invalid signature")
+	}
+	activePubkey, found, blocked := s.durableIdentitySignaturePubkey(ctx, authenticatedProviderID)
+	if blocked || !found {
+		return ModelAdmissionEvent{}, errModelAdmissionUnauthorized
+	}
+	pubkeyDigest := sha256.Sum256(activePubkey)
+	if body.SigningKeyDigest != hex.EncodeToString(pubkeyDigest[:]) {
+		return ModelAdmissionEvent{}, errModelAdmissionUnauthorized
+	}
+	canonical, err := billing.CanonicalJSON(body.canonicalMap())
+	if err != nil {
+		return ModelAdmissionEvent{}, err
+	}
+	if !ed25519.Verify(ed25519.PublicKey(activePubkey), canonical, signature) {
+		return ModelAdmissionEvent{}, errModelAdmissionUnauthorized
+	}
+	payloadDigest := sha256.Sum256(canonical)
+	signatureDigest := sha256.Sum256(signature)
+	signedAt, err := time.Parse(time.RFC3339Nano, body.Timestamp)
+	if err != nil {
+		return ModelAdmissionEvent{}, fmt.Errorf("invalid timestamp")
+	}
+	now := s.now().UTC()
+	if signedAt.Before(now.Add(-modelAdmissionMaxClockSkew)) || signedAt.After(now.Add(modelAdmissionMaxClockSkew)) {
+		return ModelAdmissionEvent{}, fmt.Errorf("invalid timestamp")
+	}
+	return ModelAdmissionEvent{
+		ProviderID:               body.ProviderID,
+		CandidateID:              body.CandidateID,
+		ServedModelRef:           body.ServedModelRef,
+		CatalogModelKey:          body.CatalogModelKey,
+		DiscoveryDigestSHA256:    body.DiscoveryDigestSHA256,
+		EvaluationDigestSHA256:   body.EvaluationDigestSHA256,
+		RequestedDisclosureClass: body.RequestedDisclosureClass,
+		State:                    modelAdmissionOfferSubmitted,
+		ReasonCode:               "provider_offer_submitted",
+		RequestID:                body.IdempotencyKey,
+		Nonce:                    body.Nonce,
+		PayloadDigestSHA256:      hex.EncodeToString(payloadDigest[:]),
+		SignatureDigestSHA256:    hex.EncodeToString(signatureDigest[:]),
+		CreatedAt:                now,
+	}, nil
+}
+
+func (s *Server) providerModelAdmissionSanctioned(providerID string) bool {
+	if s.admission != nil && s.admission.Rejected(providerID) {
+		return true
+	}
+	if s.pool == nil {
+		return false
+	}
+	for _, sanction := range s.pool.CanarySanctions() {
+		if sanction.ProviderID == providerID && sanction.FailCount > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *Server) allowModelAdmissionAttempt(providerID string) bool {
+	now := s.now().UTC()
+	s.modelAdmissionAttemptMu.Lock()
+	defer s.modelAdmissionAttemptMu.Unlock()
+	if s.modelAdmissionAttempts == nil {
+		s.modelAdmissionAttempts = map[string][]time.Time{}
+	}
+	window := pruneModelAdmissionWindow(s.modelAdmissionAttempts[providerID], now)
+	if len(window) >= modelAdmissionMaxEvents {
+		s.modelAdmissionAttempts[providerID] = window
+		return false
+	}
+	s.modelAdmissionAttempts[providerID] = append(window, now)
+	return true
+}
+
+type modelAdmissionOfferSubmitRequest struct {
+	Schema                   string                              `json:"schema"`
+	SignatureDomain          string                              `json:"signature_domain"`
+	ProviderID               string                              `json:"provider_id"`
+	CandidateID              string                              `json:"candidate_id"`
+	RuntimeSource            string                              `json:"runtime_source"`
+	ServedModelRef           string                              `json:"served_model_ref"`
+	CatalogModelKey          string                              `json:"catalog_model_key"`
+	DiscoveryDigestSHA256    string                              `json:"discovery_digest_sha256"`
+	EvaluationDigestSHA256   string                              `json:"evaluation_digest_sha256"`
+	ArtifactHashes           map[string]string                   `json:"artifact_hashes"`
+	AdvisoryCapabilities     *modelAdmissionAdvisoryCapabilities `json:"advisory_capabilities"`
+	FitEvidenceSource        string                              `json:"fit_evidence_source"`
+	LocalReadiness           string                              `json:"local_readiness"`
+	RequestedDisclosureClass string                              `json:"requested_disclosure_class"`
+	Timestamp                string                              `json:"timestamp"`
+	Nonce                    string                              `json:"nonce"`
+	IdempotencyKey           string                              `json:"idempotency_key"`
+	SigningKeyDigest         string                              `json:"signing_key_digest"`
+	SignatureAlgorithm       string                              `json:"signature_algorithm"`
+	ProviderSignature        string                              `json:"provider_signature"`
+	CLIVersion               string                              `json:"cli_version"`
+}
+
+func (p modelAdmissionOfferSubmitRequest) canonicalMap() map[string]any {
+	return map[string]any{
+		"signature_domain":           p.SignatureDomain,
+		"provider_id":                p.ProviderID,
+		"candidate_id":               p.CandidateID,
+		"runtime_source":             p.RuntimeSource,
+		"served_model_ref":           p.ServedModelRef,
+		"catalog_model_key":          p.CatalogModelKey,
+		"discovery_digest_sha256":    p.DiscoveryDigestSHA256,
+		"evaluation_digest_sha256":   p.EvaluationDigestSHA256,
+		"artifact_hashes":            modelAdmissionArtifactHashesCanonicalMap(p.ArtifactHashes),
+		"advisory_capabilities":      p.AdvisoryCapabilities.canonicalMap(),
+		"fit_evidence_source":        p.FitEvidenceSource,
+		"local_readiness":            p.LocalReadiness,
+		"requested_disclosure_class": p.RequestedDisclosureClass,
+		"timestamp":                  p.Timestamp,
+		"nonce":                      p.Nonce,
+		"idempotency_key":            p.IdempotencyKey,
+		"signing_key_digest":         p.SigningKeyDigest,
+		"cli_version":                p.CLIVersion,
+	}
+}
+
+type modelAdmissionAdvisoryCapabilities struct {
+	ChatCompletions             *bool   `json:"chat_completions"`
+	Streaming                   *bool   `json:"streaming"`
+	ToolCallPassthrough         *bool   `json:"tool_call_passthrough"`
+	StructuredOutputPassthrough *bool   `json:"structured_output_passthrough"`
+	JSONMode                    *bool   `json:"json_mode"`
+	UsageReporting              *bool   `json:"usage_reporting"`
+	MaxContextTokens            *int    `json:"max_context_tokens"`
+	Quantization                *string `json:"quantization"`
+	Family                      *string `json:"family"`
+	RuntimeVersion              *string `json:"runtime_version"`
+}
+
+func (c *modelAdmissionAdvisoryCapabilities) canonicalMap() map[string]any {
+	if c == nil {
+		return map[string]any{}
+	}
+	return map[string]any{
+		"chat_completions":              modelAdmissionBoolOrNull(c.ChatCompletions),
+		"streaming":                     modelAdmissionBoolOrNull(c.Streaming),
+		"tool_call_passthrough":         modelAdmissionBoolOrNull(c.ToolCallPassthrough),
+		"structured_output_passthrough": modelAdmissionBoolOrNull(c.StructuredOutputPassthrough),
+		"json_mode":                     modelAdmissionBoolOrNull(c.JSONMode),
+		"usage_reporting":               modelAdmissionBoolOrNull(c.UsageReporting),
+		"max_context_tokens":            modelAdmissionIntOrNull(c.MaxContextTokens),
+		"quantization":                  modelAdmissionStringOrNull(c.Quantization),
+		"family":                        modelAdmissionStringOrNull(c.Family),
+		"runtime_version":               modelAdmissionStringOrNull(c.RuntimeVersion),
+	}
+}
+
+func modelAdmissionBoolOrNull(value *bool) any {
+	if value == nil {
+		return nil
+	}
+	return *value
+}
+
+func modelAdmissionIntOrNull(value *int) any {
+	if value == nil {
+		return nil
+	}
+	return *value
+}
+
+func modelAdmissionStringOrNull(value *string) any {
+	if value == nil {
+		return nil
+	}
+	return *value
+}
+
+func (c *modelAdmissionAdvisoryCapabilities) validate() error {
+	if c == nil {
+		return fmt.Errorf("invalid model admission evidence")
+	}
+	if c.MaxContextTokens != nil && *c.MaxContextTokens < 0 {
+		return fmt.Errorf("invalid model admission evidence")
+	}
+	for _, value := range []*string{c.Quantization, c.Family, c.RuntimeVersion} {
+		if value != nil && (len(*value) > 128 || unsafeModelAdmissionMaterial(*value)) {
+			return fmt.Errorf("invalid model admission evidence")
+		}
+	}
+	return nil
+}
+
+func modelAdmissionArtifactHashesCanonicalMap(hashes map[string]string) map[string]any {
+	canonical := make(map[string]any, len(hashes))
+	for key, value := range hashes {
+		canonical[key] = value
+	}
+	return canonical
+}
+
+func validateModelAdmissionPayload(payload modelAdmissionOfferSubmitRequest) error {
+	if err := config.ValidateProviderID(payload.ProviderID); err != nil {
+		return err
+	}
+	if !validModelAdmissionCandidateID(payload.CandidateID) {
+		return fmt.Errorf("invalid candidate_id")
+	}
+	values := []string{
+		payload.CatalogModelKey,
+		payload.FitEvidenceSource,
+		payload.LocalReadiness,
+		payload.RequestedDisclosureClass,
+		payload.Nonce,
+		payload.IdempotencyKey,
+		payload.SigningKeyDigest,
+	}
+	for _, value := range values {
+		if unsafeModelAdmissionMaterial(value) {
+			return fmt.Errorf("unsafe model admission material")
+		}
+	}
+	if !validModelAdmissionServedModelRef(payload.ServedModelRef) {
+		return fmt.Errorf("invalid served_model_ref")
+	}
+	if !validModelAdmissionRuntimeSource(payload.RuntimeSource) {
+		return fmt.Errorf("invalid runtime_source")
+	}
+	if payload.CatalogModelKey != "" && len(payload.CatalogModelKey) > 128 {
+		return fmt.Errorf("invalid catalog_model_key")
+	}
+	if payload.ArtifactHashes == nil || payload.AdvisoryCapabilities == nil {
+		return fmt.Errorf("invalid model admission evidence")
+	}
+	if len(payload.ArtifactHashes) > 16 {
+		return fmt.Errorf("invalid model admission evidence")
+	}
+	for key, value := range payload.ArtifactHashes {
+		if !validModelAdmissionToken(key) || !validModelAdmissionSHA256Hex(value) {
+			return fmt.Errorf("invalid model admission evidence")
+		}
+	}
+	if err := payload.AdvisoryCapabilities.validate(); err != nil {
+		return err
+	}
+	if payload.FitEvidenceSource == "" || len(payload.FitEvidenceSource) > 64 ||
+		payload.LocalReadiness == "" || len(payload.LocalReadiness) > 64 {
+		return fmt.Errorf("invalid model admission evidence")
+	}
+	if payload.RequestedDisclosureClass != "non_earning_provider_asserted" &&
+		payload.RequestedDisclosureClass != "catalog_binding_requested" {
+		return fmt.Errorf("invalid requested_disclosure_class")
+	}
+	if !validModelAdmissionSHA256Hex(payload.DiscoveryDigestSHA256) {
+		return fmt.Errorf("invalid discovery digest")
+	}
+	if payload.EvaluationDigestSHA256 != "" && !validModelAdmissionSHA256Hex(payload.EvaluationDigestSHA256) {
+		return fmt.Errorf("invalid evaluation digest")
+	}
+	if !validModelAdmissionToken(payload.Nonce) || !validModelAdmissionToken(payload.IdempotencyKey) {
+		return fmt.Errorf("invalid replay key")
+	}
+	if !validModelAdmissionSHA256Hex(payload.SigningKeyDigest) {
+		return fmt.Errorf("invalid signing key digest")
+	}
+	if !validModelAdmissionCLIVersion(payload.CLIVersion) {
+		return fmt.Errorf("invalid cli_version")
+	}
+	if _, err := time.Parse(time.RFC3339Nano, payload.Timestamp); err != nil {
+		return fmt.Errorf("invalid timestamp")
+	}
+	return nil
+}
+
+func (s *Server) modelAdmissionStatusResponseFromEvent(event ModelAdmissionEvent, _ bool) map[string]any {
+	return map[string]any{
+		"schema":                 modelAdmissionStatusSchema,
+		"generated_at":           s.now().UTC().Format(time.RFC3339Nano),
+		"cli_version":            s.version,
+		"provider_id":            event.ProviderID,
+		"candidate_id":           event.CandidateID,
+		"served_model_ref":       event.ServedModelRef,
+		"catalog_model_key":      nullString(event.CatalogModelKey),
+		"admission_state":        event.State,
+		"admission_state_source": "coordinator",
+		"coordinator_event_id":   nullString(event.CoordinatorEventID),
+		"state_observed_at":      event.CreatedAt.UTC().Format(time.RFC3339Nano),
+		"provider_guidance":      modelAdmissionProviderGuidance(event),
+		"allowed_next_states":    modelAdmissionAllowedNextStates(event.State),
+		"warnings":               []string{},
+	}
+}
+
+func modelAdmissionProviderGuidance(event ModelAdmissionEvent) map[string]any {
+	nextAction := "wait_for_coordinator"
+	stateMeaning := "byom.admission.not_earning"
+	earningPath := "no_earning_path_in_v0_1"
+	transitionReason := any(nil)
+	switch event.State {
+	case modelAdmissionNotOffered:
+		nextAction = "submit_offer"
+		stateMeaning = "byom.admission.not_offered"
+		earningPath = "local_inventory_only"
+	case modelAdmissionOfferSubmitted:
+		nextAction = "wait_for_coordinator"
+		if event.CatalogModelKey != "" {
+			earningPath = "not_earning_yet_catalog_or_receipt_path_exists"
+		}
+	case "offer_rejected":
+		nextAction = "revise_and_reoffer"
+		transitionReason = event.ReasonCode
+	case "sandbox_probe_only", "network_visible_unpriced", "network_admitted_unsettled", "catalog_priced":
+		nextAction = "withdraw"
+		earningPath = "not_earning_yet_catalog_or_receipt_path_exists"
+		if modelAdmissionDemotionRequiresReason(event) {
+			transitionReason = event.ReasonCode
+		}
+	case "settlement_capable":
+		nextAction = "maintain_runtime"
+		earningPath = "settlement_capable"
+	case "withdrawn", "revoked":
+		nextAction = "submit_offer"
+		transitionReason = event.ReasonCode
+	}
+	return map[string]any{
+		"state_label_key":        "byom.admission." + event.State,
+		"state_meaning_key":      stateMeaning,
+		"next_action":            nextAction,
+		"transition_reason_code": transitionReason,
+		"earning_path_class":     earningPath,
+	}
+}
+
+func modelAdmissionAllowedNextStates(state string) []string {
+	switch state {
+	case modelAdmissionNotOffered, "withdrawn", "revoked":
+		return []string{modelAdmissionOfferSubmitted}
+	case "offer_rejected":
+		return []string{modelAdmissionOfferSubmitted, "revoked"}
+	case modelAdmissionOfferSubmitted:
+		return []string{"offer_rejected", "sandbox_probe_only", "network_visible_unpriced", "network_admitted_unsettled", "catalog_priced", "withdrawn", "revoked"}
+	case "sandbox_probe_only":
+		return []string{"network_visible_unpriced", "network_admitted_unsettled", "catalog_priced", "withdrawn", "revoked"}
+	case "network_visible_unpriced":
+		return []string{"network_admitted_unsettled", "catalog_priced", "withdrawn", "revoked"}
+	case "network_admitted_unsettled":
+		return []string{"catalog_priced", "settlement_capable", "withdrawn", "revoked"}
+	case "catalog_priced":
+		return []string{"network_admitted_unsettled", "settlement_capable", "withdrawn", "revoked"}
+	case "settlement_capable":
+		return []string{"network_admitted_unsettled", "catalog_priced", "withdrawn", "revoked"}
+	default:
+		return []string{}
+	}
+}
+
+func modelAdmissionError(code, message string) map[string]any {
+	return map[string]any{"error": map[string]any{"code": code, "message": message}}
+}
+
+func pruneModelAdmissionWindow(window []time.Time, now time.Time) []time.Time {
+	cutoff := now.Add(-time.Hour)
+	kept := window[:0]
+	for _, ts := range window {
+		if ts.After(cutoff) {
+			kept = append(kept, ts)
+		}
+	}
+	return kept
+}
+
+func validModelAdmissionCandidateID(value string) bool {
+	return modelAdmissionCandidatePattern.MatchString(value)
+}
+
+func validModelAdmissionToken(value string) bool {
+	if value == "" || len(value) > 128 {
+		return false
+	}
+	for _, r := range value {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') ||
+			r == '-' || r == '_' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func validModelAdmissionRuntimeSource(value string) bool {
+	switch value {
+	case "mlx_cache", "ollama_loopback":
+		return true
+	default:
+		return false
+	}
+}
+
+func validModelAdmissionCLIVersion(value string) bool {
+	return modelAdmissionCLIVersionPattern.MatchString(value)
+}
+
+func validModelAdmissionServedModelRef(value string) bool {
+	if value == "" || !modelAdmissionServedRefPattern.MatchString(value) {
+		return false
+	}
+	if unsafeModelAdmissionTextMaterial(value) {
+		return false
+	}
+	lower := strings.ToLower(value)
+	if strings.Contains(lower, "://") || strings.Contains(lower, "@") {
+		return false
+	}
+	if strings.HasPrefix(lower, "ollama:") {
+		name := value[len("ollama:"):]
+		return name != "" &&
+			!strings.HasPrefix(name, "/") &&
+			!strings.Contains(name, "//") &&
+			!strings.Contains(name, "../") &&
+			!strings.Contains(name, `..\`) &&
+			!looksLikeOllamaModelAdmissionNetworkLocation(name)
+	}
+	if strings.Contains(value, "/") {
+		firstSegment := strings.SplitN(value, "/", 2)[0]
+		return firstSegment != "" && !looksLikeModelAdmissionNetworkLocation(firstSegment)
+	}
+	return !looksLikeModelAdmissionNetworkLocation(value)
+}
+
+func looksLikeOllamaModelAdmissionNetworkLocation(value string) bool {
+	lower := strings.ToLower(value)
+	if strings.HasPrefix(value, ":") {
+		return true
+	}
+	if lower == "localhost" || strings.HasPrefix(lower, "localhost:") || strings.Contains(lower, ".localhost") {
+		return true
+	}
+	if host, port, err := net.SplitHostPort(value); err == nil {
+		if _, err := strconv.ParseUint(port, 10, 16); err != nil {
+			return looksLikeModelAdmissionNetworkLocation(host)
+		}
+		return true
+	}
+	if host, _, found := strings.Cut(value, ":"); found {
+		return looksLikeModelAdmissionNetworkLocation(host)
+	}
+	return looksLikeModelAdmissionNetworkLocation(value)
+}
+
+func modelAdmissionDemotionRequiresReason(event ModelAdmissionEvent) bool {
+	switch event.PreviousState {
+	case "settlement_capable":
+		return event.State == "catalog_priced" || event.State == "network_admitted_unsettled"
+	case "catalog_priced":
+		return event.State == "network_admitted_unsettled"
+	default:
+		return false
+	}
+}
+
+func validModelAdmissionSHA256Hex(value string) bool {
+	if len(value) != 64 {
+		return false
+	}
+	_, err := hex.DecodeString(value)
+	return err == nil && strings.ToLower(value) == value
+}
+
+func unsafeModelAdmissionMaterial(value string) bool {
+	if unsafeModelAdmissionTextMaterial(value) {
+		return true
+	}
+	if looksLikeModelAdmissionNetworkLocation(value) {
+		return true
+	}
+	return false
+}
+
+func unsafeModelAdmissionTextMaterial(value string) bool {
+	if value == "" {
+		return false
+	}
+	lower := strings.ToLower(value)
+	if strings.Contains(lower, "api_key") || strings.Contains(lower, "secret") ||
+		strings.Contains(lower, "token=") || strings.Contains(lower, "authorization") {
+		return true
+	}
+	if strings.ContainsAny(value, "\x00\r\n\t") {
+		return true
+	}
+	if strings.ContainsAny(value, "<>\"'`;") {
+		return true
+	}
+	if strings.HasPrefix(value, "/") || strings.HasPrefix(value, "~") ||
+		strings.Contains(value, "../") || strings.Contains(value, `..\`) ||
+		strings.Contains(value, `\`) {
+		return true
+	}
+	if parsed, err := url.Parse(value); err == nil && parsed.Scheme != "" {
+		switch strings.ToLower(parsed.Scheme) {
+		case "http", "https", "ws", "wss", "file", "ssh", "sftp", "ftp":
+			return true
+		}
+	}
+	if strings.Contains(value, "://") {
+		return true
+	}
+	return false
+}
+
+func looksLikeModelAdmissionNetworkLocation(value string) bool {
+	trimmed := strings.Trim(strings.TrimSpace(value), "[]")
+	lower := strings.ToLower(trimmed)
+	if strings.HasSuffix(trimmed, ".") && strings.Contains(trimmed, ".") {
+		return true
+	}
+	if lower == "localhost" || strings.HasPrefix(lower, "localhost:") {
+		return true
+	}
+	if host, _, err := net.SplitHostPort(value); err == nil {
+		return looksLikeModelAdmissionNetworkLocation(host)
+	}
+	if strings.HasPrefix(value, "[") && strings.Contains(value, "]:") {
+		if host, _, err := net.SplitHostPort(value); err == nil {
+			return looksLikeModelAdmissionNetworkLocation(host)
+		}
+	}
+	if ip := net.ParseIP(trimmed); ip != nil {
+		return true
+	}
+	if strings.HasPrefix(lower, "0x") {
+		if n, err := strconv.ParseUint(strings.TrimPrefix(lower, "0x"), 16, 32); err == nil && n > 0 {
+			return true
+		}
+	}
+	if n, err := strconv.ParseUint(lower, 10, 32); err == nil && (n <= 65535 || n >= 0x01000000) {
+		return true
+	}
+	if strings.Count(trimmed, ".") >= 1 {
+		labels := strings.Split(trimmed, ".")
+		allNumeric := true
+		for _, label := range labels {
+			if label == "" {
+				return false
+			}
+			if _, err := strconv.ParseUint(label, 0, 8); err != nil {
+				allNumeric = false
+			}
+		}
+		if allNumeric || len(labels[len(labels)-1]) >= 2 {
+			return true
+		}
+	}
+	return false
+}
+
+func nullString(value string) any {
+	if value == "" {
+		return nil
+	}
+	return value
+}

--- a/phase4-coordinator/internal/ws/model_admission_test.go
+++ b/phase4-coordinator/internal/ws/model_admission_test.go
@@ -1,0 +1,790 @@
+package ws_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/auth"
+	"github.com/augstar/macprovider-coordinator/internal/billing"
+	"github.com/augstar/macprovider-coordinator/internal/config"
+	"github.com/augstar/macprovider-coordinator/internal/pool"
+	providerws "github.com/augstar/macprovider-coordinator/internal/ws"
+)
+
+func TestModelAdmissionOfferSubmitAndStatusStayNonEarning(t *testing.T) {
+	h, bearer, priv := newModelAdmissionHarness(t, "provider-byom-a")
+	defer h.HTTP.Close()
+
+	candidateID := stableModelAdmissionCandidateID("a")
+	request := signedModelAdmissionOffer(t, "provider-byom-a", candidateID, "ollama:qwen3-8b", priv, nil)
+	status, body := postModelAdmissionOffer(t, h.HTTP.URL, bearer, request)
+	if status != http.StatusOK {
+		t.Fatalf("status=%d body=%s", status, body)
+	}
+	object := decodeMap(t, body)
+	if object["schema"] != "model_admission_status.v1" ||
+		object["admission_state"] != "offer_submitted" ||
+		object["admission_state_source"] != "coordinator" ||
+		object["state_observed_at"] == nil ||
+		object["coordinator_event_id"] == nil {
+		t.Fatalf("unexpected offer response: %#v", object)
+	}
+	guidance := object["provider_guidance"].(map[string]any)
+	if guidance["next_action"] != "wait_for_coordinator" ||
+		guidance["earning_path_class"] != "no_earning_path_in_v0_1" {
+		t.Fatalf("unexpected guidance: %#v", guidance)
+	}
+	allowed := object["allowed_next_states"].([]any)
+	if len(allowed) != 7 || allowed[0] != "offer_rejected" {
+		t.Fatalf("unexpected allowed transitions: %#v", allowed)
+	}
+	if _, leaked := object["earning_eligible"]; leaked {
+		t.Fatalf("status envelope leaked non-spec economics field: %#v", object)
+	}
+
+	status, body = getModelAdmissionStatus(t, h.HTTP.URL, bearer, candidateID)
+	if status != http.StatusOK {
+		t.Fatalf("status readback=%d body=%s", status, body)
+	}
+	readback := decodeMap(t, body)
+	if readback["admission_state"] != "offer_submitted" ||
+		readback["coordinator_event_id"] == nil ||
+		readback["provider_id"] != "provider-byom-a" {
+		t.Fatalf("unexpected status readback: %#v", readback)
+	}
+}
+
+func TestModelAdmissionStatusIsScopedByProviderAndCandidate(t *testing.T) {
+	store, err := auth.OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	_, bearerA, privA := bindAdmissionIdentityForTest(t, store, "provider-byom-a")
+	_, bearerB, _ := bindAdmissionIdentityForTest(t, store, "provider-byom-b")
+	h := newProviderHarnessWithServerOptions(t, store, []providerws.Option{
+		providerws.WithModelAdmissionStore(providerws.NewMemoryModelAdmissionStore()),
+	}, func(cfg *config.Config) {
+		cfg.Auth.RequireProviderTokens = true
+	})
+	defer h.HTTP.Close()
+
+	candidateID := stableModelAdmissionCandidateID("b")
+	request := signedModelAdmissionOffer(t, "provider-byom-a", candidateID, "ollama:qwen3-8b", privA, nil)
+	if status, body := postModelAdmissionOffer(t, h.HTTP.URL, bearerA, request); status != http.StatusOK {
+		t.Fatalf("submit status=%d body=%s", status, body)
+	}
+	status, body := getModelAdmissionStatus(t, h.HTTP.URL, bearerB, candidateID)
+	if status != http.StatusOK {
+		t.Fatalf("provider B status=%d body=%s", status, body)
+	}
+	object := decodeMap(t, body)
+	if object["admission_state"] != "not_offered" || object["provider_id"] != "provider-byom-b" {
+		t.Fatalf("cross-provider status leaked: %#v", object)
+	}
+}
+
+func TestModelAdmissionOfferRejectsWrongOrMissingCurrentIdentity(t *testing.T) {
+	h, bearer, currentPriv, authStore := newModelAdmissionHarnessWithStore(t, "provider-byom-a")
+	defer h.HTTP.Close()
+	_, wrongPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := signedModelAdmissionOffer(t, "provider-byom-a", stableModelAdmissionCandidateID("c"), "ollama:qwen3-8b", wrongPriv, nil)
+	if status, _ := postModelAdmissionOffer(t, h.HTTP.URL, bearer, request); status != http.StatusUnauthorized {
+		t.Fatalf("wrong signing key status=%d, want 401", status)
+	}
+	nextPub, nextPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := authStore.RotateAdmissionIdentity(context.Background(), "provider-byom-a", bearer, currentPriv.Public().(ed25519.PublicKey), nextPub, 1, time.Now().UTC()); err != nil {
+		t.Fatalf("rotate admission identity: %v", err)
+	}
+	request = signedModelAdmissionOffer(t, "provider-byom-a", stableModelAdmissionCandidateID("t"), "ollama:qwen3-8b", currentPriv, nil)
+	if status, _ := postModelAdmissionOffer(t, h.HTTP.URL, bearer, request); status != http.StatusUnauthorized {
+		t.Fatalf("previous signing key status=%d, want 401", status)
+	}
+
+	recoveryPub, recoveryPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	approveModelAdmissionRecoveryAuthorization(t, authStore, "provider-byom-a", nextPub, recoveryPub, 2, time.Now().UTC())
+	request = signedModelAdmissionOffer(t, "provider-byom-a", stableModelAdmissionCandidateID("u"), "ollama:qwen3-8b", recoveryPriv, nil)
+	if status, _ := postModelAdmissionOffer(t, h.HTTP.URL, bearer, request); status != http.StatusUnauthorized {
+		t.Fatalf("recovery-not-current signing key status=%d, want 401", status)
+	}
+	request = signedModelAdmissionOffer(t, "provider-byom-a", stableModelAdmissionCandidateID("v"), "ollama:qwen3-8b", nextPriv, nil)
+	if status, body := postModelAdmissionOffer(t, h.HTTP.URL, bearer, request); status != http.StatusOK {
+		t.Fatalf("current rotated signing key status=%d body=%s, want 200", status, body)
+	}
+
+	store, err := auth.OpenStore(filepath.Join(t.TempDir(), "coordinator-unbound.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	_, unboundBearer, err := store.IssueToken(context.Background(), "provider-unbound", "unbound")
+	if err != nil {
+		t.Fatal(err)
+	}
+	h2 := newProviderHarnessWithServerOptions(t, store, nil, func(cfg *config.Config) {
+		cfg.Auth.RequireProviderTokens = true
+	})
+	defer h2.HTTP.Close()
+	request = signedModelAdmissionOffer(t, "provider-unbound", stableModelAdmissionCandidateID("d"), "ollama:qwen3-8b", wrongPriv, nil)
+	if status, _ := postModelAdmissionOffer(t, h2.HTTP.URL, unboundBearer, request); status != http.StatusUnauthorized {
+		t.Fatalf("missing admission identity status=%d, want 401", status)
+	}
+}
+
+func TestModelAdmissionInvalidOfferAttemptsAreRateLimited(t *testing.T) {
+	h, bearer, currentPriv := newModelAdmissionHarness(t, "provider-byom-a")
+	defer h.HTTP.Close()
+	_, wrongPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	currentDigest := sha256.Sum256(currentPriv.Public().(ed25519.PublicKey))
+	request := signedModelAdmissionOffer(t, "provider-byom-a", stableModelAdmissionCandidateID("c"), "ollama:qwen3-8b", wrongPriv, map[string]any{
+		"signing_key_digest": hex.EncodeToString(currentDigest[:]),
+	})
+
+	for i := 0; i < 256; i++ {
+		if status, _ := postModelAdmissionOffer(t, h.HTTP.URL, bearer, request); status != http.StatusUnauthorized {
+			t.Fatalf("invalid attempt %d status=%d, want 401 before attempt limit", i, status)
+		}
+	}
+	if status, _ := postModelAdmissionOffer(t, h.HTTP.URL, bearer, request); status != http.StatusTooManyRequests {
+		t.Fatalf("invalid attempt after limit status=%d, want 429", status)
+	}
+}
+
+func TestModelAdmissionOfferRejectsSanctionedProvider(t *testing.T) {
+	store, err := auth.OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	_, bearer, priv := bindAdmissionIdentityForTest(t, store, "provider-byom-a")
+	h := newProviderHarnessWithServerOptions(t, store, []providerws.Option{
+		providerws.WithModelAdmissionStore(providerws.NewMemoryModelAdmissionStore()),
+	}, func(cfg *config.Config) {
+		cfg.Auth.RequireProviderTokens = true
+	})
+	defer h.HTTP.Close()
+	h.Registry.LoadCanarySanctions([]pool.CanarySanctionSnapshot{{
+		ProviderID: "provider-byom-a",
+		FailCount:  1,
+	}})
+
+	request := signedModelAdmissionOffer(t, "provider-byom-a", stableModelAdmissionCandidateID("e"), "ollama:qwen3-8b", priv, nil)
+	if status, _ := postModelAdmissionOffer(t, h.HTTP.URL, bearer, request); status != http.StatusUnauthorized {
+		t.Fatalf("sanctioned provider status=%d, want 401", status)
+	}
+
+	_, bearerRejected, privRejected := bindAdmissionIdentityForTest(t, store, "provider-byom-rejected")
+	h.Provider.Admission().Reject("provider-byom-rejected", "operator rejected provider")
+	request = signedModelAdmissionOffer(t, "provider-byom-rejected", stableModelAdmissionCandidateID("q"), "ollama:qwen3-8b", privRejected, nil)
+	if status, _ := postModelAdmissionOffer(t, h.HTTP.URL, bearerRejected, request); status != http.StatusUnauthorized {
+		t.Fatalf("operator-rejected provider status=%d, want 401", status)
+	}
+}
+
+func TestModelAdmissionOfferReplayAndConflict(t *testing.T) {
+	h, bearer, priv := newModelAdmissionHarness(t, "provider-byom-a")
+	defer h.HTTP.Close()
+	overrides := map[string]any{
+		"idempotency_key": "idem_replay",
+		"nonce":           "nonce_replay",
+	}
+	request := signedModelAdmissionOffer(t, "provider-byom-a", stableModelAdmissionCandidateID("f"), "ollama:qwen3-8b", priv, overrides)
+	status, body := postModelAdmissionOffer(t, h.HTTP.URL, bearer, request)
+	if status != http.StatusOK {
+		t.Fatalf("submit status=%d body=%s", status, body)
+	}
+	firstEventID := decodeMap(t, body)["coordinator_event_id"]
+	status, body = postModelAdmissionOffer(t, h.HTTP.URL, bearer, request)
+	if status != http.StatusOK {
+		t.Fatalf("replay status=%d body=%s", status, body)
+	}
+	if decodeMap(t, body)["coordinator_event_id"] != firstEventID {
+		t.Fatalf("same payload did not return original event id: %s", body)
+	}
+	conflict := signedModelAdmissionOffer(t, "provider-byom-a", stableModelAdmissionCandidateID("g"), "ollama:qwen3-8b", priv, overrides)
+	if status, _ := postModelAdmissionOffer(t, h.HTTP.URL, bearer, conflict); status != http.StatusConflict {
+		t.Fatalf("conflicting replay status=%d, want 409", status)
+	}
+}
+
+func TestModelAdmissionOfferRejectsSameCandidateTupleDrift(t *testing.T) {
+	h, bearer, priv := newModelAdmissionHarness(t, "provider-byom-a")
+	defer h.HTTP.Close()
+	candidateID := stableModelAdmissionCandidateID("h")
+	request := signedModelAdmissionOffer(t, "provider-byom-a", candidateID, "ollama:qwen3-8b", priv, nil)
+	if status, body := postModelAdmissionOffer(t, h.HTTP.URL, bearer, request); status != http.StatusOK {
+		t.Fatalf("submit status=%d body=%s", status, body)
+	}
+	drift := signedModelAdmissionOffer(t, "provider-byom-a", candidateID, "ollama:different", priv, map[string]any{
+		"nonce":           "nonce_drift",
+		"idempotency_key": "request_drift",
+	})
+	if status, _ := postModelAdmissionOffer(t, h.HTTP.URL, bearer, drift); status != http.StatusConflict {
+		t.Fatalf("tuple drift status=%d, want 409", status)
+	}
+}
+
+func TestModelAdmissionOfferRejectsClosedSchemaAndUnsafeMaterial(t *testing.T) {
+	h, bearer, priv := newModelAdmissionHarness(t, "provider-byom-a")
+	defer h.HTTP.Close()
+	request := signedModelAdmissionOffer(t, "provider-byom-a", stableModelAdmissionCandidateID("i"), "ollama:qwen3-8b", priv, nil)
+	request["unexpected"] = true
+	if status, _ := postModelAdmissionOffer(t, h.HTTP.URL, bearer, request); status != http.StatusBadRequest {
+		t.Fatalf("unknown top-level field status=%d, want 400", status)
+	}
+	unsafe := signedModelAdmissionOffer(t, "provider-byom-a", stableModelAdmissionCandidateID("j"), "http://127.0.0.1:11434/private?api_key=secret", priv, nil)
+	if status, _ := postModelAdmissionOffer(t, h.HTTP.URL, bearer, unsafe); status != http.StatusBadRequest {
+		t.Fatalf("unsafe material status=%d, want 400", status)
+	}
+	for index, servedModelRef := range []string{"ollama:qwen3:8b", "ollama:llama3.2:3b"} {
+		request := signedModelAdmissionOffer(t, "provider-byom-a", stableModelAdmissionCandidateID(string(rune('u'+index))), servedModelRef, priv, map[string]any{
+			"nonce":           "nonce_valid_" + strings.NewReplacer(":", "_", ".", "_").Replace(servedModelRef),
+			"idempotency_key": "request_valid_" + strings.NewReplacer(":", "_", ".", "_").Replace(servedModelRef),
+			"cli_version":     "1.8.111",
+		})
+		if status, body := postModelAdmissionOffer(t, h.HTTP.URL, bearer, request); status != http.StatusOK {
+			t.Fatalf("valid served ref %q status=%d body=%s, want 200", servedModelRef, status, body)
+		}
+	}
+	unknownRuntime := signedModelAdmissionOffer(t, "provider-byom-a", stableModelAdmissionCandidateID("w"), "ollama:qwen3-8b", priv, map[string]any{
+		"runtime_source":  "unknown_runtime",
+		"nonce":           "nonce_unknown_runtime",
+		"idempotency_key": "request_unknown_runtime",
+	})
+	if status, _ := postModelAdmissionOffer(t, h.HTTP.URL, bearer, unknownRuntime); status != http.StatusBadRequest {
+		t.Fatalf("unknown runtime status=%d, want 400", status)
+	}
+	for _, servedModelRef := range []string{
+		"localhost:11434",
+		"127.0.0.1",
+		"[::1]:11434",
+		"0x7f000001",
+		"2130706433",
+		"model.example.com",
+		"127.0.0.1.",
+		"model.example.com.",
+		"ollama:localhost:11434",
+		"ollama:127.0.0.1:11434",
+		"ollama:::1",
+		"ollama:::ffff:127.0.0.1",
+		"ollama:0x7f000001",
+		"ollama:2130706433",
+		"ollama:model.example.com",
+		"ollama:model.example.com:11434",
+		"ollama:model.example.com.",
+	} {
+		request := signedModelAdmissionOffer(t, "provider-byom-a", stableModelAdmissionCandidateID("k"), servedModelRef, priv, map[string]any{
+			"nonce":           "nonce_unsafe_" + strings.NewReplacer(":", "_", ".", "_", "[", "_", "]", "_").Replace(servedModelRef),
+			"idempotency_key": "request_unsafe_" + strings.NewReplacer(":", "_", ".", "_", "[", "_", "]", "_").Replace(servedModelRef),
+		})
+		if status, _ := postModelAdmissionOffer(t, h.HTTP.URL, bearer, request); status != http.StatusBadRequest {
+			t.Fatalf("unsafe %q status=%d, want 400", servedModelRef, status)
+		}
+	}
+	for _, servedModelRef := range []string{"ollama:<script>", "ollama:\"quoted\"", "ollama:'quoted'", "ollama;rm"} {
+		request := signedModelAdmissionOffer(t, "provider-byom-a", stableModelAdmissionCandidateID("r"), servedModelRef, priv, map[string]any{
+			"nonce":           "nonce_html_" + strings.NewReplacer(":", "_", "<", "_", ">", "_", "\"", "_", "'", "_", ";", "_").Replace(servedModelRef),
+			"idempotency_key": "request_html_" + strings.NewReplacer(":", "_", "<", "_", ">", "_", "\"", "_", "'", "_", ";", "_").Replace(servedModelRef),
+		})
+		if status, _ := postModelAdmissionOffer(t, h.HTTP.URL, bearer, request); status != http.StatusBadRequest {
+			t.Fatalf("unsafe %q status=%d, want 400", servedModelRef, status)
+		}
+	}
+	for _, candidateID := range []string{"byom_127.0.0.1", "byom_127:11434", "byom_candidate_a"} {
+		request := signedModelAdmissionOffer(t, "provider-byom-a", candidateID, "ollama:qwen3-8b", priv, map[string]any{
+			"nonce":           "nonce_candidate_" + strings.NewReplacer(":", "_", ".", "_").Replace(candidateID),
+			"idempotency_key": "request_candidate_" + strings.NewReplacer(":", "_", ".", "_").Replace(candidateID),
+		})
+		if status, _ := postModelAdmissionOffer(t, h.HTTP.URL, bearer, request); status != http.StatusBadRequest {
+			t.Fatalf("unsafe candidate %q status=%d, want 400", candidateID, status)
+		}
+	}
+}
+
+func TestModelAdmissionStoreRequiresFreshEvidenceForReEntry(t *testing.T) {
+	db, err := auth.OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	store, err := providerws.NewSQLiteModelAdmissionStore(db.DB())
+	if err != nil {
+		t.Fatal(err)
+	}
+	previous := providerws.ModelAdmissionEvent{
+		ProviderID:             "provider-byom-a",
+		CandidateID:            stableModelAdmissionCandidateID("s"),
+		ServedModelRef:         "ollama:qwen3-8b",
+		DiscoveryDigestSHA256:  stringsOf("a", 64),
+		EvaluationDigestSHA256: stringsOf("b", 64),
+		State:                  "withdrawn",
+		RequestID:              "request_previous",
+		Nonce:                  "nonce_previous",
+		PayloadDigestSHA256:    stringsOf("c", 64),
+		CreatedAt:              time.Now().UTC(),
+	}
+	previous = modelAdmissionTransitionForTest(previous, "offer_submitted", "withdrawn")
+	if _, err := db.DB().ExecContext(context.Background(), `
+INSERT INTO model_admission_events(
+    provider_id, candidate_id, served_model_ref, catalog_model_key,
+    discovery_digest_sha256, evaluation_digest_sha256, requested_disclosure_class,
+    previous_state, state, next_state, actor, coordinator_event_id,
+    reason_code, request_id, nonce, payload_digest_sha256,
+    signature_digest_sha256, created_at_utc
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		previous.ProviderID,
+		previous.CandidateID,
+		previous.ServedModelRef,
+		previous.CatalogModelKey,
+		previous.DiscoveryDigestSHA256,
+		previous.EvaluationDigestSHA256,
+		previous.RequestedDisclosureClass,
+		previous.PreviousState,
+		previous.State,
+		previous.NextState,
+		previous.Actor,
+		previous.CoordinatorEventID,
+		previous.ReasonCode,
+		previous.RequestID,
+		previous.Nonce,
+		previous.PayloadDigestSHA256,
+		previous.SignatureDigestSHA256,
+		previous.CreatedAt.Format(time.RFC3339Nano),
+	); err != nil {
+		t.Fatal(err)
+	}
+	fresh := previous
+	fresh.State = "offer_submitted"
+	fresh.RequestID = "request_fresh"
+	fresh.Nonce = "nonce_fresh"
+	fresh.PayloadDigestSHA256 = stringsOf("d", 64)
+	if _, _, err := store.AppendModelAdmissionOffer(context.Background(), fresh); err == nil {
+		t.Fatal("stale evidence re-entry succeeded")
+	}
+	fresh.DiscoveryDigestSHA256 = stringsOf("e", 64)
+	fresh.PayloadDigestSHA256 = stringsOf("f", 64)
+	if _, _, err := store.AppendModelAdmissionOffer(context.Background(), fresh); err != nil {
+		t.Fatalf("fresh evidence re-entry failed: %v", err)
+	}
+}
+
+func TestModelAdmissionStatusGuidanceForRejectedAndDemotion(t *testing.T) {
+	db, err := auth.OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	_, bearer, _ := bindAdmissionIdentityForTest(t, db, "provider-byom-a")
+	store, err := providerws.NewSQLiteModelAdmissionStore(db.DB())
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := newProviderHarnessWithServerOptions(t, db, []providerws.Option{
+		providerws.WithModelAdmissionStore(store),
+	}, func(cfg *config.Config) {
+		cfg.Auth.RequireProviderTokens = true
+	})
+	defer h.HTTP.Close()
+
+	rejected := modelAdmissionTransitionForTest(providerws.ModelAdmissionEvent{
+		ProviderID:             "provider-byom-a",
+		CandidateID:            stableModelAdmissionCandidateID("x"),
+		ServedModelRef:         "ollama:qwen3-8b",
+		DiscoveryDigestSHA256:  stringsOf("a", 64),
+		EvaluationDigestSHA256: stringsOf("b", 64),
+		RequestID:              "request_rejected",
+		Nonce:                  "nonce_rejected",
+		PayloadDigestSHA256:    stringsOf("c", 64),
+		CreatedAt:              time.Now().UTC(),
+	}, "offer_submitted", "offer_rejected")
+	rejected.ReasonCode = "policy_failed"
+	insertModelAdmissionEventForTest(t, db, rejected)
+
+	status, body := getModelAdmissionStatus(t, h.HTTP.URL, bearer, rejected.CandidateID)
+	if status != http.StatusOK {
+		t.Fatalf("rejected status=%d body=%s", status, body)
+	}
+	object := decodeMap(t, body)
+	allowed := object["allowed_next_states"].([]any)
+	if len(allowed) != 2 || allowed[0] != "offer_submitted" || allowed[1] != "revoked" {
+		t.Fatalf("offer_rejected allowed_next_states=%#v", allowed)
+	}
+	guidance := object["provider_guidance"].(map[string]any)
+	if guidance["transition_reason_code"] != "policy_failed" {
+		t.Fatalf("offer_rejected guidance=%#v", guidance)
+	}
+
+	demotion := modelAdmissionTransitionForTest(providerws.ModelAdmissionEvent{
+		ProviderID:             "provider-byom-a",
+		CandidateID:            stableModelAdmissionCandidateID("y"),
+		ServedModelRef:         "ollama:qwen3-8b",
+		DiscoveryDigestSHA256:  stringsOf("d", 64),
+		EvaluationDigestSHA256: stringsOf("e", 64),
+		RequestID:              "request_demoted",
+		Nonce:                  "nonce_demoted",
+		PayloadDigestSHA256:    stringsOf("f", 64),
+		CreatedAt:              time.Now().UTC(),
+	}, "settlement_capable", "catalog_priced")
+	demotion.ReasonCode = "receipt_stale"
+	insertModelAdmissionEventForTest(t, db, demotion)
+
+	status, body = getModelAdmissionStatus(t, h.HTTP.URL, bearer, demotion.CandidateID)
+	if status != http.StatusOK {
+		t.Fatalf("demotion status=%d body=%s", status, body)
+	}
+	guidance = decodeMap(t, body)["provider_guidance"].(map[string]any)
+	if guidance["transition_reason_code"] != "receipt_stale" {
+		t.Fatalf("demotion guidance=%#v", guidance)
+	}
+}
+
+func TestModelAdmissionOfferRejectsSkewedTimestampAndUsesServerTime(t *testing.T) {
+	store, err := auth.OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	clock := newLockedTime(time.Date(2026, 8, 28, 12, 0, 0, 123000000, time.UTC))
+	_, bearer, priv := bindAdmissionIdentityForTest(t, store, "provider-byom-a")
+	h := newProviderHarnessWithServerOptions(t, store, []providerws.Option{
+		providerws.WithModelAdmissionStore(providerws.NewMemoryModelAdmissionStore()),
+		providerws.WithNow(clock.Now),
+	}, func(cfg *config.Config) {
+		cfg.Auth.RequireProviderTokens = true
+	})
+	defer h.HTTP.Close()
+
+	stale := signedModelAdmissionOffer(t, "provider-byom-a", stableModelAdmissionCandidateID("l"), "ollama:qwen3-8b", priv, map[string]any{
+		"timestamp": clock.Now().Add(-6 * time.Minute).Format(time.RFC3339Nano),
+	})
+	if status, _ := postModelAdmissionOffer(t, h.HTTP.URL, bearer, stale); status != http.StatusBadRequest {
+		t.Fatalf("stale signed timestamp status=%d, want 400", status)
+	}
+	future := signedModelAdmissionOffer(t, "provider-byom-a", stableModelAdmissionCandidateID("m"), "ollama:qwen3-8b", priv, map[string]any{
+		"timestamp": clock.Now().Add(6 * time.Minute).Format(time.RFC3339Nano),
+	})
+	if status, _ := postModelAdmissionOffer(t, h.HTTP.URL, bearer, future); status != http.StatusBadRequest {
+		t.Fatalf("future signed timestamp status=%d, want 400", status)
+	}
+
+	valid := signedModelAdmissionOffer(t, "provider-byom-a", stableModelAdmissionCandidateID("n"), "ollama:qwen3-8b", priv, map[string]any{
+		"timestamp": clock.Now().Add(-30 * time.Second).Format(time.RFC3339Nano),
+	})
+	status, body := postModelAdmissionOffer(t, h.HTTP.URL, bearer, valid)
+	if status != http.StatusOK {
+		t.Fatalf("valid skew status=%d body=%s", status, body)
+	}
+	object := decodeMap(t, body)
+	if object["state_observed_at"] != clock.Now().UTC().Format(time.RFC3339Nano) {
+		t.Fatalf("event timestamp came from payload or wall clock: %#v", object)
+	}
+}
+
+func TestSQLiteModelAdmissionStorePersistsAppendOnlyStatus(t *testing.T) {
+	db, err := auth.OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	store, err := providerws.NewSQLiteModelAdmissionStore(db.DB())
+	if err != nil {
+		t.Fatal(err)
+	}
+	event := providerws.ModelAdmissionEvent{
+		ProviderID:               "provider-byom-a",
+		CandidateID:              stableModelAdmissionCandidateID("o"),
+		ServedModelRef:           "ollama:qwen3-8b",
+		DiscoveryDigestSHA256:    stringsOf("a", 64),
+		RequestedDisclosureClass: "non_earning_provider_asserted",
+		PreviousState:            "not_offered",
+		State:                    "offer_submitted",
+		NextState:                "offer_submitted",
+		Actor:                    "provider",
+		CoordinatorEventID:       "event_sqlite",
+		ReasonCode:               "provider_offer_submitted",
+		RequestID:                "request_sqlite",
+		Nonce:                    "nonce_sqlite",
+		PayloadDigestSHA256:      stringsOf("b", 64),
+		SignatureDigestSHA256:    stringsOf("c", 64),
+		CreatedAt:                time.Unix(1800000010, 0).UTC(),
+	}
+	if _, replay, err := store.AppendModelAdmissionOffer(context.Background(), event); err != nil || replay {
+		t.Fatalf("append replay=%v err=%v", replay, err)
+	}
+	reopened, err := providerws.NewSQLiteModelAdmissionStore(db.DB())
+	if err != nil {
+		t.Fatal(err)
+	}
+	readback, found, err := reopened.LatestModelAdmissionStatus(context.Background(), "provider-byom-a", stableModelAdmissionCandidateID("o"))
+	if err != nil || !found || readback.RequestID != "request_sqlite" {
+		t.Fatalf("readback found=%v event=%+v err=%v", found, readback, err)
+	}
+	if _, replay, err := reopened.AppendModelAdmissionOffer(context.Background(), event); err != nil || !replay {
+		t.Fatalf("idempotent append replay=%v err=%v", replay, err)
+	}
+}
+
+func newModelAdmissionHarness(t *testing.T, providerID string) (providerHarness, string, ed25519.PrivateKey) {
+	t.Helper()
+	h, bearer, priv, _ := newModelAdmissionHarnessWithStore(t, providerID)
+	return h, bearer, priv
+}
+
+func newModelAdmissionHarnessWithStore(t *testing.T, providerID string) (providerHarness, string, ed25519.PrivateKey, *auth.Store) {
+	t.Helper()
+	store, err := auth.OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	_, bearer, priv := bindAdmissionIdentityForTest(t, store, providerID)
+	h := newProviderHarnessWithServerOptions(t, store, []providerws.Option{
+		providerws.WithModelAdmissionStore(providerws.NewMemoryModelAdmissionStore()),
+	}, func(cfg *config.Config) {
+		cfg.Auth.RequireProviderTokens = true
+	})
+	return h, bearer, priv, store
+}
+
+func bindAdmissionIdentityForTest(t *testing.T, store *auth.Store, providerID string) (ed25519.PublicKey, string, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, bearer, err := store.IssueToken(context.Background(), providerID, providerID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.BindAdmissionIdentity(context.Background(), providerID, bearer, pub, time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+	return pub, bearer, priv
+}
+
+func signedModelAdmissionOffer(t *testing.T, providerID, candidateID, servedModelRef string, priv ed25519.PrivateKey, overrides map[string]any) map[string]any {
+	t.Helper()
+	pubkey := priv.Public().(ed25519.PublicKey)
+	pubkeyDigest := sha256.Sum256(pubkey)
+	signedFields := map[string]any{
+		"signature_domain":         "macprovider.model_admission.offer.v1",
+		"provider_id":              providerID,
+		"candidate_id":             candidateID,
+		"runtime_source":           "ollama_loopback",
+		"served_model_ref":         servedModelRef,
+		"catalog_model_key":        "",
+		"discovery_digest_sha256":  stringsOf("a", 64),
+		"evaluation_digest_sha256": stringsOf("b", 64),
+		"artifact_hashes":          map[string]any{},
+		"advisory_capabilities": map[string]any{
+			"chat_completions":              true,
+			"streaming":                     nil,
+			"tool_call_passthrough":         nil,
+			"structured_output_passthrough": nil,
+			"json_mode":                     nil,
+			"usage_reporting":               nil,
+			"max_context_tokens":            2048,
+			"quantization":                  nil,
+			"family":                        nil,
+			"runtime_version":               nil,
+		},
+		"fit_evidence_source":        "local_discovery",
+		"local_readiness":            "ready",
+		"requested_disclosure_class": "non_earning_provider_asserted",
+		"timestamp":                  time.Now().UTC().Format(time.RFC3339Nano),
+		"nonce":                      "nonce_" + candidateID,
+		"idempotency_key":            "request_" + candidateID,
+		"signing_key_digest":         hex.EncodeToString(pubkeyDigest[:]),
+		"cli_version":                "1.8.111",
+	}
+	for key, value := range overrides {
+		signedFields[key] = value
+	}
+	canonical, err := billing.CanonicalJSON(signedFields)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signature := ed25519.Sign(priv, canonical)
+	request := map[string]any{"schema": "model_admission_offer_submit.v1"}
+	for key, value := range signedFields {
+		request[key] = value
+	}
+	request["signature_algorithm"] = "ed25519"
+	request["provider_signature"] = base64.StdEncoding.EncodeToString(signature)
+	return request
+}
+
+func postModelAdmissionOffer(t *testing.T, baseURL, bearer string, payload map[string]any) (int, string) {
+	t.Helper()
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/v1/provider/model-admission/offers", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	out, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, string(out)
+}
+
+func getModelAdmissionStatus(t *testing.T, baseURL, bearer, candidateID string) (int, string) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, baseURL+"/v1/provider/model-admission/status?candidate_id="+candidateID, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	out, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, string(out)
+}
+
+func decodeMap(t *testing.T, raw string) map[string]any {
+	t.Helper()
+	var object map[string]any
+	if err := json.Unmarshal([]byte(raw), &object); err != nil {
+		t.Fatalf("decode %q: %v", raw, err)
+	}
+	return object
+}
+
+func stringsOf(value string, count int) string {
+	var b strings.Builder
+	for i := 0; i < count; i++ {
+		b.WriteString(value)
+	}
+	return b.String()
+}
+
+func stableModelAdmissionCandidateID(value string) string {
+	return "byom_" + strings.Repeat(value, 52)
+}
+
+func insertModelAdmissionEventForTest(t *testing.T, db *auth.Store, event providerws.ModelAdmissionEvent) {
+	t.Helper()
+	if _, err := db.DB().ExecContext(context.Background(), `
+INSERT INTO model_admission_events(
+    provider_id, candidate_id, served_model_ref, catalog_model_key,
+    discovery_digest_sha256, evaluation_digest_sha256, requested_disclosure_class,
+    previous_state, state, next_state, actor, coordinator_event_id,
+    reason_code, request_id, nonce, payload_digest_sha256,
+    signature_digest_sha256, created_at_utc
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		event.ProviderID,
+		event.CandidateID,
+		event.ServedModelRef,
+		event.CatalogModelKey,
+		event.DiscoveryDigestSHA256,
+		event.EvaluationDigestSHA256,
+		event.RequestedDisclosureClass,
+		event.PreviousState,
+		event.State,
+		event.NextState,
+		event.Actor,
+		event.CoordinatorEventID,
+		event.ReasonCode,
+		event.RequestID,
+		event.Nonce,
+		event.PayloadDigestSHA256,
+		event.SignatureDigestSHA256,
+		event.CreatedAt.Format(time.RFC3339Nano),
+	); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func approveModelAdmissionRecoveryAuthorization(
+	t *testing.T,
+	store *auth.Store,
+	providerID string,
+	current, candidate []byte,
+	generation int,
+	now time.Time,
+) {
+	t.Helper()
+	currentDigest := sha256.Sum256(current)
+	candidateDigest := sha256.Sum256(candidate)
+	authorization := auth.AdmissionIdentityRecoveryAuthorization{
+		PendingID:                      "recovery-" + hex.EncodeToString(candidateDigest[:8]),
+		ProviderID:                     providerID,
+		CandidatePublicKeySHA256:       hex.EncodeToString(candidateDigest[:]),
+		ExpectedCurrentPublicKeySHA256: hex.EncodeToString(currentDigest[:]),
+		ExpectedGeneration:             generation,
+		RequestedBy:                    "operator:alice",
+		RequestedUntil:                 now.Add(time.Hour),
+		Reason:                         "test recovery",
+		IncidentID:                     "INC-" + hex.EncodeToString(candidateDigest[:8]),
+	}
+	if _, err := store.RequestAdmissionIdentityRecovery(context.Background(), authorization, now); err != nil {
+		t.Fatalf("request recovery authorization: %v", err)
+	}
+	if _, err := store.ApproveAdmissionIdentityRecovery(context.Background(), authorization.PendingID, "operator:bob", now); err != nil {
+		t.Fatalf("approve recovery authorization: %v", err)
+	}
+}
+
+func modelAdmissionTransitionForTest(event providerws.ModelAdmissionEvent, previous, next string) providerws.ModelAdmissionEvent {
+	event.PreviousState = previous
+	event.State = next
+	event.NextState = next
+	event.Actor = "provider"
+	event.ReasonCode = "test_transition"
+	event.CoordinatorEventID = stringsOf("1", 64)
+	event.SignatureDigestSHA256 = stringsOf("2", 64)
+	return event
+}
+
+func TestModelAdmissionSignatureDigestFixture(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := signedModelAdmissionOffer(t, "provider-byom-a", stableModelAdmissionCandidateID("p"), "ollama:qwen3-8b", priv, nil)
+	delete(request, "schema")
+	delete(request, "signature_algorithm")
+	delete(request, "provider_signature")
+	canonical, err := billing.CanonicalJSON(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(canonical)
+	if hex.EncodeToString(sum[:]) == "" {
+		t.Fatal("empty digest")
+	}
+}

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -165,6 +165,9 @@ type Server struct {
 	credentialBootstrapMetrics     CredentialBootstrapMetrics
 	capacityOverClaimMetrics       CapacityOverClaimMetrics
 	connectionEvents               ConnectionEventStore
+	modelAdmissions                ModelAdmissionStore
+	modelAdmissionAttemptMu        sync.Mutex
+	modelAdmissionAttempts         map[string][]time.Time
 	connectionEventMetrics         ConnectionEventMetrics
 	closeEventMeta                 sync.Map // net.Conn -> closeEventMeta
 	connectionEventQueue           chan connectionEventJob
@@ -588,6 +591,14 @@ func WithComputeIntegrityStatusSource(source ComputeIntegrityStatusSource) Optio
 	}
 }
 
+func WithModelAdmissionStore(store ModelAdmissionStore) Option {
+	return func(s *Server) {
+		if store != nil {
+			s.modelAdmissions = store
+		}
+	}
+}
+
 func WithGitHubOAuthClient(client githubOAuthClient) Option {
 	return func(s *Server) {
 		s.githubOAuth = client
@@ -717,6 +728,8 @@ func NewServer(cfg config.Config, registry *pool.Registry, logger zerolog.Logger
 		losslessnessProfileCursor:     map[string]int{},
 		autotuneCatalogEnforced:       cfg.AutotuneFeeds.EnforceProviderAdmission,
 		autotuneCatalogBridgeDeadline: providerAdmissionBridgeDeadline,
+		modelAdmissions:               NewMemoryModelAdmissionStore(),
+		modelAdmissionAttempts:        map[string][]time.Time{},
 		version:                       "dev",
 	}
 	s.authAttempts = newAuthAttemptStore(1024)
@@ -1183,6 +1196,8 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/admin/provider-admission-identity/recover", s.handleAdmissionIdentityRecoveryRequest)
 	mux.HandleFunc("/admin/provider-admission-identity/recover/", s.handleAdmissionIdentityRecoveryApprove)
 	mux.HandleFunc("/v1/provider/compute-integrity", s.handleProviderComputeIntegrity)
+	mux.HandleFunc("/v1/provider/model-admission/offers", s.handleProviderModelAdmissionOffer)
+	mux.HandleFunc("/v1/provider/model-admission/status", s.handleProviderModelAdmissionStatus)
 	if s.cfg.Auth.GitHubOAuth.Enabled {
 		mux.HandleFunc("/v1/auth/github/start", s.handleGitHubStart)
 		mux.HandleFunc("/v1/auth/github/callback", s.handleGitHubCallback)


### PR DESCRIPTION
## Summary

Implements the coordinator-backed BYOM offer submission and status slice for #1253, stacked on #1263 / #1252.

- Adds `macprovider-cli models offer <candidate> --json --yes` submission using the CLI-owned current provider admission identity.
- Adds `models admission status <candidate> --json` readback through a closed `model_admission_status.v1` coordinator envelope.
- Adds coordinator offer verification, append-only event storage, status readback, replay/idempotency protection, provider-scoped attempt limiting, sanction checks, and strict provider-material validation.
- Preserves the fail-closed network boundary: `offer_submitted` and `not_offered` are not earning, buyer-routable, catalog-priced, or provider-crediting states.

Advances #1240.
Closes #1253.
Depends on #1263.
Related gates: #1243, #1244, #1246, #1247, #1248.

## SPEC Governance

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "issue": "https://github.com/Augustas11/macprovider/issues/1253",
  "specs": [
    "SPEC-047",
    "SPEC-046",
    "SPEC-026"
  ],
  "requirements": [
    "SPEC-047-R001",
    "SPEC-047-R002",
    "SPEC-047-R003",
    "SPEC-047-R004",
    "SPEC-047-R005",
    "SPEC-047-R007",
    "SPEC-047-R008"
  ],
  "authority_domains": [
    "network-model-admission",
    "provider-byom-discovery",
    "provider-onboarding-identity"
  ],
  "arbitration": [
    "DECISION_REQUIRED"
  ],
  "tests": [
    "cd phase4-coordinator && go test ./internal/ws ./cmd/coordinator -count=1",
    "cd phase3-binary && env CLANG_MODULE_CACHE_PATH=/private/tmp/macprovider-swift-module-cache swift test --filter macprovider_cliTests.BYOMAdmissionTests",
    "cd phase3-binary && env CLANG_MODULE_CACHE_PATH=/private/tmp/macprovider-swift-module-cache swift test --filter macprovider_cliTests.BYOMOfferDryRunTests",
    "git diff --check"
  ],
  "journeys": [
    "JOURNEY-NETWORK-MODEL-ADMISSION"
  ]
}
SPEC-GOVERNANCE-DECLARATION-END

## Verification

- `cd phase4-coordinator && go test ./internal/ws ./cmd/coordinator -count=1`
- `cd phase3-binary && env CLANG_MODULE_CACHE_PATH=/private/tmp/macprovider-swift-module-cache swift test --filter macprovider_cliTests.BYOMAdmissionTests`
- `cd phase3-binary && env CLANG_MODULE_CACHE_PATH=/private/tmp/macprovider-swift-module-cache swift test --filter macprovider_cliTests.BYOMOfferDryRunTests`
- `git diff --check`

Internal audit gate: code review, security review, and architecture review are clear with 0 Critical, 0 High, and 0 Medium findings. Audit artifacts are intentionally not posted publicly.

## Notes

- Withdrawal/admission decisions, settlement-compatible credit gates, null-economics scaffolding, and the full CLI onboarding E2E remain for later BYOM slices.
- The CLI overlays local candidate identity only for coordinator `not_offered` status with an empty served ref; it does not convert local discovery into network authority.
