### PR TITLE
Automate discovery-head renewal cadence + freshness alarm (#1235 child D)

### DIFF
--- a/.github/workflows/discovery-head-freshness-alarm.yml
+++ b/.github/workflows/discovery-head-freshness-alarm.yml
@@ -1,0 +1,72 @@
+name: Discovery head freshness alarm
+
+# Read-only backstop for the signed release-discovery self-heal rail. The renewal
+# workflow (renew-release-discovery-head.yml) auto-dispatches weekly at 168h
+# validity but still waits on the production-release approval; if that approval is
+# skipped/late, this alarm fails (and notifies) BEFORE the head lapses fleet-wide.
+# No secrets, no production-release environment, no signing — it only reads the
+# latest head's self-asserted expiry.
+
+on:
+  schedule:
+    # Every 6 hours: far more often than the weekly renewal, so a stale head is
+    # caught with well over a day of runway (alarm threshold is 48h).
+    - cron: "0 */6 * * *"
+  workflow_dispatch:
+    inputs:
+      min_hours:
+        description: "Alarm if the head expires within this many hours (default 48)"
+        required: false
+        default: "48"
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: discovery-head-freshness-alarm
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Alarm on a stale self-heal discovery head
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout freshness check
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Resolve latest signed discovery head and check freshness
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MIN_HOURS: ${{ github.event.inputs.min_hours || '48' }}
+        run: |
+          set -euo pipefail
+          # Mirror EXACTLY what the client sees, not what exists. The client
+          # (SelfUpdate.swift releaseDiscoveryPageSize=20) fetches only the 20
+          # most-recent releases and picks the highest-sequence
+          # release-discovery-v1-<seq> transport among them, with the strict
+          # grammar [1-9][0-9]* (SignedReleaseDiscovery.swift / the verifier at
+          # scripts/verify-release-discovery-transport.py). If 20 newer non-transport
+          # releases push every transport out of that window, the client sees NO
+          # head and the rail is down — so this alarm must use the SAME 20-release
+          # window and grammar, and alarm when no client-visible transport exists.
+          latest_tag="$(
+            gh release list --repo "$GITHUB_REPOSITORY" --limit 20 \
+              --json tagName --jq '.[].tagName' \
+            | grep -E '^release-discovery-v1-[1-9][0-9]*$' \
+            | sort -t- -k4,4n \
+            | tail -1
+          )"
+          if [ -z "${latest_tag:-}" ]; then
+            echo "::error::no client-visible release-discovery-v1-* transport in the 20 most-recent releases — the self-heal rail is DOWN for clients; renew now." >&2
+            exit 1
+          fi
+          echo "latest client-visible transport: $latest_tag"
+          gh release download "$latest_tag" --repo "$GITHUB_REPOSITORY" \
+            --pattern macprovider-release-discovery.json --output - \
+          | python3 scripts/check-discovery-head-freshness.py --min-hours "$MIN_HOURS"

--- a/.github/workflows/renew-release-discovery-head.yml
+++ b/.github/workflows/renew-release-discovery-head.yml
@@ -9,10 +9,17 @@ on:
   workflow_dispatch:
     inputs:
       validity_hours:
-        description: "Signed-head validity window in hours (1-168; default 24)"
+        description: "Signed-head validity window in hours (1-168; default 168)"
         required: false
-        default: "24"
+        default: "168"
         type: string
+  schedule:
+    # Weekly auto-dispatch, well inside the 168h (7-day) validity window, so the
+    # signed self-heal head never lapses because an operator forgot to dispatch.
+    # The run still enters the production-release environment and waits for the
+    # antfleet-ops approval; the read-only discovery-head freshness alarm
+    # (discovery-head-freshness-alarm.yml) backstops a skipped/late approval.
+    - cron: "0 16 * * 1"
 
 permissions:
   contents: read
@@ -66,7 +73,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          VALIDITY_HOURS_INPUT: ${{ github.event.inputs.validity_hours || '24' }}
+          VALIDITY_HOURS_INPUT: ${{ github.event.inputs.validity_hours || '168' }}
         run: |
           set -euo pipefail
           work="$RUNNER_TEMP/renew-discovery"

