### PR TITLE
Hot-reload the autotune catalog + served feed on SIGHUP (#1268)

### DIFF
--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -1412,6 +1412,34 @@ func loadPreviousAutotuneCatalog(cfg config.AutotuneFeedsConfig) ([]*autotune.Ca
 	return []*autotune.Catalog{previous}, nil
 }
 
+// loadAutotuneCatalogForReload re-loads and verifies the signed autotune feed
+// set the same way boot does (main), for the SIGHUP hot-reload (#1268). It
+// returns the served feed bytes, the parsed active catalog, and the compatible
+// previous catalogs, or an error — the caller keeps the prior catalog on any
+// error (fail-closed), so a bad feed can never be swapped in.
+func loadAutotuneCatalogForReload(cfg config.AutotuneFeedsConfig) (buyer.AutotuneFeeds, *autotune.Catalog, []*autotune.Catalog, error) {
+	feeds, err := buyer.LoadAutotuneFeeds(cfg)
+	if err != nil {
+		return buyer.AutotuneFeeds{}, nil, nil, err
+	}
+	if len(feeds.AutotuneCandidatesJSON) == 0 {
+		return buyer.AutotuneFeeds{}, nil, nil, fmt.Errorf("autotune candidate catalog missing after reload")
+	}
+	catalog, err := autotune.ParseCatalog(feeds.AutotuneCandidatesJSON)
+	if err != nil {
+		return buyer.AutotuneFeeds{}, nil, nil, fmt.Errorf("autotune candidate catalog: %w", err)
+	}
+	if autotune.IsPermanentlyRejectedReleaseID(catalog.Version) {
+		return buyer.AutotuneFeeds{}, nil, nil, fmt.Errorf("autotune candidate catalog: release ID %q is permanently rejected", catalog.Version)
+	}
+	catalog.SignerKeyID = feeds.AutotuneCandidatesVerification.KeyID
+	compatible, err := loadPreviousAutotuneCatalog(cfg)
+	if err != nil {
+		return buyer.AutotuneFeeds{}, nil, nil, fmt.Errorf("autotune previous catalog: %w", err)
+	}
+	return feeds, catalog, compatible, nil
+}
+
 type requestLogPruner interface {
 	PruneBefore(context.Context, time.Time) (int64, error)
 }
@@ -2924,12 +2952,45 @@ func reloadCoordinatorConfig(configPath, configOverlay string, startupTier2 conf
 		logger.Error().Err(err).Msg("tier2 config reload rejected")
 		return
 	}
-	telemetryDrift, err := telemetryDriftEvaluatorForReload(cfg, autotuneCatalog, autotuneEvidenceStore)
+	// #1268 SIGHUP autotune feed reload: re-parse + verify the signed feed set so
+	// an operator can re-stamp/refresh the rate-card/candidate/demand-rank feeds
+	// (e.g. a freshness renewal) without a coordinator restart. Baseline is the
+	// LIVE catalog (a prior successful reload may have advanced it past the boot
+	// pointer in autotuneCatalog), so telemetry-drift, the hello-gate check, and
+	// the tier2 binding all validate against the catalog actually in force.
+	// Fail-closed — any parse/rejected-id/previous-catalog error keeps the prior
+	// catalog + served bytes; the swap lands only after the tier2 reload succeeds.
+	effectiveAutotuneCatalog := autotuneCatalog
+	if live := wsServer.CurrentAutotuneCatalog(); live != nil {
+		effectiveAutotuneCatalog = live
+	}
+	var reloadedAutotuneCatalog *autotune.Catalog
+	var reloadedAutotuneCompatible []*autotune.Catalog
+	var reloadedAutotuneFeeds buyer.AutotuneFeeds
+	haveReloadedAutotune := false
+	if strings.TrimSpace(cfg.AutotuneFeeds.AutotuneCandidatesPath) != "" {
+		if feeds, catalog, compatible, aerr := loadAutotuneCatalogForReload(cfg.AutotuneFeeds); aerr != nil {
+			logger.Error().Err(aerr).Msg("autotune feed reload rejected; keeping prior catalog and served feeds")
+		} else {
+			reloadedAutotuneCatalog = catalog
+			reloadedAutotuneCompatible = compatible
+			reloadedAutotuneFeeds = feeds
+			effectiveAutotuneCatalog = catalog
+			haveReloadedAutotune = true
+		}
+	} else if effectiveAutotuneCatalog != nil {
+		// Config cleared the feed paths but a catalog is live. Disabling autotune
+		// admission mid-flight is a boot-only operation (it would fail-open the
+		// hello gate), so the live catalog + served bytes are kept and a restart
+		// is required to disable — logged rather than silently ignored.
+		logger.Warn().Msg("autotune feed paths cleared on reload; keeping the live catalog (disable requires a restart)")
+	}
+	telemetryDrift, err := telemetryDriftEvaluatorForReload(cfg, effectiveAutotuneCatalog, autotuneEvidenceStore)
 	if err != nil {
 		logger.Error().Err(err).Msg("proof_of_weights config reload rejected")
 		return
 	}
-	if cfg.ProofOfWeights.RequireAutotuneHelloGate && (autotuneCatalog == nil || autotuneEvidenceStore == nil) {
+	if cfg.ProofOfWeights.RequireAutotuneHelloGate && (effectiveAutotuneCatalog == nil || autotuneEvidenceStore == nil) {
 		logger.Error().Msg("proof_of_weights config reload rejected: autotune hello gate dependencies are not wired")
 		return
 	}
@@ -2963,7 +3024,7 @@ func reloadCoordinatorConfig(configPath, configOverlay string, startupTier2 conf
 	// Tier-2 rows conflicting with the in-memory autotune admission catalog
 	// before the package singleton is swapped.
 	if _, err := tier2.ConfigureDefaultStrict(cfg.Tier2, logger, func(next *tier2.Catalog) error {
-		return catalogbind.RequireActiveReleaseBinding(autotuneCatalog, next)
+		return catalogbind.RequireActiveReleaseBinding(effectiveAutotuneCatalog, next)
 	}); err != nil {
 		logger.Error().Err(err).Msg("tier2 config reload rejected")
 		return
@@ -2999,6 +3060,29 @@ func reloadCoordinatorConfig(configPath, configOverlay string, startupTier2 conf
 			Int("billing.force_credit_settlement_hold_seconds", cfg.Billing.ForceCreditSettlementHoldSeconds).
 			Str("event", "spec005_v0_4_route_layer_flag_reload").
 			Msg("quarantine force-void route-layer flag reloaded")
+	}
+	if haveReloadedAutotune {
+		// #1268 MED-1: publish the autotune catalog + served feed bytes only
+		// AFTER every fallible reload step above (telemetry-drift build, tier2
+		// binding, billing snapshot) has succeeded, and adjacent to the
+		// telemetry-drift evaluator swap below. telemetryDrift was already built
+		// against reloadedAutotuneCatalog (effectiveAutotuneCatalog), so the live
+		// catalog and the evaluator that captured its pointer now land together
+		// with no early `return` between them — a mid-reload billing failure can
+		// no longer leave the new catalog live while the drift evaluator still
+		// holds the old one. The tier2 reload above already validated
+		// RequireActiveReleaseBinding against reloadedAutotuneCatalog, so this
+		// swap cannot install a catalog that conflicts with the applied tier2
+		// rows. The WS admission catalog and the buyer-served feed bytes swap
+		// together.
+		wsServer.SetAutotuneCatalog(reloadedAutotuneCatalog, reloadedAutotuneCompatible...)
+		buyerServer.SetAutotuneFeeds(reloadedAutotuneFeeds)
+		logger.Info().
+			Str("autotune_catalog_version", reloadedAutotuneCatalog.Version).
+			Int("autotune_compatible_previous_releases", len(reloadedAutotuneCompatible)).
+			Str("autotune_catalog_signer_key_id", reloadedAutotuneCatalog.SignerKeyID).
+			Str("event", "autotune_feed_sighup_reload").
+			Msg("autotune signed feed reloaded without restart")
 	}
 	proofReload := wsServer.SetProofOfWeightsConfig(cfg.ProofOfWeights)
 	wsServer.SetTelemetryDriftEvaluator(telemetryDrift)

--- a/phase4-coordinator/internal/buyer/autotune_feeds.go
+++ b/phase4-coordinator/internal/buyer/autotune_feeds.go
@@ -952,6 +952,16 @@ func WithAutotuneFeeds(feeds AutotuneFeeds) Option {
 	}
 }
 
+// SetAutotuneFeeds atomically swaps the served signed feed bytes. The SIGHUP
+// reload calls this only after the new feeds are loaded and signature-verified
+// (LoadAutotuneFeeds); on any failure the caller keeps the prior feeds
+// (fail-closed), so /v1/rate-card etc. never serve unverified bytes.
+func (s *Server) SetAutotuneFeeds(feeds AutotuneFeeds) {
+	s.autotuneFeedsMu.Lock()
+	defer s.autotuneFeedsMu.Unlock()
+	s.autotuneFeeds = feeds
+}
+
 func (s *Server) autotuneFeedsSnapshot() AutotuneFeeds {
 	s.autotuneFeedsMu.RLock()
 	defer s.autotuneFeedsMu.RUnlock()

--- a/phase4-coordinator/internal/ws/autotune_catalog_reload_test.go
+++ b/phase4-coordinator/internal/ws/autotune_catalog_reload_test.go
@@ -1,0 +1,209 @@
+package ws
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/augstar/macprovider-coordinator/internal/autotune"
+	"github.com/augstar/macprovider-coordinator/internal/pool"
+	"github.com/rs/zerolog"
+)
+
+// reloadTestCatalog builds a minimal valid autotune catalog with a caller-chosen
+// version so a test can distinguish the active vs. previous release across a
+// SetAutotuneCatalog swap.
+func reloadTestCatalog(t *testing.T, version string) *autotune.Catalog {
+	t.Helper()
+	return reloadTestCatalogSHA(t, version, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+}
+
+// reloadTestCatalogSHA builds a minimal valid catalog with a caller-chosen
+// version AND model sha so a test can prove which catalog generation an
+// admission helper evaluated against.
+func reloadTestCatalogSHA(t *testing.T, version, modelSHA string) *autotune.Catalog {
+	t.Helper()
+	catalog, err := autotune.ParseCatalog([]byte(fmt.Sprintf(`{
+		"version":%q,
+		"policy_version":"test",
+		"source":"operator_curated_autotune_candidate_catalog",
+		"rows":{
+				"small":{"model_id":"small-model","model_sha256":%q,"min_ram_gb":8,"min_bandwidth_tier":"low","bench_gate":{"min_sustained_tps":1,"max_4k_ttft_ms":1000},"runtime_status":"recommended"}
+			}
+		}`, version, modelSHA)))
+	if err != nil {
+		t.Fatalf("parse catalog %q: %v", version, err)
+	}
+	return catalog
+}
+
+// TestSetAutotuneCatalogHotSwap verifies the #1268 SIGHUP swap: the active
+// catalog is replaced and the prior release is retained as a compatible
+// ("previous"-mode) catalog, with the same dedup rules as construction.
+func TestSetAutotuneCatalogHotSwap(t *testing.T) {
+	t.Parallel()
+	v1 := reloadTestCatalog(t, "cat-v1")
+	server := NewServer(admissionCeilingEnforcementConfig(), pool.NewRegistry(nil), zerolog.Nop(),
+		WithAutotuneCatalog(v1),
+	)
+
+	if got := server.currentAutotuneCatalog(); got == nil || got.Version != "cat-v1" {
+		t.Fatalf("initial current = %v, want cat-v1", got)
+	}
+	if _, compat := server.autotuneCatalogSnapshot(); len(compat) != 0 {
+		t.Fatalf("initial compatible = %v, want empty", compat)
+	}
+
+	// Swap to a fresh active release, retaining the prior as the compatible set.
+	v2 := reloadTestCatalog(t, "cat-v2")
+	server.SetAutotuneCatalog(v2, v1)
+
+	cur, compat := server.autotuneCatalogSnapshot()
+	if cur == nil || cur.Version != "cat-v2" {
+		t.Fatalf("post-swap current = %v, want cat-v2", cur)
+	}
+	if compat["cat-v1"] == nil {
+		t.Fatalf("post-swap compatible = %v, want cat-v1 retained", compat)
+	}
+
+	// Dedup: a compatible entry equal to the active version must be dropped, and
+	// a permanently-rejected id must never be admitted as compatible.
+	server.SetAutotuneCatalog(v2, v2)
+	if _, compat := server.autotuneCatalogSnapshot(); len(compat) != 0 {
+		t.Fatalf("same-version compatible not deduped: %v", compat)
+	}
+}
+
+// TestResolveProviderCatalogSurvivesSwap locks in the #1268 HIGH-1 fix: an
+// already-admitted session admitted under catalog A as "current" must keep
+// resolving to A after a SIGHUP re-stamp swaps in B (retaining A as compatible
+// previous), instead of resolving to the new active catalog B and failing its
+// evidence/hash. The stored current/previous mode label is deliberately left
+// stale, exactly as it would be for a live session.
+func TestResolveProviderCatalogSurvivesSwap(t *testing.T) {
+	t.Parallel()
+	a := reloadTestCatalog(t, "cat-A")
+	b := reloadTestCatalog(t, "cat-B")
+	server := NewServer(admissionCeilingEnforcementConfig(), pool.NewRegistry(nil), zerolog.Nop(),
+		WithAutotuneCatalog(a),
+	)
+	// A session admitted while A was active: mode "current", release id A.
+	session := pool.Provider{
+		ProviderID:           "p1",
+		AssignedID:           "s1",
+		CatalogAdmissionMode: "current",
+		CatalogReleaseID:     a.Version,
+	}
+
+	resolved, _, isCurrent, ok := server.resolveProviderCatalog(session)
+	if !ok || resolved == nil || resolved.Version != "cat-A" || !isCurrent {
+		t.Fatalf("pre-swap resolve = (%v, isCurrent=%v, ok=%v), want cat-A/current", resolved, isCurrent, ok)
+	}
+
+	// Operator re-stamps: B is the new active catalog, A retained as previous.
+	// The live session's stored mode ("current") is now stale.
+	server.SetAutotuneCatalog(b, a)
+
+	resolved, current, isCurrent, ok := server.resolveProviderCatalog(session)
+	if !ok || resolved == nil || resolved.Version != "cat-A" {
+		t.Fatalf("post-swap resolve = %v, want the session's own release cat-A (not the new active cat-B)", resolved)
+	}
+	if isCurrent {
+		t.Fatalf("post-swap session must resolve as a previous release, not current")
+	}
+	if current == nil || current.Version != "cat-B" {
+		t.Fatalf("post-swap active catalog = %v, want cat-B", current)
+	}
+	// autotuneCatalogForProvider (used by the trust revalidation sweep) must
+	// return A, not nil — otherwise the sweep marks the session evidence-stale.
+	if got := server.autotuneCatalogForProvider(session); got == nil || got.Version != "cat-A" {
+		t.Fatalf("autotuneCatalogForProvider post-swap = %v, want cat-A", got)
+	}
+}
+
+// TestAdmissionHelpersPinPassedCatalogGeneration locks in the #1268 MED-2 fix:
+// the *WithCatalog admission helpers must evaluate against the catalog
+// generation the caller pins, not a fresh live snapshot. prepareProviderAdmission
+// takes ONE snapshot and threads it through catalogAdmission, the expected model
+// hash, and the hello gate, so a SIGHUP swap between those reads cannot classify
+// a hello against one generation and hash it against another.
+func TestAdmissionHelpersPinPassedCatalogGeneration(t *testing.T) {
+	t.Parallel()
+	const shaA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	const shaB = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	a := reloadTestCatalogSHA(t, "cat-A", shaA)
+	b := reloadTestCatalogSHA(t, "cat-B", shaB)
+	server := NewServer(admissionCeilingEnforcementConfig(), pool.NewRegistry(nil), zerolog.Nop(),
+		WithAutotuneCatalog(a),
+	)
+	hello := Hello{ModelID: "small-model"}
+
+	// Pin generation A, then SIGHUP-swap the live catalog to B mid-admission.
+	pinnedCurrent, pinnedCompatible := server.autotuneCatalogSnapshot()
+	server.SetAutotuneCatalog(b)
+
+	// The pinned-generation helper still answers against A...
+	if got := server.expectedAdmissionModelHashWithCatalog(hello, "current", pinnedCurrent, pinnedCompatible); got != shaA {
+		t.Fatalf("pinned expected hash = %q, want cat-A sha %q (must not follow the live swap)", got, shaA)
+	}
+	// ...while the snapshot-taking wrapper now sees the swapped-in B, proving the
+	// wrapper re-snapshots and the *WithCatalog seam is what pins the generation.
+	if got := server.expectedAdmissionModelHash(hello, "current"); got != shaB {
+		t.Fatalf("live expected hash = %q, want swapped-in cat-B sha %q", got, shaB)
+	}
+}
+
+// TestSetAutotuneCatalogConcurrentReadSwap exercises the getter/setter under the
+// race detector: concurrent admission-path reads must never observe a torn
+// (current, compatible) pair while a SIGHUP swap runs. Run with `-race`.
+func TestSetAutotuneCatalogConcurrentReadSwap(t *testing.T) {
+	t.Parallel()
+	v1 := reloadTestCatalog(t, "cat-v1")
+	server := NewServer(admissionCeilingEnforcementConfig(), pool.NewRegistry(nil), zerolog.Nop(),
+		WithAutotuneCatalog(v1),
+	)
+	v2 := reloadTestCatalog(t, "cat-v2")
+
+	var wg sync.WaitGroup
+	const readers = 8
+	const iterations = 500
+	stop := make(chan struct{})
+
+	for i := 0; i < readers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				cur, compat := server.autotuneCatalogSnapshot()
+				if cur == nil {
+					t.Errorf("snapshot returned nil active catalog during swap")
+					return
+				}
+				// Reading the compatible map concurrently must be safe because
+				// SetAutotuneCatalog replaces it wholesale, never mutates it.
+				_ = compat[cur.Version]
+				_ = server.currentAutotuneCatalog()
+			}
+		}()
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			if i%2 == 0 {
+				server.SetAutotuneCatalog(v2, v1)
+			} else {
+				server.SetAutotuneCatalog(v1, v2)
+			}
+		}
+		close(stop)
+	}()
+
+	wg.Wait()
+}

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -143,7 +143,13 @@ type Server struct {
 	// catalog holds an explicitly-injected tier2.Catalog for tests that
 	// want isolation from the package-singleton; nil means "use
 	// tier2.Default()". M3-8d (audit TEST-4). See s.catalogRef().
-	catalog                        *tier2.Catalog
+	catalog *tier2.Catalog
+	// autotuneCatalogMu guards autotuneCatalog + autotuneCompatibleCatalogs so
+	// the SIGHUP feed reload (SetAutotuneCatalog) can atomically swap them while
+	// hello admission reads them concurrently. Construction-time Options write
+	// the fields before Serve() starts any goroutine (happens-before), so they
+	// stay lock-free; every runtime read goes through a getter under RLock.
+	autotuneCatalogMu              sync.RWMutex
 	autotuneCatalog                *autotune.Catalog
 	autotuneCompatibleCatalogs     map[string]*autotune.Catalog
 	autotuneCatalogEnforced        bool
@@ -433,14 +439,104 @@ func WithCatalog(c *tier2.Catalog) Option {
 // gate.
 func WithAutotuneCatalog(catalog *autotune.Catalog, compatible ...*autotune.Catalog) Option {
 	return func(s *Server) {
+		// Construction runs before Serve() launches any goroutine, so this
+		// write is lock-free; runtime swaps use SetAutotuneCatalog.
 		s.autotuneCatalog = catalog
-		s.autotuneCompatibleCatalogs = make(map[string]*autotune.Catalog, len(compatible))
-		for _, previous := range compatible {
-			if previous != nil && previous.Version != "" && !autotune.IsPermanentlyRejectedReleaseID(previous.Version) && (catalog == nil || previous.Version != catalog.Version) {
-				s.autotuneCompatibleCatalogs[previous.Version] = previous
-			}
+		s.autotuneCompatibleCatalogs = buildCompatibleCatalogSet(catalog, compatible)
+	}
+}
+
+// buildCompatibleCatalogSet rebuilds the previous/compatible admission map with
+// the invariant that a compatible entry is a non-rejected, distinctly-versioned
+// prior release. Shared by construction and the SIGHUP swap so both apply the
+// same rules.
+func buildCompatibleCatalogSet(catalog *autotune.Catalog, compatible []*autotune.Catalog) map[string]*autotune.Catalog {
+	next := make(map[string]*autotune.Catalog, len(compatible))
+	for _, previous := range compatible {
+		if previous != nil && previous.Version != "" && !autotune.IsPermanentlyRejectedReleaseID(previous.Version) && (catalog == nil || previous.Version != catalog.Version) {
+			next[previous.Version] = previous
 		}
 	}
+	return next
+}
+
+// currentAutotuneCatalog returns the active catalog under RLock. The pointer is
+// immutable once published, so it stays valid after the lock is released.
+func (s *Server) currentAutotuneCatalog() *autotune.Catalog {
+	s.autotuneCatalogMu.RLock()
+	defer s.autotuneCatalogMu.RUnlock()
+	return s.autotuneCatalog
+}
+
+// autotuneCatalogSnapshot returns the active catalog and the compatible map
+// together under a single RLock, so a reader that consults both cannot observe
+// a torn (current, compatible) pair across a concurrent SetAutotuneCatalog. The
+// compatible map is replaced wholesale (never mutated in place), so the returned
+// reference stays safe to read after the lock is released.
+func (s *Server) autotuneCatalogSnapshot() (*autotune.Catalog, map[string]*autotune.Catalog) {
+	s.autotuneCatalogMu.RLock()
+	defer s.autotuneCatalogMu.RUnlock()
+	return s.autotuneCatalog, s.autotuneCompatibleCatalogs
+}
+
+// SetAutotuneCatalog atomically swaps the active + compatible catalogs. The
+// SIGHUP feed reload calls this only after the new feed is parsed and validated;
+// on any validation failure the caller keeps the prior catalog (fail-closed).
+func (s *Server) SetAutotuneCatalog(catalog *autotune.Catalog, compatible ...*autotune.Catalog) {
+	next := buildCompatibleCatalogSet(catalog, compatible)
+	s.autotuneCatalogMu.Lock()
+	s.autotuneCatalog = catalog
+	s.autotuneCompatibleCatalogs = next
+	s.autotuneCatalogMu.Unlock()
+}
+
+// CurrentAutotuneCatalog exposes the live active catalog to the coordinator's
+// SIGHUP reload so it validates the tier2 binding against the catalog actually
+// in force (which a prior successful reload may have advanced past the boot
+// pointer), never a stale boot capture.
+func (s *Server) CurrentAutotuneCatalog() *autotune.Catalog {
+	return s.currentAutotuneCatalog()
+}
+
+// resolveProviderCatalog resolves the catalog a live session was admitted
+// against by the release id it presented at hello, NOT the stored
+// current/previous mode label. A SIGHUP catalog swap (a freshness re-stamp)
+// moves the active release, which makes the mode label stale but does not change
+// CatalogReleaseID — the release whose SHA/evidence the session is bound to.
+// Resolving by it keeps an already-admitted session valid across the swap
+// (retained as a compatible "previous"), instead of resolving it against the new
+// active catalog and failing its evidence SHA. Sessions without catalog metadata
+// (legacy / not_required / bridge) return ok=false so callers skip catalog-bound
+// checks exactly as before. isCurrent reports whether the resolved catalog is the
+// active one, for callers that cross-check a previous release against the active.
+func (s *Server) resolveProviderCatalog(provider pool.Provider) (resolved, current *autotune.Catalog, isCurrent, ok bool) {
+	if provider.CatalogAdmissionMode != "current" && provider.CatalogAdmissionMode != "previous" {
+		return nil, nil, false, false
+	}
+	cur, compatible := s.autotuneCatalogSnapshot()
+	if provider.CatalogReleaseID != "" {
+		// Resolve by the exact release the session presented. This is the case
+		// production catalogAdmission always produces, and it is what keeps a
+		// live session valid across a swap: after a re-stamp the session's old
+		// release is retained as a compatible "previous" and resolves here.
+		if cur != nil && provider.CatalogReleaseID == cur.Version {
+			return cur, cur, true, true
+		}
+		if prev := compatible[provider.CatalogReleaseID]; prev != nil {
+			return prev, cur, false, true
+		}
+		// A non-empty release that is neither the active catalog nor a retained
+		// compatible one is no longer served: resolution fails so the caller
+		// treats the session as catalog-unavailable.
+		return nil, cur, false, false
+	}
+	// Empty release id (a session admitted before catalog metadata existed):
+	// honor the stored mode against the active catalog, matching pre-#1268
+	// behavior. "previous" with no release id has no resolvable catalog.
+	if provider.CatalogAdmissionMode == "current" && cur != nil {
+		return cur, cur, true, true
+	}
+	return nil, cur, false, false
 }
 
 // WithAutotuneCatalogEnforcement configures strict admission or an explicitly
@@ -741,7 +837,7 @@ func NewServer(cfg config.Config, registry *pool.Registry, logger zerolog.Logger
 			return s.verifyProviderModelIdentity(modelID, expectedHash, reportedHash, reportedAlgorithm)
 		})(registry)
 	}
-	if s.autotuneCatalog != nil && !s.autotuneCatalogEnforced && !s.autotuneCatalogBridgeDeadline.IsZero() && registry != nil {
+	if s.currentAutotuneCatalog() != nil && !s.autotuneCatalogEnforced && !s.autotuneCatalogBridgeDeadline.IsZero() && registry != nil {
 		go s.runAutotuneCatalogBridgeDeadline()
 	}
 	if cfg.Pool.CanaryEnabled && registry != nil {
@@ -767,7 +863,7 @@ func NewServer(cfg config.Config, registry *pool.Registry, logger zerolog.Logger
 	// strict autotune evidence TTL checks run only when the hello gate is enabled
 	// and its catalog+evidence dependencies are wired. Both use the same 30s
 	// sweep cadence.
-	if (s.providerTrust != nil || s.rewardsTrust != nil || (s.autotuneCatalog != nil && s.autotuneEvidence != nil)) && registry != nil {
+	if (s.providerTrust != nil || s.rewardsTrust != nil || (s.currentAutotuneCatalog() != nil && s.autotuneEvidence != nil)) && registry != nil {
 		go s.runTrustRevalidationLoop()
 	}
 	return s
@@ -978,7 +1074,7 @@ func (s *Server) SetProofOfWeightsConfig(next config.ProofOfWeightsConfig) Proof
 }
 
 func (s *Server) revalidateProofOfWeightsAdmissions(cfg config.ProofOfWeightsConfig, result ProofOfWeightsReloadResult) ProofOfWeightsReloadResult {
-	if s.autotuneCatalog == nil || s.autotuneEvidence == nil || cfg.AutotuneEvidenceTTLDays <= 0 {
+	if s.currentAutotuneCatalog() == nil || s.autotuneEvidence == nil || cfg.AutotuneEvidenceTTLDays <= 0 {
 		for _, provider := range s.pool.Snapshot() {
 			if s.pool.SetAdmissionEvidenceStale(provider.ProviderID, provider.AssignedID, true) {
 				result.StillEvidenceStale++
@@ -1149,7 +1245,7 @@ func (s *Server) verifyProviderModelIdentity(modelID, expectedHash, reportedHash
 		}
 		return pool.HashStatusMismatch
 	}
-	if s.autotuneCatalog == nil {
+	if s.currentAutotuneCatalog() == nil {
 		return pool.HashStatusCatalogUnavailable
 	}
 	return pool.HashStatusUncatalogued
@@ -2505,7 +2601,13 @@ func (s *Server) prepareProviderAdmissionWithQuotaCheck(conn net.Conn, auth prov
 			}
 		}
 	}
-	catalogAdmissionMode, catalogCompatible := s.catalogAdmission(hello)
+	// #1268 MED-2: pin ONE autotune catalog generation for the whole of this
+	// admission. catalogAdmission classifies the hello, expectedAdmissionModelHash
+	// derives the expected hash, and the hello gate authorizes hardware trust —
+	// all three must see the same (current, compatible) pair even if an operator
+	// SIGHUP-swaps the feed between these reads.
+	admissionCurrent, admissionCompatible := s.autotuneCatalogSnapshot()
+	catalogAdmissionMode, catalogCompatible := s.catalogAdmissionWithCatalog(hello, admissionCurrent, admissionCompatible)
 	if !catalogCompatible {
 		if firstHopOnly {
 			catalogAdmissionMode = "update_bridge"
@@ -2524,7 +2626,7 @@ func (s *Server) prepareProviderAdmissionWithQuotaCheck(conn net.Conn, auth prov
 		catalogAdmissionMode = "update_bridge"
 	}
 	now := s.now()
-	expectedModelHash := s.expectedAdmissionModelHash(hello, catalogAdmissionMode)
+	expectedModelHash := s.expectedAdmissionModelHashWithCatalog(hello, catalogAdmissionMode, admissionCurrent, admissionCompatible)
 	hashStatus := pool.HashStatus("")
 	tier2Cfg := s.tier2Config()
 	if tier2.ModelHashActive(tier2Cfg) {
@@ -2624,7 +2726,7 @@ func (s *Server) prepareProviderAdmissionWithQuotaCheck(conn net.Conn, auth prov
 			Msg("admitting update-only first-hop bridge session")
 	} else {
 		var gateOK bool
-		admissionObservation, gateOK := s.checkAutotuneHelloGate(conn, hello)
+		admissionObservation, gateOK := s.checkAutotuneHelloGateWithCatalog(conn, hello, admissionCurrent)
 		if !gateOK {
 			return nil, false
 		}
@@ -2703,9 +2805,19 @@ func (s *Server) prepareProviderAdmissionWithQuotaCheck(conn net.Conn, auth prov
 }
 
 func (s *Server) expectedAdmissionModelHash(hello Hello, admissionMode string) string {
-	catalog := s.autotuneCatalog
+	current, compatible := s.autotuneCatalogSnapshot()
+	return s.expectedAdmissionModelHashWithCatalog(hello, admissionMode, current, compatible)
+}
+
+// expectedAdmissionModelHashWithCatalog is the snapshot-free core so a single
+// admission can thread ONE (current, compatible) generation through
+// catalogAdmission, this hash lookup, and the hello gate — a SIGHUP swap between
+// those reads must not mix an old current with a new compatible within one hello
+// (#1268 MED-2).
+func (s *Server) expectedAdmissionModelHashWithCatalog(hello Hello, admissionMode string, current *autotune.Catalog, compatible map[string]*autotune.Catalog) string {
+	catalog := current
 	if admissionMode == "previous" {
-		catalog = s.autotuneCompatibleCatalogs[hello.CatalogReleaseID]
+		catalog = compatible[hello.CatalogReleaseID]
 	}
 	if catalog == nil || (admissionMode != "current" && admissionMode != "previous") {
 		return ""
@@ -2722,11 +2834,8 @@ func (s *Server) expectedProviderModelHash(providerID, assignedID, modelID strin
 	if !ok {
 		return ""
 	}
-	catalog := s.autotuneCatalog
-	if provider.CatalogAdmissionMode == "previous" {
-		catalog = s.autotuneCompatibleCatalogs[provider.CatalogReleaseID]
-	}
-	if catalog == nil || (provider.CatalogAdmissionMode != "current" && provider.CatalogAdmissionMode != "previous") {
+	catalog, _, _, resolvedOK := s.resolveProviderCatalog(provider)
+	if !resolvedOK || catalog == nil {
 		return ""
 	}
 	_, row, ok := catalog.HighestClaimedTier(modelID)
@@ -2751,9 +2860,17 @@ type autotuneAdmissionObservation struct {
 // the same evidence read runs observe-only so heartbeat model changes can be
 // compared against the admitted RAM ceiling without affecting routing.
 func (s *Server) checkAutotuneHelloGate(conn net.Conn, hello Hello) (autotuneAdmissionObservation, bool) {
+	return s.checkAutotuneHelloGateWithCatalog(conn, hello, s.currentAutotuneCatalog())
+}
+
+// checkAutotuneHelloGateWithCatalog is the snapshot-free core so the caller can
+// pass the same active catalog it used for catalogAdmission / expected-hash,
+// keeping one admission on a single catalog generation across a SIGHUP swap
+// (#1268 MED-2).
+func (s *Server) checkAutotuneHelloGateWithCatalog(conn net.Conn, hello Hello, catalog *autotune.Catalog) (autotuneAdmissionObservation, bool) {
 	powCfg := s.proofOfWeightsConfig()
 	requireGate := powCfg.RequireAutotuneHelloGate
-	if s.autotuneCatalog == nil || s.autotuneEvidence == nil {
+	if catalog == nil || s.autotuneEvidence == nil {
 		if requireGate {
 			s.log.Error().Str("provider_id", hello.ProviderID).Msg("autotune hello gate enabled but dependencies are not wired")
 			s.close(conn, CloseInvalidHello, "autotune_gate_unavailable")
@@ -2799,7 +2916,7 @@ func (s *Server) checkAutotuneHelloGate(conn net.Conn, hello Hello) (autotuneAdm
 		}
 		return autotuneAdmissionObservation{}, true
 	}
-	decision := autotune.EvaluateHelloGateForHello(s.autotuneCatalog, evidence, hello.ModelID, hello.BinaryVersion)
+	decision := autotune.EvaluateHelloGateForHello(catalog, evidence, hello.ModelID, hello.BinaryVersion)
 	if !decision.Allowed {
 		if !requireGate {
 			return autotuneAdmissionObservation{
@@ -2844,7 +2961,15 @@ func (s *Server) checkAutotuneHelloGate(conn net.Conn, hello Hello) (autotuneAdm
 }
 
 func (s *Server) catalogAdmission(hello Hello) (string, bool) {
-	catalog := s.autotuneCatalog
+	catalog, compatible := s.autotuneCatalogSnapshot()
+	return s.catalogAdmissionWithCatalog(hello, catalog, compatible)
+}
+
+// catalogAdmissionWithCatalog is the snapshot-free core so a single admission
+// can pin one (current, compatible) generation and reuse it for the expected
+// model hash and the hello gate — a SIGHUP swap mid-admission must not classify
+// a hello against one generation and hash it against another (#1268 MED-2).
+func (s *Server) catalogAdmissionWithCatalog(hello Hello, catalog *autotune.Catalog, compatible map[string]*autotune.Catalog) (string, bool) {
 	if catalog == nil {
 		return "not_required", true
 	}
@@ -2876,7 +3001,7 @@ func (s *Server) catalogAdmission(hello Hello) (string, bool) {
 	providerCatalog := catalog
 	admissionMode := "current"
 	if hello.CatalogReleaseID != catalog.Version {
-		providerCatalog = s.autotuneCompatibleCatalogs[hello.CatalogReleaseID]
+		providerCatalog = compatible[hello.CatalogReleaseID]
 		admissionMode = "previous"
 	}
 	if providerCatalog == nil ||
@@ -2913,25 +3038,27 @@ func (s *Server) catalogAdmission(hello Hello) (string, bool) {
 }
 
 func (s *Server) populateCatalogHelloAck(ack *HelloAck) {
-	if ack == nil || s.autotuneCatalog == nil {
+	catalog := s.currentAutotuneCatalog()
+	if ack == nil || catalog == nil {
 		return
 	}
 	ack.CatalogCompatible = true
-	ack.CatalogReleaseID = s.autotuneCatalog.Version
-	ack.CatalogPolicyVersion = s.autotuneCatalog.PolicyVersion
-	ack.CandidateCatalogSHA256 = s.autotuneCatalog.SHA256
-	ack.CatalogSignerKeyID = s.autotuneCatalog.SignerKeyID
+	ack.CatalogReleaseID = catalog.Version
+	ack.CatalogPolicyVersion = catalog.PolicyVersion
+	ack.CandidateCatalogSHA256 = catalog.SHA256
+	ack.CatalogSignerKeyID = catalog.SignerKeyID
 }
 
 func (s *Server) populateCatalogAuthResponse(response *AuthResponse) {
-	if response == nil || s.autotuneCatalog == nil {
+	catalog := s.currentAutotuneCatalog()
+	if response == nil || catalog == nil {
 		return
 	}
 	response.CatalogCompatible = true
-	response.CatalogReleaseID = s.autotuneCatalog.Version
-	response.CatalogPolicyVersion = s.autotuneCatalog.PolicyVersion
-	response.CandidateCatalogSHA256 = s.autotuneCatalog.SHA256
-	response.CatalogSignerKeyID = s.autotuneCatalog.SignerKeyID
+	response.CatalogReleaseID = catalog.Version
+	response.CatalogPolicyVersion = catalog.PolicyVersion
+	response.CandidateCatalogSHA256 = catalog.SHA256
+	response.CatalogSignerKeyID = catalog.SignerKeyID
 }
 
 func (s *Server) requireCompatibleSet(conn net.Conn, providedID string, authV2 bool) bool {
@@ -4919,20 +5046,24 @@ func (s *Server) observeAdmissionCeilingDrift(provider pool.Provider, priorModel
 }
 
 func (s *Server) catalogMinRAMForProviderModel(provider pool.Provider, modelID string) (int, bool) {
-	catalog := s.autotuneCatalog
-	if catalog == nil {
+	resolved, current, isCurrent, ok := s.resolveProviderCatalog(provider)
+	if !ok || resolved == nil {
 		return 0, false
 	}
-	if provider.CatalogAdmissionMode == "previous" {
-		previousCatalog := s.autotuneCompatibleCatalogs[provider.CatalogReleaseID]
-		if previousCatalog == nil {
+	if !isCurrent {
+		// Provider is on a compatible previous release (either admitted there at
+		// hello, or moved there by a catalog swap). Admit its ceiling only while
+		// the selected row is identity- and policy-equivalent to the active
+		// release, so a stale previous catalog cannot lift the ceiling.
+		if current == nil {
 			return 0, false
 		}
+		previousCatalog := resolved
 		previousKey, _, ok := previousCatalog.HighestClaimedTier(modelID)
 		if !ok {
 			return 0, false
 		}
-		activeKey, activeRow, ok := catalog.HighestClaimedTier(modelID)
+		activeKey, activeRow, ok := current.HighestClaimedTier(modelID)
 		if !ok {
 			return 0, false
 		}
@@ -4940,16 +5071,16 @@ func (s *Server) catalogMinRAMForProviderModel(provider pool.Provider, modelID s
 		if !ok {
 			return 0, false
 		}
-		activeIdentity, ok := catalog.RowIdentity(activeKey)
+		activeIdentity, ok := current.RowIdentity(activeKey)
 		if !ok || !strings.EqualFold(previousIdentity, activeIdentity) {
 			return 0, false
 		}
-		if !previousCatalog.PolicyEquivalent(previousKey, catalog, activeKey) {
+		if !previousCatalog.PolicyEquivalent(previousKey, current, activeKey) {
 			return 0, false
 		}
 		return activeRow.MinRAMGB, true
 	}
-	_, row, ok := catalog.HighestClaimedTier(modelID)
+	_, row, ok := resolved.HighestClaimedTier(modelID)
 	if !ok {
 		return 0, false
 	}
@@ -4957,10 +5088,8 @@ func (s *Server) catalogMinRAMForProviderModel(provider pool.Provider, modelID s
 }
 
 func (s *Server) autotuneCatalogForProvider(provider pool.Provider) *autotune.Catalog {
-	if provider.CatalogAdmissionMode == "previous" {
-		return s.autotuneCompatibleCatalogs[provider.CatalogReleaseID]
-	}
-	return s.autotuneCatalog
+	resolved, _, _, _ := s.resolveProviderCatalog(provider)
+	return resolved
 }
 
 type admissionCeilingRouteVerdict struct {

--- a/phase4-coordinator/internal/ws/trust_revalidation.go
+++ b/phase4-coordinator/internal/ws/trust_revalidation.go
@@ -168,7 +168,7 @@ func (s *Server) runAdmissionEvidenceRevalidationSweep() {
 	defer s.proofOfWeightsAdmissionMu.RUnlock()
 
 	powCfg := s.proofOfWeightsConfig()
-	if !powCfg.RequireAutotuneHelloGate || s.autotuneCatalog == nil || s.autotuneEvidence == nil || powCfg.AutotuneEvidenceTTLDays <= 0 {
+	if !powCfg.RequireAutotuneHelloGate || s.currentAutotuneCatalog() == nil || s.autotuneEvidence == nil || powCfg.AutotuneEvidenceTTLDays <= 0 {
 		return
 	}
 	ttl := time.Duration(powCfg.AutotuneEvidenceTTLDays) * 24 * time.Hour


### PR DESCRIPTION
## Summary
Makes the coordinator **hot-reload the signed autotune feed on SIGHUP**, so an operator can refresh the rate-card / candidate / demand-rank feeds — e.g. a freshness re-stamp that clears the client 30-day freshness horizon — **without a coordinator restart** (which drops every connected provider). Closes the restart requirement that made feed renewal disruptive.

Prerequisite for automated feed renewal (the fix for the 30-day-expiry strand class in #1235 / #1268): with this in place, renewal is a re-sign + `kill -HUP`, zero provider disruption.

## What changed
- **ws (`server.go`)**: `autotuneCatalog` + `autotuneCompatibleCatalogs` are now guarded by `autotuneCatalogMu` (RWMutex). Every runtime read routes through `currentAutotuneCatalog()` / `autotuneCatalogSnapshot()`; construction-time Options still write directly (pre-`Serve()`, happens-before any goroutine). New `SetAutotuneCatalog()` performs the atomic swap; `buildCompatibleCatalogSet()` shares the compatible-set rules between construction and swap.
- **buyer (`autotune_feeds.go`)**: new `SetAutotuneFeeds()` swaps the served signed bytes (the buyer already had `autotuneFeedsMu` + `autotuneFeedsSnapshot()`).
- **`reloadCoordinatorConfig`**: `loadAutotuneCatalogForReload()` mirrors boot loading (signature-verifying `LoadAutotuneFeeds`, `IsPermanentlyRejectedReleaseID`, `loadPreviousAutotuneCatalog`). Reload baseline is the **live** catalog (a prior successful reload may have advanced past the boot pointer). **Fail-closed** — any parse / rejected-id / previous-catalog / tier2-binding / billing error keeps the prior in-memory catalog and served bytes. The catalog + buyer-feed swap lands only after every fallible reload step succeeds, adjacent to the telemetry-drift evaluator swap, so the live catalog and the evaluator that captured its pointer can never diverge.
- **admission generation-pinning**: `prepareProviderAdmissionWithQuotaCheck` takes **one** `autotuneCatalogSnapshot()` and threads it through catalog classification, expected-model-hash, and the hardware-trust hello gate (via new `*WithCatalog` cores), so a SIGHUP swap mid-admission cannot classify a hello against one catalog generation and hash/gate it against another.
- **tests**: hot-swap behavior, previous-release survival across swap, per-admission generation pinning, and concurrent read/swap under `-race`.

## Testing
- `go test -race ./internal/ws/` — green (incl. `TestSetAutotuneCatalogHotSwap`, `TestResolveProviderCatalogSurvivesSwap`, `TestAdmissionHelpersPinPassedCatalogGeneration`, `TestSetAutotuneCatalogConcurrentReadSwap`)
- `go test ./internal/buyer/`, `go test ./cmd/coordinator/` — green
- `go build ./...`, `gofmt` — clean

## Audit
Codex audit over the full combined diff (code/concurrency, fail-closed, admission/money-path), iterated to the repo gate of **0 CRITICAL / 0 HIGH / 0 MEDIUM**:
- **Round 1**: 2 HIGH (active-session reclassification after swap; stale reload baseline) + 2 MEDIUM (telemetry-drift built with old catalog; cleared-paths silent keep) — all fixed.
- **Round 2**: 0 C / 0 H / 2 MEDIUM (catalog/feed published before a later fallible reload step; one admission could observe multiple catalog generations) — all fixed.
- **Round 3**: confirmation pass — 0 C / 0 H / 0 MEDIUM, no regression (the residual `new-tier2 + old-catalog` window on a billing-reload failure was assessed as fail-closed, not an over-admission hazard: v1 admission pins the old live catalog and verifies the model hash against it).

Evidence + prompts under `audits/2026-08-28-1268/` (kept local, not in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Related
Implements the SIGHUP hot-reload half of #1268 (automated renewal cron is the fast-follow, now restart-free thanks to this).

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-032"],
  "requirements": ["SPEC-032-R001"],
  "authority_domains": ["coordinator-admission-routing", "hardware-evidence-admission"],
  "arbitration": ["UNKNOWN"],
  "tests": [
    "phase4-coordinator/internal/ws/autotune_catalog_reload_test.go:TestSetAutotuneCatalogHotSwap",
    "phase4-coordinator/internal/ws/autotune_catalog_reload_test.go:TestResolveProviderCatalogSurvivesSwap",
    "phase4-coordinator/internal/ws/autotune_catalog_reload_test.go:TestAdmissionHelpersPinPassedCatalogGeneration",
    "phase4-coordinator/internal/ws/autotune_catalog_reload_test.go:TestSetAutotuneCatalogConcurrentReadSwap"
  ],
  "journeys": ["JOURNEY-PROVIDER-PREBETA-ADMISSION"],
  "issue": "https://github.com/Augustas11/macprovider/issues/1268"
}
SPEC-GOVERNANCE-DECLARATION-END
