### PR TITLE
Redefine thermal veto as sustained throttle so install transients don't reject capable Macs (#1269)

### DIFF
--- a/audits/2026-08-29-1269/AUDIT_PROMPT.md
+++ b/audits/2026-08-29-1269/AUDIT_PROMPT.md
@@ -1,0 +1,57 @@
+You are auditing a money-path SPEC + implementation change to the MacProvider
+provider CLI (Epic #1235 / #1269). Full change = single commit at HEAD
+(origin/main..HEAD); diff at audits/2026-08-29-1269/full-diff.patch. Read the
+actual files.
+
+## What it does
+Redefines the paid-recommendation thermal veto from "any single throttling sample"
+to "SUSTAINED thermal throttle", so the install-time recommendation probe (which
+runs while the Mac is hot from unpacking/verifying/signing) no longer hard-rejects
+an otherwise-capable Mac on a lone transient throttle and rolls it back at upgrade.
+
+Changed:
+- specs/SPEC-023-installer-autotune-recommend.md: v0.9.3 -> v0.9.4. thermal_throttle_detected
+  amended (line ~220 field table, line ~640 gate, + changelog) to require >=2 readable
+  thermal samples throttling (.serious/.critical) AND >=50% of readable samples throttling;
+  fail-closed only when the WHOLE thermal series is unreadable. Mirrors the v0.9.0/#742
+  swap_detected redefinition.
+- phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift: ProbeSafetyAssessment.assess
+  thermal branch rewritten from `!thermalKnown || anyThrottle` to the sustained rule.
+- phase3-binary/Tests/.../AutotuneRecommendTests.swift: 5 new regression tests.
+- specs/CONFORMANCE.json + specs/README.md: version sync.
+
+## Audit at 0 CRITICAL / 0 HIGH / 0 MEDIUM. Focus on:
+
+MONEY-PATH SAFETY (most important):
+1. Does the new rule STILL hard-block a genuinely thermally-throttled node? A relaxed
+   thermal veto that lets a truly-throttled Mac become a paid provider is a money-path
+   regression (bad TTFT/throughput for buyers). Verify the sustained rule (>=2 AND >=50%
+   of readable) cannot be gamed by a node that throttles most of the probe.
+2. Fail-open risk: any input series where a real throttle now yields
+   thermal_throttle_detected == false when it should be true? Consider: mostly-throttling
+   with interspersed unreadable samples (does the readable-denominator handle it like
+   swap does?); exactly-2 short probe; 50% boundary.
+3. Does the SPEC text EXACTLY match the code (>=2, >=50% of READABLE, whole-series-unreadable
+   fail-closed)? Any SPEC-vs-code drift? Compare to the swap_detected wording/impl it mirrors.
+
+CORRECTNESS:
+4. The code: `readableThermal = samples.compactMap(\.thermalState)`; `throttleCount = readableThermal.filter{shouldThrottle}.count`; `if readableThermal.isEmpty { true } else { throttleCount >= 2 && throttleCount*2 >= readableThermal.count }`. Is `throttleCount*2 >= readableThermal.count` the correct >=50% test (matches swap's `criticalCount*2 >= readable.count`)? Off-by-one?
+5. shouldThrottle == (.serious || .critical) — confirm only genuine throttle states count.
+6. Behavior change vs old: the OLD rule failed closed if ANY sample was unreadable
+   (thermalKnown = allSatisfy non-nil). The new rule only fails closed if ALL are
+   unreadable. Is that intentional and consistent with the SPEC amendment + the swap
+   fail-closed narrowing? Any case where dropping the any-unknown fail-close is unsafe?
+7. Tests: do the 5 new tests actually pin the SPEC rule (transient-no-block, sustained-block,
+   short-probe-block, unknown-dilution, lone-spike-no-block)? Any missing boundary (exactly
+   50%, exactly 2)? Do the 2 pre-existing thermal assertions still hold?
+
+SCOPE:
+8. Confirm this ONLY changes the thermal veto semantics — no change to swap_detected,
+   ttft ceiling, RAM/bandwidth gates, catalog integrity, or the wire/evidence schema.
+9. Does the amendment stay within SPEC-023's locked-spec amendment convention (version
+   bump, changelog, manifest sync)? Is v0.9.4 the right bump?
+
+Report severity-ranked with file:line + concrete failure scenario. If handled correctly,
+say so. Do not invent findings. NOTE: a pre-existing spec-index error on
+CONFORMANCE.json requirements[9] (verifyProviderModelIdentity / SPEC-010-R005) is
+unrelated to this change (it exists on origin/main) — do not report it.

--- a/audits/2026-08-29-1269/full-diff.patch
+++ b/audits/2026-08-29-1269/full-diff.patch
@@ -1,0 +1,179 @@
+diff --git a/phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift b/phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift
+index 6002d1bc..107ec39c 100644
+--- a/phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift
++++ b/phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift
+@@ -3084,10 +3084,28 @@ struct ProbeSafetyAssessment: Equatable {
+             && warningCount >= 2
+             && warningCount * 2 >= readable.count
+ 
+-        let thermalStates = samples.map(\.thermalState)
+-        let thermalKnown = !thermalStates.isEmpty && thermalStates.allSatisfy { $0 != nil }
+-        let thermalThrottleDetected = !thermalKnown
+-            || thermalStates.compactMap { $0 }.contains { ThermalGate.shouldThrottle($0) }
++        // #1269 fix: `thermalThrottleDetected` now means "sustained thermal
++        // throttle", not "any single throttling sample". The install-time probe
++        // runs while the Mac is hot from unpacking/verifying/signing, so a lone
++        // transient throttle (the observed thermal fair/nominal oscillation) used
++        // to trip the hard veto and sink every candidate — rolling back an
++        // otherwise-capable Mac. This mirrors the #742 swap_detected sustained
++        // rule exactly, computed over the same interval series:
++        // - TRUE only when at least 2 readable samples throttle AND throttling
++        //   samples are >= 50% of the READABLE (non-nil) thermal samples, so a
++        //   genuinely throttled node still hard-blocks.
++        // - Fail-closed to TRUE only when the thermal state could not be read for
++        //   the ENTIRE series (every sample nil, or an empty series), matching the
++        //   prior nil-fail-closed intent. A single transient unreadable/throttling
++        //   sample must never veto the paid path.
++        let readableThermal = samples.compactMap(\.thermalState)
++        let throttleCount = readableThermal.filter { ThermalGate.shouldThrottle($0) }.count
++        let thermalThrottleDetected: Bool
++        if readableThermal.isEmpty {
++            thermalThrottleDetected = true
++        } else {
++            thermalThrottleDetected = throttleCount >= 2 && throttleCount * 2 >= readableThermal.count
++        }
+         return ProbeSafetyAssessment(
+             swapDetected: swapDetected,
+             thermalThrottleDetected: thermalThrottleDetected,
+diff --git a/phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift b/phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift
+index 521a40c1..f2936171 100644
+--- a/phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift
++++ b/phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift
+@@ -3132,6 +3132,68 @@ final class AutotuneRecommendTests: XCTestCase {
+         XCTAssertFalse(spike.swapDetected)
+     }
+ 
++    func testProbeSafetyAssessmentTransientThermalThrottleDoesNotBlock() {
++        // #1269: the install-time probe runs while the Mac is hot from
++        // unpacking/verifying/signing, so a lone transient throttle amid a benign
++        // fair/nominal oscillation must NOT trip the hard thermal veto — otherwise
++        // a perfectly capable Mac is rolled back at upgrade. Requires >= 2 throttling
++        // AND a majority, so this single .serious blip stays paid-eligible.
++        let transient = ProbeSafetyAssessment.assess(samples: [
++            ProbeSafetySample(pressureLevel: .normal, thermalState: .nominal),
++            ProbeSafetySample(pressureLevel: .normal, thermalState: .fair),
++            ProbeSafetySample(pressureLevel: .normal, thermalState: .serious),
++            ProbeSafetySample(pressureLevel: .normal, thermalState: .nominal),
++        ])
++        XCTAssertFalse(transient.thermalThrottleDetected)
++    }
++
++    func testProbeSafetyAssessmentSustainedThermalThrottleStillBlocks() {
++        // A genuinely thermally-throttled node (sustained .serious/.critical
++        // majority) must still hard-block the paid path — the veto is preserved,
++        // only the single-transient-sample trigger is removed.
++        let throttled = ProbeSafetyAssessment.assess(samples: [
++            ProbeSafetySample(pressureLevel: .normal, thermalState: .serious),
++            ProbeSafetySample(pressureLevel: .normal, thermalState: .critical),
++            ProbeSafetySample(pressureLevel: .normal, thermalState: .fair),
++            ProbeSafetySample(pressureLevel: .normal, thermalState: .serious),
++        ])
++        XCTAssertTrue(throttled.thermalThrottleDetected)
++    }
++
++    func testProbeSafetyAssessmentShortProbeSustainedThermalStillBlocks() {
++        // Mirror the swap short-probe fix: two synchronous samples both throttling
++        // must still veto (no >= 3 total-sample floor).
++        let shortThrottle = ProbeSafetyAssessment.assess(samples: [
++            ProbeSafetySample(pressureLevel: .normal, thermalState: .serious),
++            ProbeSafetySample(pressureLevel: .normal, thermalState: .serious),
++        ])
++        XCTAssertTrue(shortThrottle.thermalThrottleDetected)
++    }
++
++    func testProbeSafetyAssessmentUnknownThermalDoesNotDiluteThrottleMajority() {
++        // .unknown thermal readings must not dilute the denominator: two throttling
++        // among many unknown is a majority of the READABLE thermal samples => veto.
++        let throttled = ProbeSafetyAssessment.assess(samples: [
++            ProbeSafetySample(pressureLevel: .normal, thermalState: nil),
++            ProbeSafetySample(pressureLevel: .normal, thermalState: .serious),
++            ProbeSafetySample(pressureLevel: .normal, thermalState: nil),
++            ProbeSafetySample(pressureLevel: .normal, thermalState: .critical),
++            ProbeSafetySample(pressureLevel: .normal, thermalState: nil),
++        ])
++        XCTAssertTrue(throttled.thermalThrottleDetected)
++    }
++
++    func testProbeSafetyAssessmentLoneThermalSpikeAmidUnknownDoesNotBlock() {
++        // A single throttling sample among otherwise-unreadable thermal states is
++        // not sustained (needs >= 2), so it must not veto.
++        let spike = ProbeSafetyAssessment.assess(samples: [
++            ProbeSafetySample(pressureLevel: .normal, thermalState: .nominal),
++            ProbeSafetySample(pressureLevel: .normal, thermalState: .serious),
++            ProbeSafetySample(pressureLevel: .normal, thermalState: .nominal),
++        ])
++        XCTAssertFalse(spike.thermalThrottleDetected)
++    }
++
+     func testProbeSafetyAssessmentUnknownDoesNotDiluteCriticalMajority() {
+         // Round-1 audit fix (MEDIUM): .unknown readings must not dilute the
+         // denominator. Two CRITICAL among many UNKNOWN is a critical majority of
+diff --git a/specs/CONFORMANCE.json b/specs/CONFORMANCE.json
+index cb5a0433..3dd708d9 100644
+--- a/specs/CONFORMANCE.json
++++ b/specs/CONFORMANCE.json
+@@ -659,7 +659,7 @@
+     {
+       "spec_id": "SPEC-023",
+       "title": "Installer-Integrated Autotune Recommend",
+-      "version": "v0.9.3",
++      "version": "v0.9.4",
+       "path": "specs/SPEC-023-installer-autotune-recommend.md",
+       "status": "normative",
+       "owner": "@Augustas11",
+diff --git a/specs/README.md b/specs/README.md
+index 404dd46d..76054508 100644
+--- a/specs/README.md
++++ b/specs/README.md
+@@ -31,7 +31,7 @@ it can no longer drift. Do not hand-edit the table; edit each spec's
+ | SPEC-020 | Provider autoupdate | v0.1.14 | normative | pending | pending: 5 | [SPEC-020-provider-autoupdate.md](SPEC-020-provider-autoupdate.md) |
+ | SPEC-021 | MALIBU rewards emission ledger | 0.4.0 | draft | complete | pending: 10 | [SPEC-021-malibu-emission-ledger.md](SPEC-021-malibu-emission-ledger.md) |
+ | SPEC-022 | Verified model settlement | v0.1.7 | draft | complete | conformant: 11 | [SPEC-022-verified-model-settlement.md](SPEC-022-verified-model-settlement.md) |
+-| SPEC-023 | Installer-Integrated Autotune Recommend | v0.9.3 | normative | pending | conformant: 2 | [SPEC-023-installer-autotune-recommend.md](SPEC-023-installer-autotune-recommend.md) |
++| SPEC-023 | Installer-Integrated Autotune Recommend | v0.9.4 | normative | pending | conformant: 2 | [SPEC-023-installer-autotune-recommend.md](SPEC-023-installer-autotune-recommend.md) |
+ | SPEC-024 | Prefix-cache billing and provider-local cache isolation | 0.2.1 | normative | pending | pending corpus migration | [SPEC-024-prefix-cache-billing.md](SPEC-024-prefix-cache-billing.md) |
+ | SPEC-025 | Native Mac App (signed `.dmg` + menu bar wrapper) | v0.24 | draft | pending | pending corpus migration | [SPEC-025-native-mac-app.md](SPEC-025-native-mac-app.md) |
+ | SPEC-026 | Browserless Provider Onboarding (one-click Launch Provider) | v0.28 | draft | pending | pending corpus migration | [SPEC-026-browserless-provider-onboarding.md](SPEC-026-browserless-provider-onboarding.md) |
+diff --git a/specs/SPEC-023-installer-autotune-recommend.md b/specs/SPEC-023-installer-autotune-recommend.md
+index e9e85673..02d26f39 100644
+--- a/specs/SPEC-023-installer-autotune-recommend.md
++++ b/specs/SPEC-023-installer-autotune-recommend.md
+@@ -1,12 +1,18 @@
+ # SPEC-023 — Installer-Integrated Autotune Recommend
+ 
+-version: v0.9.3
++version: v0.9.4
+ status: LOCKED
+ owner: operator (a11)
+-last-locked: 2026-08-02
++last-locked: 2026-08-29
+ 
+ ## Change log
+ 
++- **v0.9.4 (2026-08-29)** — Thermal veto redefined as sustained throttle (#1269).
++  1. **`thermal_throttle_detected` now means sustained thermal throttle, not any single throttling sample.** Computed over the SAME ~250 ms interval series already sampled for `swap_detected` (§ v0.9.0.2): `thermal_throttle_detected == true` only when at least 2 readable thermal samples are throttling (`.serious`/`.critical`) AND throttling readings are ≥50% of the readable (non-Unknown) thermal samples. A genuinely thermally-throttled node (sustained majority) still fails paid eligibility, including short probes that collect only the two synchronous samples.
++  2. **Why.** The install-time recommendation probe runs while the Mac is hot from unpacking/verifying/signing, so a lone transient throttle amid a benign thermal fair/nominal oscillation flipped the old any-sample flag and hard-rejected otherwise-capable Macs at upgrade — the node was then rolled back to its prior release (the #1269 convergence blocker). The prior rule set the flag if ANY single sample throttled OR any sample's thermal state was unreadable.
++  3. **Fail-closed narrowed.** `thermal_throttle_detected` fails closed to true only when the thermal state could not be read for the ENTIRE series (every sample unreadable, or an empty series). A single transient unreadable or throttling sample MUST NOT veto the paid path. This mirrors the v0.9.0 `swap_detected` fail-closed narrowing.
++  4. **No wire/schema change.** The `thermal_throttle_detected` boolean field name, the candidate-benchmark shape, and the coordinator-facing evidence schema are unchanged; only the field's meaning tightens. The gate remains a hard block for paid recommendation.
++
+ - **v0.9.3 (2026-08-02)** — oMLX activation-gate hardening (#687, r5 convergence).
+   1. **Provenance-erasure laundering closed.** The §12.2 activation gate now bans deriving a catalog row from oMLX data in ANY form before activation — not only the `omlx_seeded` schema but any value laundered into a `policy` / `measured_single_host` / other provenance label with `gate_seed` stripped. Authoring-process prohibition (AC-OMLX-16), plus an immutable provenance-lineage Stage-2 prerequisite §12.2(b)(v) so post-activation detection is possible.
+   2. **Admission-subset digest defined.** New §3.6 defines `admission_policy_sha256`, a digest over the catalog EXCLUDING `bench_gate.min_sustained_tps`, `max_4k_ttft_ms`, `provenance`, and `gate_seed`. SPEC-032 verified-evidence admission matching uses THAT subset digest, not the full `candidate_catalog_sha256` (which stays cache/update-integrity only). This resolves the SPEC-032 admission self-contradiction and protects verified admission from advisory-only edits.
+@@ -217,7 +223,7 @@ Required hardware fields:
+ || `candidate_benchmarks[model_key].sustained_tps` | float | local autotune benchmark | Warm steady-state decode tokens/sec for each candidate. |
+ || `candidate_benchmarks[model_key].ttft_ms` | integer | local autotune benchmark | Time to first token under the v0.1 benchmark prompt shape. |
+ || `candidate_benchmarks[model_key].swap_detected` | boolean | local probe | **[amended v0.9 / #742]** True means sustained CRITICAL memory pressure across the probe (≥2 samples of `kern.memorystatus_vm_pressure_level` reading Critical AND ≥50% of the readable samples Critical); fails paid eligibility (hard block) and, when it leaves no paid row, emits `swap_observed_under_load`. Advisory Warning-majority is telemetry-only. Field name/type unchanged. Donor mode keeps swap advisory. |
+-|| `candidate_benchmarks[model_key].thermal_throttle_detected` | boolean | local probe | Thermal throttle during probe fails eligibility. **[unchanged v0.2: hard block]** |
++|| `candidate_benchmarks[model_key].thermal_throttle_detected` | boolean | local probe | **[amended v0.9.4 / #1269]** True means SUSTAINED thermal throttle across the probe (≥2 readable thermal samples `.serious`/`.critical` AND ≥50% of the readable samples throttling); a hard block for paid recommendation. A lone transient throttle amid a benign fair/nominal oscillation does NOT set it. Fail closed to true only when the whole thermal series is unreadable. Field name/type unchanged. |
+ 
+ HMAC identity rules:
+ 
+@@ -637,7 +643,7 @@ Note: `bench_gate.min_sustained_tps` and `bench_gate.max_4k_ttft_ms` are advisor
+ - `ttft_ms <= model.bench_gate.max_4k_ttft_ms` **[v0.2 amendment: advisory; missing emits `ttft_above_gate` warning but does not veto eligibility]**.
+ - `swap_detected == false` **[amended v0.9 / #742: `swap_detected` == sustained CRITICAL memory pressure (≥2 samples Critical AND ≥50% of readable samples Critical) is a hard block for paid recommendation. When it causes no paid row to land, emit `swap_observed_under_load`. Advisory Warning-majority pressure does not set `swap_detected` and does not block (telemetry only). Fail closed to true only when the whole series is unreadable. Donor mode keeps swap advisory]**.
+ - `buyer_ttft_ceiling_ms == 0 OR ttft_ms <= buyer_ttft_ceiling_ms` **[v0.8 / #744: hard block for paid recommendation only. The operator-set ceiling protects buyer UX and is independent of catalog `bench_gate.max_4k_ttft_ms`. Enabling donor mode does not bypass the paid-path ceiling; donor fallback remains local-only and may still name a compatible row separately]**.
+-- `thermal_throttle_detected == false` **[unchanged from v0.1: hard block]**.
++- `thermal_throttle_detected == false` **[amended v0.9.4 / #1269: `thermal_throttle_detected` == SUSTAINED thermal throttle (≥2 readable thermal samples `.serious`/`.critical` AND ≥50% of readable samples throttling) is a hard block for paid recommendation. A lone transient throttle amid a benign fair/nominal oscillation does NOT set it. Fail closed to true only when the whole thermal series is unreadable. Donor mode remains unaffected]**.
+ - The candidate benchmark must be from the current `benchmark_id` or from a cached run whose candidate catalog hash, binary version, model ID, and HMAC-derived hardware identity hash match and whose `generated_at` is no older than 7 days.
+ - There is no default 60_000 ms TTFT feasibility ceiling on the paid `--recommend` path. Omitting `--gate-ttft-ms` with `--recommend` disables that probe feasibility ceiling. Classic non-recommend Stage 1/2 retains the SPEC-013 default. The paid buyer-facing ceiling is the separate `--buyer-ttft-ceiling-ms` policy knob above.
+ 

--- a/phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutotuneRecommend.swift
@@ -3084,10 +3084,28 @@ struct ProbeSafetyAssessment: Equatable {
             && warningCount >= 2
             && warningCount * 2 >= readable.count
 
-        let thermalStates = samples.map(\.thermalState)
-        let thermalKnown = !thermalStates.isEmpty && thermalStates.allSatisfy { $0 != nil }
-        let thermalThrottleDetected = !thermalKnown
-            || thermalStates.compactMap { $0 }.contains { ThermalGate.shouldThrottle($0) }
+        // #1269 fix: `thermalThrottleDetected` now means "sustained thermal
+        // throttle", not "any single throttling sample". The install-time probe
+        // runs while the Mac is hot from unpacking/verifying/signing, so a lone
+        // transient throttle (the observed thermal fair/nominal oscillation) used
+        // to trip the hard veto and sink every candidate — rolling back an
+        // otherwise-capable Mac. This mirrors the #742 swap_detected sustained
+        // rule exactly, computed over the same interval series:
+        // - TRUE only when at least 2 readable samples throttle AND throttling
+        //   samples are >= 50% of the READABLE (non-nil) thermal samples, so a
+        //   genuinely throttled node still hard-blocks.
+        // - Fail-closed to TRUE only when the thermal state could not be read for
+        //   the ENTIRE series (every sample nil, or an empty series), matching the
+        //   prior nil-fail-closed intent. A single transient unreadable/throttling
+        //   sample must never veto the paid path.
+        let readableThermal = samples.compactMap(\.thermalState)
+        let throttleCount = readableThermal.filter { ThermalGate.shouldThrottle($0) }.count
+        let thermalThrottleDetected: Bool
+        if readableThermal.isEmpty {
+            thermalThrottleDetected = true
+        } else {
+            thermalThrottleDetected = throttleCount >= 2 && throttleCount * 2 >= readableThermal.count
+        }
         return ProbeSafetyAssessment(
             swapDetected: swapDetected,
             thermalThrottleDetected: thermalThrottleDetected,

--- a/phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift
@@ -3132,6 +3132,69 @@ final class AutotuneRecommendTests: XCTestCase {
         XCTAssertFalse(spike.swapDetected)
     }
 
+    func testProbeSafetyAssessmentTransientThermalThrottleDoesNotBlock() {
+        // #1269: the install-time probe runs while the Mac is hot from
+        // unpacking/verifying/signing, so a lone transient throttle amid a benign
+        // fair/nominal oscillation must NOT trip the hard thermal veto — otherwise
+        // a perfectly capable Mac is rolled back at upgrade. Requires >= 2 throttling
+        // AND a majority, so this single .serious blip stays paid-eligible.
+        let transient = ProbeSafetyAssessment.assess(samples: [
+            ProbeSafetySample(pressureLevel: .normal, thermalState: .nominal),
+            ProbeSafetySample(pressureLevel: .normal, thermalState: .fair),
+            ProbeSafetySample(pressureLevel: .normal, thermalState: .serious),
+            ProbeSafetySample(pressureLevel: .normal, thermalState: .nominal),
+        ])
+        XCTAssertFalse(transient.thermalThrottleDetected)
+    }
+
+    func testProbeSafetyAssessmentSustainedThermalThrottleStillBlocks() {
+        // A genuinely thermally-throttled node (sustained .serious/.critical
+        // majority) must still hard-block the paid path — the veto is preserved,
+        // only the single-transient-sample trigger is removed.
+        let throttled = ProbeSafetyAssessment.assess(samples: [
+            ProbeSafetySample(pressureLevel: .normal, thermalState: .serious),
+            ProbeSafetySample(pressureLevel: .normal, thermalState: .critical),
+            ProbeSafetySample(pressureLevel: .normal, thermalState: .fair),
+            ProbeSafetySample(pressureLevel: .normal, thermalState: .serious),
+        ])
+        XCTAssertTrue(throttled.thermalThrottleDetected)
+    }
+
+    func testProbeSafetyAssessmentShortProbeSustainedThermalStillBlocks() {
+        // Mirror the swap short-probe fix: two synchronous samples both throttling
+        // must still veto (no >= 3 total-sample floor).
+        let shortThrottle = ProbeSafetyAssessment.assess(samples: [
+            ProbeSafetySample(pressureLevel: .normal, thermalState: .serious),
+            ProbeSafetySample(pressureLevel: .normal, thermalState: .serious),
+        ])
+        XCTAssertTrue(shortThrottle.thermalThrottleDetected)
+    }
+
+    func testProbeSafetyAssessmentUnknownThermalDoesNotDiluteThrottleMajority() {
+        // .unknown thermal readings must not dilute the denominator: two throttling
+        // among many unknown is a majority of the READABLE thermal samples => veto.
+        let throttled = ProbeSafetyAssessment.assess(samples: [
+            ProbeSafetySample(pressureLevel: .normal, thermalState: nil),
+            ProbeSafetySample(pressureLevel: .normal, thermalState: .serious),
+            ProbeSafetySample(pressureLevel: .normal, thermalState: nil),
+            ProbeSafetySample(pressureLevel: .normal, thermalState: .critical),
+            ProbeSafetySample(pressureLevel: .normal, thermalState: nil),
+        ])
+        XCTAssertTrue(throttled.thermalThrottleDetected)
+    }
+
+    func testProbeSafetyAssessmentLoneThermalSpikeAmidUnknownDoesNotBlock() {
+        // A single throttling sample among otherwise-unreadable thermal states is
+        // not sustained (needs >= 2), so it must not veto — and the lone readable
+        // throttle must not fail-closed just because the rest are unreadable.
+        let spike = ProbeSafetyAssessment.assess(samples: [
+            ProbeSafetySample(pressureLevel: .normal, thermalState: nil),
+            ProbeSafetySample(pressureLevel: .normal, thermalState: .serious),
+            ProbeSafetySample(pressureLevel: .normal, thermalState: nil),
+        ])
+        XCTAssertFalse(spike.thermalThrottleDetected)
+    }
+
     func testProbeSafetyAssessmentUnknownDoesNotDiluteCriticalMajority() {
         // Round-1 audit fix (MEDIUM): .unknown readings must not dilute the
         // denominator. Two CRITICAL among many UNKNOWN is a critical majority of

--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -659,7 +659,7 @@
     {
       "spec_id": "SPEC-023",
       "title": "Installer-Integrated Autotune Recommend",
-      "version": "v0.9.3",
+      "version": "v0.9.4",
       "path": "specs/SPEC-023-installer-autotune-recommend.md",
       "status": "normative",
       "owner": "@Augustas11",

--- a/specs/README.md
+++ b/specs/README.md
@@ -31,7 +31,7 @@ it can no longer drift. Do not hand-edit the table; edit each spec's
 | SPEC-020 | Provider autoupdate | v0.1.14 | normative | pending | pending: 5 | [SPEC-020-provider-autoupdate.md](SPEC-020-provider-autoupdate.md) |
 | SPEC-021 | MALIBU rewards emission ledger | 0.4.0 | draft | complete | pending: 10 | [SPEC-021-malibu-emission-ledger.md](SPEC-021-malibu-emission-ledger.md) |
 | SPEC-022 | Verified model settlement | v0.1.7 | draft | complete | conformant: 11 | [SPEC-022-verified-model-settlement.md](SPEC-022-verified-model-settlement.md) |
-| SPEC-023 | Installer-Integrated Autotune Recommend | v0.9.3 | normative | pending | conformant: 2 | [SPEC-023-installer-autotune-recommend.md](SPEC-023-installer-autotune-recommend.md) |
+| SPEC-023 | Installer-Integrated Autotune Recommend | v0.9.4 | normative | pending | conformant: 2 | [SPEC-023-installer-autotune-recommend.md](SPEC-023-installer-autotune-recommend.md) |
 | SPEC-024 | Prefix-cache billing and provider-local cache isolation | 0.2.1 | normative | pending | pending corpus migration | [SPEC-024-prefix-cache-billing.md](SPEC-024-prefix-cache-billing.md) |
 | SPEC-025 | Native Mac App (signed `.dmg` + menu bar wrapper) | v0.24 | draft | pending | pending corpus migration | [SPEC-025-native-mac-app.md](SPEC-025-native-mac-app.md) |
 | SPEC-026 | Browserless Provider Onboarding (one-click Launch Provider) | v0.28 | draft | pending | pending corpus migration | [SPEC-026-browserless-provider-onboarding.md](SPEC-026-browserless-provider-onboarding.md) |

--- a/specs/SPEC-023-installer-autotune-recommend.md
+++ b/specs/SPEC-023-installer-autotune-recommend.md
@@ -1,11 +1,17 @@
 # SPEC-023 — Installer-Integrated Autotune Recommend
 
-version: v0.9.3
+version: v0.9.4
 status: LOCKED
 owner: operator (a11)
-last-locked: 2026-08-02
+last-locked: 2026-08-29
 
 ## Change log
+
+- **v0.9.4 (2026-08-29)** — Thermal veto redefined as sustained throttle (#1269).
+  1. **`thermal_throttle_detected` now means sustained thermal throttle, not any single throttling sample.** Computed over the SAME ~250 ms interval series already sampled for `swap_detected` (§ v0.9.0.2): `thermal_throttle_detected == true` only when at least 2 readable thermal samples are throttling (`.serious`/`.critical`) AND throttling readings are ≥50% of the readable (non-Unknown) thermal samples. A genuinely thermally-throttled node (sustained majority) still fails paid eligibility, including short probes that collect only the two synchronous samples.
+  2. **Why.** The install-time recommendation probe runs while the Mac is hot from unpacking/verifying/signing, so a lone transient throttle amid a benign thermal fair/nominal oscillation flipped the old any-sample flag and hard-rejected otherwise-capable Macs at upgrade — the node was then rolled back to its prior release (the #1269 convergence blocker). The prior rule set the flag if ANY single sample throttled OR any sample's thermal state was unreadable.
+  3. **Fail-closed narrowed.** `thermal_throttle_detected` fails closed to true only when the thermal state could not be read for the ENTIRE series (every sample unreadable, or an empty series). A single transient unreadable or throttling sample MUST NOT veto the paid path. This mirrors the v0.9.0 `swap_detected` fail-closed narrowing.
+  4. **No wire/schema change.** The `thermal_throttle_detected` boolean field name, the candidate-benchmark shape, and the coordinator-facing evidence schema are unchanged; only the field's meaning tightens. The gate remains a hard block for paid recommendation.
 
 - **v0.9.3 (2026-08-02)** — oMLX activation-gate hardening (#687, r5 convergence).
   1. **Provenance-erasure laundering closed.** The §12.2 activation gate now bans deriving a catalog row from oMLX data in ANY form before activation — not only the `omlx_seeded` schema but any value laundered into a `policy` / `measured_single_host` / other provenance label with `gate_seed` stripped. Authoring-process prohibition (AC-OMLX-16), plus an immutable provenance-lineage Stage-2 prerequisite §12.2(b)(v) so post-activation detection is possible.
@@ -217,7 +223,7 @@ Required hardware fields:
 || `candidate_benchmarks[model_key].sustained_tps` | float | local autotune benchmark | Warm steady-state decode tokens/sec for each candidate. |
 || `candidate_benchmarks[model_key].ttft_ms` | integer | local autotune benchmark | Time to first token under the v0.1 benchmark prompt shape. |
 || `candidate_benchmarks[model_key].swap_detected` | boolean | local probe | **[amended v0.9 / #742]** True means sustained CRITICAL memory pressure across the probe (≥2 samples of `kern.memorystatus_vm_pressure_level` reading Critical AND ≥50% of the readable samples Critical); fails paid eligibility (hard block) and, when it leaves no paid row, emits `swap_observed_under_load`. Advisory Warning-majority is telemetry-only. Field name/type unchanged. Donor mode keeps swap advisory. |
-|| `candidate_benchmarks[model_key].thermal_throttle_detected` | boolean | local probe | Thermal throttle during probe fails eligibility. **[unchanged v0.2: hard block]** |
+|| `candidate_benchmarks[model_key].thermal_throttle_detected` | boolean | local probe | **[amended v0.9.4 / #1269]** True means SUSTAINED thermal throttle across the probe (≥2 readable thermal samples `.serious`/`.critical` AND ≥50% of the readable samples throttling); a hard block for paid recommendation. A lone transient throttle amid a benign fair/nominal oscillation does NOT set it. Fail closed to true only when the whole thermal series is unreadable. Field name/type unchanged. |
 
 HMAC identity rules:
 
@@ -637,7 +643,7 @@ Note: `bench_gate.min_sustained_tps` and `bench_gate.max_4k_ttft_ms` are advisor
 - `ttft_ms <= model.bench_gate.max_4k_ttft_ms` **[v0.2 amendment: advisory; missing emits `ttft_above_gate` warning but does not veto eligibility]**.
 - `swap_detected == false` **[amended v0.9 / #742: `swap_detected` == sustained CRITICAL memory pressure (≥2 samples Critical AND ≥50% of readable samples Critical) is a hard block for paid recommendation. When it causes no paid row to land, emit `swap_observed_under_load`. Advisory Warning-majority pressure does not set `swap_detected` and does not block (telemetry only). Fail closed to true only when the whole series is unreadable. Donor mode keeps swap advisory]**.
 - `buyer_ttft_ceiling_ms == 0 OR ttft_ms <= buyer_ttft_ceiling_ms` **[v0.8 / #744: hard block for paid recommendation only. The operator-set ceiling protects buyer UX and is independent of catalog `bench_gate.max_4k_ttft_ms`. Enabling donor mode does not bypass the paid-path ceiling; donor fallback remains local-only and may still name a compatible row separately]**.
-- `thermal_throttle_detected == false` **[unchanged from v0.1: hard block]**.
+- `thermal_throttle_detected == false` **[amended v0.9.4 / #1269: `thermal_throttle_detected` == SUSTAINED thermal throttle (≥2 readable thermal samples `.serious`/`.critical` AND ≥50% of readable samples throttling) is a hard block for paid recommendation. A lone transient throttle amid a benign fair/nominal oscillation does NOT set it. Fail closed to true only when the whole thermal series is unreadable. Donor mode remains unaffected]**.
 - The candidate benchmark must be from the current `benchmark_id` or from a cached run whose candidate catalog hash, binary version, model ID, and HMAC-derived hardware identity hash match and whose `generated_at` is no older than 7 days.
 - There is no default 60_000 ms TTFT feasibility ceiling on the paid `--recommend` path. Omitting `--gate-ttft-ms` with `--recommend` disables that probe feasibility ceiling. Classic non-recommend Stage 1/2 retains the SPEC-013 default. The paid buyer-facing ceiling is the separate `--buyer-ttft-ceiling-ms` policy knob above.
 


### PR DESCRIPTION
## Summary
Fixes the #1235 convergence blocker where install-time recommendation **rejects otherwise-capable Macs** (the partner's 16GB M4 stuck on the prior release). The install probe runs while the Mac is hot from unpacking/verifying/signing, so a **lone transient thermal throttle** flipped the hard `thermal_throttle_detected` veto and sank every candidate → donor mode → rollback.

## Root cause
`ProbeSafetyAssessment.assess` set `thermal_throttle_detected` on **any single** throttling sample (`.contains{shouldThrottle}`) or **any** unreadable sample — while `swap_detected` right beside it already required **sustained** pressure (≥2 AND ≥50%) since the v0.9.0/#742 fix. That asymmetry is the bug.

## Change (mirrors the #742 swap redefinition exactly)
- `thermal_throttle_detected` now means **sustained** throttle over the same ~250ms interval series: true only when ≥2 readable thermal samples throttle (`.serious`/`.critical`) AND throttling is ≥50% of readable samples. **A genuinely throttled node still hard-blocks the paid path** — only the single-transient trigger is removed. Fail-closed narrowed to whole-series-unreadable.
- **SPEC-023 v0.9.3 → v0.9.4** amendment (changelog + field table + gate line), CONFORMANCE + README synced.
- 5 regression tests: transient-no-block (the M4 case), sustained-blocks, short-probe-blocks, unknown-dilution-blocks, lone-spike-amid-unknown-no-block.

## Testing / audit
- `swift build` clean; **179 AutotuneRecommend tests pass**; no existing test broke; governance check clean (bar the pre-existing SPEC-010-R005 drift, unrelated).
- Codex 3-lane audit over the full diff → **0 CRITICAL / 0 HIGH / 0 MEDIUM** (one LOW test-comment mismatch, fixed). Confirmed money-path safe: a genuinely throttled node still hard-blocks, the 50% boundary is correct, short two-sample probes still block, unreadable samples don't dilute a real majority.

Evidence under `audits/2026-08-29-1269/` (kept local, not in this PR). A provider release cutting a new version follows this merge.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": ["SPEC-023"],
  "requirements": ["SPEC-023-R001"],
  "authority_domains": ["installer-autotune-policy"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift:testProbeSafetyAssessmentTransientThermalThrottleDoesNotBlock",
    "phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift:testProbeSafetyAssessmentSustainedThermalThrottleStillBlocks",
    "phase3-binary/Tests/macprovider-cliTests/AutotuneRecommendTests.swift:testProbeSafetyAssessmentShortProbeSustainedThermalStillBlocks"
  ],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/1269"
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
