### PR TITLE
Coordinator telemetry: heartbeat hardware/version refresh + autoupdate ingest (#1235 child B)

### DIFF
--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -615,6 +615,13 @@ func main() {
 			wsOpts = append(wsOpts, providerws.WithProviderAuthPolicyAdminStore(onboardingStore))
 			wsOpts = append(wsOpts, providerws.WithHardwareTrustAdminStore(onboardingStore))
 		}
+		// Epic #1235 Child B: heartbeat-driven durable telemetry refresh rides
+		// the same onboarding Postgres handle regardless of whether the public
+		// App-track registration route is enabled — any already-onboarded
+		// provider connecting over ws benefits from freshness, not just new
+		// registrants.
+		wsOpts = append(wsOpts, providerws.WithHardwareProfileRefresher(onboardingStore))
+		wsOpts = append(wsOpts, providerws.WithAutoupdateOutcomeSink(onboardingStore))
 	}
 	var autotuneEvidenceStore autotune.EvidenceStore
 	if autotuneCatalog != nil && onboardingStore != nil && onboardingStore.DB() != nil {

--- a/phase4-coordinator/internal/onboarding/store_pg.go
+++ b/phase4-coordinator/internal/onboarding/store_pg.go
@@ -188,6 +188,9 @@ SELECT j.generated_at, j.evidence
 	if _, err := s.db.ExecContext(timeout, `SELECT 1 FROM provider_register_attempts LIMIT 1`); err != nil {
 		return fmt.Errorf("provider_onboarding smoke provider_register_attempts read: %w", err)
 	}
+	if _, err := s.db.ExecContext(timeout, `SELECT provider_id, observed_at, outcome FROM provider_autoupdate_events LIMIT 0`); err != nil {
+		return fmt.Errorf("provider_onboarding smoke provider_autoupdate_events read: %w", err)
+	}
 	if _, err := s.db.ExecContext(timeout, `SELECT 1 FROM provider_auth_policy LIMIT 1`); err != nil {
 		return fmt.Errorf("provider_onboarding smoke provider_auth_policy read: %w", err)
 	}
@@ -464,6 +467,89 @@ ON CONFLICT (provider_id) DO UPDATE
        last_reported_at = $7
  WHERE provider_hardware_profiles.last_reported_at <= $7`,
 		providerID, chip, normalized, memoryGB, macosVersion, appVersion, observedAt.UTC(),
+	)
+	return err
+}
+
+// RefreshProviderHardwareProfile keeps provider_hardware_profiles from going
+// stale for a provider that stays connected across an autoupdate without ever
+// re-registering or re-submitting autotune evidence (Epic #1235 Child B / B1).
+// Unlike UpsertProviderHardwareProfile this is UPDATE-only and never inserts:
+// a heartbeat carries neither macos_version nor a value valid for the `source`
+// CHECK constraint (app_register/cli_hello/operator), so seeding a fresh row
+// from it would fabricate a profile the provider never actually submitted at
+// onboarding. An unknown provider_id is left absent; empty/non-positive
+// arguments leave the corresponding column untouched (COALESCE-style) so a
+// heartbeat that omits hardware_summary still advances last_reported_at and
+// app_version without blanking a chip/memory value learned at registration.
+func (s *PGStore) RefreshProviderHardwareProfile(ctx context.Context, providerID, appVersion string, observedAt time.Time) error {
+	if s == nil || s.db == nil {
+		return errors.New("onboarding postgres store is nil")
+	}
+	appVersion = trimForStorage(appVersion, 80)
+	// Observe-only: refresh ONLY the freshness (last_reported_at) and reported
+	// version (app_version). We deliberately do NOT touch chip_normalized or
+	// unified_memory_gb — the migration-019 trust trigger clears `verified` when
+	// provider_onboarding changes those, which would let a heartbeat demote a
+	// verified provider and affect admission/routing. Hardware identity is
+	// established at registration/verification, not on a heartbeat.
+	_, err := s.db.ExecContext(ctx, `
+UPDATE provider_hardware_profiles
+   SET app_version = CASE WHEN $2 <> '' THEN $2 ELSE app_version END,
+       last_reported_at = $3
+ WHERE provider_id = $1
+   AND last_reported_at <= $3`,
+		providerID, appVersion, observedAt.UTC(),
+	)
+	return err
+}
+
+// AutoupdateOutcomeRecord is one coordinator-observed autoupdate event
+// reported by a provider's heartbeat/state_update `last_autoupdate_event`
+// field (Epic #1235 Child B / B2). Phase/outcome/reason/failure_class/
+// current_version/target_version are free-form client-reported text with NO
+// enum CHECK, mirroring provider_hardware_profiles.macos_version/app_version:
+// the client-side taxonomy (AutoUpdateEvent.swift) evolves independently of
+// this schema.
+type AutoupdateOutcomeRecord struct {
+	ProviderID     string
+	ObservedAt     time.Time
+	UpdateID       string
+	CurrentVersion string
+	TargetVersion  string
+	Source         string
+	Phase          string
+	Outcome        string
+	Reason         string
+	FailureClass   string
+}
+
+// RecordAutoupdateOutcome durably ingests one DISTINCT autoupdate event so
+// fleet-wide autoupdate convergence is queryable. Callers are expected to
+// de-duplicate repeated heartbeat echoes of the same event before calling
+// this (see internal/ws heartbeat handling) — this method always inserts.
+func (s *PGStore) RecordAutoupdateOutcome(ctx context.Context, rec AutoupdateOutcomeRecord) error {
+	if s == nil || s.db == nil {
+		return errors.New("onboarding postgres store is nil")
+	}
+	if strings.TrimSpace(rec.ProviderID) == "" {
+		return errors.New("autoupdate outcome provider_id is required")
+	}
+	_, err := s.db.ExecContext(ctx, `
+INSERT INTO provider_autoupdate_events (
+    provider_id, observed_at, update_id, current_version, target_version,
+    source, phase, outcome, reason, failure_class
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+		rec.ProviderID,
+		rec.ObservedAt.UTC(),
+		trimForStorage(rec.UpdateID, 128),
+		trimForStorage(rec.CurrentVersion, 80),
+		trimForStorage(rec.TargetVersion, 80),
+		trimForStorage(rec.Source, 40),
+		trimForStorage(rec.Phase, 40),
+		trimForStorage(rec.Outcome, 40),
+		trimForStorage(rec.Reason, 256),
+		trimForStorage(rec.FailureClass, 80),
 	)
 	return err
 }

