### PR TITLE
Gate BYOM settlement credit on trusted admission evidence

### DIFF
--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -899,6 +899,7 @@ func main() {
 		buyer.WithBillingSnapshotID(snapshotID),
 		buyer.WithRateCardUSDPerMillionCredits(cfg.Stats.Rollup.UsdPerMillionCredits),
 		buyer.WithAutotuneFeeds(autotuneFeeds),
+		buyer.WithModelAdmissionStore(byomOfferStore),
 		buyer.WithStreamingMetricsMaxSamples(cfg.Stats.StreamingMetrics.MaxSamples),
 		buyer.WithPreflight(func(provider pool.Provider, requestID string, estimatedTokens int, timeout time.Duration) (buyer.PreflightResult, bool, error) {
 			ack, ok, err := wsServer.Preflight(provider, requestID, estimatedTokens, timeout)

--- a/phase4-coordinator/internal/billing/route_snapshot.go
+++ b/phase4-coordinator/internal/billing/route_snapshot.go
@@ -36,33 +36,39 @@ var (
 )
 
 type RouteSnapshot struct {
-	AccountScope                       string  `json:"account_scope"`
-	RequestID                          string  `json:"request_id"`
-	AttemptN                           int64   `json:"attempt_n"`
-	ProviderID                         string  `json:"provider_id"`
-	ProviderSessionID                  *string `json:"provider_session_id"`
-	ProviderGenerationID               *string `json:"provider_generation_id"`
-	PaidEntrypoint                     string  `json:"paid_entrypoint"`
-	ProviderReceiptKeyID               string  `json:"provider_receipt_key_id"`
-	ProviderReceiptKeySource           string  `json:"provider_receipt_key_source"`
-	ModelID                            string  `json:"model_id"`
-	ProviderReportedModelHash          string  `json:"provider_reported_model_hash"`
-	ProviderReportedModelHashAlgorithm string  `json:"provider_reported_model_hash_algorithm"`
-	ExpectedCatalogModelHash           string  `json:"expected_catalog_model_hash"`
-	ExpectedCatalogModelHashAlgorithm  string  `json:"expected_catalog_model_hash_algorithm"`
-	CatalogID                          string  `json:"catalog_id"`
-	CatalogBodyDigest                  string  `json:"catalog_body_digest"`
-	CatalogSignatureKeyID              string  `json:"catalog_signature_key_id"`
-	CatalogSignaturePubkeyFingerprint  string  `json:"catalog_signature_pubkey_fingerprint"`
-	CatalogExpiresAtUnixMS             int64   `json:"catalog_expires_at_unix_ms"`
-	Spec008HashStatus                  string  `json:"spec008_hash_status"`
-	RouteSnapshotPolicyVersion         string  `json:"route_snapshot_policy_version"`
-	RouteSnapshotMode                  string  `json:"route_snapshot_mode"`
-	RouteDecisionTSUnixMS              int64   `json:"route_decision_ts_unix_ms"`
-	RequestStartTSUnixMS               int64   `json:"request_start_ts_unix_ms"`
-	PendingDeadlineSeconds             int64   `json:"pending_deadline_seconds"`
-	PromptHashBasis                    string  `json:"prompt_hash_basis"`
-	PromptHash                         string  `json:"prompt_hash"`
+	AccountScope                         string  `json:"account_scope"`
+	RequestID                            string  `json:"request_id"`
+	AttemptN                             int64   `json:"attempt_n"`
+	ProviderID                           string  `json:"provider_id"`
+	ProviderSessionID                    *string `json:"provider_session_id"`
+	ProviderGenerationID                 *string `json:"provider_generation_id"`
+	PaidEntrypoint                       string  `json:"paid_entrypoint"`
+	ProviderReceiptKeyID                 string  `json:"provider_receipt_key_id"`
+	ProviderReceiptKeySource             string  `json:"provider_receipt_key_source"`
+	ModelID                              string  `json:"model_id"`
+	ProviderReportedModelHash            string  `json:"provider_reported_model_hash"`
+	ProviderReportedModelHashAlgorithm   string  `json:"provider_reported_model_hash_algorithm"`
+	ExpectedCatalogModelHash             string  `json:"expected_catalog_model_hash"`
+	ExpectedCatalogModelHashAlgorithm    string  `json:"expected_catalog_model_hash_algorithm"`
+	CatalogID                            string  `json:"catalog_id"`
+	CatalogBodyDigest                    string  `json:"catalog_body_digest"`
+	CatalogSignatureKeyID                string  `json:"catalog_signature_key_id"`
+	CatalogSignaturePubkeyFingerprint    string  `json:"catalog_signature_pubkey_fingerprint"`
+	CatalogExpiresAtUnixMS               int64   `json:"catalog_expires_at_unix_ms"`
+	Spec008HashStatus                    string  `json:"spec008_hash_status"`
+	RouteSnapshotPolicyVersion           string  `json:"route_snapshot_policy_version"`
+	RouteSnapshotMode                    string  `json:"route_snapshot_mode"`
+	RouteDecisionTSUnixMS                int64   `json:"route_decision_ts_unix_ms"`
+	RequestStartTSUnixMS                 int64   `json:"request_start_ts_unix_ms"`
+	PendingDeadlineSeconds               int64   `json:"pending_deadline_seconds"`
+	PromptHashBasis                      string  `json:"prompt_hash_basis"`
+	PromptHash                           string  `json:"prompt_hash"`
+	ModelAdmissionCandidateID            string  `json:"model_admission_candidate_id,omitempty"`
+	ModelAdmissionCoordinatorEventID     string  `json:"model_admission_coordinator_event_id,omitempty"`
+	ModelAdmissionServedModelRef         string  `json:"model_admission_served_model_ref,omitempty"`
+	ModelAdmissionCatalogModelKey        string  `json:"model_admission_catalog_model_key,omitempty"`
+	ModelAdmissionDiscoveryDigestSHA256  string  `json:"model_admission_discovery_digest_sha256,omitempty"`
+	ModelAdmissionEvaluationDigestSHA256 string  `json:"model_admission_evaluation_digest_sha256,omitempty"`
 	// PoolID is the SPEC-042 Trusted Pool that served this request ("" for
 	// global). It binds into the canonical route-snapshot digest / settlement
 	// context (SPEC-042 R006) but ONLY when non-empty, so poolless snapshots
@@ -120,6 +126,14 @@ func (r RouteSnapshot) Value() map[string]any {
 	// and keeps a byte-identical digest to pre-SPEC-042.
 	if r.PoolID != "" {
 		value["pool_id"] = r.PoolID
+	}
+	if r.ModelAdmissionCandidateID != "" {
+		value["model_admission_candidate_id"] = r.ModelAdmissionCandidateID
+		value["model_admission_coordinator_event_id"] = r.ModelAdmissionCoordinatorEventID
+		value["model_admission_served_model_ref"] = r.ModelAdmissionServedModelRef
+		value["model_admission_catalog_model_key"] = r.ModelAdmissionCatalogModelKey
+		value["model_admission_discovery_digest_sha256"] = r.ModelAdmissionDiscoveryDigestSHA256
+		value["model_admission_evaluation_digest_sha256"] = r.ModelAdmissionEvaluationDigestSHA256
 	}
 	return value
 }
@@ -199,6 +213,28 @@ func (r RouteSnapshot) Validate() error {
 		}
 		if !computeIntegrityDigestPattern.MatchString(r.ComputeIntegrityHardwareDigest) {
 			return fmt.Errorf("compute integrity hardware runtime class digest invalid")
+		}
+	}
+	if r.ModelAdmissionCandidateID != "" {
+		for field, value := range map[string]string{
+			"model_admission_coordinator_event_id":     r.ModelAdmissionCoordinatorEventID,
+			"model_admission_served_model_ref":         r.ModelAdmissionServedModelRef,
+			"model_admission_catalog_model_key":        r.ModelAdmissionCatalogModelKey,
+			"model_admission_discovery_digest_sha256":  r.ModelAdmissionDiscoveryDigestSHA256,
+			"model_admission_evaluation_digest_sha256": r.ModelAdmissionEvaluationDigestSHA256,
+		} {
+			if strings.TrimSpace(value) == "" {
+				return fmt.Errorf("route snapshot missing %s", field)
+			}
+		}
+		for field, value := range map[string]string{
+			"model_admission_coordinator_event_id":     r.ModelAdmissionCoordinatorEventID,
+			"model_admission_discovery_digest_sha256":  r.ModelAdmissionDiscoveryDigestSHA256,
+			"model_admission_evaluation_digest_sha256": r.ModelAdmissionEvaluationDigestSHA256,
+		} {
+			if !hex64Pattern.MatchString(value) {
+				return fmt.Errorf("route snapshot %s must be 64 lowercase hex chars", field)
+			}
 		}
 	}
 	return nil

--- a/phase4-coordinator/internal/billing/route_snapshot_test.go
+++ b/phase4-coordinator/internal/billing/route_snapshot_test.go
@@ -133,6 +133,67 @@ func TestRouteSnapshotPoolID_RoundTripsThroughSettlementLoader(t *testing.T) {
 	}
 }
 
+func TestRouteSnapshotBYOMAdmissionBindingDigestAndRoundTrip(t *testing.T) {
+	_, store := newRequestAndBillingStores(t)
+	snap := testRouteSnapshot()
+	snap.ModelAdmissionCandidateID = "byom_abcdefghijklmnopqrstuvwxyz234567abcdefghijklmnopqrstuvwxyz"
+	snap.ModelAdmissionCoordinatorEventID = strings.Repeat("7", 64)
+	snap.ModelAdmissionServedModelRef = "ollama:qwen3-8b"
+	snap.ModelAdmissionCatalogModelKey = "qwen3-8b-q4"
+	snap.ModelAdmissionDiscoveryDigestSHA256 = strings.Repeat("8", 64)
+	snap.ModelAdmissionEvaluationDigestSHA256 = strings.Repeat("9", 64)
+
+	value := snap.Value()
+	for _, key := range []string{
+		"model_admission_candidate_id",
+		"model_admission_coordinator_event_id",
+		"model_admission_served_model_ref",
+		"model_admission_catalog_model_key",
+		"model_admission_discovery_digest_sha256",
+		"model_admission_evaluation_digest_sha256",
+	} {
+		if _, ok := value[key]; !ok {
+			t.Fatalf("missing BYOM route snapshot key %q", key)
+		}
+	}
+	digest, err := store.InsertRouteSnapshot(context.Background(), snap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mutated := snap
+	mutated.ModelAdmissionCoordinatorEventID = strings.Repeat("a", 64)
+	mutatedDigest, _, err := mutated.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mutatedDigest == digest {
+		t.Fatal("BYOM coordinator event id must change the route snapshot digest")
+	}
+
+	conn, err := store.db.Conn(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	loaded, loadedDigest, err := loadSettlementRouteSnapshotConn(context.Background(), conn, SettlementReceiptIdentity{
+		AccountScope: snap.AccountScope,
+		RequestID:    snap.RequestID,
+		AttemptN:     snap.AttemptN,
+		ProviderID:   snap.ProviderID,
+	})
+	if err != nil {
+		t.Fatalf("loader returned error: %v", err)
+	}
+	if loadedDigest != digest {
+		t.Fatalf("recompute digest %q != insert digest %q", loadedDigest, digest)
+	}
+	if loaded.ModelAdmissionCoordinatorEventID != snap.ModelAdmissionCoordinatorEventID ||
+		loaded.ModelAdmissionDiscoveryDigestSHA256 != snap.ModelAdmissionDiscoveryDigestSHA256 ||
+		loaded.ModelAdmissionEvaluationDigestSHA256 != snap.ModelAdmissionEvaluationDigestSHA256 {
+		t.Fatalf("loader did not recover BYOM binding: %+v", loaded)
+	}
+}
+
 func TestInsertRouteSnapshotPersistsCanonicalDigestAndRejectsRewrite(t *testing.T) {
 	_, store := newRequestAndBillingStores(t)
 	snapshot := testRouteSnapshot()

--- a/phase4-coordinator/internal/billing/settlement_receipts.go
+++ b/phase4-coordinator/internal/billing/settlement_receipts.go
@@ -833,8 +833,14 @@ WHERE account_scope = ? AND request_id = ? AND attempt_n = ? AND provider_id = ?
 		r.ProviderGenerationID = &providerGeneration.String
 	}
 	var recovered struct {
-		ProviderReported string `json:"provider_reported_model_hash_algorithm"`
-		ExpectedCatalog  string `json:"expected_catalog_model_hash_algorithm"`
+		ProviderReported                     string `json:"provider_reported_model_hash_algorithm"`
+		ExpectedCatalog                      string `json:"expected_catalog_model_hash_algorithm"`
+		ModelAdmissionCandidateID            string `json:"model_admission_candidate_id"`
+		ModelAdmissionCoordinatorEventID     string `json:"model_admission_coordinator_event_id"`
+		ModelAdmissionServedModelRef         string `json:"model_admission_served_model_ref"`
+		ModelAdmissionCatalogModelKey        string `json:"model_admission_catalog_model_key"`
+		ModelAdmissionDiscoveryDigestSHA256  string `json:"model_admission_discovery_digest_sha256"`
+		ModelAdmissionEvaluationDigestSHA256 string `json:"model_admission_evaluation_digest_sha256"`
 		// SPEC-042 R006: pool_id is carried in route_snapshot_json (not a
 		// column), so it MUST be recovered here before the digest recompute
 		// below, or a pool snapshot's recompute-digest would omit pool_id and
@@ -846,6 +852,12 @@ WHERE account_scope = ? AND request_id = ? AND attempt_n = ? AND provider_id = ?
 	}
 	r.ProviderReportedModelHashAlgorithm = recovered.ProviderReported
 	r.ExpectedCatalogModelHashAlgorithm = recovered.ExpectedCatalog
+	r.ModelAdmissionCandidateID = recovered.ModelAdmissionCandidateID
+	r.ModelAdmissionCoordinatorEventID = recovered.ModelAdmissionCoordinatorEventID
+	r.ModelAdmissionServedModelRef = recovered.ModelAdmissionServedModelRef
+	r.ModelAdmissionCatalogModelKey = recovered.ModelAdmissionCatalogModelKey
+	r.ModelAdmissionDiscoveryDigestSHA256 = recovered.ModelAdmissionDiscoveryDigestSHA256
+	r.ModelAdmissionEvaluationDigestSHA256 = recovered.ModelAdmissionEvaluationDigestSHA256
 	r.PoolID = recovered.PoolID
 	r.ComputeIntegrityCaptureRequired = computeIntegrityCaptureRequired == 1
 	r.ComputeIntegritySamplingCovered = computeIntegritySamplingCovered == 1

--- a/phase4-coordinator/internal/buyer/model_admission.go
+++ b/phase4-coordinator/internal/buyer/model_admission.go
@@ -1,0 +1,166 @@
+package buyer
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/augstar/macprovider-coordinator/internal/billing"
+	"github.com/augstar/macprovider-coordinator/internal/modelidentity"
+	"github.com/augstar/macprovider-coordinator/internal/pool"
+	"github.com/augstar/macprovider-coordinator/internal/tier2"
+	providerws "github.com/augstar/macprovider-coordinator/internal/ws"
+)
+
+func byomAdmissionCandidate(p pool.Provider) bool {
+	return strings.TrimSpace(p.ModelAdmissionCandidateID) != "" ||
+		strings.TrimSpace(p.ModelAdmissionServedModelRef) != "" ||
+		strings.TrimSpace(p.ModelAdmissionCatalogModelKey) != ""
+}
+
+func (s *Server) byomDefaultPaidRoutingEligible(p pool.Provider) bool {
+	marked := byomAdmissionCandidate(p)
+	if s == nil || s.modelAdmissionStore == nil {
+		return !marked
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), requestLogWriteTimeout)
+	defer cancel()
+	reportedHash := strings.TrimSpace(p.ModelHash)
+	material, ok := tier2.SnapshotMaterial(p.ModelID, reportedHash)
+	if !ok {
+		_, found, err := s.modelAdmissionStore.LatestModelAdmissionRouteStatus(
+			ctx,
+			p.ProviderID,
+			"",
+			"",
+		)
+		if err != nil || found {
+			return false
+		}
+		return !marked
+	}
+	_, found, eligible := s.byomRouteSnapshotBinding(ctx, p, material)
+	if found {
+		return eligible
+	}
+	return !marked
+}
+
+func (s *Server) byomRouteSnapshotBinding(ctx context.Context, p pool.Provider, material tier2.RouteSnapshotMaterial) (providerws.ModelAdmissionSettlementBinding, bool, bool) {
+	if s == nil || s.modelAdmissionStore == nil {
+		return providerws.ModelAdmissionSettlementBinding{}, false, false
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	marked := byomAdmissionCandidate(p)
+	candidateID := strings.TrimSpace(p.ModelAdmissionCandidateID)
+	servedModelRef := strings.TrimSpace(p.ModelAdmissionServedModelRef)
+	if servedModelRef == "" {
+		servedModelRef = strings.TrimSpace(p.ModelID)
+	}
+	catalogModelKey := strings.ToLower(strings.TrimSpace(p.ModelAdmissionCatalogModelKey))
+	if catalogModelKey == "" {
+		catalogModelKey = strings.ToLower(strings.TrimSpace(material.CatalogModelKey))
+	}
+
+	var (
+		event providerws.ModelAdmissionEvent
+		found bool
+		err   error
+	)
+	if candidateID != "" {
+		event, found, err = s.modelAdmissionStore.LatestModelAdmissionStatus(ctx, p.ProviderID, candidateID)
+	} else if marked {
+		event, found, err = s.modelAdmissionStore.LatestModelAdmissionRouteStatus(ctx, p.ProviderID, servedModelRef, catalogModelKey)
+	} else {
+		event, found, err = s.modelAdmissionStore.LatestModelAdmissionRouteStatus(ctx, p.ProviderID, servedModelRef, catalogModelKey)
+		if err == nil && !found {
+			event, found, err = s.modelAdmissionStore.LatestModelAdmissionRouteStatus(ctx, p.ProviderID, "", catalogModelKey)
+		}
+		if err == nil && !found {
+			_, providerFound, providerErr := s.modelAdmissionStore.LatestModelAdmissionRouteStatus(ctx, p.ProviderID, "", "")
+			if providerErr != nil || providerFound {
+				return providerws.ModelAdmissionSettlementBinding{}, true, false
+			}
+		}
+	}
+	if err != nil || !found {
+		if err != nil {
+			return providerws.ModelAdmissionSettlementBinding{}, true, false
+		}
+		return providerws.ModelAdmissionSettlementBinding{}, false, false
+	}
+	if marked {
+		if candidateID != "" && event.CandidateID != candidateID {
+			return providerws.ModelAdmissionSettlementBinding{}, true, false
+		}
+		if explicitServed := strings.TrimSpace(p.ModelAdmissionServedModelRef); explicitServed != "" && event.ServedModelRef != explicitServed {
+			return providerws.ModelAdmissionSettlementBinding{}, true, false
+		}
+		if explicitCatalogKey := strings.ToLower(strings.TrimSpace(p.ModelAdmissionCatalogModelKey)); explicitCatalogKey != "" && event.CatalogModelKey != explicitCatalogKey {
+			return providerws.ModelAdmissionSettlementBinding{}, true, false
+		}
+	}
+	if !s.byomSettlementPrereqsReady(p, material) {
+		return providerws.ModelAdmissionSettlementBinding{}, true, false
+	}
+	binding, ok := providerws.ModelAdmissionSettlementBindingForRouteSnapshot(event, providerws.ModelAdmissionSettlementPredicate{
+		ProviderID:                        p.ProviderID,
+		CandidateID:                       event.CandidateID,
+		ServedModelRef:                    event.ServedModelRef,
+		CatalogModelKey:                   material.CatalogModelKey,
+		DiscoveryDigestSHA256:             event.DiscoveryDigestSHA256,
+		EvaluationDigestSHA256:            event.EvaluationDigestSHA256,
+		CatalogID:                         material.CatalogID,
+		CatalogBodyDigest:                 material.CatalogBodyDigest,
+		CatalogSignatureKeyID:             material.CatalogSignatureKeyID,
+		CatalogSignaturePubkeyFingerprint: material.CatalogSignaturePubkeyFingerprint,
+		ExpectedCatalogModelHash:          material.ExpectedModelHash,
+		ExpectedCatalogModelHashAlgorithm: material.ExpectedModelHashAlgorithm,
+	})
+	return binding, true, ok
+}
+
+func (s *Server) byomSettlementPrereqsReady(p pool.Provider, material tier2.RouteSnapshotMaterial) bool {
+	if s == nil || !s.settlementEnforceMode() {
+		return false
+	}
+	reportedHash := strings.TrimSpace(p.ModelHash)
+	expectedHash := strings.TrimSpace(p.ExpectedModelHash)
+	return validProviderReceiptPubkey(p) &&
+		p.ModelHashAlgorithm == modelidentity.SnapshotManifestV1 &&
+		isLowerHex64(reportedHash) &&
+		isLowerHex64(expectedHash) &&
+		reportedHash == expectedHash &&
+		material.HashStatus == pool.HashStatusVerified &&
+		material.ExpectedModelHash == expectedHash
+}
+
+func validProviderReceiptPubkey(p pool.Provider) bool {
+	_, err := billing.ReceiptKeyID(p.ReceiptPubkey)
+	return err == nil
+}
+
+func (s *Server) requireBYOMRouteSnapshotBinding(ctx context.Context, p pool.Provider, material tier2.RouteSnapshotMaterial) (providerws.ModelAdmissionSettlementBinding, error) {
+	binding, found, eligible := s.byomRouteSnapshotBinding(ctx, p, material)
+	if !found && !byomAdmissionCandidate(p) {
+		return providerws.ModelAdmissionSettlementBinding{}, nil
+	}
+	if !eligible {
+		return providerws.ModelAdmissionSettlementBinding{}, fmt.Errorf("BYOM model admission is not settlement capable")
+	}
+	return binding, nil
+}
+
+func applyBYOMRouteSnapshotBinding(snapshot *billing.RouteSnapshot, binding providerws.ModelAdmissionSettlementBinding) {
+	if snapshot == nil || binding.CandidateID == "" {
+		return
+	}
+	snapshot.ModelAdmissionCandidateID = binding.CandidateID
+	snapshot.ModelAdmissionCoordinatorEventID = binding.CoordinatorEventID
+	snapshot.ModelAdmissionServedModelRef = binding.ServedModelRef
+	snapshot.ModelAdmissionCatalogModelKey = binding.CatalogModelKey
+	snapshot.ModelAdmissionDiscoveryDigestSHA256 = binding.DiscoveryDigestSHA256
+	snapshot.ModelAdmissionEvaluationDigestSHA256 = binding.EvaluationDigestSHA256
+}

--- a/phase4-coordinator/internal/buyer/route_snapshot.go
+++ b/phase4-coordinator/internal/buyer/route_snapshot.go
@@ -66,10 +66,19 @@ func (b *billingRecorder) recordRouteSnapshot(providerBody []byte, provider pool
 	}
 	material, ok := tier2.SnapshotMaterial(provider.ModelID, reportedHash)
 	if !ok {
+		if byomAdmissionCandidate(provider) {
+			return nil, fmt.Errorf("BYOM model admission requires trusted catalog material")
+		}
 		return skipOrEnforceError("missing catalog material")
 	}
 	if material.HashStatus != pool.HashStatusVerified || material.ExpectedModelHash != expectedHash {
 		return nil, fmt.Errorf("tier2 catalog does not match signed admission row")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), requestLogWriteTimeout)
+	defer cancel()
+	byomBinding, err := b.server.requireBYOMRouteSnapshotBinding(ctx, provider, material)
+	if err != nil {
+		return nil, err
 	}
 	promptHash, err := coordinatorPromptHash(providerBody)
 	if err != nil {
@@ -125,6 +134,7 @@ func (b *billingRecorder) recordRouteSnapshot(providerBody []byte, provider pool
 		// that served the request ("" for global -> omitted from the digest).
 		PoolID: b.state.poolID,
 	}
+	applyBYOMRouteSnapshotBinding(&snapshot, byomBinding)
 	computeIntegrityRequired, computeIntegrityCovered, computeIntegrityHardwareDigest, err := computeIntegrityRouteBinding(provider, routeMode)
 	if err != nil {
 		return nil, err
@@ -132,8 +142,6 @@ func (b *billingRecorder) recordRouteSnapshot(providerBody []byte, provider pool
 	snapshot.ComputeIntegrityCaptureRequired = computeIntegrityRequired
 	snapshot.ComputeIntegritySamplingCovered = computeIntegrityCovered
 	snapshot.ComputeIntegrityHardwareDigest = computeIntegrityHardwareDigest
-	ctx, cancel := context.WithTimeout(context.Background(), requestLogWriteTimeout)
-	defer cancel()
 	digest, err := store.InsertRouteSnapshot(ctx, snapshot)
 	if err != nil {
 		return nil, err

--- a/phase4-coordinator/internal/buyer/route_snapshot_test.go
+++ b/phase4-coordinator/internal/buyer/route_snapshot_test.go
@@ -748,6 +748,447 @@ func TestRouteSnapshotSkippedForNonSettlementCapableModelHash(t *testing.T) {
 	}
 }
 
+func TestBYOMCatalogPricedIsHiddenFromDefaultPaidModelsAndRouting(t *testing.T) {
+	tier2.ResetForTest()
+	t.Cleanup(tier2.ResetForTest)
+	raw, pubkey := routeSnapshotCatalogFixture(t, "byom-catalog-priced-catalog", time.Now().UTC().Add(time.Hour))
+	if err := tier2.Configure(config.Tier2Config{
+		ObserveEnabled:      true,
+		CatalogPath:         writeRouteSnapshotCatalog(t, raw),
+		CatalogPublicKey:    pubkey,
+		RequireHashVerified: true,
+	}, zerolog.Nop()); err != nil {
+		t.Fatalf("tier2.Configure: %v", err)
+	}
+
+	reqLog, dbPath := openBuyerRequestLog(t)
+	t.Cleanup(func() { _ = reqLog.Close() })
+	billingStore, err := billing.NewStore(reqLog.DB())
+	if err != nil {
+		t.Fatalf("billing.NewStore: %v", err)
+	}
+	setSettlementModeForTest(billingStore, billing.RouteSnapshotModeObserve)
+	cfg := config.Default().Rewards
+	snapshotID, err := billingStore.InsertConfigSnapshot(context.Background(), cfg, time.Unix(1716768000, 0).UTC())
+	if err != nil {
+		t.Fatalf("InsertConfigSnapshot: %v", err)
+	}
+
+	var reachedProvider bool
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reachedProvider = true
+		writeProviderOK(w)
+	}))
+	defer upstream.Close()
+
+	registry := pool.NewRegistry(nil)
+	registerSettlementProvider(registry, "p1", "session-1", upstream.URL, 30, bytes.Repeat([]byte{0x78}, 32))
+	provider := byomAdmissionProvider(t, registry.Snapshot()[0])
+	store := providerws.NewMemoryModelAdmissionStore()
+	seedBYOMAdmissionState(t, store, provider, "catalog_priced")
+	routeProvider := clearBYOMAdmissionFields(provider)
+	registry.Register(&routeProvider, nil)
+	server := buyer.NewServer(
+		registry,
+		zerolog.Nop(),
+		time.Unix(1716768000, 0),
+		buyer.WithRequestLog(reqLog),
+		buyer.WithBilling(billingStore, cfg),
+		buyer.WithBillingSnapshotID(snapshotID),
+		buyer.WithModelAdmissionStore(store),
+	)
+
+	modelsRR := httptest.NewRecorder()
+	server.Handler().ServeHTTP(modelsRR, httptest.NewRequest(http.MethodGet, "/v1/models", nil))
+	if modelsRR.Code != http.StatusOK {
+		t.Fatalf("models status=%d body=%s", modelsRR.Code, modelsRR.Body.String())
+	}
+	var models struct {
+		Data []map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal(modelsRR.Body.Bytes(), &models); err != nil {
+		t.Fatalf("models json: %v", err)
+	}
+	if len(models.Data) != 0 {
+		t.Fatalf("catalog_priced BYOM leaked into default /v1/models: %s", modelsRR.Body.String())
+	}
+
+	rr := postChat(t, server, []byte(`{"model":"model-a","messages":[{"role":"user","content":"hi"}]}`), nil)
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d body=%s, want no provider available", rr.Code, rr.Body.String())
+	}
+	assertOpenAIErrorEnvelope(t, rr, "byom_non_settlement_unavailable", "server_error")
+	if reachedProvider {
+		t.Fatal("catalog_priced BYOM provider was reached by default paid routing")
+	}
+	if got := routeSnapshotCount(t, dbPath); got != 0 {
+		t.Fatalf("route snapshots=%d want 0 for non-settlement BYOM", got)
+	}
+	if got := ledgerCreditCount(t, dbPath); got != 0 {
+		t.Fatalf("ledger credits=%d want 0 for non-settlement BYOM", got)
+	}
+}
+
+func TestBYOMHiddenProviderDoesNotShadowModelClassAlias(t *testing.T) {
+	var reachedHidden bool
+	hiddenUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reachedHidden = true
+		writeProviderOK(w)
+	}))
+	defer hiddenUpstream.Close()
+
+	var reachedClassMember bool
+	classMemberUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reachedClassMember = true
+		writeProviderOK(w)
+	}))
+	defer classMemberUpstream.Close()
+
+	registry := pool.NewRegistry(nil)
+	registerSettlementProvider(registry, "hidden-byom", "session-hidden", hiddenUpstream.URL, 40, bytes.Repeat([]byte{0x66}, 32))
+	hidden := registry.Snapshot()[0]
+	hidden.ModelID = "mlx-fast"
+	hidden = byomAdmissionProvider(t, hidden)
+	hidden.ModelAdmissionServedModelRef = "mlx-fast"
+	hidden.ModelAdmissionCatalogModelKey = ""
+	store := providerws.NewMemoryModelAdmissionStore()
+	seedBYOMAdmissionState(t, store, hidden, "offer_submitted")
+	routeHidden := clearBYOMAdmissionFields(hidden)
+	registry.Register(&routeHidden, nil)
+	registerSettlementProvider(registry, "class-member", "session-member", classMemberUpstream.URL, 30, bytes.Repeat([]byte{0x67}, 32))
+
+	server := buyer.NewServer(
+		registry,
+		zerolog.Nop(),
+		time.Unix(1716768000, 0),
+		buyer.WithModelAdmissionStore(store),
+		buyer.WithRoutingConfig(config.RoutingConfig{
+			ModelClasses: map[string]config.ModelClassConfig{
+				"mlx-fast": {Models: []string{"model-a"}, Objective: "fast"},
+			},
+		}),
+	)
+
+	rr := postChat(t, server, []byte(`{"model":"mlx-fast","messages":[{"role":"user","content":"hi"}]}`), nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	if reachedHidden {
+		t.Fatal("hidden non-settlement BYOM provider was reached for class alias")
+	}
+	if !reachedClassMember {
+		t.Fatal("class member was not reached after hidden BYOM provider was skipped")
+	}
+}
+
+func TestBYOMSettlementCapableBindsAdmissionEventIntoRouteSnapshot(t *testing.T) {
+	tier2.ResetForTest()
+	t.Cleanup(tier2.ResetForTest)
+	raw, pubkey := routeSnapshotCatalogFixture(t, "byom-settlement-capable-catalog", time.Now().UTC().Add(time.Hour))
+	if err := tier2.Configure(config.Tier2Config{
+		ObserveEnabled:      true,
+		CatalogPath:         writeRouteSnapshotCatalog(t, raw),
+		CatalogPublicKey:    pubkey,
+		RequireHashVerified: true,
+	}, zerolog.Nop()); err != nil {
+		t.Fatalf("tier2.Configure: %v", err)
+	}
+
+	reqLog, dbPath := openBuyerRequestLog(t)
+	t.Cleanup(func() { _ = reqLog.Close() })
+	billingStore, err := billing.NewStore(reqLog.DB())
+	if err != nil {
+		t.Fatalf("billing.NewStore: %v", err)
+	}
+	setSettlementModeForTest(billingStore, billing.RouteSnapshotModeEnforce)
+	cfg := config.Default().Rewards
+	snapshotID, err := billingStore.InsertConfigSnapshot(context.Background(), cfg, time.Unix(1716768000, 0).UTC())
+	if err != nil {
+		t.Fatalf("InsertConfigSnapshot: %v", err)
+	}
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeProviderOK(w)
+	}))
+	defer upstream.Close()
+
+	registry := pool.NewRegistry(nil)
+	registerSettlementProvider(registry, "p1", "session-1", upstream.URL, 30, bytes.Repeat([]byte{0x79}, 32))
+	provider := byomAdmissionProvider(t, registry.Snapshot()[0])
+	store := providerws.NewMemoryModelAdmissionStore()
+	event := seedBYOMAdmissionState(t, store, provider, "settlement_capable")
+	routeProvider := clearBYOMAdmissionFields(provider)
+	registry.Register(&routeProvider, nil)
+	server := buyer.NewServer(
+		registry,
+		zerolog.Nop(),
+		time.Unix(1716768000, 0),
+		buyer.WithRequestLog(reqLog),
+		buyer.WithBilling(billingStore, cfg),
+		buyer.WithBillingSnapshotID(snapshotID),
+		buyer.WithModelAdmissionStore(store),
+	)
+
+	rr := postChat(t, server, []byte(`{"model":"model-a","messages":[{"role":"user","content":"hi"}]}`), nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	rows := queryRouteSnapshots(t, dbPath)
+	if len(rows) != 1 {
+		t.Fatalf("route snapshots=%d want 1: %#v", len(rows), rows)
+	}
+	binding := queryRouteSnapshotBYOMBinding(t, dbPath)
+	if binding["model_admission_candidate_id"] != event.CandidateID ||
+		binding["model_admission_coordinator_event_id"] != event.CoordinatorEventID ||
+		binding["model_admission_served_model_ref"] != event.ServedModelRef ||
+		binding["model_admission_catalog_model_key"] != event.CatalogModelKey {
+		t.Fatalf("route snapshot missing current BYOM binding: %#v", binding)
+	}
+	if got := binding["model_admission_discovery_digest_sha256"]; got != event.DiscoveryDigestSHA256 {
+		t.Fatalf("discovery digest=%v want %s", got, event.DiscoveryDigestSHA256)
+	}
+	if got := binding["model_admission_evaluation_digest_sha256"]; got != event.EvaluationDigestSHA256 {
+		t.Fatalf("evaluation digest=%v want %s", got, event.EvaluationDigestSHA256)
+	}
+	if got := ledgerCreditCount(t, dbPath); got != 1 {
+		t.Fatalf("ledger credits=%d want 1 for settlement-capable BYOM", got)
+	}
+}
+
+func TestBYOMSettlementCapableRequiresValidReceiptKeyBeforeRouting(t *testing.T) {
+	tier2.ResetForTest()
+	t.Cleanup(tier2.ResetForTest)
+	raw, pubkey := routeSnapshotCatalogFixture(t, "byom-invalid-receipt-catalog", time.Now().UTC().Add(time.Hour))
+	if err := tier2.Configure(config.Tier2Config{
+		ObserveEnabled:      true,
+		CatalogPath:         writeRouteSnapshotCatalog(t, raw),
+		CatalogPublicKey:    pubkey,
+		RequireHashVerified: true,
+	}, zerolog.Nop()); err != nil {
+		t.Fatalf("tier2.Configure: %v", err)
+	}
+
+	reqLog, dbPath := openBuyerRequestLog(t)
+	t.Cleanup(func() { _ = reqLog.Close() })
+	billingStore, err := billing.NewStore(reqLog.DB())
+	if err != nil {
+		t.Fatalf("billing.NewStore: %v", err)
+	}
+	setSettlementModeForTest(billingStore, billing.RouteSnapshotModeEnforce)
+	cfg := config.Default().Rewards
+	snapshotID, err := billingStore.InsertConfigSnapshot(context.Background(), cfg, time.Unix(1716768000, 0).UTC())
+	if err != nil {
+		t.Fatalf("InsertConfigSnapshot: %v", err)
+	}
+
+	var reachedProvider bool
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reachedProvider = true
+		writeProviderOK(w)
+	}))
+	defer upstream.Close()
+
+	registry := pool.NewRegistry(nil)
+	registerSettlementProvider(registry, "p1", "session-1", upstream.URL, 30, []byte("not-an-ed25519-key"))
+	provider := byomAdmissionProvider(t, registry.Snapshot()[0])
+	store := providerws.NewMemoryModelAdmissionStore()
+	seedBYOMAdmissionState(t, store, provider, "settlement_capable")
+	routeProvider := clearBYOMAdmissionFields(provider)
+	registry.Register(&routeProvider, nil)
+	server := buyer.NewServer(
+		registry,
+		zerolog.Nop(),
+		time.Unix(1716768000, 0),
+		buyer.WithRequestLog(reqLog),
+		buyer.WithBilling(billingStore, cfg),
+		buyer.WithBillingSnapshotID(snapshotID),
+		buyer.WithModelAdmissionStore(store),
+	)
+
+	modelsRR := httptest.NewRecorder()
+	server.Handler().ServeHTTP(modelsRR, httptest.NewRequest(http.MethodGet, "/v1/models", nil))
+	if modelsRR.Code != http.StatusOK {
+		t.Fatalf("models status=%d body=%s", modelsRR.Code, modelsRR.Body.String())
+	}
+	if bytes.Contains(modelsRR.Body.Bytes(), []byte(`"id":"model-a"`)) {
+		t.Fatalf("BYOM with malformed receipt key leaked into /v1/models: %s", modelsRR.Body.String())
+	}
+	rr := postChat(t, server, []byte(`{"model":"model-a","messages":[{"role":"user","content":"hi"}]}`), nil)
+	assertOpenAIErrorEnvelope(t, rr, "byom_non_settlement_unavailable", "server_error")
+	if reachedProvider {
+		t.Fatal("BYOM provider with malformed receipt key was reached")
+	}
+	if got := routeSnapshotCount(t, dbPath); got != 0 {
+		t.Fatalf("route snapshots=%d want 0 for malformed receipt key", got)
+	}
+	if got := ledgerCreditCount(t, dbPath); got != 0 {
+		t.Fatalf("ledger credits=%d want 0 for malformed receipt key", got)
+	}
+}
+
+func TestBYOMCatalogKeyMismatchFailsClosed(t *testing.T) {
+	tier2.ResetForTest()
+	t.Cleanup(tier2.ResetForTest)
+	raw, pubkey := routeSnapshotCatalogFixture(t, "byom-catalog-key-mismatch-catalog", time.Now().UTC().Add(time.Hour))
+	if err := tier2.Configure(config.Tier2Config{
+		ObserveEnabled:      true,
+		CatalogPath:         writeRouteSnapshotCatalog(t, raw),
+		CatalogPublicKey:    pubkey,
+		RequireHashVerified: true,
+	}, zerolog.Nop()); err != nil {
+		t.Fatalf("tier2.Configure: %v", err)
+	}
+
+	reqLog, dbPath := openBuyerRequestLog(t)
+	t.Cleanup(func() { _ = reqLog.Close() })
+	billingStore, err := billing.NewStore(reqLog.DB())
+	if err != nil {
+		t.Fatalf("billing.NewStore: %v", err)
+	}
+	setSettlementModeForTest(billingStore, billing.RouteSnapshotModeEnforce)
+	cfg := config.Default().Rewards
+	snapshotID, err := billingStore.InsertConfigSnapshot(context.Background(), cfg, time.Unix(1716768000, 0).UTC())
+	if err != nil {
+		t.Fatalf("InsertConfigSnapshot: %v", err)
+	}
+
+	var reachedProvider bool
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reachedProvider = true
+		writeProviderOK(w)
+	}))
+	defer upstream.Close()
+
+	registry := pool.NewRegistry(nil)
+	registerSettlementProvider(registry, "p1", "session-1", upstream.URL, 30, bytes.Repeat([]byte{0x6b}, 32))
+	provider := byomAdmissionProvider(t, registry.Snapshot()[0])
+	provider.ModelAdmissionCatalogModelKey = "qwen3-8b-q4"
+	store := providerws.NewMemoryModelAdmissionStore()
+	seedBYOMAdmissionState(t, store, provider, "settlement_capable")
+	routeProvider := clearBYOMAdmissionFields(provider)
+	registry.Register(&routeProvider, nil)
+	server := buyer.NewServer(
+		registry,
+		zerolog.Nop(),
+		time.Unix(1716768000, 0),
+		buyer.WithRequestLog(reqLog),
+		buyer.WithBilling(billingStore, cfg),
+		buyer.WithBillingSnapshotID(snapshotID),
+		buyer.WithModelAdmissionStore(store),
+	)
+
+	rr := postChat(t, server, []byte(`{"model":"model-a","messages":[{"role":"user","content":"hi"}]}`), nil)
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d body=%s, want no provider available", rr.Code, rr.Body.String())
+	}
+	assertOpenAIErrorEnvelope(t, rr, "byom_non_settlement_unavailable", "server_error")
+	if reachedProvider {
+		t.Fatal("BYOM provider with mismatched catalog key was reached by default paid routing")
+	}
+	if got := routeSnapshotCount(t, dbPath); got != 0 {
+		t.Fatalf("route snapshots=%d want 0 for mismatched BYOM catalog key", got)
+	}
+	if got := ledgerCreditCount(t, dbPath); got != 0 {
+		t.Fatalf("ledger credits=%d want 0 for mismatched BYOM catalog key", got)
+	}
+}
+
+func TestBYOMReadmissionRotatesRouteSnapshotAdmissionEvent(t *testing.T) {
+	tier2.ResetForTest()
+	t.Cleanup(tier2.ResetForTest)
+	raw, pubkey := routeSnapshotCatalogFixture(t, "byom-readmission-catalog", time.Now().UTC().Add(time.Hour))
+	if err := tier2.Configure(config.Tier2Config{
+		ObserveEnabled:      true,
+		CatalogPath:         writeRouteSnapshotCatalog(t, raw),
+		CatalogPublicKey:    pubkey,
+		RequireHashVerified: true,
+	}, zerolog.Nop()); err != nil {
+		t.Fatalf("tier2.Configure: %v", err)
+	}
+
+	reqLog, dbPath := openBuyerRequestLog(t)
+	t.Cleanup(func() { _ = reqLog.Close() })
+	billingStore, err := billing.NewStore(reqLog.DB())
+	if err != nil {
+		t.Fatalf("billing.NewStore: %v", err)
+	}
+	setSettlementModeForTest(billingStore, billing.RouteSnapshotModeEnforce)
+	cfg := config.Default().Rewards
+	snapshotID, err := billingStore.InsertConfigSnapshot(context.Background(), cfg, time.Unix(1716768000, 0).UTC())
+	if err != nil {
+		t.Fatalf("InsertConfigSnapshot: %v", err)
+	}
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeProviderOK(w)
+	}))
+	defer upstream.Close()
+
+	registry := pool.NewRegistry(nil)
+	registerSettlementProvider(registry, "p1", "session-1", upstream.URL, 30, bytes.Repeat([]byte{0x7a}, 32))
+	provider := byomAdmissionProvider(t, registry.Snapshot()[0])
+	store := providerws.NewMemoryModelAdmissionStore()
+	first := seedBYOMAdmissionState(t, store, provider, "settlement_capable")
+	routeProvider := clearBYOMAdmissionFields(provider)
+	registry.Register(&routeProvider, nil)
+	server := buyer.NewServer(
+		registry,
+		zerolog.Nop(),
+		time.Unix(1716768000, 0),
+		buyer.WithRequestLog(reqLog),
+		buyer.WithBilling(billingStore, cfg),
+		buyer.WithBillingSnapshotID(snapshotID),
+		buyer.WithModelAdmissionStore(store),
+	)
+
+	firstRR := postChat(t, server, []byte(`{"model":"model-a","messages":[{"role":"user","content":"hi"}]}`), nil)
+	if firstRR.Code != http.StatusOK {
+		t.Fatalf("first status=%d body=%s", firstRR.Code, firstRR.Body.String())
+	}
+	withdraw := first
+	withdraw.ReasonCode = "provider_requested"
+	withdraw.RequestID = "withdraw-before-readmission"
+	withdraw.Nonce = "nonce-withdraw-before-readmission"
+	withdraw.PayloadDigestSHA256 = strings.Repeat("2", 64)
+	withdraw.SignatureDigestSHA256 = strings.Repeat("3", 64)
+	withdraw.CreatedAt = time.Unix(1800000030, 0).UTC()
+	if _, _, err := store.AppendModelAdmissionWithdrawal(context.Background(), withdraw); err != nil {
+		t.Fatalf("AppendModelAdmissionWithdrawal: %v", err)
+	}
+
+	provider.ModelAdmissionDiscoveryDigestSHA256 = strings.Repeat("4", 64)
+	provider.ModelAdmissionEvaluationDigestSHA256 = strings.Repeat("5", 64)
+	second := seedBYOMAdmissionStateWithSuffix(t, store, provider, "settlement_capable", "settlement-capable-readmit")
+	if second.CoordinatorEventID == first.CoordinatorEventID {
+		t.Fatal("readmission reused coordinator event id")
+	}
+	routeProvider = clearBYOMAdmissionFields(provider)
+	registry.Register(&routeProvider, nil)
+	slotsFree := 1
+	registry.ApplyStateUpdate(provider.ProviderID, provider.AssignedID, pool.StateUpdate{State: pool.StateReady, SlotsFree: &slotsFree, At: time.Now().UTC()})
+	secondRR := postChat(t, server, []byte(`{"model":"model-a","messages":[{"role":"user","content":"hi again"}]}`), nil)
+	if secondRR.Code != http.StatusOK {
+		t.Fatalf("second status=%d body=%s", secondRR.Code, secondRR.Body.String())
+	}
+
+	bindings := queryRouteSnapshotBYOMBindings(t, dbPath)
+	if len(bindings) != 2 {
+		t.Fatalf("BYOM route snapshots=%d want 2: %#v", len(bindings), bindings)
+	}
+	if bindings[0]["model_admission_coordinator_event_id"] != first.CoordinatorEventID {
+		t.Fatalf("first snapshot event=%v want %s", bindings[0]["model_admission_coordinator_event_id"], first.CoordinatorEventID)
+	}
+	if bindings[1]["model_admission_coordinator_event_id"] != second.CoordinatorEventID {
+		t.Fatalf("second snapshot event=%v want %s", bindings[1]["model_admission_coordinator_event_id"], second.CoordinatorEventID)
+	}
+	if bindings[1]["model_admission_discovery_digest_sha256"] == bindings[0]["model_admission_discovery_digest_sha256"] {
+		t.Fatalf("readmission snapshot reused stale discovery digest: %#v", bindings)
+	}
+	if bindings[1]["model_admission_discovery_digest_sha256"] != provider.ModelAdmissionDiscoveryDigestSHA256 {
+		t.Fatalf("second snapshot discovery digest=%v want %s", bindings[1]["model_admission_discovery_digest_sha256"], provider.ModelAdmissionDiscoveryDigestSHA256)
+	}
+}
+
 func TestRouteSnapshotSkippedForUppercaseModelHash(t *testing.T) {
 	tier2.ResetForTest()
 	t.Cleanup(tier2.ResetForTest)
@@ -1222,6 +1663,139 @@ func routeSnapshotCount(t *testing.T, dbPath string) int {
 		t.Fatalf("count snapshots: %v", err)
 	}
 	return count
+}
+
+func queryRouteSnapshotBYOMBinding(t *testing.T, dbPath string) map[string]any {
+	t.Helper()
+	bindings := queryRouteSnapshotBYOMBindings(t, dbPath)
+	if len(bindings) == 0 {
+		t.Fatal("no route snapshot rows")
+	}
+	return bindings[0]
+}
+
+func queryRouteSnapshotBYOMBindings(t *testing.T, dbPath string) []map[string]any {
+	t.Helper()
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+	rows, err := db.Query(`SELECT route_snapshot_json FROM settlement_route_snapshots ORDER BY id ASC`)
+	if err != nil {
+		t.Fatalf("query route snapshot json: %v", err)
+	}
+	defer rows.Close()
+	var got []map[string]any
+	for rows.Next() {
+		var raw string
+		if err := rows.Scan(&raw); err != nil {
+			t.Fatalf("scan route snapshot json: %v", err)
+		}
+		var one map[string]any
+		if err := json.Unmarshal([]byte(raw), &one); err != nil {
+			t.Fatalf("route snapshot json: %v", err)
+		}
+		got = append(got, one)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("route snapshot json rows: %v", err)
+	}
+	return got
+}
+
+func byomAdmissionProvider(t *testing.T, provider pool.Provider) pool.Provider {
+	t.Helper()
+	provider.ModelAdmissionCandidateID = "byom_" + strings.Repeat("a", 52)
+	provider.ModelAdmissionServedModelRef = "ollama:qwen3-8b"
+	provider.ModelAdmissionCatalogModelKey = "model-a"
+	provider.ModelAdmissionDiscoveryDigestSHA256 = strings.Repeat("b", 64)
+	provider.ModelAdmissionEvaluationDigestSHA256 = strings.Repeat("c", 64)
+	return provider
+}
+
+func clearBYOMAdmissionFields(provider pool.Provider) pool.Provider {
+	provider.ModelAdmissionCandidateID = ""
+	provider.ModelAdmissionServedModelRef = ""
+	provider.ModelAdmissionCatalogModelKey = ""
+	provider.ModelAdmissionCoordinatorEventID = ""
+	provider.ModelAdmissionDiscoveryDigestSHA256 = ""
+	provider.ModelAdmissionEvaluationDigestSHA256 = ""
+	return provider
+}
+
+func seedBYOMAdmissionState(t *testing.T, store providerws.ModelAdmissionStore, provider pool.Provider, state string) providerws.ModelAdmissionEvent {
+	t.Helper()
+	return seedBYOMAdmissionStateWithSuffix(t, store, provider, state, state)
+}
+
+func seedBYOMAdmissionStateWithSuffix(t *testing.T, store providerws.ModelAdmissionStore, provider pool.Provider, state, suffix string) providerws.ModelAdmissionEvent {
+	t.Helper()
+	if store == nil {
+		t.Fatal("nil model admission store")
+	}
+	offer := providerws.ModelAdmissionEvent{
+		ProviderID:               provider.ProviderID,
+		CandidateID:              provider.ModelAdmissionCandidateID,
+		ServedModelRef:           provider.ModelAdmissionServedModelRef,
+		CatalogModelKey:          provider.ModelAdmissionCatalogModelKey,
+		DiscoveryDigestSHA256:    provider.ModelAdmissionDiscoveryDigestSHA256,
+		EvaluationDigestSHA256:   provider.ModelAdmissionEvaluationDigestSHA256,
+		RequestedDisclosureClass: "network_admitted_unsettled",
+		RequestID:                "offer-" + suffix,
+		Nonce:                    "nonce-offer-" + suffix,
+		PayloadDigestSHA256:      strings.Repeat("d", 64),
+		SignatureDigestSHA256:    strings.Repeat("e", 64),
+		CreatedAt:                time.Unix(1800000000, 0).UTC(),
+	}
+	stored, _, err := store.AppendModelAdmissionOffer(context.Background(), offer)
+	if err != nil {
+		t.Fatalf("AppendModelAdmissionOffer: %v", err)
+	}
+	if state == "offer_submitted" {
+		return stored
+	}
+	catalogPriced := stored
+	catalogPriced.State = "catalog_priced"
+	catalogPriced.RequestID = "decision-catalog-priced-" + suffix
+	catalogPriced.Nonce = "nonce-catalog-priced-" + suffix
+	catalogPriced.PayloadDigestSHA256 = strings.Repeat("f", 64)
+	catalogPriced.CreatedAt = time.Unix(1800000010, 0).UTC()
+	catalogPriced = withBYOMTrustedCatalogDecisionFields(t, catalogPriced, provider)
+	stored, err = store.AppendModelAdmissionDecision(context.Background(), catalogPriced)
+	if err != nil {
+		t.Fatalf("AppendModelAdmissionDecision(catalog_priced): %v", err)
+	}
+	if state == "catalog_priced" {
+		return stored
+	}
+	settlement := stored
+	settlement.State = state
+	settlement.RequestID = "decision-" + suffix
+	settlement.Nonce = "nonce-" + suffix
+	settlement.PayloadDigestSHA256 = strings.Repeat("1", 64)
+	settlement.CreatedAt = time.Unix(1800000020, 0).UTC()
+	settlement = withBYOMTrustedCatalogDecisionFields(t, settlement, provider)
+	stored, err = store.AppendModelAdmissionDecision(context.Background(), settlement)
+	if err != nil {
+		t.Fatalf("AppendModelAdmissionDecision(%s): %v", state, err)
+	}
+	return stored
+}
+
+func withBYOMTrustedCatalogDecisionFields(t *testing.T, event providerws.ModelAdmissionEvent, provider pool.Provider) providerws.ModelAdmissionEvent {
+	t.Helper()
+	material, ok := tier2.SnapshotMaterial(provider.ModelID, strings.TrimSpace(provider.ModelHash))
+	if !ok {
+		t.Fatalf("missing trusted catalog material for %s", provider.ModelID)
+	}
+	event.CatalogID = material.CatalogID
+	event.CatalogBodyDigest = material.CatalogBodyDigest
+	event.CatalogSignatureKeyID = material.CatalogSignatureKeyID
+	event.CatalogSignaturePubkeyFingerprint = material.CatalogSignaturePubkeyFingerprint
+	event.ExpectedCatalogModelHash = material.ExpectedModelHash
+	event.ExpectedCatalogModelHashAlgorithm = material.ExpectedModelHashAlgorithm
+	return event
 }
 
 func expectedRouteSnapshotPromptHash(t *testing.T, model string) string {

--- a/phase4-coordinator/internal/buyer/server.go
+++ b/phase4-coordinator/internal/buyer/server.go
@@ -81,6 +81,10 @@ var spec018RetryableByCode = map[string]bool{
 	// succeed once a provider upgrades and reconnects.
 	"model_version_floor_unmet": true,
 	"rate_limited":              true, // 429, Tier-2 disclosure endpoints already ship Retry-After: 1
+	// BYOM admission states below settlement_capable are intentionally
+	// terminal for the current request: retrying the same paid route must not
+	// imply earning or catalog-priced settlement.
+	"byom_non_settlement_unavailable": false,
 	// SPEC-042 R005/R010 tenant isolation.
 	"pool_state_stale":                     true,  // 409, pool membership changed during routing; re-select
 	"pool_unavailable":                     false, // 503, unknown/unauthorized/disabled/non-active pool; same request must not be retried unchanged
@@ -214,6 +218,7 @@ type Server struct {
 	relay                    RelayFunc
 	settlementRelay          SettlementRelayFunc
 	admission                *providerws.AdmissionManager
+	modelAdmissionStore      providerws.ModelAdmissionStore
 	requestTimeout           time.Duration
 	failoverEnabled          bool
 	failoverTimeout          time.Duration
@@ -635,6 +640,12 @@ func WithAdmission(admission *providerws.AdmissionManager, provisionalWeight flo
 		if provisionalWeight > 0 {
 			s.provisionalWeight = provisionalWeight
 		}
+	}
+}
+
+func WithModelAdmissionStore(store providerws.ModelAdmissionStore) Option {
+	return func(s *Server) {
+		s.modelAdmissionStore = store
 	}
 }
 
@@ -2005,6 +2016,9 @@ func (s *Server) handleModels(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 		if !pillarAActive && (p.State != pool.StateReady || !p.CapacityEligible()) {
+			continue
+		}
+		if !s.byomDefaultPaidRoutingEligible(p) {
 			continue
 		}
 		excluded := tier2Active && s.tier2ProviderExcludedForConfig(p, cfg)
@@ -5881,6 +5895,15 @@ type routeError struct {
 	typ     string
 }
 
+func byomNonSettlementRouteError(model string) *routeError {
+	return &routeError{
+		status:  http.StatusServiceUnavailable,
+		code:    "byom_non_settlement_unavailable",
+		message: "No settlement-capable BYOM provider is available for model " + model,
+		typ:     "server_error",
+	}
+}
+
 func (s *Server) selectProvider(ctx context.Context, requestID string, req chatRequest, headers http.Header, dailyKey string, state *forwardState) (pool.Provider, *routeError) {
 	return s.selectProviderExcluding(ctx, requestID, req, headers, nil, dailyKey, state)
 }
@@ -6164,6 +6187,9 @@ func (s *Server) selectProviderExcluding(ctx context.Context, requestID string, 
 		if poolActive && result.Counts[routing.ReasonPoolNotMember] > 0 {
 			return pool.Provider{}, &routeError{status: http.StatusServiceUnavailable, code: "pool_no_eligible_member", message: "No eligible member is available for the selected pool"}
 		}
+		if result.Counts[routing.ReasonBYOMNonSettlement] > 0 {
+			return pool.Provider{}, byomNonSettlementRouteError(req.Model)
+		}
 		return pool.Provider{}, &routeError{status: http.StatusServiceUnavailable, code: "no_provider_available", message: "No provider available for model " + req.Model}
 	}
 	objective := s.objectiveForRequest(headers, class)
@@ -6342,6 +6368,9 @@ func stringSliceEqual(a, b []string) bool {
 
 func (s *Server) classForRequest(model string, providers []pool.Provider) *config.ModelClassConfig {
 	for _, p := range providers {
+		if !s.byomDefaultPaidRoutingEligible(p) {
+			continue
+		}
 		if modelIDEqual(p.ModelID, model) {
 			return nil
 		}
@@ -6647,6 +6676,8 @@ func routeKeyedFilterCounts(counts map[routing.RejectionReason]int) map[string]i
 			key = "pool_provider_capability_unsatisfied" // SPEC-042 R010: provider-side positive capability advertisement missing
 		case routing.ReasonPoolBinaryTooOld:
 			key = "pool_binary_too_old" // SPEC-042 R004/R010: under-version pool member, observable distinctly
+		case routing.ReasonBYOMNonSettlement:
+			key = "byom_non_settlement"
 		default:
 			key = "other"
 		}
@@ -6868,6 +6899,9 @@ func (s *Server) validatePinnedProviderForRequest(p pool.Provider, model string,
 	if !s.providerMatchesRequest(p, model, class) {
 		return pool.Provider{}, &routeError{status: http.StatusNotFound, code: "model_not_found", message: "Pinned provider serves different model"}
 	}
+	if !s.byomDefaultPaidRoutingEligible(p) {
+		return pool.Provider{}, byomNonSettlementRouteError(model)
+	}
 	// #768 self-route preflight gate. The pinned/self-route path bypasses
 	// routing.EligibleCandidates entirely, so the floor must be re-applied here
 	// or a hard pin would be a hole straight through the public routing gate.
@@ -7073,7 +7107,7 @@ func (s *Server) pollQueuedProvider(waiter *slotWaiter, model string, class *con
 		if s.poolSettlementModeUnsatisfied(state) {
 			return pool.Provider{}, queuedProviderPoolSettlementUnsatisfied
 		}
-		if !s.providerMatchesRequest(provider, model, class) || provider.MaxContextTokens < estimatedTokens {
+		if !s.providerMatchesRequest(provider, model, class) || !s.byomDefaultPaidRoutingEligible(provider) || provider.MaxContextTokens < estimatedTokens {
 			return pool.Provider{}, queuedProviderTerminal
 		}
 		// #768 audit R1 (security+architect MEDIUM): the waiter stores only
@@ -7121,7 +7155,7 @@ func (s *Server) slotQueueCandidates(providers []pool.Provider, excluded routing
 		if excluded.Has(provider.SortKey()) || !s.providerSlotQueueEligible(provider) {
 			continue
 		}
-		if !s.providerMatchesRequest(provider, checker.model, checker.class) || !checker.ProviderContextSufficient(provider) {
+		if !s.providerMatchesRequest(provider, checker.model, checker.class) || !s.byomDefaultPaidRoutingEligible(provider) || !checker.ProviderContextSufficient(provider) {
 			continue
 		}
 		// SPEC-042 R005: the slot queue re-derives the routing gate by hand,
@@ -7306,6 +7340,10 @@ type eligibilityCtx struct {
 // either failure as ReasonModelMismatch to preserve byte identity.
 func (c *eligibilityCtx) ProviderMatchesRequest(p pool.Provider) bool {
 	return c.s.providerMatchesRequest(p, c.model, c.class) && p.RoutingEligible()
+}
+
+func (c *eligibilityCtx) ProviderBYOMSettlementEligible(p pool.Provider) bool {
+	return c.s.byomDefaultPaidRoutingEligible(p)
 }
 
 // ProviderMeetsModelVersionFloor delegates to the shared #768 gate. See

--- a/phase4-coordinator/internal/buyer/server_internal_test.go
+++ b/phase4-coordinator/internal/buyer/server_internal_test.go
@@ -687,6 +687,7 @@ func TestRetryableByCodeClassification(t *testing.T) {
 		"session_ended", "tier2_hash_verified_required", "tier2_encrypted_leg_required",
 		"tier2_attestation_required", "tier2_hard_pin_predicate_failed",
 		"tier2_hash_mismatch", "tier2_aead_decrypt_failed", "tier2_output_encoding_invalid",
+		"byom_non_settlement_unavailable",
 		// Round-3 sweep additions: reviewed and confirmed permanent.
 		"autotune_feed_not_found", "invalid_tools",
 	}
@@ -740,6 +741,7 @@ var coordinatorEmittedErrorCodes = []string{
 	"tool_call_id_not_found", "tool_call_result_out_of_order", "tool_result_too_large",
 	"tool_results_aggregate_too_large", "unauthorized", "unsupported_content_shape",
 	"unsupported_modelID_for_multi_turn",
+	"byom_non_settlement_unavailable",
 	// SPEC-042 R005/R010 tenant isolation.
 	"pool_no_eligible_member", "pool_state_stale", "pool_unavailable", "pool_binary_too_old",
 	"pool_policy_stale", "pool_model_not_allowed", "pool_attestation_unsatisfied", "pool_encrypted_leg_unsatisfied",

--- a/phase4-coordinator/internal/buyer/server_test.go
+++ b/phase4-coordinator/internal/buyer/server_test.go
@@ -8305,7 +8305,12 @@ func TestSlotQueueBurstSweepAvoidsBuyerVisible503(t *testing.T) {
 }
 
 func TestSlotQueueAppliesToHTTPRetryReplacementProvider(t *testing.T) {
+	failHit := make(chan struct{}, 1)
 	failUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case failHit <- struct{}{}:
+		default:
+		}
 		http.Error(w, "bad gateway", http.StatusBadGateway)
 	}))
 	defer failUpstream.Close()
@@ -8334,6 +8339,11 @@ func TestSlotQueueAppliesToHTTPRetryReplacementProvider(t *testing.T) {
 		buyer.WithSlotQueueConfig(4, 100*time.Millisecond, time.Millisecond),
 	)
 	go func() {
+		select {
+		case <-failHit:
+		case <-time.After(time.Second):
+			return
+		}
 		time.Sleep(10 * time.Millisecond)
 		one := 1
 		registry.ApplyStateUpdate("queued", "s2", pool.StateUpdate{State: pool.StateReady, SlotsFree: &one, At: time.Now().UTC()})

--- a/phase4-coordinator/internal/pool/provider.go
+++ b/phase4-coordinator/internal/pool/provider.go
@@ -170,6 +170,16 @@ type Provider struct {
 	CandidateCatalogSHA256 string `json:"catalog_candidate_sha256,omitempty"`
 	CatalogSignerKeyID     string `json:"catalog_signer_key_id,omitempty"`
 	CandidateRowIdentity   string `json:"catalog_row_identity,omitempty"`
+	// BYOM model-admission binding. These fields are coordinator-authored
+	// settlement inputs for provider-supplied models; provider-reported model
+	// names/catalog keys remain non-authoritative without a current admission
+	// event that matches this tuple.
+	ModelAdmissionCandidateID            string `json:"model_admission_candidate_id,omitempty"`
+	ModelAdmissionCoordinatorEventID     string `json:"model_admission_coordinator_event_id,omitempty"`
+	ModelAdmissionServedModelRef         string `json:"model_admission_served_model_ref,omitempty"`
+	ModelAdmissionCatalogModelKey        string `json:"model_admission_catalog_model_key,omitempty"`
+	ModelAdmissionDiscoveryDigestSHA256  string `json:"model_admission_discovery_digest_sha256,omitempty"`
+	ModelAdmissionEvaluationDigestSHA256 string `json:"model_admission_evaluation_digest_sha256,omitempty"`
 	// SPEC-015 v0.1.3 / SPEC-001 v1.6 — raw ed25519 public key bytes
 	// populated from auth_request.provider_receipt_public_key when present.
 	ReceiptPubkey []byte `json:"-"`

--- a/phase4-coordinator/internal/routing/filter.go
+++ b/phase4-coordinator/internal/routing/filter.go
@@ -80,6 +80,10 @@ const (
 	// selected, the checker returns true and this reason never fires, so
 	// poolless selection stays byte-identical.
 	ReasonPoolProviderCapability
+	// ReasonBYOMNonSettlement — provider advertises the requested model/class
+	// but has coordinator-owned BYOM admission state that is not currently
+	// settlement_capable for the trusted catalog/hash tuple.
+	ReasonBYOMNonSettlement
 )
 
 // EligibilityChecker is the cross-package boundary between the
@@ -100,6 +104,12 @@ type EligibilityChecker interface {
 	// class check with RoutingEligible(); a false return is
 	// reported as ReasonModelMismatch.
 	ProviderMatchesRequest(p pool.Provider) bool
+
+	// ProviderBYOMSettlementEligible reports whether a matching provider may
+	// enter default paid routing under SPEC-047/SPEC-022 BYOM admission rules.
+	// It is separate from model/class matching so hidden BYOM states cannot
+	// shadow aliases or surface as model_not_found.
+	ProviderBYOMSettlementEligible(p pool.Provider) bool
 
 	// ProviderMeetsModelVersionFloor reports whether the provider's
 	// reported binary_version satisfies the per-model minimum
@@ -220,21 +230,21 @@ type FilterResult struct {
 //  2. ProviderMatchesRequest (model/class + FR-P5 state) — combined
 //     gate; either failure is ReasonModelMismatch (the inline loop
 //     short-circuits to `continue` without separating the two)
-//  3. ProviderMeetsModelVersionFloor — ReasonModelVersionFloor
-//     (#768). Runs immediately after the model match because the
-//     floor is keyed BY model; a no-op when no floors are
-//     configured, so default-config selection stays byte-identical
-//     (AC-SR-1).
-//     3b. ProviderHasSettlementReceiptKey — ReasonReceiptKeyMissing
+//  3. ProviderBYOMSettlementEligible — ReasonBYOMNonSettlement
+//  4. ProviderMeetsModelVersionFloor — ReasonModelVersionFloor
+//     (#768). Runs after the BYOM money gate because hidden admission states
+//     must not enter paid routing even when their binary version is current;
+//     a no-op when no floors are configured.
+//     4b. ProviderHasSettlementReceiptKey — ReasonReceiptKeyMissing
 //     (SPEC-022 R-2.4/R-2.5). A no-op in observe mode / when the
 //     settlement store is unavailable, so default / observe selection
 //     stays byte-identical; under enforce it drops providers with no
 //     active receipt key so routing never selects a box whose route
 //     snapshot is guaranteed to fail pre-dispatch.
-//  4. ProviderContextSufficient — ReasonContextTooSmall
-//  5. Tier2Decision — ReasonTier2HashMismatch / ReasonTier2Hash
+//  5. ProviderContextSufficient — ReasonContextTooSmall
+//  6. Tier2Decision — ReasonTier2HashMismatch / ReasonTier2Hash
 //     Required / ReasonTier2EncryptedLeg / ReasonTier2Attestation
-//  6. QuotaPermits — ReasonQuotaBlocked (applied as a second pass
+//  7. QuotaPermits — ReasonQuotaBlocked (applied as a second pass
 //     here to preserve the "quota is soft, drives 429 only when
 //     every other check passed" semantics)
 //
@@ -286,6 +296,10 @@ func EligibleCandidates(
 		}
 		if !checker.ProviderMatchesRequest(p) {
 			res.Counts[ReasonModelMismatch]++
+			continue
+		}
+		if !checker.ProviderBYOMSettlementEligible(p) {
+			res.Counts[ReasonBYOMNonSettlement]++
 			continue
 		}
 		if !checker.ProviderMeetsModelVersionFloor(p) {

--- a/phase4-coordinator/internal/routing/filter_test.go
+++ b/phase4-coordinator/internal/routing/filter_test.go
@@ -13,6 +13,7 @@ type stubChecker struct {
 	matches        map[string]bool
 	versionFloorOK map[string]bool
 	receiptKeyOK   map[string]bool
+	byomOK         map[string]bool
 	contextOK      map[string]bool
 	tier2          map[string]routing.RejectionReason
 	tier2Hash      map[string]pool.HashStatus
@@ -24,6 +25,12 @@ type stubChecker struct {
 
 func (s *stubChecker) ProviderMatchesRequest(p pool.Provider) bool {
 	if v, ok := s.matches[p.ProviderID]; ok {
+		return v
+	}
+	return true
+}
+func (s *stubChecker) ProviderBYOMSettlementEligible(p pool.Provider) bool {
+	if v, ok := s.byomOK[p.ProviderID]; ok {
 		return v
 	}
 	return true
@@ -245,6 +252,7 @@ type recordingChecker struct {
 	matchFail        map[string]bool
 	versionFloorFail map[string]bool
 	receiptKeyFail   map[string]bool
+	byomFail         map[string]bool
 	contextFail      map[string]bool
 	tier2Reason      map[string]routing.RejectionReason
 	quotaFail        map[string]bool
@@ -255,6 +263,10 @@ type recordingChecker struct {
 func (r *recordingChecker) ProviderMatchesRequest(p pool.Provider) bool {
 	r.calls = append(r.calls, p.ProviderID+"/match")
 	return !r.matchFail[p.ProviderID]
+}
+func (r *recordingChecker) ProviderBYOMSettlementEligible(p pool.Provider) bool {
+	r.calls = append(r.calls, p.ProviderID+"/byom")
+	return !r.byomFail[p.ProviderID]
 }
 func (r *recordingChecker) ProviderMeetsModelVersionFloor(p pool.Provider) bool {
 	r.calls = append(r.calls, p.ProviderID+"/version_floor")
@@ -300,15 +312,15 @@ func TestEligibleCandidates_OrderingExcludedShortCircuitsEverything(t *testing.T
 	ex.Add(providers[0], keyer)
 	checker := &recordingChecker{t: t, matchFail: map[string]bool{"match-fail-y": true}}
 	res := routing.EligibleCandidates(providers, ex, keyer, checker)
-	// Excluded provider MUST never reach match/version_floor/context/tier2/quota.
+	// Excluded provider MUST never reach match/byom/version_floor/context/tier2/quota.
 	for _, c := range checker.calls {
-		if c == "excluded-x/match" || c == "excluded-x/version_floor" || c == "excluded-x/context" || c == "excluded-x/tier2" || c == "excluded-x/quota" {
+		if c == "excluded-x/match" || c == "excluded-x/byom" || c == "excluded-x/version_floor" || c == "excluded-x/context" || c == "excluded-x/tier2" || c == "excluded-x/quota" {
 			t.Fatalf("excluded provider hit later gate: %q (full calls: %v)", c, checker.calls)
 		}
 	}
-	// match-fail-y reaches match but NOT version_floor/context/tier2/quota.
+	// match-fail-y reaches match but NOT byom/version_floor/context/tier2/quota.
 	for _, c := range checker.calls {
-		if c == "match-fail-y/version_floor" || c == "match-fail-y/context" || c == "match-fail-y/tier2" || c == "match-fail-y/quota" {
+		if c == "match-fail-y/byom" || c == "match-fail-y/version_floor" || c == "match-fail-y/context" || c == "match-fail-y/tier2" || c == "match-fail-y/quota" {
 			t.Fatalf("match-rejected provider hit later gate: %q", c)
 		}
 	}
@@ -319,17 +331,16 @@ func TestEligibleCandidates_OrderingExcludedShortCircuitsEverything(t *testing.T
 
 func TestEligibleCandidates_OrderingPerProviderSequence(t *testing.T) {
 	// For a provider that passes every gate, the call sequence MUST
-	// be exactly match → version_floor → receipt_key → context →
-	// tier2 → quota. FR-SR-18 order, with the #768 per-model version
-	// floor inserted right after the model match (keyed BY model) and
-	// the SPEC-022 R-2.4/R-2.5 receipt-key gate immediately after it.
+	// be exactly match → byom → version_floor → receipt_key → context →
+	// tier2 → quota. FR-SR-18 order keeps the BYOM money gate after the
+	// model/class match and before settlement-specific route prerequisites.
 	t.Parallel()
 	providers := []pool.Provider{{ProviderID: "p", AssignedID: "s"}}
 	checker := &recordingChecker{t: t}
 	routing.EligibleCandidates(providers, routing.NewExcluded(0), keyer, checker)
 	// SPEC-042 R005 pool-membership gate is first among property gates
 	// (right after excluded), before the model match.
-	want := []string{"p/pool", "p/pool_cap", "p/pool_binary", "p/match", "p/version_floor", "p/receipt_key", "p/context", "p/tier2", "p/quota"}
+	want := []string{"p/pool", "p/pool_cap", "p/pool_binary", "p/match", "p/byom", "p/version_floor", "p/receipt_key", "p/context", "p/tier2", "p/quota"}
 	if len(checker.calls) != len(want) {
 		t.Fatalf("call count: want %d, got %d (calls=%v)", len(want), len(checker.calls), checker.calls)
 	}
@@ -345,7 +356,7 @@ func TestEligibleCandidates_OrderingContextRejectStopsBeforeTier2AndQuota(t *tes
 	providers := []pool.Provider{{ProviderID: "p", AssignedID: "s"}}
 	checker := &recordingChecker{t: t, contextFail: map[string]bool{"p": true}}
 	routing.EligibleCandidates(providers, routing.NewExcluded(0), keyer, checker)
-	want := []string{"p/pool", "p/pool_cap", "p/pool_binary", "p/match", "p/version_floor", "p/receipt_key", "p/context"}
+	want := []string{"p/pool", "p/pool_cap", "p/pool_binary", "p/match", "p/byom", "p/version_floor", "p/receipt_key", "p/context"}
 	if len(checker.calls) != len(want) {
 		t.Fatalf("context-reject: want sequence %v, got %v", want, checker.calls)
 	}
@@ -370,6 +381,19 @@ func TestEligibleCandidates_ReceiptKeyMissingExcluded(t *testing.T) {
 	}
 	if res.Counts[routing.ReasonReceiptKeyMissing] != 1 {
 		t.Fatalf("want ReasonReceiptKeyMissing==1, got %d (counts=%v)", res.Counts[routing.ReasonReceiptKeyMissing], res.Counts)
+	}
+}
+
+func TestEligibleCandidates_BYOMNonSettlementExcluded(t *testing.T) {
+	t.Parallel()
+	providers := []pool.Provider{mkProvider("settlement"), mkProvider("offered")}
+	checker := &stubChecker{byomOK: map[string]bool{"offered": false}}
+	res := routing.EligibleCandidates(providers, routing.NewExcluded(0), keyer, checker)
+	if len(res.Eligible) != 1 || res.Eligible[0].ProviderID != "settlement" {
+		t.Fatalf("want only settlement-capable BYOM eligible, got %+v", res.Eligible)
+	}
+	if res.Counts[routing.ReasonBYOMNonSettlement] != 1 {
+		t.Fatalf("want ReasonBYOMNonSettlement==1, got %d (counts=%v)", res.Counts[routing.ReasonBYOMNonSettlement], res.Counts)
 	}
 }
 
@@ -498,7 +522,7 @@ func TestEligibleCandidates_OrderingVersionFloorRejectStopsBeforeContext(t *test
 	providers := []pool.Provider{{ProviderID: "p", AssignedID: "s"}}
 	checker := &recordingChecker{t: t, versionFloorFail: map[string]bool{"p": true}}
 	routing.EligibleCandidates(providers, routing.NewExcluded(0), keyer, checker)
-	want := []string{"p/pool", "p/pool_cap", "p/pool_binary", "p/match", "p/version_floor"}
+	want := []string{"p/pool", "p/pool_cap", "p/pool_binary", "p/match", "p/byom", "p/version_floor"}
 	if len(checker.calls) != len(want) {
 		t.Fatalf("calls = %v, want exactly %v", checker.calls, want)
 	}

--- a/phase4-coordinator/internal/tier2/catalog.go
+++ b/phase4-coordinator/internal/tier2/catalog.go
@@ -58,7 +58,9 @@ type ParsedCatalog struct {
 
 type RouteSnapshotMaterial struct {
 	CatalogID                         string
+	CatalogModelKey                   string
 	ExpectedModelHash                 string
+	ExpectedModelHashAlgorithm        string
 	CatalogBodyDigest                 string
 	CatalogSignatureKeyID             string
 	CatalogSignaturePubkeyFingerprint string
@@ -456,7 +458,9 @@ func (c *Catalog) RouteSnapshotMaterial(modelID, reportedHash string) (RouteSnap
 	}
 	return RouteSnapshotMaterial{
 		CatalogID:                         parsed.CatalogID,
+		CatalogModelKey:                   catalogModelKey(model.ModelID),
 		ExpectedModelHash:                 model.SHA256,
+		ExpectedModelHashAlgorithm:        modelidentity.SnapshotManifestV1,
 		CatalogBodyDigest:                 parsed.CatalogBodyDigest,
 		CatalogSignatureKeyID:             parsed.CatalogSignatureKeyID,
 		CatalogSignaturePubkeyFingerprint: parsed.CatalogSignaturePubkeyFingerprint,

--- a/phase4-coordinator/internal/ws/model_admission.go
+++ b/phase4-coordinator/internal/ws/model_admission.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/augstar/macprovider-coordinator/internal/billing"
 	"github.com/augstar/macprovider-coordinator/internal/config"
+	"github.com/augstar/macprovider-coordinator/internal/modelidentity"
 	"github.com/augstar/macprovider-coordinator/internal/sqliteutil"
 )
 
@@ -57,27 +58,34 @@ type ModelAdmissionStore interface {
 	AppendModelAdmissionWithdrawal(context.Context, ModelAdmissionEvent) (ModelAdmissionEvent, bool, error)
 	AppendModelAdmissionDecision(context.Context, ModelAdmissionEvent) (ModelAdmissionEvent, error)
 	LatestModelAdmissionStatus(context.Context, string, string) (ModelAdmissionEvent, bool, error)
+	LatestModelAdmissionRouteStatus(context.Context, string, string, string) (ModelAdmissionEvent, bool, error)
 }
 
 type ModelAdmissionEvent struct {
-	CoordinatorEventID       string
-	Actor                    string
-	ProviderID               string
-	CandidateID              string
-	ServedModelRef           string
-	CatalogModelKey          string
-	DiscoveryDigestSHA256    string
-	EvaluationDigestSHA256   string
-	RequestedDisclosureClass string
-	PreviousState            string
-	State                    string
-	NextState                string
-	ReasonCode               string
-	RequestID                string
-	Nonce                    string
-	PayloadDigestSHA256      string
-	SignatureDigestSHA256    string
-	CreatedAt                time.Time
+	CoordinatorEventID                string
+	Actor                             string
+	ProviderID                        string
+	CandidateID                       string
+	ServedModelRef                    string
+	CatalogModelKey                   string
+	CatalogID                         string
+	CatalogBodyDigest                 string
+	CatalogSignatureKeyID             string
+	CatalogSignaturePubkeyFingerprint string
+	ExpectedCatalogModelHash          string
+	ExpectedCatalogModelHashAlgorithm string
+	DiscoveryDigestSHA256             string
+	EvaluationDigestSHA256            string
+	RequestedDisclosureClass          string
+	PreviousState                     string
+	State                             string
+	NextState                         string
+	ReasonCode                        string
+	RequestID                         string
+	Nonce                             string
+	PayloadDigestSHA256               string
+	SignatureDigestSHA256             string
+	CreatedAt                         time.Time
 }
 
 type memoryModelAdmissionStore struct {
@@ -186,7 +194,7 @@ func (s *memoryModelAdmissionStore) appendCoordinatorModelAdmissionEvent(event M
 	if !modelAdmissionCoordinatorTransitionAllowed(previous.State, event.State) {
 		return ModelAdmissionEvent{}, false, errModelAdmissionReplayConflict
 	}
-	if modelAdmissionTransitionRequiresCatalogKey(event.State) && strings.TrimSpace(event.CatalogModelKey) == "" {
+	if modelAdmissionTransitionRequiresCatalogAuthority(event.State) && !modelAdmissionEventHasTrustedCatalogAuthority(event) {
 		return ModelAdmissionEvent{}, false, errModelAdmissionReplayConflict
 	}
 	if modelAdmissionTransitionReasonRequired(previous.State, event.State) && strings.TrimSpace(event.ReasonCode) == "" {
@@ -220,6 +228,12 @@ func (s *memoryModelAdmissionStore) LatestModelAdmissionStatus(_ context.Context
 	return event, ok, nil
 }
 
+func (s *memoryModelAdmissionStore) LatestModelAdmissionRouteStatus(_ context.Context, providerID, servedModelRef, catalogModelKey string) (ModelAdmissionEvent, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return latestModelAdmissionRouteStatusFromEvents(s.latest, providerID, servedModelRef, catalogModelKey)
+}
+
 type SQLiteModelAdmissionStore struct {
 	db *sql.DB
 }
@@ -235,6 +249,12 @@ CREATE TABLE IF NOT EXISTS model_admission_events (
     candidate_id TEXT NOT NULL,
     served_model_ref TEXT NOT NULL,
     catalog_model_key TEXT NOT NULL,
+    catalog_id TEXT NOT NULL DEFAULT '',
+    catalog_body_digest TEXT NOT NULL DEFAULT '',
+    catalog_signature_key_id TEXT NOT NULL DEFAULT '',
+    catalog_signature_pubkey_fingerprint TEXT NOT NULL DEFAULT '',
+    expected_catalog_model_hash TEXT NOT NULL DEFAULT '',
+    expected_catalog_model_hash_algorithm TEXT NOT NULL DEFAULT '',
     discovery_digest_sha256 TEXT NOT NULL,
     evaluation_digest_sha256 TEXT NOT NULL,
     requested_disclosure_class TEXT NOT NULL,
@@ -252,6 +272,9 @@ CREATE TABLE IF NOT EXISTS model_admission_events (
 )`); err != nil {
 		return nil, err
 	}
+	if err := ensureSQLiteModelAdmissionColumns(db); err != nil {
+		return nil, err
+	}
 	if _, err := db.ExecContext(context.Background(), `
 CREATE UNIQUE INDEX IF NOT EXISTS model_admission_events_provider_request_id
 ON model_admission_events(provider_id, request_id)`); err != nil {
@@ -262,7 +285,64 @@ CREATE UNIQUE INDEX IF NOT EXISTS model_admission_events_provider_nonce
 ON model_admission_events(provider_id, nonce)`); err != nil {
 		return nil, err
 	}
+	if _, err := db.ExecContext(context.Background(), `
+CREATE INDEX IF NOT EXISTS model_admission_events_provider_route_tuple
+ON model_admission_events(provider_id, served_model_ref, LOWER(catalog_model_key), id DESC)`); err != nil {
+		return nil, err
+	}
+	if _, err := db.ExecContext(context.Background(), `
+CREATE INDEX IF NOT EXISTS model_admission_events_provider_catalog
+ON model_admission_events(provider_id, LOWER(catalog_model_key), id DESC)`); err != nil {
+		return nil, err
+	}
+	if _, err := db.ExecContext(context.Background(), `
+CREATE INDEX IF NOT EXISTS model_admission_events_provider_latest
+ON model_admission_events(provider_id, id DESC)`); err != nil {
+		return nil, err
+	}
 	return &SQLiteModelAdmissionStore{db: db}, nil
+}
+
+func ensureSQLiteModelAdmissionColumns(db *sql.DB) error {
+	rows, err := db.QueryContext(context.Background(), `PRAGMA table_info(model_admission_events)`)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	columns := map[string]bool{}
+	for rows.Next() {
+		var cid int
+		var name, typ string
+		var notNull int
+		var defaultValue sql.NullString
+		var pk int
+		if err := rows.Scan(&cid, &name, &typ, &notNull, &defaultValue, &pk); err != nil {
+			return err
+		}
+		columns[name] = true
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	for _, column := range []struct {
+		name string
+		sql  string
+	}{
+		{name: "catalog_id", sql: `ALTER TABLE model_admission_events ADD COLUMN catalog_id TEXT NOT NULL DEFAULT ''`},
+		{name: "catalog_body_digest", sql: `ALTER TABLE model_admission_events ADD COLUMN catalog_body_digest TEXT NOT NULL DEFAULT ''`},
+		{name: "catalog_signature_key_id", sql: `ALTER TABLE model_admission_events ADD COLUMN catalog_signature_key_id TEXT NOT NULL DEFAULT ''`},
+		{name: "catalog_signature_pubkey_fingerprint", sql: `ALTER TABLE model_admission_events ADD COLUMN catalog_signature_pubkey_fingerprint TEXT NOT NULL DEFAULT ''`},
+		{name: "expected_catalog_model_hash", sql: `ALTER TABLE model_admission_events ADD COLUMN expected_catalog_model_hash TEXT NOT NULL DEFAULT ''`},
+		{name: "expected_catalog_model_hash_algorithm", sql: `ALTER TABLE model_admission_events ADD COLUMN expected_catalog_model_hash_algorithm TEXT NOT NULL DEFAULT ''`},
+	} {
+		if columns[column.name] {
+			continue
+		}
+		if _, err := db.ExecContext(context.Background(), column.sql); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (s *SQLiteModelAdmissionStore) AppendModelAdmissionOffer(ctx context.Context, event ModelAdmissionEvent) (ModelAdmissionEvent, bool, error) {
@@ -350,15 +430,24 @@ SELECT COUNT(DISTINCT candidate_id) FROM model_admission_events WHERE provider_i
 		if _, err := conn.ExecContext(txCtx, `
 INSERT INTO model_admission_events(
     provider_id, candidate_id, served_model_ref, catalog_model_key,
+    catalog_id, catalog_body_digest, catalog_signature_key_id,
+    catalog_signature_pubkey_fingerprint, expected_catalog_model_hash,
+    expected_catalog_model_hash_algorithm,
     discovery_digest_sha256, evaluation_digest_sha256, requested_disclosure_class,
     previous_state, state, next_state, actor, coordinator_event_id,
     reason_code, request_id, nonce, payload_digest_sha256,
     signature_digest_sha256, created_at_utc
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			event.ProviderID,
 			event.CandidateID,
 			event.ServedModelRef,
 			event.CatalogModelKey,
+			event.CatalogID,
+			event.CatalogBodyDigest,
+			event.CatalogSignatureKeyID,
+			event.CatalogSignaturePubkeyFingerprint,
+			event.ExpectedCatalogModelHash,
+			event.ExpectedCatalogModelHashAlgorithm,
 			event.DiscoveryDigestSHA256,
 			event.EvaluationDigestSHA256,
 			event.RequestedDisclosureClass,
@@ -405,7 +494,7 @@ func (s *SQLiteModelAdmissionStore) appendCoordinatorModelAdmissionEvent(ctx con
 		if !modelAdmissionCoordinatorTransitionAllowed(previous.State, event.State) {
 			return errModelAdmissionReplayConflict
 		}
-		if modelAdmissionTransitionRequiresCatalogKey(event.State) && strings.TrimSpace(event.CatalogModelKey) == "" {
+		if modelAdmissionTransitionRequiresCatalogAuthority(event.State) && !modelAdmissionEventHasTrustedCatalogAuthority(event) {
 			return errModelAdmissionReplayConflict
 		}
 		if modelAdmissionTransitionReasonRequired(previous.State, event.State) && strings.TrimSpace(event.ReasonCode) == "" {
@@ -432,15 +521,24 @@ func (s *SQLiteModelAdmissionStore) appendCoordinatorModelAdmissionEvent(ctx con
 		if _, err := conn.ExecContext(txCtx, `
 INSERT INTO model_admission_events(
     provider_id, candidate_id, served_model_ref, catalog_model_key,
+    catalog_id, catalog_body_digest, catalog_signature_key_id,
+    catalog_signature_pubkey_fingerprint, expected_catalog_model_hash,
+    expected_catalog_model_hash_algorithm,
     discovery_digest_sha256, evaluation_digest_sha256, requested_disclosure_class,
     previous_state, state, next_state, actor, coordinator_event_id,
     reason_code, request_id, nonce, payload_digest_sha256,
     signature_digest_sha256, created_at_utc
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			event.ProviderID,
 			event.CandidateID,
 			event.ServedModelRef,
 			event.CatalogModelKey,
+			event.CatalogID,
+			event.CatalogBodyDigest,
+			event.CatalogSignatureKeyID,
+			event.CatalogSignaturePubkeyFingerprint,
+			event.ExpectedCatalogModelHash,
+			event.ExpectedCatalogModelHashAlgorithm,
 			event.DiscoveryDigestSHA256,
 			event.EvaluationDigestSHA256,
 			event.RequestedDisclosureClass,
@@ -472,6 +570,67 @@ func (s *SQLiteModelAdmissionStore) LatestModelAdmissionStatus(ctx context.Conte
  LIMIT 1`), providerID, candidateID)
 }
 
+func (s *SQLiteModelAdmissionStore) LatestModelAdmissionRouteStatus(ctx context.Context, providerID, servedModelRef, catalogModelKey string) (ModelAdmissionEvent, bool, error) {
+	servedModelRef = strings.TrimSpace(servedModelRef)
+	catalogModelKey = strings.ToLower(strings.TrimSpace(catalogModelKey))
+	if servedModelRef == "" && catalogModelKey == "" {
+		return scanModelAdmissionEvent(ctx, s.db, modelAdmissionEventSelect(`
+  FROM model_admission_events
+ WHERE provider_id = ?
+ ORDER BY id DESC
+ LIMIT 1`), providerID)
+	}
+	if servedModelRef == "" {
+		return scanModelAdmissionEvent(ctx, s.db, modelAdmissionEventSelect(`
+  FROM model_admission_events
+ WHERE provider_id = ? AND LOWER(catalog_model_key) = ?
+ ORDER BY id DESC
+ LIMIT 1`), providerID, catalogModelKey)
+	}
+	if catalogModelKey == "" {
+		return scanModelAdmissionEvent(ctx, s.db, modelAdmissionEventSelect(`
+  FROM model_admission_events
+ WHERE provider_id = ? AND served_model_ref = ?
+ ORDER BY id DESC
+ LIMIT 1`), providerID, servedModelRef)
+	}
+	return scanModelAdmissionEvent(ctx, s.db, modelAdmissionEventSelect(`
+  FROM model_admission_events
+ WHERE provider_id = ? AND served_model_ref = ? AND LOWER(catalog_model_key) = ?
+ ORDER BY id DESC
+ LIMIT 1`), providerID, servedModelRef, catalogModelKey)
+}
+
+func latestModelAdmissionRouteStatusFromEvents(events map[string]ModelAdmissionEvent, providerID, servedModelRef, catalogModelKey string) (ModelAdmissionEvent, bool, error) {
+	servedModelRef = strings.TrimSpace(servedModelRef)
+	catalogModelKey = strings.ToLower(strings.TrimSpace(catalogModelKey))
+	var latest ModelAdmissionEvent
+	var found bool
+	for _, event := range events {
+		if event.ProviderID != providerID {
+			continue
+		}
+		if servedModelRef == "" && catalogModelKey == "" {
+			if !found || event.CreatedAt.After(latest.CreatedAt) {
+				latest = event
+				found = true
+			}
+			continue
+		}
+		if servedModelRef != "" && event.ServedModelRef != servedModelRef {
+			continue
+		}
+		if catalogModelKey != "" && strings.ToLower(strings.TrimSpace(event.CatalogModelKey)) != catalogModelKey {
+			continue
+		}
+		if !found || event.CreatedAt.After(latest.CreatedAt) {
+			latest = event
+			found = true
+		}
+	}
+	return latest, found, nil
+}
+
 type modelAdmissionQueryer interface {
 	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
@@ -486,6 +645,12 @@ func scanModelAdmissionEvent(ctx context.Context, q modelAdmissionQueryer, query
 		&event.CandidateID,
 		&event.ServedModelRef,
 		&event.CatalogModelKey,
+		&event.CatalogID,
+		&event.CatalogBodyDigest,
+		&event.CatalogSignatureKeyID,
+		&event.CatalogSignaturePubkeyFingerprint,
+		&event.ExpectedCatalogModelHash,
+		&event.ExpectedCatalogModelHashAlgorithm,
 		&event.DiscoveryDigestSHA256,
 		&event.EvaluationDigestSHA256,
 		&event.RequestedDisclosureClass,
@@ -515,6 +680,8 @@ func scanModelAdmissionEvent(ctx context.Context, q modelAdmissionQueryer, query
 
 func modelAdmissionEventSelect(tail string) string {
 	return `SELECT coordinator_event_id, actor, provider_id, candidate_id, served_model_ref, catalog_model_key,
+       catalog_id, catalog_body_digest, catalog_signature_key_id, catalog_signature_pubkey_fingerprint,
+       expected_catalog_model_hash, expected_catalog_model_hash_algorithm,
        discovery_digest_sha256, evaluation_digest_sha256, requested_disclosure_class,
        previous_state, state, next_state, reason_code, request_id, nonce, payload_digest_sha256,
        signature_digest_sha256, created_at_utc` + tail
@@ -564,8 +731,18 @@ func modelAdmissionTransitionReasonRequired(previousState, nextState string) boo
 	}
 }
 
-func modelAdmissionTransitionRequiresCatalogKey(nextState string) bool {
+func modelAdmissionTransitionRequiresCatalogAuthority(nextState string) bool {
 	return nextState == "catalog_priced" || nextState == "settlement_capable"
+}
+
+func modelAdmissionEventHasTrustedCatalogAuthority(event ModelAdmissionEvent) bool {
+	return strings.TrimSpace(event.CatalogModelKey) != "" &&
+		strings.TrimSpace(event.CatalogID) != "" &&
+		validModelAdmissionSHA256Hex(event.CatalogBodyDigest) &&
+		strings.TrimSpace(event.CatalogSignatureKeyID) != "" &&
+		validModelAdmissionReceiptKeyFingerprint(event.CatalogSignaturePubkeyFingerprint) &&
+		validModelAdmissionSHA256Hex(event.ExpectedCatalogModelHash) &&
+		event.ExpectedCatalogModelHashAlgorithm == modelidentity.SnapshotManifestV1
 }
 
 func sameModelAdmissionTuple(previous, next ModelAdmissionEvent) bool {
@@ -596,6 +773,7 @@ func modelAdmissionEvidenceRefreshed(previous, next ModelAdmissionEvent) bool {
 }
 
 func prepareModelAdmissionTransition(event ModelAdmissionEvent, previousState, actor, nextState string) ModelAdmissionEvent {
+	event.CatalogModelKey = strings.ToLower(strings.TrimSpace(event.CatalogModelKey))
 	event.Actor = actor
 	event.PreviousState = previousState
 	event.State = nextState
@@ -609,6 +787,12 @@ func prepareModelAdmissionTransition(event ModelAdmissionEvent, previousState, a
 		event.PreviousState,
 		event.NextState,
 		event.PayloadDigestSHA256,
+		event.CatalogID,
+		event.CatalogBodyDigest,
+		event.CatalogSignatureKeyID,
+		event.CatalogSignaturePubkeyFingerprint,
+		event.ExpectedCatalogModelHash,
+		event.ExpectedCatalogModelHashAlgorithm,
 	}, "\x00")))
 	event.CoordinatorEventID = hex.EncodeToString(sum[:])
 	return event
@@ -623,6 +807,12 @@ func fillCoordinatorModelAdmissionReplayKeys(event ModelAdmissionEvent, previous
 		event.CandidateID,
 		event.ServedModelRef,
 		event.CatalogModelKey,
+		event.CatalogID,
+		event.CatalogBodyDigest,
+		event.CatalogSignatureKeyID,
+		event.CatalogSignaturePubkeyFingerprint,
+		event.ExpectedCatalogModelHash,
+		event.ExpectedCatalogModelHashAlgorithm,
 		previousState,
 		event.State,
 		event.ReasonCode,
@@ -649,21 +839,90 @@ func ModelAdmissionSettlementStateCandidate(event ModelAdmissionEvent) bool {
 }
 
 type ModelAdmissionPaidRoutingPredicate struct {
-	ProviderID             string
+	ProviderID                        string
+	CandidateID                       string
+	ServedModelRef                    string
+	CatalogModelKey                   string
+	DiscoveryDigestSHA256             string
+	EvaluationDigestSHA256            string
+	CatalogID                         string
+	CatalogBodyDigest                 string
+	CatalogSignatureKeyID             string
+	CatalogSignaturePubkeyFingerprint string
+	ExpectedCatalogModelHash          string
+	ExpectedCatalogModelHashAlgorithm string
+}
+
+func ModelAdmissionDefaultPaidRoutingEligible(event ModelAdmissionEvent, predicate ModelAdmissionPaidRoutingPredicate) bool {
+	_, ok := ModelAdmissionSettlementBindingForRouteSnapshot(event, ModelAdmissionSettlementPredicate(predicate))
+	return ok
+}
+
+type ModelAdmissionSettlementPredicate struct {
+	ProviderID                        string
+	CandidateID                       string
+	ServedModelRef                    string
+	CatalogModelKey                   string
+	DiscoveryDigestSHA256             string
+	EvaluationDigestSHA256            string
+	CatalogID                         string
+	CatalogBodyDigest                 string
+	CatalogSignatureKeyID             string
+	CatalogSignaturePubkeyFingerprint string
+	ExpectedCatalogModelHash          string
+	ExpectedCatalogModelHashAlgorithm string
+}
+
+type ModelAdmissionSettlementBinding struct {
 	CandidateID            string
+	CoordinatorEventID     string
 	ServedModelRef         string
 	CatalogModelKey        string
 	DiscoveryDigestSHA256  string
 	EvaluationDigestSHA256 string
 }
 
-func ModelAdmissionDefaultPaidRoutingEligible(ModelAdmissionEvent, ModelAdmissionPaidRoutingPredicate) bool {
-	// SPEC-047 #1254 is the withdrawal/revocation gate, not the positive
-	// economics gate. Until the SPEC-022 route-snapshot and signed-catalog
-	// authority are wired by the later settlement slices, BYOM remains excluded
-	// from default paid routing even if the coordinator records a
-	// settlement_capable admission state.
-	return false
+func ModelAdmissionSettlementBindingForRouteSnapshot(event ModelAdmissionEvent, predicate ModelAdmissionSettlementPredicate) (ModelAdmissionSettlementBinding, bool) {
+	if !ModelAdmissionSettlementStateCandidate(event) {
+		return ModelAdmissionSettlementBinding{}, false
+	}
+	if event.ProviderID != predicate.ProviderID ||
+		event.CandidateID != predicate.CandidateID ||
+		event.ServedModelRef != predicate.ServedModelRef ||
+		event.CatalogModelKey != predicate.CatalogModelKey ||
+		event.DiscoveryDigestSHA256 != predicate.DiscoveryDigestSHA256 ||
+		event.EvaluationDigestSHA256 != predicate.EvaluationDigestSHA256 ||
+		event.CatalogID != predicate.CatalogID ||
+		event.CatalogBodyDigest != predicate.CatalogBodyDigest ||
+		event.CatalogSignatureKeyID != predicate.CatalogSignatureKeyID ||
+		event.CatalogSignaturePubkeyFingerprint != predicate.CatalogSignaturePubkeyFingerprint ||
+		event.ExpectedCatalogModelHash != predicate.ExpectedCatalogModelHash ||
+		event.ExpectedCatalogModelHashAlgorithm != predicate.ExpectedCatalogModelHashAlgorithm {
+		return ModelAdmissionSettlementBinding{}, false
+	}
+	if predicate.ExpectedCatalogModelHashAlgorithm != modelidentity.SnapshotManifestV1 {
+		return ModelAdmissionSettlementBinding{}, false
+	}
+	if !validModelAdmissionSHA256Hex(event.CoordinatorEventID) ||
+		!validModelAdmissionSHA256Hex(predicate.DiscoveryDigestSHA256) ||
+		!validModelAdmissionSHA256Hex(predicate.EvaluationDigestSHA256) ||
+		!validModelAdmissionSHA256Hex(predicate.CatalogBodyDigest) ||
+		!validModelAdmissionSHA256Hex(predicate.ExpectedCatalogModelHash) {
+		return ModelAdmissionSettlementBinding{}, false
+	}
+	if strings.TrimSpace(predicate.CatalogID) == "" ||
+		strings.TrimSpace(predicate.CatalogSignatureKeyID) == "" ||
+		!validModelAdmissionReceiptKeyFingerprint(predicate.CatalogSignaturePubkeyFingerprint) {
+		return ModelAdmissionSettlementBinding{}, false
+	}
+	return ModelAdmissionSettlementBinding{
+		CandidateID:            event.CandidateID,
+		CoordinatorEventID:     event.CoordinatorEventID,
+		ServedModelRef:         event.ServedModelRef,
+		CatalogModelKey:        event.CatalogModelKey,
+		DiscoveryDigestSHA256:  event.DiscoveryDigestSHA256,
+		EvaluationDigestSHA256: event.EvaluationDigestSHA256,
+	}, true
 }
 
 func ModelAdmissionRevocationForRuntimeDrift(current ModelAdmissionEvent, predicate ModelAdmissionPaidRoutingPredicate, reasonCode string, now time.Time) (ModelAdmissionEvent, bool) {
@@ -687,6 +946,12 @@ func ModelAdmissionRevocationForRuntimeDrift(current ModelAdmissionEvent, predic
 		predicate.CatalogModelKey,
 		predicate.DiscoveryDigestSHA256,
 		predicate.EvaluationDigestSHA256,
+		predicate.CatalogID,
+		predicate.CatalogBodyDigest,
+		predicate.CatalogSignatureKeyID,
+		predicate.CatalogSignaturePubkeyFingerprint,
+		predicate.ExpectedCatalogModelHash,
+		predicate.ExpectedCatalogModelHashAlgorithm,
 		reasonCode,
 		now.UTC().Format(time.RFC3339Nano),
 	}, "\x00")))
@@ -708,7 +973,18 @@ func modelAdmissionRuntimePredicateMatches(event ModelAdmissionEvent, predicate 
 		event.ServedModelRef == predicate.ServedModelRef &&
 		event.CatalogModelKey == predicate.CatalogModelKey &&
 		event.DiscoveryDigestSHA256 == predicate.DiscoveryDigestSHA256 &&
-		event.EvaluationDigestSHA256 == predicate.EvaluationDigestSHA256
+		event.EvaluationDigestSHA256 == predicate.EvaluationDigestSHA256 &&
+		event.CatalogID == predicate.CatalogID &&
+		event.CatalogBodyDigest == predicate.CatalogBodyDigest &&
+		event.CatalogSignatureKeyID == predicate.CatalogSignatureKeyID &&
+		event.CatalogSignaturePubkeyFingerprint == predicate.CatalogSignaturePubkeyFingerprint &&
+		event.ExpectedCatalogModelHash == predicate.ExpectedCatalogModelHash &&
+		event.ExpectedCatalogModelHashAlgorithm == predicate.ExpectedCatalogModelHashAlgorithm
+}
+
+func validModelAdmissionReceiptKeyFingerprint(value string) bool {
+	const prefix = "ed25519-sha256:"
+	return strings.HasPrefix(value, prefix) && validModelAdmissionSHA256Hex(strings.TrimPrefix(value, prefix))
 }
 
 func (s *Server) handleProviderModelAdmissionOffer(w http.ResponseWriter, r *http.Request) {
@@ -926,11 +1202,12 @@ func (s *Server) verifyModelAdmissionOffer(ctx context.Context, authenticatedPro
 	if signedAt.Before(now.Add(-modelAdmissionMaxClockSkew)) || signedAt.After(now.Add(modelAdmissionMaxClockSkew)) {
 		return ModelAdmissionEvent{}, fmt.Errorf("invalid timestamp")
 	}
+	catalogModelKey := strings.ToLower(strings.TrimSpace(body.CatalogModelKey))
 	return ModelAdmissionEvent{
 		ProviderID:               body.ProviderID,
 		CandidateID:              body.CandidateID,
 		ServedModelRef:           body.ServedModelRef,
-		CatalogModelKey:          body.CatalogModelKey,
+		CatalogModelKey:          catalogModelKey,
 		DiscoveryDigestSHA256:    body.DiscoveryDigestSHA256,
 		EvaluationDigestSHA256:   body.EvaluationDigestSHA256,
 		RequestedDisclosureClass: body.RequestedDisclosureClass,
@@ -989,11 +1266,12 @@ func (s *Server) verifyModelAdmissionWithdrawal(ctx context.Context, authenticat
 	if signedAt.Before(now.Add(-modelAdmissionMaxClockSkew)) || signedAt.After(now.Add(modelAdmissionMaxClockSkew)) {
 		return ModelAdmissionEvent{}, fmt.Errorf("invalid timestamp")
 	}
+	catalogModelKey := strings.ToLower(strings.TrimSpace(modelAdmissionNullableStringValue(body.CatalogModelKey.Value)))
 	return ModelAdmissionEvent{
 		ProviderID:            body.ProviderID,
 		CandidateID:           body.CandidateID,
 		ServedModelRef:        body.ServedModelRef,
-		CatalogModelKey:       modelAdmissionNullableStringValue(body.CatalogModelKey.Value),
+		CatalogModelKey:       catalogModelKey,
 		State:                 modelAdmissionWithdrawn,
 		ReasonCode:            body.ReasonCode,
 		RequestID:             body.IdempotencyKey,

--- a/phase4-coordinator/internal/ws/model_admission_test.go
+++ b/phase4-coordinator/internal/ws/model_admission_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/augstar/macprovider-coordinator/internal/auth"
 	"github.com/augstar/macprovider-coordinator/internal/billing"
 	"github.com/augstar/macprovider-coordinator/internal/config"
+	"github.com/augstar/macprovider-coordinator/internal/modelidentity"
 	"github.com/augstar/macprovider-coordinator/internal/pool"
 	providerws "github.com/augstar/macprovider-coordinator/internal/ws"
 )
@@ -538,6 +539,7 @@ func TestModelAdmissionDecisionStateMachineAndRoutingGate(t *testing.T) {
 	catalogPriced.Nonce = "nonce_catalog_priced"
 	catalogPriced.PayloadDigestSHA256 = stringsOf("e", 64)
 	catalogPriced.CreatedAt = time.Unix(1800000030, 0).UTC()
+	catalogPriced = withTrustedCatalogDecisionFields(catalogPriced)
 	catalogPriced, err = store.AppendModelAdmissionDecision(context.Background(), catalogPriced)
 	if err != nil {
 		t.Fatalf("catalog_priced decision failed: %v", err)
@@ -552,6 +554,7 @@ func TestModelAdmissionDecisionStateMachineAndRoutingGate(t *testing.T) {
 	settlement.Nonce = "nonce_settlement_capable"
 	settlement.PayloadDigestSHA256 = stringsOf("f", 64)
 	settlement.CreatedAt = time.Unix(1800000040, 0).UTC()
+	settlement = withTrustedCatalogDecisionFields(settlement)
 	settlement, err = store.AppendModelAdmissionDecision(context.Background(), settlement)
 	if err != nil {
 		t.Fatalf("settlement_capable decision failed: %v", err)
@@ -560,24 +563,48 @@ func TestModelAdmissionDecisionStateMachineAndRoutingGate(t *testing.T) {
 		t.Fatal("settlement_capable with catalog binding must pass the preliminary settlement-state predicate")
 	}
 	matching := providerws.ModelAdmissionPaidRoutingPredicate{
-		ProviderID:             settlement.ProviderID,
-		CandidateID:            settlement.CandidateID,
-		ServedModelRef:         settlement.ServedModelRef,
-		CatalogModelKey:        settlement.CatalogModelKey,
-		DiscoveryDigestSHA256:  settlement.DiscoveryDigestSHA256,
-		EvaluationDigestSHA256: settlement.EvaluationDigestSHA256,
+		ProviderID:                        settlement.ProviderID,
+		CandidateID:                       settlement.CandidateID,
+		ServedModelRef:                    settlement.ServedModelRef,
+		CatalogModelKey:                   settlement.CatalogModelKey,
+		DiscoveryDigestSHA256:             settlement.DiscoveryDigestSHA256,
+		EvaluationDigestSHA256:            settlement.EvaluationDigestSHA256,
+		CatalogID:                         settlement.CatalogID,
+		CatalogBodyDigest:                 settlement.CatalogBodyDigest,
+		CatalogSignatureKeyID:             settlement.CatalogSignatureKeyID,
+		CatalogSignaturePubkeyFingerprint: settlement.CatalogSignaturePubkeyFingerprint,
+		ExpectedCatalogModelHash:          settlement.ExpectedCatalogModelHash,
+		ExpectedCatalogModelHashAlgorithm: settlement.ExpectedCatalogModelHashAlgorithm,
 	}
-	if providerws.ModelAdmissionDefaultPaidRoutingEligible(settlement, matching) {
-		t.Fatal("settlement_capable remains default paid-routing excluded until SPEC-022/catalog authority is wired")
+	if !providerws.ModelAdmissionDefaultPaidRoutingEligible(settlement, matching) {
+		t.Fatal("settlement_capable with trusted catalog binding must pass default paid-routing predicate")
+	}
+	untrustedCatalog := matching
+	untrustedCatalog.CatalogBodyDigest = ""
+	if providerws.ModelAdmissionDefaultPaidRoutingEligible(settlement, untrustedCatalog) {
+		t.Fatal("settlement_capable without trusted catalog binding must fail closed")
+	}
+	untrustedAlgorithm := matching
+	untrustedAlgorithm.ExpectedCatalogModelHashAlgorithm = ""
+	if providerws.ModelAdmissionDefaultPaidRoutingEligible(settlement, untrustedAlgorithm) {
+		t.Fatal("settlement_capable without trusted catalog hash algorithm must fail closed")
 	}
 	drifted := matching
 	drifted.ServedModelRef = "ollama:different"
 	if providerws.ModelAdmissionDefaultPaidRoutingEligible(settlement, drifted) {
 		t.Fatal("served-model drift must fail closed for default paid routing")
 	}
+	catalogDrifted := matching
+	catalogDrifted.CatalogBodyDigest = stringsOf("6", 64)
+	if providerws.ModelAdmissionDefaultPaidRoutingEligible(settlement, catalogDrifted) {
+		t.Fatal("catalog body drift must fail closed for default paid routing")
+	}
 	revocation, drift := providerws.ModelAdmissionRevocationForRuntimeDrift(settlement, drifted, "runtime_identity_drift", time.Unix(1800000050, 0).UTC())
 	if !drift {
 		t.Fatal("drifted route predicate did not create revocation event")
+	}
+	if _, drift := providerws.ModelAdmissionRevocationForRuntimeDrift(settlement, catalogDrifted, "catalog_identity_drift", time.Unix(1800000051, 0).UTC()); !drift {
+		t.Fatal("catalog identity drift did not create revocation event")
 	}
 	revoked, err := store.AppendModelAdmissionDecision(context.Background(), revocation)
 	if err != nil {
@@ -617,6 +644,15 @@ func TestModelAdmissionDecisionRejectsInvalidCatalogAndReasonTransitions(t *test
 	withoutCatalog.PayloadDigestSHA256 = stringsOf("e", 64)
 	if _, err := store.AppendModelAdmissionDecision(context.Background(), withoutCatalog); err == nil {
 		t.Fatal("catalog_priced transition without catalog binding succeeded")
+	}
+	withoutTrustedCatalog := submitted
+	withoutTrustedCatalog.CatalogModelKey = "qwen3-8b"
+	withoutTrustedCatalog.State = "catalog_priced"
+	withoutTrustedCatalog.RequestID = "request_no_trusted_catalog"
+	withoutTrustedCatalog.Nonce = "nonce_no_trusted_catalog"
+	withoutTrustedCatalog.PayloadDigestSHA256 = stringsOf("1", 64)
+	if _, err := store.AppendModelAdmissionDecision(context.Background(), withoutTrustedCatalog); err == nil {
+		t.Fatal("catalog_priced transition with only provider catalog key succeeded")
 	}
 	rejectedWithoutReason := submitted
 	rejectedWithoutReason.State = "offer_rejected"
@@ -814,6 +850,113 @@ func TestSQLiteModelAdmissionStorePersistsAppendOnlyStatus(t *testing.T) {
 	readback, found, err = reopenedAgain.LatestModelAdmissionStatus(context.Background(), event.ProviderID, event.CandidateID)
 	if err != nil || !found || readback.State != "withdrawn" || readback.DiscoveryDigestSHA256 != event.DiscoveryDigestSHA256 {
 		t.Fatalf("withdraw readback found=%v event=%+v err=%v", found, readback, err)
+	}
+}
+
+func TestSQLiteModelAdmissionStorePersistsRouteStatusLookup(t *testing.T) {
+	db, err := auth.OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	store, err := providerws.NewSQLiteModelAdmissionStore(db.DB())
+	if err != nil {
+		t.Fatal(err)
+	}
+	providerID := "provider-byom-a"
+	first := providerws.ModelAdmissionEvent{
+		ProviderID:               providerID,
+		CandidateID:              stableModelAdmissionCandidateID("p"),
+		ServedModelRef:           "ollama:qwen3-8b",
+		CatalogModelKey:          "model-a",
+		DiscoveryDigestSHA256:    stringsOf("a", 64),
+		EvaluationDigestSHA256:   stringsOf("b", 64),
+		RequestedDisclosureClass: "catalog_binding_requested",
+		ReasonCode:               "provider_offer_submitted",
+		RequestID:                "sqlite_route_offer",
+		Nonce:                    "sqlite_route_nonce",
+		PayloadDigestSHA256:      stringsOf("c", 64),
+		SignatureDigestSHA256:    stringsOf("d", 64),
+		CreatedAt:                time.Unix(1800000100, 0).UTC(),
+	}
+	if _, replay, err := store.AppendModelAdmissionOffer(context.Background(), first); err != nil || replay {
+		t.Fatalf("append first replay=%v err=%v", replay, err)
+	}
+	catalogPriced := withTrustedCatalogDecisionFields(first)
+	catalogPriced.State = "catalog_priced"
+	catalogPriced.RequestID = "sqlite_route_catalog_priced"
+	catalogPriced.Nonce = "sqlite_route_catalog_priced_nonce"
+	catalogPriced.PayloadDigestSHA256 = stringsOf("e", 64)
+	catalogPriced.CreatedAt = time.Unix(1800000110, 0).UTC()
+	catalogPriced, err = store.AppendModelAdmissionDecision(context.Background(), catalogPriced)
+	if err != nil {
+		t.Fatalf("catalog_priced decision: %v", err)
+	}
+	readback, found, err := store.LatestModelAdmissionRouteStatus(context.Background(), providerID, "ollama:qwen3-8b", "model-a")
+	if err != nil || !found || readback.State != "catalog_priced" || readback.CoordinatorEventID != catalogPriced.CoordinatorEventID {
+		t.Fatalf("route readback found=%v event=%+v err=%v", found, readback, err)
+	}
+
+	second := first
+	second.CandidateID = stableModelAdmissionCandidateID("q")
+	second.ServedModelRef = "ollama:qwen3-8b-alt"
+	second.DiscoveryDigestSHA256 = stringsOf("6", 64)
+	second.EvaluationDigestSHA256 = stringsOf("7", 64)
+	second.RequestID = "sqlite_route_second_offer"
+	second.Nonce = "sqlite_route_second_nonce"
+	second.PayloadDigestSHA256 = stringsOf("8", 64)
+	second.SignatureDigestSHA256 = stringsOf("9", 64)
+	second.CreatedAt = time.Unix(1800000120, 0).UTC()
+	if _, replay, err := store.AppendModelAdmissionOffer(context.Background(), second); err != nil || replay {
+		t.Fatalf("append second replay=%v err=%v", replay, err)
+	}
+	secondCatalogPriced := withTrustedCatalogDecisionFields(second)
+	secondCatalogPriced.State = "catalog_priced"
+	secondCatalogPriced.RequestID = "sqlite_route_second_catalog_priced"
+	secondCatalogPriced.Nonce = "sqlite_route_second_catalog_priced_nonce"
+	secondCatalogPriced.PayloadDigestSHA256 = stringsOf("0", 64)
+	secondCatalogPriced.CreatedAt = time.Unix(1800000125, 0).UTC()
+	_, err = store.AppendModelAdmissionDecision(context.Background(), secondCatalogPriced)
+	if err != nil {
+		t.Fatalf("second catalog_priced decision: %v", err)
+	}
+	settlement := withTrustedCatalogDecisionFields(second)
+	settlement.State = "settlement_capable"
+	settlement.RequestID = "sqlite_route_second_settlement"
+	settlement.Nonce = "sqlite_route_second_settlement_nonce"
+	settlement.PayloadDigestSHA256 = stringsOf("1", 64)
+	settlement.CreatedAt = time.Unix(1800000130, 0).UTC()
+	settlement, err = store.AppendModelAdmissionDecision(context.Background(), settlement)
+	if err != nil {
+		t.Fatalf("settlement decision: %v", err)
+	}
+	readback, found, err = store.LatestModelAdmissionRouteStatus(context.Background(), providerID, "", "model-a")
+	if err != nil || !found || readback.CandidateID != settlement.CandidateID {
+		t.Fatalf("catalog-key route lookup did not return latest admission event found=%v event=%+v err=%v", found, readback, err)
+	}
+	readback, found, err = store.LatestModelAdmissionRouteStatus(context.Background(), providerID, "ollama:qwen3-8b", "model-a")
+	if err != nil || !found || readback.CandidateID != catalogPriced.CandidateID {
+		t.Fatalf("exact route lookup did not preserve served-ref boundary found=%v event=%+v err=%v", found, readback, err)
+	}
+	withdraw := settlement
+	withdraw.State = "withdrawn"
+	withdraw.ReasonCode = "provider_requested"
+	withdraw.RequestID = "sqlite_route_second_withdraw"
+	withdraw.Nonce = "sqlite_route_second_withdraw_nonce"
+	withdraw.PayloadDigestSHA256 = stringsOf("2", 64)
+	withdraw.SignatureDigestSHA256 = stringsOf("3", 64)
+	withdraw.CreatedAt = time.Unix(1800000140, 0).UTC()
+	withdrawn, replay, err := store.AppendModelAdmissionWithdrawal(context.Background(), withdraw)
+	if err != nil || replay {
+		t.Fatalf("withdraw replay=%v err=%v", replay, err)
+	}
+	reopened, err := providerws.NewSQLiteModelAdmissionStore(db.DB())
+	if err != nil {
+		t.Fatal(err)
+	}
+	readback, found, err = reopened.LatestModelAdmissionRouteStatus(context.Background(), providerID, "ollama:qwen3-8b-alt", "model-a")
+	if err != nil || !found || readback.State != "withdrawn" || readback.CoordinatorEventID != withdrawn.CoordinatorEventID {
+		t.Fatalf("withdrawn route readback found=%v event=%+v err=%v", found, readback, err)
 	}
 }
 
@@ -1033,20 +1176,39 @@ func stableModelAdmissionCandidateID(value string) string {
 	return "byom_" + strings.Repeat(value, 52)
 }
 
+func withTrustedCatalogDecisionFields(event providerws.ModelAdmissionEvent) providerws.ModelAdmissionEvent {
+	event.CatalogID = "settlement-catalog"
+	event.CatalogBodyDigest = stringsOf("3", 64)
+	event.CatalogSignatureKeyID = "test-key"
+	event.CatalogSignaturePubkeyFingerprint = "ed25519-sha256:" + stringsOf("4", 64)
+	event.ExpectedCatalogModelHash = stringsOf("5", 64)
+	event.ExpectedCatalogModelHashAlgorithm = modelidentity.SnapshotManifestV1
+	return event
+}
+
 func insertModelAdmissionEventForTest(t *testing.T, db *auth.Store, event providerws.ModelAdmissionEvent) {
 	t.Helper()
 	if _, err := db.DB().ExecContext(context.Background(), `
 INSERT INTO model_admission_events(
     provider_id, candidate_id, served_model_ref, catalog_model_key,
+    catalog_id, catalog_body_digest, catalog_signature_key_id,
+    catalog_signature_pubkey_fingerprint, expected_catalog_model_hash,
+    expected_catalog_model_hash_algorithm,
     discovery_digest_sha256, evaluation_digest_sha256, requested_disclosure_class,
     previous_state, state, next_state, actor, coordinator_event_id,
     reason_code, request_id, nonce, payload_digest_sha256,
     signature_digest_sha256, created_at_utc
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		event.ProviderID,
 		event.CandidateID,
 		event.ServedModelRef,
 		event.CatalogModelKey,
+		event.CatalogID,
+		event.CatalogBodyDigest,
+		event.CatalogSignatureKeyID,
+		event.CatalogSignaturePubkeyFingerprint,
+		event.ExpectedCatalogModelHash,
+		event.ExpectedCatalogModelHashAlgorithm,
 		event.DiscoveryDigestSHA256,
 		event.EvaluationDigestSHA256,
 		event.RequestedDisclosureClass,

--- a/phase4-coordinator/internal/ws/relay_test.go
+++ b/phase4-coordinator/internal/ws/relay_test.go
@@ -1278,6 +1278,26 @@ func TestRelayRequestBufferCapReleasesDeliveredChunks(t *testing.T) {
 	if _, _, err := wsutil.ReadServerData(providerConn); err != nil {
 		t.Fatalf("read inference_request: %v", err)
 	}
+	waitForBufferedBytes := func(want int64) {
+		t.Helper()
+		deadline := time.Now().Add(time.Second)
+		for {
+			active, ok := session.activeFor("req-cap-release")
+			if !ok {
+				t.Fatalf("active request retired before buffer counter reached %d", want)
+			}
+			active.bufferMu.Lock()
+			got := active.bufferedBytes
+			active.bufferMu.Unlock()
+			if got == want {
+				return
+			}
+			if time.Now().After(deadline) {
+				t.Fatalf("bufferedBytes=%d, want %d", got, want)
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}
 
 	s.handleInferenceChunk("p1", "s1", mustJSON(InferenceResponseChunk{Type: "inference_response_chunk", RequestID: "req-cap-release", Seq: 0, Data: "1234"}))
 	select {
@@ -1290,6 +1310,7 @@ func TestRelayRequestBufferCapReleasesDeliveredChunks(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("first chunk timeout")
 	}
+	waitForBufferedBytes(0)
 
 	s.handleInferenceChunk("p1", "s1", mustJSON(InferenceResponseChunk{Type: "inference_response_chunk", RequestID: "req-cap-release", Seq: 1, Data: "abcd"}))
 	select {

--- a/phase5-gateway/internal/router/server.go
+++ b/phase5-gateway/internal/router/server.go
@@ -1313,7 +1313,8 @@ var gatewayRetryableByCode = map[string]bool{
 var gatewayPermanentCodes = map[string]bool{
 	"method_not_allowed": true, "invalid_window": true, "invalid_kill_switch": true,
 	"invalid_kill_switch_version": true, "invalid_capacity_signal": true,
-	"invalid_operator_token": true, "invalid_demo_token": true, "missing_bearer_token": true,
+	"byom_non_settlement_unavailable": true,
+	"invalid_operator_token":          true, "invalid_demo_token": true, "missing_bearer_token": true,
 	"invalid_api_key": true, "api_key_revoked": true, "account_blocked": true,
 	"not_found": true, "session_id_untyped": true, "query_timeout": true,
 	"oauth_callback_not_allowed": true, "oauth_action_unknown": true,

--- a/phase5-gateway/internal/router/server_test.go
+++ b/phase5-gateway/internal/router/server_test.go
@@ -6596,6 +6596,16 @@ func TestGatewayRetryableByCodeClassification(t *testing.T) {
 	}
 }
 
+func TestBYOMNonSettlementUnavailableIsPermanent(t *testing.T) {
+	const code = "byom_non_settlement_unavailable"
+	if gatewayRetryable(code) {
+		t.Fatalf("code %q must be retryable=false", code)
+	}
+	if !gatewayPermanentCodes[code] {
+		t.Fatalf("code %q must be explicitly classified as permanent", code)
+	}
+}
+
 // gatewayEmittedErrorCodes is every literal string passed as the `code`
 // argument to writeError, writeSSEError, or writeSpec019PreflightError
 // across the non-test .go files in this package, as of the round-2 3-lane
@@ -7459,6 +7469,69 @@ func TestCoordinator404ModelNotFoundPassesThroughAndDoesNotChargeQuota(t *testin
 			}
 			if reserved := quota["daily_tokens_reserved"].(float64); reserved != 0 {
 				t.Fatalf("daily_tokens_reserved=%v, want 0 — reservation must be refunded on coord 404", reserved)
+			}
+		})
+	}
+}
+
+func TestBYOMNonSettlementCoordinatorUnavailableDoesNotChargeOrClaimVerified(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		name := "non_stream"
+		if stream {
+			name = "stream"
+		}
+		t.Run(name, func(t *testing.T) {
+			coordModelsBody := `{"object":"list","data":[],"tier1_disclosure":{"verified_model_settlement":{"enforce_mode":"Enforce mode may settle only covered paid entrypoints listed in this disclosure whose settlement-capable receipt reaches verified finality; mixed pools are not described as fully verified."}}}`
+			coordChatBody := `{"error":{"code":"byom_non_settlement_unavailable","message":"No settlement-capable BYOM provider is available for model model-a","param":null,"type":"api_error","inference_ran":false,"settlement_ran":false}}`
+			client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				switch r.URL.Path {
+				case "/v1/models":
+					return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}}, coordModelsBody), nil
+				case "/v1/chat/completions":
+					return responseWithBody(http.StatusServiceUnavailable, http.Header{"Content-Type": []string{"application/json"}}, coordChatBody), nil
+				default:
+					return responseWithBody(http.StatusNotFound, http.Header{"Content-Type": []string{"application/json"}}, `{"error":{"code":"not_found"}}`), nil
+				}
+			})}
+			h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+				cfg.Coordinator.BuyerURL = "http://coordinator.test"
+			}, WithHTTPClient(client))
+			fullKey := createAccountAndKey(t, store, cfg, "acct_byom_non_settlement_"+name)
+
+			modelsResp := assertStatus(t, h, http.MethodGet, "/v1/models", fullKey, "", "1.2.3.4", http.StatusOK)
+			var models struct {
+				Data []map[string]any `json:"data"`
+			}
+			if err := json.Unmarshal(modelsResp.Body.Bytes(), &models); err != nil {
+				t.Fatalf("models json: %v", err)
+			}
+			if len(models.Data) != 0 {
+				t.Fatalf("gateway synthesized hidden non-settlement BYOM model: %s", modelsResp.Body.String())
+			}
+			if strings.Contains(modelsResp.Body.String(), "settlement_capable") ||
+				strings.Contains(modelsResp.Body.String(), `"verified":true`) {
+				t.Fatalf("gateway exposed buyer-visible verified BYOM claim: %s", modelsResp.Body.String())
+			}
+
+			body := `{"model":"model-a","max_tokens":1000,"messages":[{"role":"user","content":"x"}]}`
+			if stream {
+				body = `{"model":"model-a","max_tokens":1000,"stream":true,"messages":[{"role":"user","content":"x"}]}`
+			}
+			resp := postChat(t, h, fullKey, body, nil)
+			if resp.Code != http.StatusServiceUnavailable {
+				t.Fatalf("status=%d body=%s, want coordinator non-settlement unavailable passthrough", resp.Code, resp.Body.String())
+			}
+			if !strings.Contains(resp.Body.String(), `"code":"byom_non_settlement_unavailable"`) {
+				t.Fatalf("coordinator BYOM unavailable code not preserved: %s", resp.Body.String())
+			}
+
+			usageResp := assertStatus(t, h, http.MethodGet, "/v1/usage", fullKey, "", "1.2.3.4", http.StatusOK)
+			quota := readQuota(t, usageResp)
+			if used := quota["daily_tokens_used"].(float64); used != 0 {
+				t.Fatalf("daily_tokens_used=%v, want 0 for non-settlement BYOM unavailable", used)
+			}
+			if reserved := quota["daily_tokens_reserved"].(float64); reserved != 0 {
+				t.Fatalf("daily_tokens_reserved=%v, want 0 for non-settlement BYOM unavailable", reserved)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Advances #1240.
Closes #1255.
Depends on #1254.
Applies gate issues #1243, #1247, and #1248.

- Gates BYOM default paid `/v1/models`, routing, route snapshots, buyer debit, and positive provider credit on `settlement_capable` admission plus trusted catalog/hash and SPEC-022 receipt prerequisites.
- Binds BYOM settlement route snapshots to the coordinator-owned admission event, catalog identity/body digest/signing fingerprint, expected model hash, discovery/evaluation digests, and receipt profile.
- Keeps non-settlement BYOM states fail-closed with explicit `byom_non_settlement_unavailable`, including pinned, queued, class-alias, catalog-priced, malformed receipt-key, withdrawal, and re-admission paths.
- Keeps the gateway no-charge/no-verified-claim behavior aligned with the coordinator BYOM unavailable code.

## Authority

Exact requirements:
- SPEC-047-R001
- SPEC-047-R003
- SPEC-047-R004
- SPEC-047-R006
- SPEC-044-R001
- SPEC-022-R001
- SPEC-006-R001
- SPEC-005-R001

Consumed authority domains:
- `network-model-admission`
- `model-catalog-identity`
- `verified-model-settlement`
- `buyer-api-error-contract`
- `billing-settlement-formula`

SPEC-GOVERNANCE-DECLARATION-BEGIN
{"schema_version":"spec-pr-governance-v1","behavior_change":"yes","contract_change":"none","issue":"https://github.com/Augustas11/macprovider/issues/1255","specs":["SPEC-047","SPEC-044","SPEC-022","SPEC-006","SPEC-005"],"requirements":["SPEC-047-R001","SPEC-047-R003","SPEC-047-R004","SPEC-047-R006","SPEC-044-R001","SPEC-022-R001","SPEC-006-R001","SPEC-005-R001"],"authority_domains":["network-model-admission","model-catalog-identity","verified-model-settlement","buyer-api-error-contract","billing-settlement-formula"],"arbitration":["DECISION_REQUIRED","UNKNOWN"],"tests":["cd phase4-coordinator && go test ./internal/routing ./internal/ws ./internal/billing ./internal/buyer ./cmd/coordinator -count=1","cd phase4-coordinator && go test ./... -count=1","cd phase4-coordinator && go vet ./internal/ws ./internal/billing ./internal/buyer ./internal/routing ./cmd/coordinator","cd phase5-gateway && go test ./... -count=1","cd phase5-gateway && go vet ./...","cd phase4-coordinator && go test ./internal/ws ./internal/buyer -count=1","cd phase5-gateway && go test ./internal/router -run TestGatewayRetryableByCodeClassification -count=1","git diff --cached --check"],"journeys":["not-required"]}
SPEC-GOVERNANCE-DECLARATION-END

## Verification

- `cd phase4-coordinator && go test ./internal/routing ./internal/ws ./internal/billing ./internal/buyer ./cmd/coordinator -count=1`
- `cd phase4-coordinator && go test ./... -count=1`
- `cd phase4-coordinator && go vet ./internal/ws ./internal/billing ./internal/buyer ./internal/routing ./cmd/coordinator`
- `cd phase5-gateway && go test ./... -count=1`
- `cd phase5-gateway && go vet ./...`
- `cd phase4-coordinator && go test ./internal/ws ./internal/buyer -count=1`
- `cd phase5-gateway && go test ./internal/router -run 'TestGatewayRetryableByCodeClassification|TestGatewayErrorCodeCompleteness|TestBYOMNonSettlementCoordinatorUnavailableDoesNotChargeOrClaimVerified' -count=1`
- `cd phase5-gateway && go vet ./internal/router`
- `git diff --cached --check`
- `python3 scripts/check_spec_pr_declaration.py --event /private/tmp/pr-event-1255.json --base origin/codex/1254-byom-withdraw-routing-gate --head HEAD`

Note: full phase4/phase5 suites were not rerun after the final gateway taxonomy-only edit; the targeted gateway taxonomy tests and vet were rerun after that edit.
