### PR TITLE
Refresh SPEC-032-R003 selector after #1268 hello-gate split

### DIFF
--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -2224,7 +2224,7 @@
         "phase4-coordinator/internal/pool/provider.go:func (r *Registry) QuarantineForProofOfWeightsReload",
         "phase4-coordinator/internal/ws/server.go:func (s *Server) SetProofOfWeightsConfig",
         "phase4-coordinator/internal/ws/server.go:func (s *Server) revalidateProofOfWeightsAdmissions",
-        "phase4-coordinator/internal/ws/server.go:func (s *Server) checkAutotuneHelloGate",
+        "phase4-coordinator/internal/ws/server.go:func (s *Server) checkAutotuneHelloGateWithCatalog",
         "phase4-coordinator/cmd/coordinator/main.go:func reloadCoordinatorConfig",
         "phase4-coordinator/cmd/coordinator/main.go:func telemetryDriftEvaluatorForReload"
       ],


### PR DESCRIPTION
## Summary
Refresh a stale CONFORMANCE mapping selector after the #1268 SIGHUP hot-reload merge (7ec6ea69). No behavior change — this is a governance-manifest (`specs/CONFORMANCE.json`) selector correction only.

## What changed
`SPEC-032-R003.implementation[6]` pointed at `func (s *Server) checkAutotuneHelloGate`. #1268 split that method into a snapshot-taking wrapper plus a `checkAutotuneHelloGateWithCatalog` core (so one admission pins a single autotune-catalog generation). The bare-prefix selector now matches **both** functions, so `check_spec_governance` reports it as unresolved. Re-point the mapping at the core `func (s *Server) checkAutotuneHelloGateWithCatalog`, where the hello-gate authorization logic now lives. Unique, resolves cleanly.

## Known remaining spec-index item (not fixed here)
`SPEC-010-R005` (conformant) still reports a commit-evidence drift: #1268 converted a `s.autotuneCatalog` read inside `verifyProviderModelIdentity` to the thread-safe getter `s.currentAutotuneCatalog()` (required — that read is concurrent with the new SIGHUP `SetAutotuneCatalog` writer). That is a behavior-preserving change, but it moved the mapped fragment, and R005's commit anchor is cryptographically bound to a **signed provider-prebeta-admission journey-result** (commit c59568b). Re-anchoring requires a fresh signed journey capture against the new binary (live air5 provider + journey-result signing) — tracked as recapture debt, not fixable by editing the manifest. Left truthfully flagged rather than downgraded or re-stamped.

## Validation
`python3 scripts/check_spec_governance.py --base-ref origin/main` — the `checkAutotuneHelloGate` selector error is resolved (only the R005 recapture item remains).

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "none",
  "contract_change": "yes",
  "specs": [],
  "requirements": [],
  "authority_domains": [],
  "arbitration": [],
  "tests": [],
  "journeys": [],
  "issue": "https://github.com/Augustas11/macprovider/issues/1268"
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
