### PR TITLE
BYOM: add withdrawal and fail-closed routing gate

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/BYOMDiscovery.swift
+++ b/phase3-binary/Sources/macprovider-cli/BYOMDiscovery.swift
@@ -666,6 +666,103 @@ struct BYOMAdmissionStatusWire: Codable, Equatable, Sendable {
     }
 }
 
+struct BYOMAdmissionWithdrawWire: Codable, Equatable, Sendable {
+    let schema: String
+    let generatedAt: String
+    let cliVersion: String
+    let providerID: String
+    let candidateID: String
+    let servedModelRef: String
+    let catalogModelKey: String?
+    let idempotencyKey: String
+    let reasonCode: String
+    let previousAdmissionState: String
+    let coordinatorEventID: String
+    let acceptedAt: String
+    let resultingAdmissionState: String
+    let providerGuidance: BYOMDiscoveryWire.Guidance
+    let warnings: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case schema
+        case generatedAt = "generated_at"
+        case cliVersion = "cli_version"
+        case providerID = "provider_id"
+        case candidateID = "candidate_id"
+        case servedModelRef = "served_model_ref"
+        case catalogModelKey = "catalog_model_key"
+        case idempotencyKey = "idempotency_key"
+        case reasonCode = "reason_code"
+        case previousAdmissionState = "previous_admission_state"
+        case coordinatorEventID = "coordinator_event_id"
+        case acceptedAt = "accepted_at"
+        case resultingAdmissionState = "resulting_admission_state"
+        case providerGuidance = "provider_guidance"
+        case warnings
+    }
+}
+
+extension BYOMAdmissionWithdrawWire {
+    private static let topLevelKeys: Set<String> = [
+        "schema",
+        "generated_at",
+        "cli_version",
+        "provider_id",
+        "candidate_id",
+        "served_model_ref",
+        "catalog_model_key",
+        "idempotency_key",
+        "reason_code",
+        "previous_admission_state",
+        "coordinator_event_id",
+        "accepted_at",
+        "resulting_admission_state",
+        "provider_guidance",
+        "warnings",
+    ]
+    private static let guidanceKeys: Set<String> = [
+        "state_label_key",
+        "state_meaning_key",
+        "next_action",
+        "transition_reason_code",
+        "earning_path_class",
+    ]
+    private static let reasonCodes: Set<String> = [
+        "provider_requested",
+        "wrong_model",
+        "runtime_unavailable",
+        "identity_mismatch",
+        "policy_uncertain",
+        "other_operator_reason",
+    ]
+
+    static func decodeStrictWithdrawal(
+        from data: Data,
+        expectedProviderID: String,
+        expectedCandidateID: String
+    ) throws -> BYOMAdmissionWithdrawWire {
+        guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              Set(object.keys) == topLevelKeys,
+              let guidance = object["provider_guidance"] as? [String: Any],
+              Set(guidance.keys) == guidanceKeys else {
+            throw BYOMModelAdmissionError.invalidStatusSchema
+        }
+        let withdrawal = try JSONDecoder().decode(BYOMAdmissionWithdrawWire.self, from: data)
+        guard withdrawal.schema == "model_admission_withdraw.v1",
+              withdrawal.providerID == expectedProviderID,
+              withdrawal.candidateID == expectedCandidateID,
+              withdrawal.resultingAdmissionState == "withdrawn",
+              !withdrawal.coordinatorEventID.isEmpty,
+              reasonCodes.contains(withdrawal.reasonCode),
+              withdrawal.providerGuidance.nextAction == "submit_offer",
+              withdrawal.providerGuidance.earningPathClass == "no_earning_path_in_v0_1",
+              withdrawal.providerGuidance.transitionReasonCode == withdrawal.reasonCode else {
+            throw BYOMModelAdmissionError.invalidStatusSchema
+        }
+        return withdrawal
+    }
+}
+
 extension BYOMAdmissionStatusWire {
     private static let topLevelKeys: Set<String> = [
         "schema",
@@ -989,6 +1086,81 @@ extension BYOMOfferSubmitRequestWire.AdvisoryCapabilities {
     }
 }
 
+struct BYOMWithdrawRequestWire: Codable, Equatable, Sendable {
+    let schema: String
+    let generatedAt: String
+    let cliVersion: String
+    let signatureDomain: String
+    let providerID: String
+    let candidateID: String
+    let servedModelRef: String
+    let catalogModelKey: String?
+    let idempotencyKey: String
+    let nonce: String
+    let timestamp: String
+    let reasonCode: String
+    let signingKeyDigest: String
+    let signatureAlgorithm: String
+    var providerSignature: String
+
+    enum CodingKeys: String, CodingKey {
+        case schema
+        case generatedAt = "generated_at"
+        case cliVersion = "cli_version"
+        case signatureDomain = "signature_domain"
+        case providerID = "provider_id"
+        case candidateID = "candidate_id"
+        case servedModelRef = "served_model_ref"
+        case catalogModelKey = "catalog_model_key"
+        case idempotencyKey = "idempotency_key"
+        case nonce
+        case timestamp
+        case reasonCode = "reason_code"
+        case signingKeyDigest = "signing_key_digest"
+        case signatureAlgorithm = "signature_algorithm"
+        case providerSignature = "provider_signature"
+    }
+
+    func canonicalValue() -> RFC8785JCS.Value {
+        .object([
+            "signature_domain": .string(signatureDomain),
+            "provider_id": .string(providerID),
+            "candidate_id": .string(candidateID),
+            "served_model_ref": .string(servedModelRef),
+            "catalog_model_key": catalogModelKey.map(RFC8785JCS.Value.string) ?? .null,
+            "idempotency_key": .string(idempotencyKey),
+            "nonce": .string(nonce),
+            "timestamp": .string(timestamp),
+            "reason_code": .string(reasonCode),
+            "signing_key_digest": .string(signingKeyDigest),
+            "cli_version": .string(cliVersion),
+        ])
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(schema, forKey: .schema)
+        try container.encode(generatedAt, forKey: .generatedAt)
+        try container.encode(cliVersion, forKey: .cliVersion)
+        try container.encode(signatureDomain, forKey: .signatureDomain)
+        try container.encode(providerID, forKey: .providerID)
+        try container.encode(candidateID, forKey: .candidateID)
+        try container.encode(servedModelRef, forKey: .servedModelRef)
+        if let catalogModelKey {
+            try container.encode(catalogModelKey, forKey: .catalogModelKey)
+        } else {
+            try container.encodeNil(forKey: .catalogModelKey)
+        }
+        try container.encode(idempotencyKey, forKey: .idempotencyKey)
+        try container.encode(nonce, forKey: .nonce)
+        try container.encode(timestamp, forKey: .timestamp)
+        try container.encode(reasonCode, forKey: .reasonCode)
+        try container.encode(signingKeyDigest, forKey: .signingKeyDigest)
+        try container.encode(signatureAlgorithm, forKey: .signatureAlgorithm)
+        try container.encode(providerSignature, forKey: .providerSignature)
+    }
+}
+
 enum BYOMModelAdmissionError: Error, Equatable, CustomStringConvertible {
     case missingProviderID
     case missingCoordinatorURL
@@ -998,6 +1170,8 @@ enum BYOMModelAdmissionError: Error, Equatable, CustomStringConvertible {
     case candidateUnstable
     case candidateNotOfferable
     case invalidEvaluationDigest
+    case invalidWithdrawalReason
+    case missingWithdrawalTuple
     case invalidCoordinatorURL
     case httpStatus(Int)
     case invalidStatusSchema
@@ -1020,6 +1194,10 @@ enum BYOMModelAdmissionError: Error, Equatable, CustomStringConvertible {
             return "BYOM candidate is not offerable; run models evaluate and models offer --dry-run --json before submitting"
         case .invalidEvaluationDigest:
             return "evaluation digest must be a 64-character lowercase SHA-256 hex value"
+        case .invalidWithdrawalReason:
+            return "withdrawal reason must be one of provider_requested, wrong_model, runtime_unavailable, identity_mismatch, policy_uncertain, or other_operator_reason"
+        case .missingWithdrawalTuple:
+            return "coordinator status does not contain a withdrawable BYOM admission tuple"
         case .invalidCoordinatorURL:
             return "invalid coordinator URL; use wss:// or https://"
         case .httpStatus(let status):
@@ -1032,6 +1210,12 @@ enum BYOMModelAdmissionError: Error, Equatable, CustomStringConvertible {
 
 struct BYOMOfferSubmissionPackage: Equatable, Sendable {
     let request: BYOMOfferSubmitRequestWire
+    let encodedRequest: Data
+    let payloadDigestSHA256: String
+}
+
+struct BYOMWithdrawalPackage: Equatable, Sendable {
+    let request: BYOMWithdrawRequestWire
     let encodedRequest: Data
     let payloadDigestSHA256: String
 }
@@ -1139,6 +1323,110 @@ struct BYOMOfferSubmissionBuilder {
     }
 }
 
+struct BYOMWithdrawalBuilder {
+    private static let stableCandidatePattern = #"^byom_[a-z2-7]{52}$"#
+    private static let reasonCodes: Set<String> = [
+        "provider_requested",
+        "wrong_model",
+        "runtime_unavailable",
+        "identity_mismatch",
+        "policy_uncertain",
+        "other_operator_reason",
+    ]
+
+    static func isStableCandidateID(_ value: String) -> Bool {
+        value.range(of: stableCandidatePattern, options: .regularExpression) != nil
+    }
+
+    static func makePackage(
+        providerID: String,
+        candidate: BYOMDiscoveryWire.Candidate,
+        admissionIdentity: Curve25519.Signing.PrivateKey,
+        reasonCode: String,
+        now: Date = Date(),
+        nonce: String = UUID().uuidString.lowercased(),
+        idempotencyKey: String = UUID().uuidString.lowercased(),
+        cliVersion: String = CoordinatorClient.binaryVersion
+    ) throws -> BYOMWithdrawalPackage {
+        guard isStableCandidateID(candidate.candidateID),
+              !candidate.warningCodes.contains(BYOMDiscoveryWarning.candidateIDUnstable.rawValue),
+              !candidate.warningCodes.contains(BYOMDiscoveryWarning.namespacePermissionInvalid.rawValue) else {
+            throw BYOMModelAdmissionError.candidateUnstable
+        }
+        return try makePackage(
+            providerID: providerID,
+            candidateID: candidate.candidateID,
+            servedModelRef: candidate.servedModelRef,
+            catalogModelKey: candidate.catalogModelKey,
+            admissionIdentity: admissionIdentity,
+            reasonCode: reasonCode,
+            now: now,
+            nonce: nonce,
+            idempotencyKey: idempotencyKey,
+            cliVersion: cliVersion
+        )
+    }
+
+    static func makePackage(
+        providerID: String,
+        candidateID: String,
+        servedModelRef: String,
+        catalogModelKey: String?,
+        admissionIdentity: Curve25519.Signing.PrivateKey,
+        reasonCode: String,
+        now: Date = Date(),
+        nonce: String = UUID().uuidString.lowercased(),
+        idempotencyKey: String = UUID().uuidString.lowercased(),
+        cliVersion: String = CoordinatorClient.binaryVersion
+    ) throws -> BYOMWithdrawalPackage {
+        let candidateID = candidateID.trimmingCharacters(in: .whitespacesAndNewlines)
+        let servedModelRef = servedModelRef.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard isStableCandidateID(candidateID) else {
+            throw BYOMModelAdmissionError.candidateUnstable
+        }
+        guard !servedModelRef.isEmpty else {
+            throw BYOMModelAdmissionError.missingWithdrawalTuple
+        }
+        let reason = reasonCode.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard reasonCodes.contains(reason) else {
+            throw BYOMModelAdmissionError.invalidWithdrawalReason
+        }
+        let publicKey = admissionIdentity.publicKey.rawRepresentation
+        let signingKeyDigest = sha256Hex(publicKey)
+        let timestamp = ModelSwitchingWireCodec.timestamp(now)
+        var request = BYOMWithdrawRequestWire(
+            schema: "model_admission_withdraw_request.v1",
+            generatedAt: timestamp,
+            cliVersion: cliVersion,
+            signatureDomain: "macprovider.model_admission.withdraw.v1",
+            providerID: providerID,
+            candidateID: candidateID,
+            servedModelRef: servedModelRef,
+            catalogModelKey: catalogModelKey,
+            idempotencyKey: idempotencyKey,
+            nonce: nonce,
+            timestamp: timestamp,
+            reasonCode: reason,
+            signingKeyDigest: signingKeyDigest,
+            signatureAlgorithm: "ed25519",
+            providerSignature: ""
+        )
+        let canonical = try RFC8785JCS.canonicalString(request.canonicalValue())
+        let canonicalData = Data(canonical.utf8)
+        let signatureData = try admissionIdentity.signature(for: canonicalData)
+        request.providerSignature = signatureData.base64EncodedString()
+        return BYOMWithdrawalPackage(
+            request: request,
+            encodedRequest: Data(try ModelSwitchingWireCodec.encode(request).utf8),
+            payloadDigestSHA256: sha256Hex(canonicalData)
+        )
+    }
+
+    private static func sha256Hex(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+}
+
 struct BYOMModelAdmissionClient: Sendable {
     private static let maxStatusResponseBytes = 64 * 1024
 
@@ -1196,6 +1484,20 @@ struct BYOMModelAdmissionClient: Sendable {
         )
     }
 
+    func withdraw(_ package: BYOMWithdrawalPackage, bearerToken: String) async throws -> BYOMAdmissionWithdrawWire {
+        var request = URLRequest(url: baseURL.appendingPathComponent("v1/provider/model-admission/withdrawals"))
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(bearerToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "content-type")
+        request.setValue("application/json", forHTTPHeaderField: "accept")
+        request.httpBody = package.encodedRequest
+        return try await performWithdrawal(
+            request,
+            expectedProviderID: package.request.providerID,
+            expectedCandidateID: package.request.candidateID
+        )
+    }
+
     func status(candidateID: String, providerID: String? = nil, bearerToken: String) async throws -> BYOMAdmissionStatusWire {
         var components = URLComponents(url: baseURL.appendingPathComponent("v1/provider/model-admission/status"), resolvingAgainstBaseURL: false)
         components?.queryItems = [URLQueryItem(name: "candidate_id", value: candidateID)]
@@ -1207,6 +1509,36 @@ struct BYOMModelAdmissionClient: Sendable {
         request.setValue("Bearer \(bearerToken)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "accept")
         return try await perform(request, expectedProviderID: providerID, expectedCandidateID: candidateID)
+    }
+
+    private func performWithdrawal(
+        _ request: URLRequest,
+        expectedProviderID: String,
+        expectedCandidateID: String
+    ) async throws -> BYOMAdmissionWithdrawWire {
+        let data: Data
+        let response: URLResponse
+        if let session {
+            (data, response) = try await session.data(for: request)
+        } else {
+            let ephemeral = URLSession(configuration: .ephemeral, delegate: NoRedirectURLSessionDelegate(), delegateQueue: nil)
+            defer { ephemeral.finishTasksAndInvalidate() }
+            (data, response) = try await ephemeral.data(for: request)
+        }
+        guard let http = response as? HTTPURLResponse else {
+            throw BYOMModelAdmissionError.invalidStatusSchema
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            throw BYOMModelAdmissionError.httpStatus(http.statusCode)
+        }
+        guard data.count <= Self.maxStatusResponseBytes else {
+            throw BYOMModelAdmissionError.invalidStatusSchema
+        }
+        return try BYOMAdmissionWithdrawWire.decodeStrictWithdrawal(
+            from: data,
+            expectedProviderID: expectedProviderID,
+            expectedCandidateID: expectedCandidateID
+        )
     }
 
     private func perform(
@@ -1303,6 +1635,44 @@ struct BYOMModelAdmissionRuntime: Sendable {
         }
         let status = try await client.status(candidateID: candidateID, providerID: providerID, bearerToken: bearer)
         return status.withLocalCandidateIdentityIfCoordinatorHasNoOffer(candidate)
+    }
+
+    func withdraw(providerID: String, target: String, reasonCode: String) async throws -> BYOMAdmissionWithdrawWire {
+        let candidate = await resolveCandidate(target)
+        let candidateID = candidate?.candidateID ?? target.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard candidate != nil || BYOMWithdrawalBuilder.isStableCandidateID(candidateID) else {
+            throw BYOMModelAdmissionError.candidateNotFound
+        }
+        guard let bearer = try credentialStore.load(providerID: providerID) else {
+            throw BYOMModelAdmissionError.missingBearer(providerID: providerID)
+        }
+        guard let identity = try identityStore.loadAdmissionIdentity(providerId: providerID) else {
+            throw BYOMModelAdmissionError.missingAdmissionIdentity(providerID: providerID)
+        }
+        let package: BYOMWithdrawalPackage
+        if let candidate {
+            package = try BYOMWithdrawalBuilder.makePackage(
+                providerID: providerID,
+                candidate: candidate,
+                admissionIdentity: identity,
+                reasonCode: reasonCode
+            )
+        } else {
+            let status = try await client.status(candidateID: candidateID, providerID: providerID, bearerToken: bearer)
+            guard status.admissionStateSource == "coordinator",
+                  status.admissionState != "not_offered" else {
+                throw BYOMModelAdmissionError.missingWithdrawalTuple
+            }
+            package = try BYOMWithdrawalBuilder.makePackage(
+                providerID: providerID,
+                candidateID: status.candidateID,
+                servedModelRef: status.servedModelRef,
+                catalogModelKey: status.catalogModelKey,
+                admissionIdentity: identity,
+                reasonCode: reasonCode
+            )
+        }
+        return try await client.withdraw(package, bearerToken: bearer)
     }
 
     private func resolveCandidate(_ target: String) async -> BYOMDiscoveryWire.Candidate? {

--- a/phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift
@@ -198,9 +198,10 @@ struct ModelsOfferCommand: AsyncParsableCommand {
 struct ModelsAdmissionCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "admission",
-        abstract: "Read BYOM model admission state.",
+        abstract: "Read or withdraw BYOM model admission state.",
         subcommands: [
             ModelsAdmissionStatusCommand.self,
+            ModelsAdmissionWithdrawCommand.self,
         ]
     )
 }
@@ -258,6 +259,80 @@ struct ModelsAdmissionStatusCommand: AsyncParsableCommand {
             let runtime = BYOMModelAdmissionRuntime(environment: environment, client: client)
             let status = try await runtime.status(providerID: resolved.providerID, target: candidate)
             try ModelSwitchingWireCodec.printJSON(status)
+        } catch let error as BYOMModelAdmissionError {
+            writeStderr(error.description)
+            throw ExitCode(2)
+        }
+    }
+}
+
+struct ModelsAdmissionWithdrawCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "withdraw",
+        abstract: "Withdraw a coordinator-backed BYOM admission offer."
+    )
+
+    @Argument(help: "Candidate id, served model reference, or display name from models discover --json.")
+    var candidate: String
+
+    @Flag(name: .customLong("json"), help: "Emit the strict model_admission_withdraw.v1 JSON contract.")
+    var emitJSON = false
+
+    @Flag(help: "Confirm coordinator state mutation for BYOM withdrawal.")
+    var yes = false
+
+    @Option(help: "Closed withdrawal reason code.")
+    var reasonCode: String = "provider_requested"
+
+    @Option(help: "YAML config path. Overrides MACPROVIDER_CONFIG.")
+    var config: String?
+
+    @Option(help: "Coordinator WebSocket/HTTPS URL. Overrides MACPROVIDER_COORDINATOR_URL and config file coordinator_url.")
+    var coordinatorURL: String?
+
+    @Option(help: "Stable provider identifier. Overrides MACPROVIDER_PROVIDER_ID and config file provider_id.")
+    var providerID: String?
+
+    @Option(help: ArgumentHelp("CLI-owned local discovery namespace path.", visibility: .hidden))
+    var localDiscoveryNamespacePath: String?
+
+    @Option(help: "HuggingFace cache root to inspect read-only. Defaults to HF_HUB_CACHE, HF_HOME/hub, or ~/.cache/huggingface/hub.")
+    var mlxCacheDir: String?
+
+    @Option(help: "Ollama-compatible loopback origin to query. Must be http://127.0.0.0/8:<port> or http://[::1]:<port>.")
+    var ollamaOrigin: String = "http://127.0.0.1:11434"
+
+    @Flag(help: "Skip the Ollama-compatible loopback adapter during candidate lookup.")
+    var skipOllama = false
+
+    func run() async throws {
+        guard emitJSON else {
+            writeStderr("models admission withdraw is JSON-only in this release; pass --json")
+            throw ExitCode(2)
+        }
+        guard yes else {
+            writeStderr("models admission withdraw mutates coordinator admission state; pass --yes --json after reviewing models admission status --json")
+            throw ExitCode(2)
+        }
+        do {
+            let resolved = try loadModelAdmissionConfig(
+                config: config,
+                coordinatorURL: coordinatorURL,
+                providerID: providerID
+            )
+            let environment = BYOMDiscoveryEnvironment.production(
+                namespacePath: localDiscoveryNamespacePath,
+                mlxCacheDir: mlxCacheDir,
+                ollamaOrigin: skipOllama ? nil : ollamaOrigin
+            )
+            let client = try BYOMModelAdmissionClient(coordinatorURL: resolved.coordinatorURL)
+            let runtime = BYOMModelAdmissionRuntime(environment: environment, client: client)
+            let withdrawal = try await runtime.withdraw(
+                providerID: resolved.providerID,
+                target: candidate,
+                reasonCode: reasonCode
+            )
+            try ModelSwitchingWireCodec.printJSON(withdrawal)
         } catch let error as BYOMModelAdmissionError {
             writeStderr(error.description)
             throw ExitCode(2)

--- a/phase3-binary/Tests/macprovider-cliTests/BYOMAdmissionTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/BYOMAdmissionTests.swift
@@ -168,6 +168,172 @@ final class BYOMAdmissionTests: XCTestCase {
         XCTAssertEqual(status.admissionStateSource, "coordinator")
     }
 
+    func testWithdrawCommandRequiresExplicitYesForCoordinatorMutation() async throws {
+        let command = try ModelsAdmissionWithdrawCommand.parse([
+            "ollama:tiny-offer-1b-q4",
+            "--json",
+            "--skip-ollama",
+            "--coordinator-url", "wss://coordinator.example/ws/provider",
+            "--provider-id", "provider-byom-a",
+        ])
+        let capture = await captureBYOMAdmissionOutput {
+            try await command.run()
+        }
+
+        XCTAssertFalse(command.yes)
+        XCTAssertEqual((capture.error as? ExitCode), ExitCode(2))
+    }
+
+    func testWithdrawalPackageBindsAdmissionIdentityAndNullableCatalogKey() throws {
+        let identity = Curve25519.Signing.PrivateKey()
+        let candidate = byomAdmissionCandidate(
+            candidateID: stableBYOMAdmissionCandidateID("o"),
+            servedModelRef: "ollama:qwen3-8b"
+        )
+
+        let package = try BYOMWithdrawalBuilder.makePackage(
+            providerID: "provider-byom-a",
+            candidate: candidate,
+            admissionIdentity: identity,
+            reasonCode: "provider_requested",
+            now: Date(timeIntervalSince1970: 1_800_000_000),
+            nonce: "withdraw_nonce_test",
+            idempotencyKey: "withdraw_request_test",
+            cliVersion: "test"
+        )
+
+        XCTAssertEqual(package.request.schema, "model_admission_withdraw_request.v1")
+        XCTAssertEqual(package.request.signatureDomain, "macprovider.model_admission.withdraw.v1")
+        XCTAssertEqual(package.request.providerID, "provider-byom-a")
+        XCTAssertNil(package.request.catalogModelKey)
+        XCTAssertEqual(package.request.reasonCode, "provider_requested")
+        XCTAssertFalse(String(decoding: package.encodedRequest, as: UTF8.self).contains("previous_admission_state"))
+        XCTAssertFalse(String(decoding: package.encodedRequest, as: UTF8.self).contains("endpoint"))
+        XCTAssertFalse(String(decoding: package.encodedRequest, as: UTF8.self).contains("payout"))
+
+        let canonical = try RFC8785JCS.canonicalString(package.request.canonicalValue())
+        let signature = try XCTUnwrap(Data(base64Encoded: package.request.providerSignature))
+        XCTAssertTrue(identity.publicKey.isValidSignature(signature, for: Data(canonical.utf8)))
+    }
+
+    func testAdmissionRuntimeWithdrawPostsPackageAndPreservesNonEarningStatus() async throws {
+        let root = try temporaryBYOMAdmissionDirectory("byom-admission-withdraw")
+        let namespace = root.appendingPathComponent("ns")
+        let cache = root.appendingPathComponent("hf", isDirectory: true)
+        try writeBYOMAdmissionNamespace(at: namespace)
+        try createBYOMAdmissionMLXSnapshot(cacheRoot: cache, modelID: "mlx-community/Tiny-1B-4bit")
+
+        let identity = Curve25519.Signing.PrivateKey()
+        let credentialStore = BYOMAdmissionCredentialStore(token: "provider-token-test")
+        let identityStore = BYOMAdmissionIdentityStore(identity: identity)
+        let session = makeBYOMAdmissionSession { request in
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer provider-token-test")
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertEqual(request.url?.path, "/v1/provider/model-admission/withdrawals")
+            let body = try XCTUnwrap(byomAdmissionRequestBody(request))
+            let object = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            XCTAssertEqual(object["schema"] as? String, "model_admission_withdraw_request.v1")
+            XCTAssertEqual(object["signature_domain"] as? String, "macprovider.model_admission.withdraw.v1")
+            XCTAssertEqual(object["provider_id"] as? String, "provider-byom-a")
+            XCTAssertEqual(object["served_model_ref"] as? String, "mlx-community/Tiny-1B-4bit")
+            XCTAssertEqual(object["reason_code"] as? String, "wrong_model")
+            XCTAssertNil(object["catalog_model_key"] as? String)
+            XCTAssertNil(object["previous_admission_state"])
+            XCTAssertNotNil(object["provider_signature"] as? String)
+            let candidateID = try XCTUnwrap(object["candidate_id"] as? String)
+            let idempotencyKey = try XCTUnwrap(object["idempotency_key"] as? String)
+            return BYOMAdmissionMockHTTPResponse(
+                statusCode: 200,
+                body: """
+                {"accepted_at":"2027-01-15T08:00:01Z","candidate_id":"\(candidateID)","catalog_model_key":null,"cli_version":"test","coordinator_event_id":"withdraw_event_test","generated_at":"2027-01-15T08:00:01Z","idempotency_key":"\(idempotencyKey)","previous_admission_state":"offer_submitted","provider_guidance":{"earning_path_class":"no_earning_path_in_v0_1","next_action":"submit_offer","state_label_key":"byom.admission.withdrawn","state_meaning_key":"byom.admission.not_earning","transition_reason_code":"wrong_model"},"provider_id":"provider-byom-a","reason_code":"wrong_model","resulting_admission_state":"withdrawn","schema":"model_admission_withdraw.v1","served_model_ref":"mlx-community/Tiny-1B-4bit","warnings":[]}
+                """
+            )
+        }
+        let runtime = BYOMModelAdmissionRuntime(
+            environment: BYOMDiscoveryEnvironment(namespaceURL: namespace, mlxCacheRoot: cache, ollamaOrigin: nil),
+            credentialStore: credentialStore,
+            identityStore: identityStore,
+            client: BYOMModelAdmissionClient(baseURL: URL(string: "https://coordinator.test")!, session: session),
+            httpClient: BYOMAdmissionDiscoveryHTTPClient()
+        )
+
+        let withdrawal = try await runtime.withdraw(
+            providerID: "provider-byom-a",
+            target: "mlx-community/Tiny-1B-4bit",
+            reasonCode: "wrong_model"
+        )
+
+        XCTAssertEqual(withdrawal.schema, "model_admission_withdraw.v1")
+        XCTAssertEqual(withdrawal.resultingAdmissionState, "withdrawn")
+        XCTAssertEqual(withdrawal.providerGuidance.nextAction, "submit_offer")
+        XCTAssertEqual(withdrawal.providerGuidance.earningPathClass, "no_earning_path_in_v0_1")
+    }
+
+    func testAdmissionRuntimeWithdrawFallsBackToCoordinatorStatusWhenRuntimeUnavailable() async throws {
+        let root = try temporaryBYOMAdmissionDirectory("byom-admission-withdraw-status-fallback")
+        let namespace = root.appendingPathComponent("ns")
+        let cache = root.appendingPathComponent("hf", isDirectory: true)
+        try writeBYOMAdmissionNamespace(at: namespace)
+        try FileManager.default.createDirectory(at: cache, withIntermediateDirectories: true)
+
+        let candidateID = stableBYOMAdmissionCandidateID("q")
+        let identity = Curve25519.Signing.PrivateKey()
+        let credentialStore = BYOMAdmissionCredentialStore(token: "provider-token-test")
+        let identityStore = BYOMAdmissionIdentityStore(identity: identity)
+        let recorder = BYOMAdmissionRequestRecorder()
+        let session = makeBYOMAdmissionSession { request in
+            let count = recorder.record(request)
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer provider-token-test")
+            if request.url?.path == "/v1/provider/model-admission/status" {
+                XCTAssertEqual(count, 1)
+                XCTAssertEqual(request.httpMethod, "GET")
+                XCTAssertEqual(URLComponents(url: request.url!, resolvingAgainstBaseURL: false)?
+                    .queryItems?.first(where: { $0.name == "candidate_id" })?.value, candidateID)
+                return BYOMAdmissionMockHTTPResponse(
+                    statusCode: 200,
+                    body: """
+                    {"admission_state":"offer_submitted","admission_state_source":"coordinator","allowed_next_states":["offer_rejected","sandbox_probe_only","network_visible_unpriced","network_admitted_unsettled","catalog_priced","withdrawn","revoked"],"candidate_id":"\(candidateID)","catalog_model_key":"qwen3-8b","cli_version":"test","coordinator_event_id":"event_test","generated_at":"2027-01-15T08:00:00Z","provider_guidance":{"earning_path_class":"not_earning_yet_catalog_or_receipt_path_exists","next_action":"wait_for_coordinator","state_label_key":"byom.admission.offer_submitted","state_meaning_key":"byom.admission.not_earning","transition_reason_code":null},"provider_id":"provider-byom-a","schema":"model_admission_status.v1","served_model_ref":"ollama:qwen3-8b","state_observed_at":"2027-01-15T08:00:00Z","warnings":[]}
+                    """
+                )
+            }
+            XCTAssertEqual(count, 2)
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertEqual(request.url?.path, "/v1/provider/model-admission/withdrawals")
+            let body = try XCTUnwrap(byomAdmissionRequestBody(request))
+            let object = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            XCTAssertEqual(object["schema"] as? String, "model_admission_withdraw_request.v1")
+            XCTAssertEqual(object["candidate_id"] as? String, candidateID)
+            XCTAssertEqual(object["served_model_ref"] as? String, "ollama:qwen3-8b")
+            XCTAssertEqual(object["catalog_model_key"] as? String, "qwen3-8b")
+            XCTAssertEqual(object["reason_code"] as? String, "runtime_unavailable")
+            let idempotencyKey = try XCTUnwrap(object["idempotency_key"] as? String)
+            return BYOMAdmissionMockHTTPResponse(
+                statusCode: 200,
+                body: """
+                {"accepted_at":"2027-01-15T08:00:01Z","candidate_id":"\(candidateID)","catalog_model_key":"qwen3-8b","cli_version":"test","coordinator_event_id":"withdraw_event_test","generated_at":"2027-01-15T08:00:01Z","idempotency_key":"\(idempotencyKey)","previous_admission_state":"offer_submitted","provider_guidance":{"earning_path_class":"no_earning_path_in_v0_1","next_action":"submit_offer","state_label_key":"byom.admission.withdrawn","state_meaning_key":"byom.admission.not_earning","transition_reason_code":"runtime_unavailable"},"provider_id":"provider-byom-a","reason_code":"runtime_unavailable","resulting_admission_state":"withdrawn","schema":"model_admission_withdraw.v1","served_model_ref":"ollama:qwen3-8b","warnings":[]}
+                """
+            )
+        }
+        let runtime = BYOMModelAdmissionRuntime(
+            environment: BYOMDiscoveryEnvironment(namespaceURL: namespace, mlxCacheRoot: cache, ollamaOrigin: nil),
+            credentialStore: credentialStore,
+            identityStore: identityStore,
+            client: BYOMModelAdmissionClient(baseURL: URL(string: "https://coordinator.test")!, session: session),
+            httpClient: BYOMAdmissionDiscoveryHTTPClient()
+        )
+
+        let withdrawal = try await runtime.withdraw(
+            providerID: "provider-byom-a",
+            target: candidateID,
+            reasonCode: "runtime_unavailable"
+        )
+
+        XCTAssertEqual(withdrawal.resultingAdmissionState, "withdrawn")
+        XCTAssertEqual(withdrawal.servedModelRef, "ollama:qwen3-8b")
+        XCTAssertEqual(withdrawal.catalogModelKey, "qwen3-8b")
+        XCTAssertEqual(recorder.count, 2)
+    }
+
     func testAdmissionStatusClientAcceptsCatalogPricedSettlementTransition() async throws {
         let session = makeBYOMAdmissionSession { _ in
             BYOMAdmissionMockHTTPResponse(
@@ -252,6 +418,32 @@ final class BYOMAdmissionTests: XCTestCase {
             evaluationDigestSHA256: String(repeating: "b", count: 64),
             requestedDisclosureClass: "non_earning_provider_asserted"
         ))
+    }
+
+    func testWithdrawalPackageRejectsUnstableCandidateAndInvalidReason() throws {
+        let identity = Curve25519.Signing.PrivateKey()
+        let unstable = byomAdmissionCandidate(
+            candidateID: "byom_unstable_123",
+            servedModelRef: "ollama:qwen3-8b",
+            warningCodes: ["candidate_id_unstable"]
+        )
+        XCTAssertThrowsError(try BYOMWithdrawalBuilder.makePackage(
+            providerID: "provider-byom-a",
+            candidate: unstable,
+            admissionIdentity: identity,
+            reasonCode: "provider_requested"
+        )) { error in
+            XCTAssertEqual(error as? BYOMModelAdmissionError, .candidateUnstable)
+        }
+        let stable = byomAdmissionCandidate(candidateID: stableBYOMAdmissionCandidateID("p"), servedModelRef: "ollama:qwen3-8b")
+        XCTAssertThrowsError(try BYOMWithdrawalBuilder.makePackage(
+            providerID: "provider-byom-a",
+            candidate: stable,
+            admissionIdentity: identity,
+            reasonCode: "because I said so"
+        )) { error in
+            XCTAssertEqual(error as? BYOMModelAdmissionError, .invalidWithdrawalReason)
+        }
     }
 
     func testAdmissionClientRejectsNonClosedOrInvalidStatusEnvelope() async throws {
@@ -485,6 +677,24 @@ private func byomAdmissionRequestBody(_ request: URLRequest) -> Data? {
         data.append(buffer, count: count)
     }
     return data
+}
+
+private final class BYOMAdmissionRequestRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var requests: [URLRequest] = []
+
+    var count: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return requests.count
+    }
+
+    func record(_ request: URLRequest) -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        requests.append(request)
+        return requests.count
+    }
 }
 
 private final class BYOMAdmissionMockURLProtocol: URLProtocol {

--- a/phase4-coordinator/internal/ws/model_admission.go
+++ b/phase4-coordinator/internal/ws/model_admission.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -24,16 +25,22 @@ import (
 )
 
 const (
-	modelAdmissionOfferSubmitSchema = "model_admission_offer_submit.v1"
-	modelAdmissionStatusSchema      = "model_admission_status.v1"
-	modelAdmissionSignedDomain      = "macprovider.model_admission.offer.v1"
-	modelAdmissionOfferSubmitted    = "offer_submitted"
-	modelAdmissionNotOffered        = "not_offered"
-	modelAdmissionActorProvider     = "provider"
-	modelAdmissionMaxBodyBytes      = 64 * 1024
-	modelAdmissionMaxEvents         = 256
-	modelAdmissionMaxCandidates     = 64
-	modelAdmissionMaxClockSkew      = 5 * time.Minute
+	modelAdmissionOfferSubmitSchema      = "model_admission_offer_submit.v1"
+	modelAdmissionStatusSchema           = "model_admission_status.v1"
+	modelAdmissionWithdrawRequestSchema  = "model_admission_withdraw_request.v1"
+	modelAdmissionWithdrawResponseSchema = "model_admission_withdraw.v1"
+	modelAdmissionOfferDomain            = "macprovider.model_admission.offer.v1"
+	modelAdmissionWithdrawDomain         = "macprovider.model_admission.withdraw.v1"
+	modelAdmissionOfferSubmitted         = "offer_submitted"
+	modelAdmissionNotOffered             = "not_offered"
+	modelAdmissionWithdrawn              = "withdrawn"
+	modelAdmissionRevoked                = "revoked"
+	modelAdmissionActorProvider          = "provider"
+	modelAdmissionActorCoordinator       = "coordinator"
+	modelAdmissionMaxBodyBytes           = 64 * 1024
+	modelAdmissionMaxEvents              = 256
+	modelAdmissionMaxCandidates          = 64
+	modelAdmissionMaxClockSkew           = 5 * time.Minute
 )
 
 var (
@@ -47,6 +54,8 @@ var (
 
 type ModelAdmissionStore interface {
 	AppendModelAdmissionOffer(context.Context, ModelAdmissionEvent) (ModelAdmissionEvent, bool, error)
+	AppendModelAdmissionWithdrawal(context.Context, ModelAdmissionEvent) (ModelAdmissionEvent, bool, error)
+	AppendModelAdmissionDecision(context.Context, ModelAdmissionEvent) (ModelAdmissionEvent, error)
 	LatestModelAdmissionStatus(context.Context, string, string) (ModelAdmissionEvent, bool, error)
 }
 
@@ -92,6 +101,19 @@ func NewMemoryModelAdmissionStore() ModelAdmissionStore {
 }
 
 func (s *memoryModelAdmissionStore) AppendModelAdmissionOffer(_ context.Context, event ModelAdmissionEvent) (ModelAdmissionEvent, bool, error) {
+	return s.appendProviderModelAdmissionEvent(event, modelAdmissionOfferSubmitted)
+}
+
+func (s *memoryModelAdmissionStore) AppendModelAdmissionWithdrawal(_ context.Context, event ModelAdmissionEvent) (ModelAdmissionEvent, bool, error) {
+	return s.appendProviderModelAdmissionEvent(event, modelAdmissionWithdrawn)
+}
+
+func (s *memoryModelAdmissionStore) AppendModelAdmissionDecision(_ context.Context, event ModelAdmissionEvent) (ModelAdmissionEvent, error) {
+	stored, _, err := s.appendCoordinatorModelAdmissionEvent(event)
+	return stored, err
+}
+
+func (s *memoryModelAdmissionStore) appendProviderModelAdmissionEvent(event ModelAdmissionEvent, nextState string) (ModelAdmissionEvent, bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	now := event.CreatedAt
@@ -129,16 +151,61 @@ func (s *memoryModelAdmissionStore) AppendModelAdmissionOffer(_ context.Context,
 		if !sameModelAdmissionTuple(previous, event) {
 			return ModelAdmissionEvent{}, false, errModelAdmissionReplayConflict
 		}
+		if nextState == modelAdmissionWithdrawn {
+			event = modelAdmissionEventWithPriorEvidence(event, previous)
+		}
 		if modelAdmissionRequiresRefreshedEvidence(previousState) && !modelAdmissionEvidenceRefreshed(previous, event) {
 			return ModelAdmissionEvent{}, false, errModelAdmissionReplayConflict
 		}
 	}
-	if !modelAdmissionCanSubmitOffer(previousState) {
+	if !modelAdmissionProviderTransitionAllowed(previousState, nextState) {
 		return ModelAdmissionEvent{}, false, errModelAdmissionReplayConflict
 	}
-	event = prepareModelAdmissionTransition(event, previousState)
+	event = prepareModelAdmissionTransition(event, previousState, modelAdmissionActorProvider, nextState)
 	candidateSet[event.CandidateID] = struct{}{}
 	s.providerEvent[event.ProviderID] = append(window, now)
+	s.events = append(s.events, event)
+	s.latest[event.ProviderID+"|"+event.CandidateID] = event
+	s.requestIDs[event.ProviderID+"|"+event.RequestID] = event
+	s.nonces[event.ProviderID+"|"+event.Nonce] = event
+	return event, false, nil
+}
+
+func (s *memoryModelAdmissionStore) appendCoordinatorModelAdmissionEvent(event ModelAdmissionEvent) (ModelAdmissionEvent, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := event.CreatedAt
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	event.CreatedAt = now.UTC()
+	previous, ok := s.latest[event.ProviderID+"|"+event.CandidateID]
+	if !ok || !sameModelAdmissionTuple(previous, event) {
+		return ModelAdmissionEvent{}, false, errModelAdmissionReplayConflict
+	}
+	if !modelAdmissionCoordinatorTransitionAllowed(previous.State, event.State) {
+		return ModelAdmissionEvent{}, false, errModelAdmissionReplayConflict
+	}
+	if modelAdmissionTransitionRequiresCatalogKey(event.State) && strings.TrimSpace(event.CatalogModelKey) == "" {
+		return ModelAdmissionEvent{}, false, errModelAdmissionReplayConflict
+	}
+	if modelAdmissionTransitionReasonRequired(previous.State, event.State) && strings.TrimSpace(event.ReasonCode) == "" {
+		return ModelAdmissionEvent{}, false, errModelAdmissionReplayConflict
+	}
+	event = fillCoordinatorModelAdmissionReplayKeys(event, previous.State)
+	if existing, ok := s.requestIDs[event.ProviderID+"|"+event.RequestID]; ok {
+		if existing.PayloadDigestSHA256 == event.PayloadDigestSHA256 {
+			return existing, true, nil
+		}
+		return ModelAdmissionEvent{}, false, errModelAdmissionReplayConflict
+	}
+	if existing, ok := s.nonces[event.ProviderID+"|"+event.Nonce]; ok {
+		if existing.PayloadDigestSHA256 == event.PayloadDigestSHA256 {
+			return existing, true, nil
+		}
+		return ModelAdmissionEvent{}, false, errModelAdmissionReplayConflict
+	}
+	event = prepareModelAdmissionTransition(event, previous.State, modelAdmissionActorCoordinator, event.State)
 	s.events = append(s.events, event)
 	s.latest[event.ProviderID+"|"+event.CandidateID] = event
 	s.requestIDs[event.ProviderID+"|"+event.RequestID] = event
@@ -199,6 +266,19 @@ ON model_admission_events(provider_id, nonce)`); err != nil {
 }
 
 func (s *SQLiteModelAdmissionStore) AppendModelAdmissionOffer(ctx context.Context, event ModelAdmissionEvent) (ModelAdmissionEvent, bool, error) {
+	return s.appendProviderModelAdmissionEvent(ctx, event, modelAdmissionOfferSubmitted)
+}
+
+func (s *SQLiteModelAdmissionStore) AppendModelAdmissionWithdrawal(ctx context.Context, event ModelAdmissionEvent) (ModelAdmissionEvent, bool, error) {
+	return s.appendProviderModelAdmissionEvent(ctx, event, modelAdmissionWithdrawn)
+}
+
+func (s *SQLiteModelAdmissionStore) AppendModelAdmissionDecision(ctx context.Context, event ModelAdmissionEvent) (ModelAdmissionEvent, error) {
+	stored, _, err := s.appendCoordinatorModelAdmissionEvent(ctx, event)
+	return stored, err
+}
+
+func (s *SQLiteModelAdmissionStore) appendProviderModelAdmissionEvent(ctx context.Context, event ModelAdmissionEvent, nextState string) (ModelAdmissionEvent, bool, error) {
 	now := event.CreatedAt
 	if now.IsZero() {
 		now = time.Now().UTC()
@@ -256,14 +336,99 @@ SELECT COUNT(DISTINCT candidate_id) FROM model_admission_events WHERE provider_i
 			if !sameModelAdmissionTuple(previous, event) {
 				return errModelAdmissionReplayConflict
 			}
+			if nextState == modelAdmissionWithdrawn {
+				event = modelAdmissionEventWithPriorEvidence(event, previous)
+			}
 			if modelAdmissionRequiresRefreshedEvidence(previousState) && !modelAdmissionEvidenceRefreshed(previous, event) {
 				return errModelAdmissionReplayConflict
 			}
 		}
-		if !modelAdmissionCanSubmitOffer(previousState) {
+		if !modelAdmissionProviderTransitionAllowed(previousState, nextState) {
 			return errModelAdmissionReplayConflict
 		}
-		event = prepareModelAdmissionTransition(event, previousState)
+		event = prepareModelAdmissionTransition(event, previousState, modelAdmissionActorProvider, nextState)
+		if _, err := conn.ExecContext(txCtx, `
+INSERT INTO model_admission_events(
+    provider_id, candidate_id, served_model_ref, catalog_model_key,
+    discovery_digest_sha256, evaluation_digest_sha256, requested_disclosure_class,
+    previous_state, state, next_state, actor, coordinator_event_id,
+    reason_code, request_id, nonce, payload_digest_sha256,
+    signature_digest_sha256, created_at_utc
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			event.ProviderID,
+			event.CandidateID,
+			event.ServedModelRef,
+			event.CatalogModelKey,
+			event.DiscoveryDigestSHA256,
+			event.EvaluationDigestSHA256,
+			event.RequestedDisclosureClass,
+			event.PreviousState,
+			event.State,
+			event.NextState,
+			event.Actor,
+			event.CoordinatorEventID,
+			event.ReasonCode,
+			event.RequestID,
+			event.Nonce,
+			event.PayloadDigestSHA256,
+			event.SignatureDigestSHA256,
+			event.CreatedAt.Format(time.RFC3339Nano),
+		); err != nil {
+			return err
+		}
+		stored = event
+		return nil
+	})
+	return stored, replay, err
+}
+
+func (s *SQLiteModelAdmissionStore) appendCoordinatorModelAdmissionEvent(ctx context.Context, event ModelAdmissionEvent) (ModelAdmissionEvent, bool, error) {
+	now := event.CreatedAt
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	event.CreatedAt = now.UTC()
+	var stored ModelAdmissionEvent
+	var replay bool
+	err := sqliteutil.Transact(ctx, s.db, func(txCtx context.Context, conn *sql.Conn) error {
+		previous, found, err := scanModelAdmissionEvent(txCtx, conn, modelAdmissionEventSelect(`
+  FROM model_admission_events
+ WHERE provider_id = ? AND candidate_id = ?
+ ORDER BY id DESC
+ LIMIT 1`), event.ProviderID, event.CandidateID)
+		if err != nil {
+			return err
+		}
+		if !found || !sameModelAdmissionTuple(previous, event) {
+			return errModelAdmissionReplayConflict
+		}
+		if !modelAdmissionCoordinatorTransitionAllowed(previous.State, event.State) {
+			return errModelAdmissionReplayConflict
+		}
+		if modelAdmissionTransitionRequiresCatalogKey(event.State) && strings.TrimSpace(event.CatalogModelKey) == "" {
+			return errModelAdmissionReplayConflict
+		}
+		if modelAdmissionTransitionReasonRequired(previous.State, event.State) && strings.TrimSpace(event.ReasonCode) == "" {
+			return errModelAdmissionReplayConflict
+		}
+		event = fillCoordinatorModelAdmissionReplayKeys(event, previous.State)
+		existing, found, err := scanModelAdmissionEvent(txCtx, conn, modelAdmissionEventSelect(`
+  FROM model_admission_events
+ WHERE provider_id = ? AND (request_id = ? OR nonce = ?)
+ ORDER BY id DESC
+ LIMIT 1`), event.ProviderID, event.RequestID, event.Nonce)
+		if err != nil {
+			return err
+		}
+		if found {
+			if existing.PayloadDigestSHA256 == event.PayloadDigestSHA256 {
+				stored = existing
+				replay = true
+				return nil
+			}
+			return errModelAdmissionReplayConflict
+		}
+		event = prepareModelAdmissionTransition(event, previous.State, modelAdmissionActorCoordinator, event.State)
 		if _, err := conn.ExecContext(txCtx, `
 INSERT INTO model_admission_events(
     provider_id, candidate_id, served_model_ref, catalog_model_key,
@@ -355,19 +520,65 @@ func modelAdmissionEventSelect(tail string) string {
        signature_digest_sha256, created_at_utc` + tail
 }
 
-func modelAdmissionCanSubmitOffer(previousState string) bool {
-	switch previousState {
-	case modelAdmissionNotOffered, "offer_rejected", "withdrawn", "revoked":
-		return true
+func modelAdmissionProviderTransitionAllowed(previousState, nextState string) bool {
+	switch nextState {
+	case modelAdmissionOfferSubmitted:
+		switch previousState {
+		case modelAdmissionNotOffered, "offer_rejected", modelAdmissionWithdrawn, modelAdmissionRevoked:
+			return true
+		default:
+			return false
+		}
+	case modelAdmissionWithdrawn:
+		return modelAdmissionAllowedNextState(previousState, modelAdmissionWithdrawn)
 	default:
 		return false
 	}
+}
+
+func modelAdmissionCoordinatorTransitionAllowed(previousState, nextState string) bool {
+	if nextState == modelAdmissionWithdrawn || nextState == modelAdmissionOfferSubmitted {
+		return false
+	}
+	return modelAdmissionAllowedNextState(previousState, nextState)
+}
+
+func modelAdmissionAllowedNextState(previousState, nextState string) bool {
+	for _, allowed := range modelAdmissionAllowedNextStates(previousState) {
+		if allowed == nextState {
+			return true
+		}
+	}
+	return false
+}
+
+func modelAdmissionTransitionReasonRequired(previousState, nextState string) bool {
+	switch nextState {
+	case "offer_rejected", modelAdmissionWithdrawn, modelAdmissionRevoked:
+		return true
+	default:
+		return modelAdmissionDemotionRequiresReason(ModelAdmissionEvent{
+			PreviousState: previousState,
+			State:         nextState,
+		})
+	}
+}
+
+func modelAdmissionTransitionRequiresCatalogKey(nextState string) bool {
+	return nextState == "catalog_priced" || nextState == "settlement_capable"
 }
 
 func sameModelAdmissionTuple(previous, next ModelAdmissionEvent) bool {
 	return previous.CandidateID == next.CandidateID &&
 		previous.ServedModelRef == next.ServedModelRef &&
 		previous.CatalogModelKey == next.CatalogModelKey
+}
+
+func modelAdmissionEventWithPriorEvidence(event, previous ModelAdmissionEvent) ModelAdmissionEvent {
+	event.DiscoveryDigestSHA256 = previous.DiscoveryDigestSHA256
+	event.EvaluationDigestSHA256 = previous.EvaluationDigestSHA256
+	event.RequestedDisclosureClass = previous.RequestedDisclosureClass
+	return event
 }
 
 func modelAdmissionRequiresRefreshedEvidence(previousState string) bool {
@@ -384,11 +595,13 @@ func modelAdmissionEvidenceRefreshed(previous, next ModelAdmissionEvent) bool {
 		previous.EvaluationDigestSHA256 != next.EvaluationDigestSHA256
 }
 
-func prepareModelAdmissionTransition(event ModelAdmissionEvent, previousState string) ModelAdmissionEvent {
-	event.Actor = modelAdmissionActorProvider
+func prepareModelAdmissionTransition(event ModelAdmissionEvent, previousState, actor, nextState string) ModelAdmissionEvent {
+	event.Actor = actor
 	event.PreviousState = previousState
-	event.NextState = modelAdmissionOfferSubmitted
+	event.State = nextState
+	event.NextState = nextState
 	sum := sha256.Sum256([]byte(strings.Join([]string{
+		event.Actor,
 		event.ProviderID,
 		event.CandidateID,
 		event.RequestID,
@@ -399,6 +612,103 @@ func prepareModelAdmissionTransition(event ModelAdmissionEvent, previousState st
 	}, "\x00")))
 	event.CoordinatorEventID = hex.EncodeToString(sum[:])
 	return event
+}
+
+func fillCoordinatorModelAdmissionReplayKeys(event ModelAdmissionEvent, previousState string) ModelAdmissionEvent {
+	if event.RequestID != "" && event.Nonce != "" {
+		return event
+	}
+	sum := sha256.Sum256([]byte(strings.Join([]string{
+		event.ProviderID,
+		event.CandidateID,
+		event.ServedModelRef,
+		event.CatalogModelKey,
+		previousState,
+		event.State,
+		event.ReasonCode,
+		event.PayloadDigestSHA256,
+		event.CreatedAt.UTC().Format(time.RFC3339Nano),
+	}, "\x00")))
+	digest := hex.EncodeToString(sum[:32])
+	if event.RequestID == "" {
+		event.RequestID = "coordinator_" + event.State + "_" + digest[:32]
+	}
+	if event.Nonce == "" {
+		event.Nonce = "coordinator_nonce_" + event.State + "_" + digest[:32]
+	}
+	return event
+}
+
+func ModelAdmissionSettlementStateCandidate(event ModelAdmissionEvent) bool {
+	return event.State == "settlement_capable" &&
+		event.ProviderID != "" &&
+		event.CandidateID != "" &&
+		event.ServedModelRef != "" &&
+		event.CatalogModelKey != "" &&
+		event.CoordinatorEventID != ""
+}
+
+type ModelAdmissionPaidRoutingPredicate struct {
+	ProviderID             string
+	CandidateID            string
+	ServedModelRef         string
+	CatalogModelKey        string
+	DiscoveryDigestSHA256  string
+	EvaluationDigestSHA256 string
+}
+
+func ModelAdmissionDefaultPaidRoutingEligible(ModelAdmissionEvent, ModelAdmissionPaidRoutingPredicate) bool {
+	// SPEC-047 #1254 is the withdrawal/revocation gate, not the positive
+	// economics gate. Until the SPEC-022 route-snapshot and signed-catalog
+	// authority are wired by the later settlement slices, BYOM remains excluded
+	// from default paid routing even if the coordinator records a
+	// settlement_capable admission state.
+	return false
+}
+
+func ModelAdmissionRevocationForRuntimeDrift(current ModelAdmissionEvent, predicate ModelAdmissionPaidRoutingPredicate, reasonCode string, now time.Time) (ModelAdmissionEvent, bool) {
+	if modelAdmissionRuntimePredicateMatches(current, predicate) {
+		return ModelAdmissionEvent{}, false
+	}
+	reasonCode = strings.TrimSpace(reasonCode)
+	if reasonCode == "" {
+		return ModelAdmissionEvent{}, false
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	sum := sha256.Sum256([]byte(strings.Join([]string{
+		current.ProviderID,
+		current.CandidateID,
+		current.State,
+		predicate.ProviderID,
+		predicate.CandidateID,
+		predicate.ServedModelRef,
+		predicate.CatalogModelKey,
+		predicate.DiscoveryDigestSHA256,
+		predicate.EvaluationDigestSHA256,
+		reasonCode,
+		now.UTC().Format(time.RFC3339Nano),
+	}, "\x00")))
+	digest := hex.EncodeToString(sum[:])
+	event := current
+	event.State = modelAdmissionRevoked
+	event.ReasonCode = reasonCode
+	event.RequestID = "coordinator_revoke_" + digest[:32]
+	event.Nonce = "coordinator_revoke_nonce_" + digest[:32]
+	event.PayloadDigestSHA256 = digest
+	event.SignatureDigestSHA256 = ""
+	event.CreatedAt = now.UTC()
+	return event, true
+}
+
+func modelAdmissionRuntimePredicateMatches(event ModelAdmissionEvent, predicate ModelAdmissionPaidRoutingPredicate) bool {
+	return event.ProviderID == predicate.ProviderID &&
+		event.CandidateID == predicate.CandidateID &&
+		event.ServedModelRef == predicate.ServedModelRef &&
+		event.CatalogModelKey == predicate.CatalogModelKey &&
+		event.DiscoveryDigestSHA256 == predicate.DiscoveryDigestSHA256 &&
+		event.EvaluationDigestSHA256 == predicate.EvaluationDigestSHA256
 }
 
 func (s *Server) handleProviderModelAdmissionOffer(w http.ResponseWriter, r *http.Request) {
@@ -454,6 +764,57 @@ func (s *Server) handleProviderModelAdmissionOffer(w http.ResponseWriter, r *htt
 		return
 	}
 	writeJSON(w, http.StatusOK, s.modelAdmissionStatusResponseFromEvent(stored, replay))
+}
+
+func (s *Server) handleProviderModelAdmissionWithdrawal(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	providerID, ok := s.authenticateProviderReadOnly(w, r)
+	if !ok {
+		return
+	}
+	if !s.allowModelAdmissionAttempt(providerID) {
+		writeJSON(w, http.StatusTooManyRequests, modelAdmissionError("rate_limited", "model admission withdrawal rejected"))
+		return
+	}
+	var body modelAdmissionWithdrawRequest
+	r.Body = http.MaxBytesReader(w, r.Body, modelAdmissionMaxBodyBytes+1)
+	if err := decodeStrictJSON(r.Body, &body); err != nil {
+		writeJSON(w, http.StatusBadRequest, modelAdmissionError("invalid_json", "invalid model admission withdrawal package"))
+		return
+	}
+	event, err := s.verifyModelAdmissionWithdrawal(r.Context(), providerID, body)
+	if err != nil {
+		status := http.StatusBadRequest
+		code := "invalid_withdrawal"
+		switch {
+		case errors.Is(err, errModelAdmissionRateLimited):
+			status, code = http.StatusTooManyRequests, "rate_limited"
+		case errors.Is(err, errModelAdmissionReplayConflict):
+			status, code = http.StatusConflict, "replay_conflict"
+		case errors.Is(err, errModelAdmissionUnauthorized):
+			status, code = http.StatusUnauthorized, "unauthorized"
+		}
+		writeJSON(w, status, modelAdmissionError(code, "model admission withdrawal rejected"))
+		return
+	}
+	stored, replay, err := s.modelAdmissions.AppendModelAdmissionWithdrawal(r.Context(), event)
+	if err != nil {
+		status := http.StatusInternalServerError
+		code := "model_admission_store_error"
+		switch {
+		case errors.Is(err, errModelAdmissionRateLimited):
+			status, code = http.StatusTooManyRequests, "rate_limited"
+		case errors.Is(err, errModelAdmissionReplayConflict):
+			status, code = http.StatusConflict, "replay_conflict"
+		}
+		writeJSON(w, status, modelAdmissionError(code, "model admission withdrawal rejected"))
+		return
+	}
+	writeJSON(w, http.StatusOK, s.modelAdmissionWithdrawalResponseFromEvent(stored, replay))
 }
 
 func (s *Server) handleProviderModelAdmissionStatus(w http.ResponseWriter, r *http.Request) {
@@ -527,7 +888,7 @@ func (s *Server) verifyModelAdmissionOffer(ctx context.Context, authenticatedPro
 	if body.Schema != modelAdmissionOfferSubmitSchema {
 		return ModelAdmissionEvent{}, fmt.Errorf("invalid schema")
 	}
-	if body.SignatureDomain != modelAdmissionSignedDomain || body.ProviderID != authenticatedProviderID {
+	if body.SignatureDomain != modelAdmissionOfferDomain || body.ProviderID != authenticatedProviderID {
 		return ModelAdmissionEvent{}, errModelAdmissionUnauthorized
 	}
 	if err := validateModelAdmissionPayload(body); err != nil {
@@ -580,6 +941,66 @@ func (s *Server) verifyModelAdmissionOffer(ctx context.Context, authenticatedPro
 		PayloadDigestSHA256:      hex.EncodeToString(payloadDigest[:]),
 		SignatureDigestSHA256:    hex.EncodeToString(signatureDigest[:]),
 		CreatedAt:                now,
+	}, nil
+}
+
+func (s *Server) verifyModelAdmissionWithdrawal(ctx context.Context, authenticatedProviderID string, body modelAdmissionWithdrawRequest) (ModelAdmissionEvent, error) {
+	if s.providerModelAdmissionSanctioned(authenticatedProviderID) {
+		return ModelAdmissionEvent{}, errModelAdmissionUnauthorized
+	}
+	if body.Schema != modelAdmissionWithdrawRequestSchema {
+		return ModelAdmissionEvent{}, fmt.Errorf("invalid schema")
+	}
+	if body.SignatureDomain != modelAdmissionWithdrawDomain || body.ProviderID != authenticatedProviderID {
+		return ModelAdmissionEvent{}, errModelAdmissionUnauthorized
+	}
+	if err := validateModelAdmissionWithdrawalPayload(body); err != nil {
+		return ModelAdmissionEvent{}, err
+	}
+	if body.SignatureAlgorithm != "ed25519" {
+		return ModelAdmissionEvent{}, fmt.Errorf("invalid signature algorithm")
+	}
+	signature, err := base64.StdEncoding.DecodeString(body.ProviderSignature)
+	if err != nil || len(signature) != ed25519.SignatureSize {
+		return ModelAdmissionEvent{}, fmt.Errorf("invalid signature")
+	}
+	activePubkey, found, blocked := s.durableIdentitySignaturePubkey(ctx, authenticatedProviderID)
+	if blocked || !found {
+		return ModelAdmissionEvent{}, errModelAdmissionUnauthorized
+	}
+	pubkeyDigest := sha256.Sum256(activePubkey)
+	if body.SigningKeyDigest != hex.EncodeToString(pubkeyDigest[:]) {
+		return ModelAdmissionEvent{}, errModelAdmissionUnauthorized
+	}
+	canonical, err := billing.CanonicalJSON(body.canonicalMap())
+	if err != nil {
+		return ModelAdmissionEvent{}, err
+	}
+	if !ed25519.Verify(ed25519.PublicKey(activePubkey), canonical, signature) {
+		return ModelAdmissionEvent{}, errModelAdmissionUnauthorized
+	}
+	payloadDigest := sha256.Sum256(canonical)
+	signatureDigest := sha256.Sum256(signature)
+	signedAt, err := time.Parse(time.RFC3339Nano, body.Timestamp)
+	if err != nil {
+		return ModelAdmissionEvent{}, fmt.Errorf("invalid timestamp")
+	}
+	now := s.now().UTC()
+	if signedAt.Before(now.Add(-modelAdmissionMaxClockSkew)) || signedAt.After(now.Add(modelAdmissionMaxClockSkew)) {
+		return ModelAdmissionEvent{}, fmt.Errorf("invalid timestamp")
+	}
+	return ModelAdmissionEvent{
+		ProviderID:            body.ProviderID,
+		CandidateID:           body.CandidateID,
+		ServedModelRef:        body.ServedModelRef,
+		CatalogModelKey:       modelAdmissionNullableStringValue(body.CatalogModelKey.Value),
+		State:                 modelAdmissionWithdrawn,
+		ReasonCode:            body.ReasonCode,
+		RequestID:             body.IdempotencyKey,
+		Nonce:                 body.Nonce,
+		PayloadDigestSHA256:   hex.EncodeToString(payloadDigest[:]),
+		SignatureDigestSHA256: hex.EncodeToString(signatureDigest[:]),
+		CreatedAt:             now,
 	}, nil
 }
 
@@ -636,6 +1057,60 @@ type modelAdmissionOfferSubmitRequest struct {
 	SignatureAlgorithm       string                              `json:"signature_algorithm"`
 	ProviderSignature        string                              `json:"provider_signature"`
 	CLIVersion               string                              `json:"cli_version"`
+}
+
+type modelAdmissionWithdrawRequest struct {
+	Schema             string                       `json:"schema"`
+	GeneratedAt        string                       `json:"generated_at"`
+	CLIVersion         string                       `json:"cli_version"`
+	SignatureDomain    string                       `json:"signature_domain"`
+	ProviderID         string                       `json:"provider_id"`
+	CandidateID        string                       `json:"candidate_id"`
+	ServedModelRef     string                       `json:"served_model_ref"`
+	CatalogModelKey    modelAdmissionNullableString `json:"catalog_model_key"`
+	IdempotencyKey     string                       `json:"idempotency_key"`
+	Nonce              string                       `json:"nonce"`
+	Timestamp          string                       `json:"timestamp"`
+	ReasonCode         string                       `json:"reason_code"`
+	SigningKeyDigest   string                       `json:"signing_key_digest"`
+	SignatureAlgorithm string                       `json:"signature_algorithm"`
+	ProviderSignature  string                       `json:"provider_signature"`
+}
+
+func (p modelAdmissionWithdrawRequest) canonicalMap() map[string]any {
+	return map[string]any{
+		"signature_domain":   p.SignatureDomain,
+		"provider_id":        p.ProviderID,
+		"candidate_id":       p.CandidateID,
+		"served_model_ref":   p.ServedModelRef,
+		"catalog_model_key":  modelAdmissionStringOrNull(p.CatalogModelKey.Value),
+		"idempotency_key":    p.IdempotencyKey,
+		"nonce":              p.Nonce,
+		"timestamp":          p.Timestamp,
+		"reason_code":        p.ReasonCode,
+		"signing_key_digest": p.SigningKeyDigest,
+		"cli_version":        p.CLIVersion,
+	}
+}
+
+type modelAdmissionNullableString struct {
+	Value   *string
+	Present bool
+}
+
+func (v *modelAdmissionNullableString) UnmarshalJSON(data []byte) error {
+	v.Present = true
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "null" {
+		v.Value = nil
+		return nil
+	}
+	var value string
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	v.Value = &value
+	return nil
 }
 
 func (p modelAdmissionOfferSubmitRequest) canonicalMap() map[string]any {
@@ -809,6 +1284,54 @@ func validateModelAdmissionPayload(payload modelAdmissionOfferSubmitRequest) err
 	return nil
 }
 
+func validateModelAdmissionWithdrawalPayload(payload modelAdmissionWithdrawRequest) error {
+	if err := config.ValidateProviderID(payload.ProviderID); err != nil {
+		return err
+	}
+	if !validModelAdmissionCandidateID(payload.CandidateID) {
+		return fmt.Errorf("invalid candidate_id")
+	}
+	values := []string{
+		payload.Nonce,
+		payload.IdempotencyKey,
+		payload.ReasonCode,
+		payload.SigningKeyDigest,
+	}
+	for _, value := range values {
+		if unsafeModelAdmissionMaterial(value) {
+			return fmt.Errorf("unsafe model admission material")
+		}
+	}
+	if !validModelAdmissionServedModelRef(payload.ServedModelRef) {
+		return fmt.Errorf("invalid served_model_ref")
+	}
+	if !payload.CatalogModelKey.Present {
+		return fmt.Errorf("missing catalog_model_key")
+	}
+	if payload.CatalogModelKey.Value != nil && (len(*payload.CatalogModelKey.Value) > 128 || unsafeModelAdmissionMaterial(*payload.CatalogModelKey.Value)) {
+		return fmt.Errorf("invalid catalog_model_key")
+	}
+	if !validModelAdmissionWithdrawReason(payload.ReasonCode) {
+		return fmt.Errorf("invalid reason_code")
+	}
+	if !validModelAdmissionToken(payload.Nonce) || !validModelAdmissionToken(payload.IdempotencyKey) {
+		return fmt.Errorf("invalid replay key")
+	}
+	if !validModelAdmissionSHA256Hex(payload.SigningKeyDigest) {
+		return fmt.Errorf("invalid signing key digest")
+	}
+	if !validModelAdmissionCLIVersion(payload.CLIVersion) {
+		return fmt.Errorf("invalid cli_version")
+	}
+	if _, err := time.Parse(time.RFC3339Nano, payload.GeneratedAt); err != nil {
+		return fmt.Errorf("invalid generated_at")
+	}
+	if _, err := time.Parse(time.RFC3339Nano, payload.Timestamp); err != nil {
+		return fmt.Errorf("invalid timestamp")
+	}
+	return nil
+}
+
 func (s *Server) modelAdmissionStatusResponseFromEvent(event ModelAdmissionEvent, _ bool) map[string]any {
 	return map[string]any{
 		"schema":                 modelAdmissionStatusSchema,
@@ -825,6 +1348,26 @@ func (s *Server) modelAdmissionStatusResponseFromEvent(event ModelAdmissionEvent
 		"provider_guidance":      modelAdmissionProviderGuidance(event),
 		"allowed_next_states":    modelAdmissionAllowedNextStates(event.State),
 		"warnings":               []string{},
+	}
+}
+
+func (s *Server) modelAdmissionWithdrawalResponseFromEvent(event ModelAdmissionEvent, _ bool) map[string]any {
+	return map[string]any{
+		"schema":                    modelAdmissionWithdrawResponseSchema,
+		"generated_at":              s.now().UTC().Format(time.RFC3339Nano),
+		"cli_version":               s.version,
+		"provider_id":               event.ProviderID,
+		"candidate_id":              event.CandidateID,
+		"served_model_ref":          event.ServedModelRef,
+		"catalog_model_key":         nullString(event.CatalogModelKey),
+		"idempotency_key":           event.RequestID,
+		"reason_code":               event.ReasonCode,
+		"previous_admission_state":  event.PreviousState,
+		"coordinator_event_id":      event.CoordinatorEventID,
+		"accepted_at":               event.CreatedAt.UTC().Format(time.RFC3339Nano),
+		"resulting_admission_state": event.State,
+		"provider_guidance":         modelAdmissionProviderGuidance(event),
+		"warnings":                  []string{},
 	}
 }
 
@@ -927,6 +1470,15 @@ func validModelAdmissionToken(value string) bool {
 func validModelAdmissionRuntimeSource(value string) bool {
 	switch value {
 	case "mlx_cache", "ollama_loopback":
+		return true
+	default:
+		return false
+	}
+}
+
+func validModelAdmissionWithdrawReason(value string) bool {
+	switch value {
+	case "provider_requested", "wrong_model", "runtime_unavailable", "identity_mismatch", "policy_uncertain", "other_operator_reason":
 		return true
 	default:
 		return false
@@ -1096,4 +1648,11 @@ func nullString(value string) any {
 		return nil
 	}
 	return value
+}
+
+func modelAdmissionNullableStringValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
 }

--- a/phase4-coordinator/internal/ws/model_admission_test.go
+++ b/phase4-coordinator/internal/ws/model_admission_test.go
@@ -66,6 +66,120 @@ func TestModelAdmissionOfferSubmitAndStatusStayNonEarning(t *testing.T) {
 	}
 }
 
+func TestModelAdmissionWithdrawalSubmitReplayConflictAndStatus(t *testing.T) {
+	h, bearer, priv := newModelAdmissionHarness(t, "provider-byom-a")
+	defer h.HTTP.Close()
+
+	candidateID := stableModelAdmissionCandidateID("z")
+	offer := signedModelAdmissionOffer(t, "provider-byom-a", candidateID, "ollama:qwen3-8b", priv, nil)
+	if status, body := postModelAdmissionOffer(t, h.HTTP.URL, bearer, offer); status != http.StatusOK {
+		t.Fatalf("offer status=%d body=%s", status, body)
+	}
+	withdrawal := signedModelAdmissionWithdrawal(t, "provider-byom-a", candidateID, "ollama:qwen3-8b", priv, map[string]any{
+		"idempotency_key": "withdraw_request_replay",
+		"nonce":           "withdraw_nonce_replay",
+		"reason_code":     "provider_requested",
+	})
+	status, body := postModelAdmissionWithdrawal(t, h.HTTP.URL, bearer, withdrawal)
+	if status != http.StatusOK {
+		t.Fatalf("withdraw status=%d body=%s", status, body)
+	}
+	object := decodeMap(t, body)
+	if object["schema"] != "model_admission_withdraw.v1" ||
+		object["previous_admission_state"] != "offer_submitted" ||
+		object["resulting_admission_state"] != "withdrawn" ||
+		object["reason_code"] != "provider_requested" ||
+		object["coordinator_event_id"] == "" {
+		t.Fatalf("unexpected withdrawal response: %#v", object)
+	}
+	guidance := object["provider_guidance"].(map[string]any)
+	if guidance["next_action"] != "submit_offer" ||
+		guidance["transition_reason_code"] != "provider_requested" ||
+		guidance["earning_path_class"] != "no_earning_path_in_v0_1" {
+		t.Fatalf("unexpected withdrawal guidance: %#v", guidance)
+	}
+	firstEventID := object["coordinator_event_id"]
+	status, body = postModelAdmissionWithdrawal(t, h.HTTP.URL, bearer, withdrawal)
+	if status != http.StatusOK {
+		t.Fatalf("withdraw replay status=%d body=%s", status, body)
+	}
+	if decodeMap(t, body)["coordinator_event_id"] != firstEventID {
+		t.Fatalf("idempotent withdrawal appended new event: %s", body)
+	}
+	conflict := signedModelAdmissionWithdrawal(t, "provider-byom-a", candidateID, "ollama:qwen3-8b", priv, map[string]any{
+		"idempotency_key": "withdraw_request_replay",
+		"nonce":           "withdraw_nonce_replay",
+		"reason_code":     "wrong_model",
+	})
+	if status, _ := postModelAdmissionWithdrawal(t, h.HTTP.URL, bearer, conflict); status != http.StatusConflict {
+		t.Fatalf("conflicting withdrawal status=%d, want 409", status)
+	}
+	status, body = getModelAdmissionStatus(t, h.HTTP.URL, bearer, candidateID)
+	if status != http.StatusOK {
+		t.Fatalf("withdrawn status readback=%d body=%s", status, body)
+	}
+	readback := decodeMap(t, body)
+	if readback["admission_state"] != "withdrawn" {
+		t.Fatalf("withdrawn status readback=%#v", readback)
+	}
+
+	sameEvidence := signedModelAdmissionOffer(t, "provider-byom-a", candidateID, "ollama:qwen3-8b", priv, map[string]any{
+		"idempotency_key": "request_reoffer_same_evidence",
+		"nonce":           "nonce_reoffer_same_evidence",
+	})
+	if status, _ := postModelAdmissionOffer(t, h.HTTP.URL, bearer, sameEvidence); status != http.StatusConflict {
+		t.Fatalf("same-evidence re-offer after withdrawal status=%d, want 409", status)
+	}
+	freshEvidence := signedModelAdmissionOffer(t, "provider-byom-a", candidateID, "ollama:qwen3-8b", priv, map[string]any{
+		"idempotency_key":            "request_reoffer_fresh_evidence",
+		"nonce":                      "nonce_reoffer_fresh_evidence",
+		"evaluation_digest_sha256":   stringsOf("e", 64),
+		"discovery_digest_sha256":    stringsOf("f", 64),
+		"requested_disclosure_class": "catalog_binding_requested",
+	})
+	if status, body := postModelAdmissionOffer(t, h.HTTP.URL, bearer, freshEvidence); status != http.StatusOK {
+		t.Fatalf("fresh-evidence re-offer after withdrawal status=%d body=%s", status, body)
+	}
+}
+
+func TestModelAdmissionWithdrawalRejectsInvalidTransitionAndTupleDrift(t *testing.T) {
+	h, bearer, priv := newModelAdmissionHarness(t, "provider-byom-a")
+	defer h.HTTP.Close()
+
+	noOffer := signedModelAdmissionWithdrawal(t, "provider-byom-a", stableModelAdmissionCandidateID("d"), "ollama:qwen3-8b", priv, nil)
+	if status, _ := postModelAdmissionWithdrawal(t, h.HTTP.URL, bearer, noOffer); status != http.StatusConflict {
+		t.Fatalf("withdraw without active offer status=%d, want 409", status)
+	}
+	candidateID := stableModelAdmissionCandidateID("e")
+	offer := signedModelAdmissionOffer(t, "provider-byom-a", candidateID, "ollama:qwen3-8b", priv, nil)
+	if status, body := postModelAdmissionOffer(t, h.HTTP.URL, bearer, offer); status != http.StatusOK {
+		t.Fatalf("offer status=%d body=%s", status, body)
+	}
+	drift := signedModelAdmissionWithdrawal(t, "provider-byom-a", candidateID, "ollama:different", priv, map[string]any{
+		"idempotency_key": "withdraw_request_drift",
+		"nonce":           "withdraw_nonce_drift",
+	})
+	if status, _ := postModelAdmissionWithdrawal(t, h.HTTP.URL, bearer, drift); status != http.StatusConflict {
+		t.Fatalf("tuple-drift withdrawal status=%d, want 409", status)
+	}
+	unknownField := signedModelAdmissionWithdrawal(t, "provider-byom-a", candidateID, "ollama:qwen3-8b", priv, map[string]any{
+		"idempotency_key": "withdraw_request_unknown",
+		"nonce":           "withdraw_nonce_unknown",
+	})
+	unknownField["previous_admission_state"] = "offer_submitted"
+	if status, _ := postModelAdmissionWithdrawal(t, h.HTTP.URL, bearer, unknownField); status != http.StatusBadRequest {
+		t.Fatalf("client-provided previous state status=%d, want 400", status)
+	}
+	missingNullableCatalog := signedModelAdmissionWithdrawal(t, "provider-byom-a", candidateID, "ollama:qwen3-8b", priv, map[string]any{
+		"idempotency_key": "withdraw_request_missing_catalog",
+		"nonce":           "withdraw_nonce_missing_catalog",
+	})
+	delete(missingNullableCatalog, "catalog_model_key")
+	if status, _ := postModelAdmissionWithdrawal(t, h.HTTP.URL, bearer, missingNullableCatalog); status != http.StatusBadRequest {
+		t.Fatalf("missing catalog_model_key status=%d, want 400", status)
+	}
+}
+
 func TestModelAdmissionStatusIsScopedByProviderAndCandidate(t *testing.T) {
 	store, err := auth.OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
 	if err != nil {
@@ -392,6 +506,129 @@ INSERT INTO model_admission_events(
 	}
 }
 
+func TestModelAdmissionDecisionStateMachineAndRoutingGate(t *testing.T) {
+	store := providerws.NewMemoryModelAdmissionStore()
+	offer := providerws.ModelAdmissionEvent{
+		ProviderID:               "provider-byom-a",
+		CandidateID:              stableModelAdmissionCandidateID("r"),
+		ServedModelRef:           "ollama:qwen3-8b",
+		CatalogModelKey:          "qwen3-8b",
+		DiscoveryDigestSHA256:    stringsOf("a", 64),
+		EvaluationDigestSHA256:   stringsOf("b", 64),
+		RequestedDisclosureClass: "catalog_binding_requested",
+		ReasonCode:               "provider_offer_submitted",
+		RequestID:                "request_offer_decision",
+		Nonce:                    "nonce_offer_decision",
+		PayloadDigestSHA256:      stringsOf("c", 64),
+		SignatureDigestSHA256:    stringsOf("d", 64),
+		CreatedAt:                time.Unix(1800000020, 0).UTC(),
+	}
+	submitted, replay, err := store.AppendModelAdmissionOffer(context.Background(), offer)
+	if err != nil || replay {
+		t.Fatalf("append offer replay=%v err=%v", replay, err)
+	}
+	if providerws.ModelAdmissionSettlementStateCandidate(submitted) {
+		t.Fatal("offer_submitted must not be a settlement-state candidate")
+	}
+
+	catalogPriced := submitted
+	catalogPriced.State = "catalog_priced"
+	catalogPriced.ReasonCode = ""
+	catalogPriced.RequestID = "request_catalog_priced"
+	catalogPriced.Nonce = "nonce_catalog_priced"
+	catalogPriced.PayloadDigestSHA256 = stringsOf("e", 64)
+	catalogPriced.CreatedAt = time.Unix(1800000030, 0).UTC()
+	catalogPriced, err = store.AppendModelAdmissionDecision(context.Background(), catalogPriced)
+	if err != nil {
+		t.Fatalf("catalog_priced decision failed: %v", err)
+	}
+	if providerws.ModelAdmissionSettlementStateCandidate(catalogPriced) {
+		t.Fatal("catalog_priced must not be a settlement-state candidate")
+	}
+
+	settlement := catalogPriced
+	settlement.State = "settlement_capable"
+	settlement.RequestID = "request_settlement_capable"
+	settlement.Nonce = "nonce_settlement_capable"
+	settlement.PayloadDigestSHA256 = stringsOf("f", 64)
+	settlement.CreatedAt = time.Unix(1800000040, 0).UTC()
+	settlement, err = store.AppendModelAdmissionDecision(context.Background(), settlement)
+	if err != nil {
+		t.Fatalf("settlement_capable decision failed: %v", err)
+	}
+	if !providerws.ModelAdmissionSettlementStateCandidate(settlement) {
+		t.Fatal("settlement_capable with catalog binding must pass the preliminary settlement-state predicate")
+	}
+	matching := providerws.ModelAdmissionPaidRoutingPredicate{
+		ProviderID:             settlement.ProviderID,
+		CandidateID:            settlement.CandidateID,
+		ServedModelRef:         settlement.ServedModelRef,
+		CatalogModelKey:        settlement.CatalogModelKey,
+		DiscoveryDigestSHA256:  settlement.DiscoveryDigestSHA256,
+		EvaluationDigestSHA256: settlement.EvaluationDigestSHA256,
+	}
+	if providerws.ModelAdmissionDefaultPaidRoutingEligible(settlement, matching) {
+		t.Fatal("settlement_capable remains default paid-routing excluded until SPEC-022/catalog authority is wired")
+	}
+	drifted := matching
+	drifted.ServedModelRef = "ollama:different"
+	if providerws.ModelAdmissionDefaultPaidRoutingEligible(settlement, drifted) {
+		t.Fatal("served-model drift must fail closed for default paid routing")
+	}
+	revocation, drift := providerws.ModelAdmissionRevocationForRuntimeDrift(settlement, drifted, "runtime_identity_drift", time.Unix(1800000050, 0).UTC())
+	if !drift {
+		t.Fatal("drifted route predicate did not create revocation event")
+	}
+	revoked, err := store.AppendModelAdmissionDecision(context.Background(), revocation)
+	if err != nil {
+		t.Fatalf("revocation decision failed: %v", err)
+	}
+	if revoked.State != "revoked" ||
+		providerws.ModelAdmissionSettlementStateCandidate(revoked) ||
+		providerws.ModelAdmissionDefaultPaidRoutingEligible(revoked, matching) {
+		t.Fatalf("revoked state leaked routing eligibility: %+v", revoked)
+	}
+}
+
+func TestModelAdmissionDecisionRejectsInvalidCatalogAndReasonTransitions(t *testing.T) {
+	store := providerws.NewMemoryModelAdmissionStore()
+	offer := providerws.ModelAdmissionEvent{
+		ProviderID:               "provider-byom-a",
+		CandidateID:              stableModelAdmissionCandidateID("v"),
+		ServedModelRef:           "ollama:qwen3-8b",
+		DiscoveryDigestSHA256:    stringsOf("a", 64),
+		EvaluationDigestSHA256:   stringsOf("b", 64),
+		RequestedDisclosureClass: "non_earning_provider_asserted",
+		ReasonCode:               "provider_offer_submitted",
+		RequestID:                "request_offer_invalid_decision",
+		Nonce:                    "nonce_offer_invalid_decision",
+		PayloadDigestSHA256:      stringsOf("c", 64),
+		SignatureDigestSHA256:    stringsOf("d", 64),
+		CreatedAt:                time.Unix(1800000060, 0).UTC(),
+	}
+	submitted, _, err := store.AppendModelAdmissionOffer(context.Background(), offer)
+	if err != nil {
+		t.Fatalf("append offer: %v", err)
+	}
+	withoutCatalog := submitted
+	withoutCatalog.State = "catalog_priced"
+	withoutCatalog.RequestID = "request_no_catalog"
+	withoutCatalog.Nonce = "nonce_no_catalog"
+	withoutCatalog.PayloadDigestSHA256 = stringsOf("e", 64)
+	if _, err := store.AppendModelAdmissionDecision(context.Background(), withoutCatalog); err == nil {
+		t.Fatal("catalog_priced transition without catalog binding succeeded")
+	}
+	rejectedWithoutReason := submitted
+	rejectedWithoutReason.State = "offer_rejected"
+	rejectedWithoutReason.RequestID = "request_reject_no_reason"
+	rejectedWithoutReason.Nonce = "nonce_reject_no_reason"
+	rejectedWithoutReason.PayloadDigestSHA256 = stringsOf("f", 64)
+	rejectedWithoutReason.ReasonCode = ""
+	if _, err := store.AppendModelAdmissionDecision(context.Background(), rejectedWithoutReason); err == nil {
+		t.Fatal("offer_rejected transition without reason succeeded")
+	}
+}
+
 func TestModelAdmissionStatusGuidanceForRejectedAndDemotion(t *testing.T) {
 	db, err := auth.OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
 	if err != nil {
@@ -546,6 +783,38 @@ func TestSQLiteModelAdmissionStorePersistsAppendOnlyStatus(t *testing.T) {
 	if _, replay, err := reopened.AppendModelAdmissionOffer(context.Background(), event); err != nil || !replay {
 		t.Fatalf("idempotent append replay=%v err=%v", replay, err)
 	}
+	withdrawal := providerws.ModelAdmissionEvent{
+		ProviderID:            event.ProviderID,
+		CandidateID:           event.CandidateID,
+		ServedModelRef:        event.ServedModelRef,
+		State:                 "withdrawn",
+		ReasonCode:            "runtime_unavailable",
+		RequestID:             "request_sqlite_withdraw",
+		Nonce:                 "nonce_sqlite_withdraw",
+		PayloadDigestSHA256:   stringsOf("d", 64),
+		SignatureDigestSHA256: stringsOf("e", 64),
+		CreatedAt:             time.Unix(1800000020, 0).UTC(),
+	}
+	withdrawn, replay, err := reopened.AppendModelAdmissionWithdrawal(context.Background(), withdrawal)
+	if err != nil || replay {
+		t.Fatalf("withdraw replay=%v err=%v", replay, err)
+	}
+	if withdrawn.DiscoveryDigestSHA256 != event.DiscoveryDigestSHA256 ||
+		withdrawn.RequestedDisclosureClass != event.RequestedDisclosureClass {
+		t.Fatalf("withdrawal lost prior evidence: %+v", withdrawn)
+	}
+	replayed, replay, err := reopened.AppendModelAdmissionWithdrawal(context.Background(), withdrawal)
+	if err != nil || !replay || replayed.CoordinatorEventID != withdrawn.CoordinatorEventID {
+		t.Fatalf("withdraw replay event=%+v replay=%v err=%v", replayed, replay, err)
+	}
+	reopenedAgain, err := providerws.NewSQLiteModelAdmissionStore(db.DB())
+	if err != nil {
+		t.Fatal(err)
+	}
+	readback, found, err = reopenedAgain.LatestModelAdmissionStatus(context.Background(), event.ProviderID, event.CandidateID)
+	if err != nil || !found || readback.State != "withdrawn" || readback.DiscoveryDigestSHA256 != event.DiscoveryDigestSHA256 {
+		t.Fatalf("withdraw readback found=%v event=%+v err=%v", found, readback, err)
+	}
 }
 
 func newModelAdmissionHarness(t *testing.T, providerID string) (providerHarness, string, ed25519.PrivateKey) {
@@ -638,6 +907,53 @@ func signedModelAdmissionOffer(t *testing.T, providerID, candidateID, servedMode
 	return request
 }
 
+func signedModelAdmissionWithdrawal(t *testing.T, providerID, candidateID, servedModelRef string, priv ed25519.PrivateKey, overrides map[string]any) map[string]any {
+	t.Helper()
+	pubkey := priv.Public().(ed25519.PublicKey)
+	pubkeyDigest := sha256.Sum256(pubkey)
+	signedFields := map[string]any{
+		"generated_at":       time.Now().UTC().Format(time.RFC3339Nano),
+		"cli_version":        "1.8.111",
+		"signature_domain":   "macprovider.model_admission.withdraw.v1",
+		"provider_id":        providerID,
+		"candidate_id":       candidateID,
+		"served_model_ref":   servedModelRef,
+		"catalog_model_key":  nil,
+		"idempotency_key":    "withdraw_request_" + candidateID,
+		"nonce":              "withdraw_nonce_" + candidateID,
+		"timestamp":          time.Now().UTC().Format(time.RFC3339Nano),
+		"reason_code":        "provider_requested",
+		"signing_key_digest": hex.EncodeToString(pubkeyDigest[:]),
+	}
+	for key, value := range overrides {
+		signedFields[key] = value
+	}
+	canonical, err := billing.CanonicalJSON(map[string]any{
+		"signature_domain":   signedFields["signature_domain"],
+		"provider_id":        signedFields["provider_id"],
+		"candidate_id":       signedFields["candidate_id"],
+		"served_model_ref":   signedFields["served_model_ref"],
+		"catalog_model_key":  signedFields["catalog_model_key"],
+		"idempotency_key":    signedFields["idempotency_key"],
+		"nonce":              signedFields["nonce"],
+		"timestamp":          signedFields["timestamp"],
+		"reason_code":        signedFields["reason_code"],
+		"signing_key_digest": signedFields["signing_key_digest"],
+		"cli_version":        signedFields["cli_version"],
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	signature := ed25519.Sign(priv, canonical)
+	request := map[string]any{"schema": "model_admission_withdraw_request.v1"}
+	for key, value := range signedFields {
+		request[key] = value
+	}
+	request["signature_algorithm"] = "ed25519"
+	request["provider_signature"] = base64.StdEncoding.EncodeToString(signature)
+	return request
+}
+
 func postModelAdmissionOffer(t *testing.T, baseURL, bearer string, payload map[string]any) (int, string) {
 	t.Helper()
 	body, err := json.Marshal(payload)
@@ -645,6 +961,27 @@ func postModelAdmissionOffer(t *testing.T, baseURL, bearer string, payload map[s
 		t.Fatal(err)
 	}
 	req, err := http.NewRequest(http.MethodPost, baseURL+"/v1/provider/model-admission/offers", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	out, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, string(out)
+}
+
+func postModelAdmissionWithdrawal(t *testing.T, baseURL, bearer string, payload map[string]any) (int, string) {
+	t.Helper()
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/v1/provider/model-admission/withdrawals", bytes.NewReader(body))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -1197,6 +1197,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/admin/provider-admission-identity/recover/", s.handleAdmissionIdentityRecoveryApprove)
 	mux.HandleFunc("/v1/provider/compute-integrity", s.handleProviderComputeIntegrity)
 	mux.HandleFunc("/v1/provider/model-admission/offers", s.handleProviderModelAdmissionOffer)
+	mux.HandleFunc("/v1/provider/model-admission/withdrawals", s.handleProviderModelAdmissionWithdrawal)
 	mux.HandleFunc("/v1/provider/model-admission/status", s.handleProviderModelAdmissionStatus)
 	if s.cfg.Auth.GitHubOAuth.Enabled {
 		mux.HandleFunc("/v1/auth/github/start", s.handleGitHubStart)


### PR DESCRIPTION
## Summary

- Add provider-signed BYOM withdrawal with `models admission withdraw <candidate> --json --yes`, `model_admission_withdraw_request.v1`, and coordinator-derived `model_admission_withdraw.v1` responses.
- Extend coordinator admission storage with append-only withdrawal, coordinator decision/revocation transitions, durable replay/idempotency handling, state-machine validation, and withdrawn re-entry freshness checks.
- Keep BYOM paid routing and economics fail-closed in this slice: admission rows, including `settlement_capable`, do not enter default paid routing until later SPEC-022 route-snapshot and trusted catalog/hash authority are wired.

## Issues / Authority

Part of #1240. Advances #1254.

Applicable gates: #1243, #1244, #1247, #1248.

Authority: SPEC-047-R001, SPEC-047-R002, SPEC-047-R003, SPEC-047-R005, SPEC-047-R006, SPEC-047-R007, SPEC-047-R008. The SPEC-022 route-snapshot/receipt boundary remains intentionally fail-closed and out of scope for positive settlement in this PR.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "issue": "https://github.com/Augustas11/macprovider/issues/1254",
  "specs": [
    "SPEC-047",
    "SPEC-022"
  ],
  "requirements": [
    "SPEC-047-R001",
    "SPEC-047-R002",
    "SPEC-047-R003",
    "SPEC-047-R005",
    "SPEC-047-R006",
    "SPEC-047-R007",
    "SPEC-047-R008"
  ],
  "authority_domains": [
    "network-model-admission"
  ],
  "arbitration": [
    "DECISION_REQUIRED"
  ],
  "tests": [
    "cd phase4-coordinator && go test ./internal/ws ./cmd/coordinator -count=1",
    "cd phase4-coordinator && go test ./internal/buyer -run TestModels -count=1",
    "cd phase3-binary && env CLANG_MODULE_CACHE_PATH=/private/tmp/macprovider-swift-module-cache swift test --filter macprovider_cliTests.BYOMAdmissionTests",
    "cd phase3-binary && env CLANG_MODULE_CACHE_PATH=/private/tmp/macprovider-swift-module-cache swift test --filter macprovider_cliTests.BYOMOfferDryRunTests",
    "git diff --check"
  ],
  "journeys": [
    "JOURNEY-NETWORK-MODEL-ADMISSION"
  ]
}
SPEC-GOVERNANCE-DECLARATION-END

## Tests

- `cd phase4-coordinator && go test ./internal/ws ./cmd/coordinator -count=1`
- `cd phase4-coordinator && go test ./internal/buyer -run TestModels -count=1`
- `cd phase3-binary && env CLANG_MODULE_CACHE_PATH=/private/tmp/macprovider-swift-module-cache swift test --filter macprovider_cliTests.BYOMAdmissionTests`
- `cd phase3-binary && env CLANG_MODULE_CACHE_PATH=/private/tmp/macprovider-swift-module-cache swift test --filter macprovider_cliTests.BYOMOfferDryRunTests`
- `git diff --check`

## Notes

- This PR does not enable positive BYOM settlement, payout-ready rows, buyer-final debit, default paid buyer routing, or Malibu UI.
- Synthetic probe journey coverage remains a later promotion/e2e requirement; this slice introduces no coordinator dereference of provider-submitted endpoints.