--- a/scripts/check-discovery-head-freshness.py
+++ b/scripts/check-discovery-head-freshness.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Alarm check for the signed release-discovery head freshness.
+
+Reads a signed release-discovery head JSON on stdin and fails (exit 1) when the
+head is already expired or within --min-hours of expiry, so a missed/late renewal
+is caught BEFORE the coordinator-independent self-heal rail lapses fleet-wide.
+
+Read-only: no secrets, no network, no signature trust decision (that is the
+client's job) — this only reads the self-asserted validity window to alarm on
+staleness. Intended to run on a schedule far more often than the renewal cadence.
+
+Usage:
+  gh release download <latest release-discovery-v1-*> --pattern macprovider-release-discovery.json -O - \
+    | python3 scripts/check-discovery-head-freshness.py --min-hours 48
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sys
+
+
+def fail(message: str) -> "NoReturn":  # type: ignore[name-defined]
+    print(f"[discovery-head-freshness] ALARM: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--min-hours",
+        type=float,
+        default=48.0,
+        help="alarm if the head expires within this many hours (default 48)",
+    )
+    args = parser.parse_args(argv)
+    if args.min_hours < 0:
+        fail("--min-hours must be non-negative")
+
+    raw = sys.stdin.read()
+    if not raw.strip():
+        fail("no discovery head on stdin (could not resolve/download the latest head?)")
+    try:
+        head = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        fail(f"discovery head is not valid JSON: {exc}")
+    if not isinstance(head, dict):
+        fail("discovery head must be a JSON object")
+
+    signed = head.get("signed")
+    if not isinstance(signed, dict):
+        fail("discovery head has no 'signed' object")
+    expires_raw = signed.get("expires_at")
+    if not isinstance(expires_raw, str) or not expires_raw:
+        fail("discovery head 'signed.expires_at' is missing")
+    try:
+        expires = dt.datetime.strptime(expires_raw, "%Y-%m-%dT%H:%M:%SZ").replace(
+            tzinfo=dt.timezone.utc
+        )
+    except ValueError as exc:
+        fail(f"unparseable expires_at {expires_raw!r}: {exc}")
+
+    now = dt.datetime.now(dt.timezone.utc)
+    remaining_hours = (expires - now).total_seconds() / 3600.0
+    issued = signed.get("issued_at", "?")
+    print(
+        f"[discovery-head-freshness] issued={issued} expires={expires_raw} "
+        f"remaining={remaining_hours:.1f}h threshold={args.min_hours:.1f}h"
+    )
+    if remaining_hours <= 0:
+        fail(
+            f"self-heal discovery head is EXPIRED ({-remaining_hours:.1f}h ago) — "
+            f"the coordinator-independent recovery rail is DOWN; renew now."
+        )
+    if remaining_hours < args.min_hours:
+        fail(
+            f"self-heal discovery head expires in {remaining_hours:.1f}h "
+            f"(< {args.min_hours:.1f}h) — dispatch/approve a renewal before it lapses."
+        )
+    print("[discovery-head-freshness] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Closes the chronic-lapse of the signed release-discovery **self-heal rail** (Epic #1235 block-class #3). The head has a 24h validity but was renewed only by manual dispatch, so it repeatedly lapsed — leaving the coordinator-independent recovery path down fleet-wide for days at a time (e.g. a ~5-day gap 08-19→08-25).

## What changed
- **`renew-release-discovery-head.yml`**: adds a **weekly `schedule:`** and bumps the default validity **24h → 168h** (the workflow/builder/verifier/client all already cap at 7 days), so the head is auto-dispatched well inside its window. Security posture is unchanged — the renewing job still runs in `environment: production-release` (antfleet-ops approval), seals OpenSSL, and scopes `contents: write` to that job only.
- **`discovery-head-freshness-alarm.yml`** (new): a **read-only, secret-free** scheduled check (every 6h) that fails/notifies when the client-visible head is expired or within 48h of expiry — backstopping a skipped/late approval **before** the rail lapses. It mirrors the client's exact selection (the 20 most-recent releases, strict `release-discovery-v1-[1-9][0-9]*` grammar, highest sequence), so it alarms on what clients actually see, not merely what exists.
- **`scripts/check-discovery-head-freshness.py`** (new): the freshness check (stdin head JSON → exit 1 if expired/imminent/malformed/empty), unit-tested.

## What this does NOT change
The **antfleet-ops approval gate stays intact.** This turns "remember to dispatch or the rail lapses" into "auto-dispatched weekly, approve when pinged, alarm catches a miss." Making the *scheduled* renewal fully unattended (it only re-signs an already-approved target) is a separate key-custody decision, deliberately not taken here.

## Testing / audit
- `actionlint`, both workflows valid YAML, `test-renew-release-discovery-head.sh` passes; freshness script unit-tested (valid/expired/imminent/malformed/empty); selection logic verified (highest sequence, rejects leading-zero/malformed).
- Codex 3-lane audit over the full diff → **0 CRITICAL / 0 HIGH**. The one MEDIUM (alarm scanned 200 releases while the client sees only 20 → could pass on a head clients can't see) and one LOW (looser tag grammar) are fixed by mirroring the client's 20-release window + strict grammar.

Evidence under `audits/2026-08-29-dh-automation/` (kept local, not in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