--- a/phase4-coordinator/internal/stats/migrations/026_provider_autoupdate_events.up.sql
+++ b/phase4-coordinator/internal/stats/migrations/026_provider_autoupdate_events.up.sql
@@ -1,0 +1,77 @@
+-- Fleet autoupdate convergence telemetry (Epic #1235 Child B / B2).
+--
+-- The provider CLI already reports its most recent autoupdate outcome/reason
+-- on every heartbeat and state_update (`last_autoupdate_event`), but the
+-- coordinator only ever kept the LATEST one in memory (pool.Provider), exposed
+-- through the operator admin API — it was never durably ingested, so
+-- fleet-wide autoupdate convergence (how many providers landed a given
+-- release, and why the rest didn't) was not measurable. This table is an
+-- append-only ingest of each DISTINCT autoupdate event a provider reports;
+-- the coordinator de-duplicates repeated heartbeat echoes of the same event
+-- before inserting (see internal/ws heartbeat handling), so this is not one
+-- row per heartbeat.
+--
+-- Free-form fields (source/phase/outcome/reason/failure_class/
+-- current_version/target_version) mirror provider_hardware_profiles'
+-- macos_version/app_version: client-reported text with NO enum CHECK, because
+-- the client-side taxonomy (AutoUpdateEvent.swift) evolves independently of
+-- this schema.
+CREATE TABLE IF NOT EXISTS provider_autoupdate_events (
+    id              BIGSERIAL PRIMARY KEY,
+    provider_id     TEXT NOT NULL,
+    observed_at     TIMESTAMPTZ NOT NULL,
+    update_id       TEXT NOT NULL DEFAULT '',
+    current_version TEXT NOT NULL DEFAULT '',
+    target_version  TEXT NOT NULL DEFAULT '',
+    source          TEXT NOT NULL DEFAULT '',
+    phase           TEXT NOT NULL DEFAULT '',
+    outcome         TEXT NOT NULL DEFAULT '',
+    reason          TEXT NOT NULL DEFAULT '',
+    failure_class   TEXT NOT NULL DEFAULT '',
+    recorded_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_provider_autoupdate_events_provider_observed
+    ON provider_autoupdate_events(provider_id, observed_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_provider_autoupdate_events_recorded_at
+    ON provider_autoupdate_events(recorded_at);
+
+-- Append-only from the runtime role, matching provider_register_attempts
+-- (migration 018): the coordinator can record and read events but cannot
+-- mutate or delete them.
+GRANT SELECT ON provider_autoupdate_events TO provider_onboarding;
+GRANT INSERT (
+    provider_id, observed_at, update_id, current_version, target_version,
+    source, phase, outcome, reason, failure_class
+) ON provider_autoupdate_events TO provider_onboarding;
+-- BIGSERIAL id: INSERT must be able to call nextval() on the owned sequence,
+-- otherwise every runtime insert fails "permission denied for sequence" (the
+-- boot smoke only SELECTs, so it would not catch this).
+GRANT USAGE, SELECT ON SEQUENCE provider_autoupdate_events_id_seq TO provider_onboarding;
+
+GRANT SELECT ON provider_autoupdate_events TO stats_rollup;
+REVOKE ALL ON provider_autoupdate_events FROM stats_reader, provider_portal;
+
+CREATE OR REPLACE FUNCTION prune_provider_autoupdate_events(retain_for INTERVAL DEFAULT INTERVAL '30 days')
+RETURNS BIGINT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public, pg_temp
+AS $$
+DECLARE
+    deleted_count BIGINT;
+BEGIN
+    IF retain_for < INTERVAL '7 days' THEN
+        RAISE EXCEPTION 'retain_for must be at least 7 days';
+    END IF;
+
+    DELETE FROM provider_autoupdate_events
+     WHERE recorded_at < NOW() - retain_for;
+    GET DIAGNOSTICS deleted_count = ROW_COUNT;
+    RETURN deleted_count;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION prune_provider_autoupdate_events(INTERVAL) FROM PUBLIC;
+REVOKE ALL ON FUNCTION prune_provider_autoupdate_events(INTERVAL) FROM provider_onboarding;

--- a/phase4-coordinator/internal/stats/migrations/migrations_test.go
+++ b/phase4-coordinator/internal/stats/migrations/migrations_test.go
@@ -46,6 +46,7 @@ func TestEmbeddedMigrationsLoad(t *testing.T) {
 		{23, "malibu_reward_audit_events"},
 		{24, "malibu_epoch_disposition_facts"},
 		{25, "routability_current"},
+		{26, "provider_autoupdate_events"},
 	}
 	if len(all) != len(want) {
 		t.Fatalf("got %d migrations, want %d", len(all), len(want))
@@ -925,4 +926,43 @@ func TestApptrackRegisterAttemptsMigrationShape(t *testing.T) {
 	} {
 		mustContain(t, downSQL, needle, "registration attempt rollback artifact")
 	}
+}
+
+// TestProviderAutoupdateEventsMigrationShape locks the Epic #1235 Child B / B2
+// append-only ingest table's grants, including the BIGSERIAL sequence USAGE grant
+// without which every runtime insert fails "permission denied for sequence" (the
+// boot smoke only SELECTs, so it would not catch a missing sequence grant).
+func TestProviderAutoupdateEventsMigrationShape(t *testing.T) {
+	all, err := All()
+	if err != nil {
+		t.Fatalf("All: %v", err)
+	}
+	var body string
+	for _, m := range all {
+		if m.Name == "provider_autoupdate_events" {
+			body = m.SQL
+		}
+	}
+	if body == "" {
+		t.Fatal("provider_autoupdate_events migration body is empty")
+	}
+	for _, needle := range []string{
+		"CREATE TABLE IF NOT EXISTS provider_autoupdate_events",
+		"id              BIGSERIAL PRIMARY KEY",
+		"GRANT SELECT ON provider_autoupdate_events TO provider_onboarding",
+		"GRANT INSERT (",
+		// The append-only runtime insert needs nextval() on the owned sequence.
+		"GRANT USAGE, SELECT ON SEQUENCE provider_autoupdate_events_id_seq TO provider_onboarding",
+		"REVOKE ALL ON provider_autoupdate_events FROM stats_reader, provider_portal",
+		"CREATE OR REPLACE FUNCTION prune_provider_autoupdate_events",
+		"SET search_path = pg_catalog, public, pg_temp",
+	} {
+		mustContain(t, body, needle, "autoupdate outcome ingest migration")
+	}
+	// Runtime onboarding role must not receive table-level insert (column-scoped
+	// only) or delete on the append-only ledger.
+	mustNotContain(t, body, "GRANT SELECT, INSERT ON provider_autoupdate_events",
+		"runtime onboarding role must not receive table-level insert")
+	mustNotContain(t, body, "GRANT DELETE ON provider_autoupdate_events",
+		"runtime onboarding role must not delete durable autoupdate events")
 }

--- a/phase4-coordinator/internal/ws/heartbeat_telemetry.go
+++ b/phase4-coordinator/internal/ws/heartbeat_telemetry.go
@@ -1,0 +1,173 @@
+package ws
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/onboarding"
+)
+
+// Epic #1235 Child B: heartbeat-driven durable telemetry refresh.
+//
+// Both lanes below are deliberately OFF the heartbeat hot path — they run in
+// their own bounded-concurrency goroutine (mirroring
+// onboarding.Handler.persistHardwareProfileAsync, the sibling async write
+// path for the same provider_hardware_profiles table) so a slow or
+// unreachable Postgres can never stall heartbeat processing. A dropped slot
+// or a failed write is logged/metriced and otherwise ignored: this is
+// best-effort dashboard telemetry, never a routing or billing input.
+const (
+	// hardwareProfileHeartbeatRefreshInterval throttles the B1 Postgres write
+	// to at most once per provider per interval. Heartbeats arrive far more
+	// often than dashboards need chip/memory/version freshness, and hammering
+	// Postgres once per heartbeat per connected provider does not buy anything
+	// the dashboards use. Mirrors the coalescing already done for the
+	// providerevents last-known snapshot (lastKnownMinInterval).
+	hardwareProfileHeartbeatRefreshInterval = 5 * time.Minute
+	hardwareProfileHeartbeatPersistTimeout  = 2 * time.Second
+	hardwareProfileHeartbeatPersistSlots    = 2
+
+	autoupdateOutcomePersistTimeout = 2 * time.Second
+	autoupdateOutcomePersistSlots   = 2
+)
+
+// defaultHardwareProfileRefreshSlots/defaultAutoupdateOutcomeSlots bound the
+// process-wide concurrent write fan-out when a Server was not given a
+// private lane (tests may inject one via the unexported fields directly).
+var (
+	defaultHardwareProfileRefreshSlots = make(chan struct{}, hardwareProfileHeartbeatPersistSlots)
+	defaultAutoupdateOutcomeSlots      = make(chan struct{}, autoupdateOutcomePersistSlots)
+)
+
+// allowHardwareProfileHeartbeatRefresh reports whether enough time has passed
+// since the last B1 refresh attempt for providerID. It is intentionally a
+// simple per-provider timestamp map (no TTL eviction) — the key space is
+// bounded by distinct authenticated provider_ids ever seen, the same
+// trade-off already accepted for lastKnownFlush/diagnosticLastKnownFlush.
+func (s *Server) allowHardwareProfileHeartbeatRefresh(providerID string) bool {
+	now := s.now().UTC()
+	s.hardwareProfileRefreshFlushMu.Lock()
+	defer s.hardwareProfileRefreshFlushMu.Unlock()
+	if s.hardwareProfileRefreshFlush == nil {
+		s.hardwareProfileRefreshFlush = make(map[string]time.Time)
+	}
+	if last, ok := s.hardwareProfileRefreshFlush[providerID]; ok && now.Sub(last) < hardwareProfileHeartbeatRefreshInterval {
+		return false
+	}
+	s.hardwareProfileRefreshFlush[providerID] = now
+	return true
+}
+
+// refreshHardwareProfileHeartbeatAsync is Epic #1235 Child B / B1. appVersion is
+// the running binary version already known from this connection's Hello. It
+// refreshes ONLY the freshness (last_reported_at) and reported version so
+// version/hardware dashboards stop going stale for providers that upgraded
+// without re-registering. It deliberately does NOT carry the heartbeat's
+// chip/ram: writing chip_normalized/unified_memory_gb would trip the
+// migration-019 trust trigger that clears `verified`, which could demote a
+// provider and change admission/routing — this lane must stay observe-only.
+func (s *Server) refreshHardwareProfileHeartbeatAsync(providerID, appVersion string, observedAt time.Time) {
+	if s == nil || s.hardwareProfileRefresher == nil {
+		return
+	}
+	if !s.allowHardwareProfileHeartbeatRefresh(providerID) {
+		return
+	}
+	slots := s.hardwareProfileRefreshSlots
+	if slots == nil {
+		slots = defaultHardwareProfileRefreshSlots
+	}
+	select {
+	case slots <- struct{}{}:
+	default:
+		return
+	}
+	refresher := s.hardwareProfileRefresher
+	go func() {
+		defer func() { <-slots }()
+		ctx, cancel := context.WithTimeout(context.Background(), hardwareProfileHeartbeatPersistTimeout)
+		defer cancel()
+		if err := refresher.RefreshProviderHardwareProfile(ctx, providerID, appVersion, observedAt); err != nil {
+			s.log.Warn().Err(err).Str("provider_id", providerID).Msg("hardware profile heartbeat refresh failed")
+		}
+	}()
+}
+
+// autoupdateOutcomeWire is the subset of the provider's freeform
+// `last_autoupdate_event` object (see AutoUpdateEvent.wireObject() on the
+// Swift side) the coordinator persists. Unknown/extra keys (extra_metadata,
+// attempt_history, release_url, attempt) are intentionally not carried into
+// the durable row: they are either heavy, unstable in shape, or not needed
+// for convergence measurement.
+type autoupdateOutcomeWire struct {
+	UpdateID       string `json:"update_id"`
+	CurrentVersion string `json:"current_version"`
+	TargetVersion  string `json:"target_version"`
+	Source         string `json:"source"`
+	Phase          string `json:"phase"`
+	Outcome        string `json:"outcome"`
+	Reason         string `json:"reason"`
+	FailureClass   string `json:"failure_class"`
+}
+
+// recordAutoupdateOutcomeIfChanged is Epic #1235 Child B / B2. raw is the
+// heartbeat/state_update `last_autoupdate_event` payload as already validated
+// by ParseHeartbeat/ParseStateUpdate (a JSON object, <=4096 bytes, or nil).
+// The Swift client resends the SAME last event on every heartbeat/state_update
+// for the remainder of the connection, so this de-duplicates by raw byte
+// content per provider before persisting — otherwise one real autoupdate
+// event would fan out into one row per heartbeat for the rest of the session.
+//
+// The dedup cache advances before the async persist completes: a failed write
+// is logged and NOT retried for that exact event. That is an accepted
+// trade-off for best-effort dashboard telemetry (matches
+// persistHardwareProfileAsync's error handling), not a delivery guarantee.
+func (s *Server) recordAutoupdateOutcomeIfChanged(providerID string, raw json.RawMessage, observedAt time.Time) {
+	if s == nil || s.autoupdateOutcomes == nil || len(raw) == 0 {
+		return
+	}
+	fingerprint := string(raw)
+	if seen, ok := s.autoupdateOutcomeSeen.Load(providerID); ok && seen.(string) == fingerprint {
+		return
+	}
+	var wire autoupdateOutcomeWire
+	if err := json.Unmarshal(raw, &wire); err != nil {
+		return
+	}
+	slots := s.autoupdateOutcomeSlots
+	if slots == nil {
+		slots = defaultAutoupdateOutcomeSlots
+	}
+	select {
+	case slots <- struct{}{}:
+	default:
+		// Both persist slots are busy: drop this observation WITHOUT advancing the
+		// dedup cache, so a later heartbeat echo of the same event is retried
+		// rather than permanently suppressed for the session.
+		return
+	}
+	// A slot is held: mark the event seen so subsequent identical echoes coalesce.
+	s.autoupdateOutcomeSeen.Store(providerID, fingerprint)
+	sink := s.autoupdateOutcomes
+	rec := onboarding.AutoupdateOutcomeRecord{
+		ProviderID:     providerID,
+		ObservedAt:     observedAt,
+		UpdateID:       wire.UpdateID,
+		CurrentVersion: wire.CurrentVersion,
+		TargetVersion:  wire.TargetVersion,
+		Source:         wire.Source,
+		Phase:          wire.Phase,
+		Outcome:        wire.Outcome,
+		Reason:         wire.Reason,
+		FailureClass:   wire.FailureClass,
+	}
+	go func() {
+		defer func() { <-slots }()
+		ctx, cancel := context.WithTimeout(context.Background(), autoupdateOutcomePersistTimeout)
+		defer cancel()
+		if err := sink.RecordAutoupdateOutcome(ctx, rec); err != nil {
+			s.log.Warn().Err(err).Str("provider_id", providerID).Msg("autoupdate outcome persist failed")
+		}
+	}()
+}

--- a/phase4-coordinator/internal/ws/heartbeat_telemetry_test.go
+++ b/phase4-coordinator/internal/ws/heartbeat_telemetry_test.go
@@ -1,0 +1,256 @@
+package ws
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	"github.com/augstar/macprovider-coordinator/internal/onboarding"
+	"github.com/augstar/macprovider-coordinator/internal/pool"
+)
+
+// fakeHardwareProfileRefresher records every RefreshProviderHardwareProfile
+// call and signals doneCh so async tests do not need a sleep-based wait.
+type fakeHardwareProfileRefresher struct {
+	mu      sync.Mutex
+	calls   []hardwareProfileRefreshCall
+	doneCh  chan struct{}
+	failErr error
+}
+
+type hardwareProfileRefreshCall struct {
+	providerID string
+	appVersion string
+	observedAt time.Time
+}
+
+func (f *fakeHardwareProfileRefresher) RefreshProviderHardwareProfile(_ context.Context, providerID, appVersion string, observedAt time.Time) error {
+	f.mu.Lock()
+	f.calls = append(f.calls, hardwareProfileRefreshCall{providerID, appVersion, observedAt})
+	f.mu.Unlock()
+	if f.doneCh != nil {
+		f.doneCh <- struct{}{}
+	}
+	return f.failErr
+}
+
+func (f *fakeHardwareProfileRefresher) snapshot() []hardwareProfileRefreshCall {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]hardwareProfileRefreshCall(nil), f.calls...)
+}
+
+// fakeAutoupdateOutcomeSink records every RecordAutoupdateOutcome call.
+type fakeAutoupdateOutcomeSink struct {
+	mu     sync.Mutex
+	calls  []onboarding.AutoupdateOutcomeRecord
+	doneCh chan struct{}
+}
+
+func (f *fakeAutoupdateOutcomeSink) RecordAutoupdateOutcome(_ context.Context, rec onboarding.AutoupdateOutcomeRecord) error {
+	f.mu.Lock()
+	f.calls = append(f.calls, rec)
+	f.mu.Unlock()
+	if f.doneCh != nil {
+		f.doneCh <- struct{}{}
+	}
+	return nil
+}
+
+func (f *fakeAutoupdateOutcomeSink) snapshot() []onboarding.AutoupdateOutcomeRecord {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]onboarding.AutoupdateOutcomeRecord(nil), f.calls...)
+}
+
+func waitOrTimeout(t *testing.T, ch chan struct{}) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for async telemetry dispatch")
+	}
+}
+
+// Epic #1235 Child B / B1: a heartbeat refreshes the durable
+// provider_hardware_profiles row's freshness + reported version, using the
+// binary version already known from this connection's Hello (heartbeat itself
+// carries no binary_version field). It is observe-only: the refresher signature
+// carries NO chip/memory, so a heartbeat can never mutate the trust-relevant
+// hardware-identity columns (which would trip the migration-019 verified-clear
+// trigger and affect admission).
+func TestHeartbeatRefreshesHardwareProfile(t *testing.T) {
+	t.Parallel()
+	registry := pool.NewRegistry(nil)
+	refresher := &fakeHardwareProfileRefresher{doneCh: make(chan struct{}, 1)}
+	server := NewServer(capacityTestConfig(0), registry, zerolog.Nop(),
+		WithHardwareProfileRefresher(refresher))
+	server.hardwareProfileRefreshSlots = make(chan struct{}, 2)
+	registerCapacityTestProvider(t, server, registry, 4)
+
+	// Even a heartbeat that DOES carry a hardware_summary must not forward chip/ram
+	// to the refresh — the refresher only ever receives providerID/appVersion.
+	payload := []byte(`{"type":"heartbeat","status":"ready","model_id":"model-a","model_params_b":7.0,"ram_gb":32,"max_context_tokens":32768,"max_concurrency":4,"slots_free":4,"slots_total":4,"throughput_tps_estimate":19.8,"requests_served_since_last":0,"avg_latency_ms_since_last":0.0,"throughput_tps_since_last":0.0,"hardware_summary":{"chip":"Apple M3 Max","gpu_cores_total":40,"cpu_cores_total":16}}`)
+	server.handleHeartbeat(nil, "provider-a", "assigned-a", payload)
+	waitOrTimeout(t, refresher.doneCh)
+
+	calls := refresher.snapshot()
+	if len(calls) != 1 {
+		t.Fatalf("refresh calls = %d, want 1", len(calls))
+	}
+	got := calls[0]
+	if got.providerID != "provider-a" {
+		t.Errorf("providerID = %q, want provider-a", got.providerID)
+	}
+	// capacityTestHello sets BinaryVersion "1.8.48"; the heartbeat wire itself
+	// has no binary_version field, so this must come from the pool entry's
+	// value learned at Hello.
+	if got.appVersion != "1.8.48" {
+		t.Errorf("appVersion = %q, want the Hello-reported binary version 1.8.48", got.appVersion)
+	}
+}
+
+// A heartbeat with no hardware_summary still refreshes freshness + binary
+// version (the refresh never depended on hardware fields).
+func TestHeartbeatRefreshesHardwareProfileWithoutHardwareSummary(t *testing.T) {
+	t.Parallel()
+	registry := pool.NewRegistry(nil)
+	refresher := &fakeHardwareProfileRefresher{doneCh: make(chan struct{}, 1)}
+	server := NewServer(capacityTestConfig(0), registry, zerolog.Nop(),
+		WithHardwareProfileRefresher(refresher))
+	server.hardwareProfileRefreshSlots = make(chan struct{}, 2)
+	registerCapacityTestProvider(t, server, registry, 4)
+
+	payload := []byte(`{"type":"heartbeat","status":"ready","model_id":"model-a","model_params_b":7.0,"ram_gb":16,"max_context_tokens":32768,"max_concurrency":4,"slots_free":4,"slots_total":4,"throughput_tps_estimate":19.8,"requests_served_since_last":0,"avg_latency_ms_since_last":0.0,"throughput_tps_since_last":0.0}`)
+	server.handleHeartbeat(nil, "provider-a", "assigned-a", payload)
+	waitOrTimeout(t, refresher.doneCh)
+
+	calls := refresher.snapshot()
+	if len(calls) != 1 {
+		t.Fatalf("refresh calls = %d, want 1", len(calls))
+	}
+	if calls[0].appVersion != "1.8.48" {
+		t.Errorf("appVersion = %q, want 1.8.48", calls[0].appVersion)
+	}
+}
+
+// The refresh is throttled per provider: a second heartbeat within the
+// interval must not dispatch another Postgres write.
+func TestHeartbeatHardwareProfileRefreshIsThrottled(t *testing.T) {
+	t.Parallel()
+	registry := pool.NewRegistry(nil)
+	refresher := &fakeHardwareProfileRefresher{doneCh: make(chan struct{}, 4)}
+	server := NewServer(capacityTestConfig(0), registry, zerolog.Nop(),
+		WithHardwareProfileRefresher(refresher))
+	server.hardwareProfileRefreshSlots = make(chan struct{}, 2)
+	registerCapacityTestProvider(t, server, registry, 4)
+
+	payload := []byte(`{"type":"heartbeat","status":"ready","model_id":"model-a","model_params_b":7.0,"ram_gb":16,"max_context_tokens":32768,"max_concurrency":4,"slots_free":4,"slots_total":4,"throughput_tps_estimate":19.8,"requests_served_since_last":0,"avg_latency_ms_since_last":0.0,"throughput_tps_since_last":0.0}`)
+	server.handleHeartbeat(nil, "provider-a", "assigned-a", payload)
+	waitOrTimeout(t, refresher.doneCh)
+	server.handleHeartbeat(nil, "provider-a", "assigned-a", payload)
+	server.handleHeartbeat(nil, "provider-a", "assigned-a", payload)
+
+	// Give any (incorrect) second dispatch a moment to land before asserting
+	// it did not.
+	time.Sleep(50 * time.Millisecond)
+	if calls := refresher.snapshot(); len(calls) != 1 {
+		t.Fatalf("refresh calls = %d, want 1 (throttled)", len(calls))
+	}
+}
+
+// No refresher wired (nil) must be a no-op, not a panic — the default
+// pre-Child-B behavior.
+func TestHeartbeatHardwareProfileRefreshNilIsNoop(t *testing.T) {
+	t.Parallel()
+	registry := pool.NewRegistry(nil)
+	server := NewServer(capacityTestConfig(0), registry, zerolog.Nop())
+	registerCapacityTestProvider(t, server, registry, 4)
+
+	payload := []byte(`{"type":"heartbeat","status":"ready","model_id":"model-a","model_params_b":7.0,"ram_gb":16,"max_context_tokens":32768,"max_concurrency":4,"slots_free":4,"slots_total":4,"throughput_tps_estimate":19.8,"requests_served_since_last":0,"avg_latency_ms_since_last":0.0,"throughput_tps_since_last":0.0}`)
+	server.handleHeartbeat(nil, "provider-a", "assigned-a", payload)
+}
+
+// Epic #1235 Child B / B2: a heartbeat carrying last_autoupdate_event is
+// durably ingested with its outcome/reason/phase scalars extracted.
+func TestHeartbeatRecordsAutoupdateOutcome(t *testing.T) {
+	t.Parallel()
+	registry := pool.NewRegistry(nil)
+	sink := &fakeAutoupdateOutcomeSink{doneCh: make(chan struct{}, 1)}
+	server := NewServer(capacityTestConfig(0), registry, zerolog.Nop(),
+		WithAutoupdateOutcomeSink(sink))
+	server.autoupdateOutcomeSlots = make(chan struct{}, 2)
+	registerCapacityTestProvider(t, server, registry, 4)
+
+	payload := []byte(`{"type":"heartbeat","status":"ready","model_id":"model-a","model_params_b":7.0,"ram_gb":16,"max_context_tokens":32768,"max_concurrency":4,"slots_free":4,"slots_total":4,"throughput_tps_estimate":19.8,"requests_served_since_last":0,"avg_latency_ms_since_last":0.0,"throughput_tps_since_last":0.0,"last_autoupdate_event":{"event":"provider_autoupdate","update_id":"upd-1","current_version":"1.8.48","target_version":"1.8.50","source":"coordinator","phase":"swap","outcome":"success","reason":"binary_swap_complete","attempt":1,"timestamp":"2026-08-27T00:00:00Z"}}`)
+	server.handleHeartbeat(nil, "provider-a", "assigned-a", payload)
+	waitOrTimeout(t, sink.doneCh)
+
+	calls := sink.snapshot()
+	if len(calls) != 1 {
+		t.Fatalf("outcome calls = %d, want 1", len(calls))
+	}
+	got := calls[0]
+	if got.ProviderID != "provider-a" || got.UpdateID != "upd-1" || got.Phase != "swap" ||
+		got.Outcome != "success" || got.Reason != "binary_swap_complete" ||
+		got.CurrentVersion != "1.8.48" || got.TargetVersion != "1.8.50" {
+		t.Fatalf("unexpected record: %+v", got)
+	}
+}
+
+// The provider CLI resends the SAME last_autoupdate_event on every heartbeat
+// for the rest of the connection; repeating it must not fan out into one row
+// per heartbeat.
+func TestHeartbeatAutoupdateOutcomeDedupedAcrossHeartbeats(t *testing.T) {
+	t.Parallel()
+	registry := pool.NewRegistry(nil)
+	sink := &fakeAutoupdateOutcomeSink{doneCh: make(chan struct{}, 4)}
+	server := NewServer(capacityTestConfig(0), registry, zerolog.Nop(),
+		WithAutoupdateOutcomeSink(sink))
+	server.autoupdateOutcomeSlots = make(chan struct{}, 2)
+	registerCapacityTestProvider(t, server, registry, 4)
+
+	payload := []byte(`{"type":"heartbeat","status":"ready","model_id":"model-a","model_params_b":7.0,"ram_gb":16,"max_context_tokens":32768,"max_concurrency":4,"slots_free":4,"slots_total":4,"throughput_tps_estimate":19.8,"requests_served_since_last":0,"avg_latency_ms_since_last":0.0,"throughput_tps_since_last":0.0,"last_autoupdate_event":{"event":"provider_autoupdate","update_id":"upd-1","current_version":"1.8.48","target_version":"1.8.50","source":"coordinator","phase":"swap","outcome":"success","reason":"binary_swap_complete","attempt":1,"timestamp":"2026-08-27T00:00:00Z"}}`)
+	server.handleHeartbeat(nil, "provider-a", "assigned-a", payload)
+	waitOrTimeout(t, sink.doneCh)
+	server.handleHeartbeat(nil, "provider-a", "assigned-a", payload)
+	server.handleHeartbeat(nil, "provider-a", "assigned-a", payload)
+
+	time.Sleep(50 * time.Millisecond)
+	if calls := sink.snapshot(); len(calls) != 1 {
+		t.Fatalf("outcome calls = %d, want 1 (deduped identical echo)", len(calls))
+	}
+}
+
+// A genuinely NEW event (different phase/outcome) after a prior one must
+// still be recorded — dedup is by exact content, not a one-shot latch.
+func TestHeartbeatAutoupdateOutcomeRecordsDistinctEvents(t *testing.T) {
+	t.Parallel()
+	registry := pool.NewRegistry(nil)
+	sink := &fakeAutoupdateOutcomeSink{doneCh: make(chan struct{}, 4)}
+	server := NewServer(capacityTestConfig(0), registry, zerolog.Nop(),
+		WithAutoupdateOutcomeSink(sink))
+	server.autoupdateOutcomeSlots = make(chan struct{}, 2)
+	registerCapacityTestProvider(t, server, registry, 4)
+
+	const base = `{"type":"heartbeat","status":"ready","model_id":"model-a","model_params_b":7.0,"ram_gb":16,"max_context_tokens":32768,"max_concurrency":4,"slots_free":4,"slots_total":4,"throughput_tps_estimate":19.8,"requests_served_since_last":0,"avg_latency_ms_since_last":0.0,"throughput_tps_since_last":0.0,"last_autoupdate_event":{"event":"provider_autoupdate","update_id":"upd-1","current_version":"1.8.48","target_version":"1.8.50","source":"coordinator","phase":"swap","outcome":%q,"reason":%q,"attempt":1,"timestamp":"2026-08-27T00:00:00Z"}}`
+	first := []byte(fmt.Sprintf(base, "in_progress", "binary_swap_started"))
+	second := []byte(fmt.Sprintf(base, "success", "binary_swap_complete"))
+
+	server.handleHeartbeat(nil, "provider-a", "assigned-a", first)
+	waitOrTimeout(t, sink.doneCh)
+	server.handleHeartbeat(nil, "provider-a", "assigned-a", second)
+	waitOrTimeout(t, sink.doneCh)
+
+	calls := sink.snapshot()
+	if len(calls) != 2 {
+		t.Fatalf("outcome calls = %d, want 2 (two distinct events)", len(calls))
+	}
+	if calls[0].Outcome != "in_progress" || calls[1].Outcome != "success" {
+		t.Fatalf("unexpected outcomes: %+v", calls)
+	}
+}

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -194,6 +194,18 @@ type Server struct {
 	idlePrewarmLimits              sync.Map
 	idlePrewarmQueue               chan idlePrewarmRecord
 
+	// Epic #1235 Child B: heartbeat-driven durable telemetry refresh.
+	// hardwareProfileRefresher/autoupdateOutcomes are nil-checked optional
+	// Postgres sinks (wired only when the onboarding store is available),
+	// mirroring providerTrust/idlePrewarm above.
+	hardwareProfileRefresher      HardwareProfileRefresher
+	hardwareProfileRefreshFlushMu sync.Mutex
+	hardwareProfileRefreshFlush   map[string]time.Time
+	hardwareProfileRefreshSlots   chan struct{}
+	autoupdateOutcomes            AutoupdateOutcomeSink
+	autoupdateOutcomeSeen         sync.Map
+	autoupdateOutcomeSlots        chan struct{}
+
 	// SE liveness (Phase 1, Track P1-C).
 	// seLivenessChans maps sessionKey → chan SELivenessResponse for in-flight probes.
 	// seLivenessInFlight guards against concurrent probes for the same session.
@@ -358,6 +370,25 @@ type ProviderTrustChecker interface {
 
 type IdlePrewarmRecorder interface {
 	RecordIdlePrewarmEvent(ctx context.Context, providerID, event, reason string) error
+}
+
+// HardwareProfileRefresher backs Epic #1235 Child B / B1: refreshing the
+// onboarding-only provider_hardware_profiles row from heartbeat-observed
+// fields (chip, unified memory, running binary version) so it does not go
+// stale for a provider that stays connected across an autoupdate without
+// re-registering. See onboarding.PGStore.RefreshProviderHardwareProfile for
+// why this is UPDATE-only.
+type HardwareProfileRefresher interface {
+	RefreshProviderHardwareProfile(ctx context.Context, providerID, appVersion string, observedAt time.Time) error
+}
+
+// AutoupdateOutcomeSink backs Epic #1235 Child B / B2: durably ingesting each
+// DISTINCT autoupdate outcome/reason a provider reports on heartbeat/
+// state_update so fleet-wide autoupdate convergence is queryable. Callers
+// must de-duplicate repeated heartbeat echoes of the same event themselves
+// (see recordAutoupdateOutcomeIfChanged) — this sink always inserts.
+type AutoupdateOutcomeSink interface {
+	RecordAutoupdateOutcome(ctx context.Context, rec onboarding.AutoupdateOutcomeRecord) error
 }
 
 type IdlePrewarmMetrics interface {
@@ -651,6 +682,24 @@ func WithProviderRewardsTrustTierStore(store ProviderRewardsTrustTierStore) Opti
 func WithIdlePrewarmRecorder(recorder IdlePrewarmRecorder) Option {
 	return func(s *Server) {
 		s.idlePrewarm = recorder
+	}
+}
+
+// WithHardwareProfileRefresher installs the Epic #1235 Child B / B1 durable
+// hardware-profile freshness backend. Nil (unset) keeps heartbeat handling
+// exactly as it was before Child B: no Postgres write is attempted.
+func WithHardwareProfileRefresher(refresher HardwareProfileRefresher) Option {
+	return func(s *Server) {
+		s.hardwareProfileRefresher = refresher
+	}
+}
+
+// WithAutoupdateOutcomeSink installs the Epic #1235 Child B / B2 durable
+// autoupdate-outcome ingest backend. Nil (unset) keeps heartbeat/state_update
+// handling exactly as it was before Child B: no Postgres write is attempted.
+func WithAutoupdateOutcomeSink(sink AutoupdateOutcomeSink) Option {
+	return func(s *Server) {
+		s.autoupdateOutcomes = sink
 	}
 }
 
@@ -4989,6 +5038,8 @@ func (s *Server) handleHeartbeat(conn net.Conn, providerID, assignedID string, p
 	}
 	s.applyAdmissionCeilingRouteExclusion(entry, "heartbeat")
 	s.rememberProviderSnapshotCoalesced(*entry)
+	s.refreshHardwareProfileHeartbeatAsync(providerID, entry.BinaryVersion, s.now())
+	s.recordAutoupdateOutcomeIfChanged(providerID, hb.LastAutoupdateEvent, s.now())
 	threshold := s.cfg.HeartbeatInterval() + s.cfg.HeartbeatInterval()/2
 	if gap > threshold {
 		s.log.Warn().Str("provider_id", providerID).Dur("gap", gap).Dur("threshold", threshold).Msg("provider heartbeat stale")
@@ -5403,6 +5454,7 @@ func (s *Server) handleStateUpdate(providerID, assignedID string, payload []byte
 		s.log.Warn().Str("provider_id", providerID).Msg("state_update for unknown provider")
 		return
 	}
+	s.recordAutoupdateOutcomeIfChanged(providerID, update.LastAutoupdateEvent, s.now())
 	if state == pool.StateReady {
 		if timer, ok := s.timers.LoadAndDelete(providerID); ok {
 			timer.(*time.Timer).Stop()


### PR DESCRIPTION
## Summary
Makes fleet autoupdate/version **convergence measurable** — the Epic #1235 acceptance criterion *"convergence proven in fleet telemetry."* Both lanes use fields already on the wire (no client protocol change) and run async, off the heartbeat hot path.

## What changed
- **B1 — hardware/version freshness on heartbeat.** `provider_hardware_profiles` was written only on the onboarding/`cli_hello` path, so version/hardware dashboards went stale for any provider that upgraded without re-onboarding. Heartbeat now UPDATE-refreshes `last_reported_at` + `app_version`, throttled once/provider/5m. **Observe-only:** it deliberately does **not** touch `chip_normalized`/`unified_memory_gb` — writing those would trip the migration-019 trigger that clears `verified` and could affect admission/routing.
- **B2 — autoupdate outcome ingest.** The client already reports `last_autoupdate_event` on every heartbeat/state_update, but the coordinator kept only the latest in memory (admin API) and never ingested it. New **append-only** `provider_autoupdate_events` table (migration 026, migration-018 grant pattern), recording each **distinct** event, deduped coordinator-side against repeated heartbeat echoes, so autoupdate failure reasons become queryable.

## Fail-closed / safety
- Both lanes async with bounded concurrency (2 slots, 2s timeout); a saturated slot **drops without poisoning dedup**, so a later echo retries.
- Migration 026 is additive, append-only (INSERT+SELECT column grants + **sequence USAGE grant** so `BIGSERIAL` inserts can `nextval()`), REVOKEs reader roles, and prunes with a `SECURITY DEFINER` function with pinned `search_path`.
- No money-path files touched (billing/buyer/auth/requestlog/router); observe-only telemetry.

## Testing / audit
- `go build`, `go vet`, and `go test ./internal/ws ./internal/onboarding ./internal/stats/migrations` (incl. `-race`) all green; new tests: 7 heartbeat-telemetry regression tests + a migration-shape test asserting the grants (including the sequence grant).
- Codex 3-lane audit over the full diff, iterated to **0 CRITICAL / 0 HIGH / 0 MEDIUM**:
  - Round 1: 1 HIGH (missing `BIGSERIAL` sequence grant → every prod insert would fail "permission denied"; boot smoke is SELECT-only) + 2 MEDIUM (dedup poisoned on a dropped event; B1 wrote trust-relevant hardware fields) — all fixed.
  - Round 2: confirmation — resolved, no regression.

Evidence under `audits/2026-08-29-child-b/` (kept local, not in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
