### PR TITLE
Bound installer network stalls so fresh installs can't hang at "Starting installer…"

### DIFF
--- a/phase3-binary/dist/install.sh
+++ b/phase3-binary/dist/install.sh
@@ -8570,7 +8570,12 @@ latest_release_tag() {
   # release published under the same repo (e.g. macprovider-verify
   # under tag verify-vX.Y.Z) silently hijacks the installer.
   api_url="https://api.github.com/repos/${GITHUB_REPO}/releases?per_page=30"
-  json="$(curl -fsSL "$api_url")" || die 3 "failed to query GitHub Releases API: $api_url"
+  # Bound network stalls: --connect-timeout guards a captive portal / black-holed
+  # socket, --speed-limit/--speed-time abort a mid-transfer stall, and --retry
+  # rides out transient failures. Without these the installer hangs indefinitely
+  # on a stalled GitHub API socket and the Malibu UI is stuck at "Starting
+  # installer…" (its progress monitor only tracks macprovider-cli processes).
+  json="$(curl -fsSL --connect-timeout 15 --speed-limit 1024 --speed-time 120 --retry 3 --retry-connrefused --retry-max-time 300 "$api_url")" || die 3 "failed to query GitHub Releases API: $api_url"
   tag="$(
     printf "%s" "$json" \
       | awk '
@@ -8947,8 +8952,8 @@ download_release() {
       || die 3 "failed to stage acceptance-candidate.json.sig"
     log "Using protected non-public acceptance assets for $tag."
   else
-    curl -fL "$base/checksums.txt" -o "$checksums_path" || die 3 "failed to download checksums.txt"
-    curl -fL "$base/checksums.txt.sig" -o "$checksums_sig_path" || die 3 "failed to download checksums.txt.sig"
+    curl -fL --connect-timeout 15 --speed-limit 1024 --speed-time 120 --retry 3 --retry-connrefused --retry-max-time 300 "$base/checksums.txt" -o "$checksums_path" || die 3 "failed to download checksums.txt"
+    curl -fL --connect-timeout 15 --speed-limit 1024 --speed-time 120 --retry 3 --retry-connrefused --retry-max-time 300 "$base/checksums.txt.sig" -o "$checksums_sig_path" || die 3 "failed to download checksums.txt.sig"
   fi
   verify_checksum_signature
 
@@ -8966,7 +8971,7 @@ download_release() {
         cp "$acceptance_dir/$pkg_asset" "$pkg_path" || die 3 "failed to stage acceptance package"
       else
         log "Downloading signed package $pkg_asset from GitHub Releases."
-        curl -fL "$base/$pkg_asset" -o "$pkg_path" || die 3 "failed to download release package"
+        curl -fL --connect-timeout 15 --speed-limit 1024 --speed-time 120 --retry 3 --retry-connrefused --retry-max-time 300 "$base/$pkg_asset" -o "$pkg_path" || die 3 "failed to download release package"
       fi
       asset_path="$pkg_path"
       asset_kind="pkg"
@@ -8982,7 +8987,7 @@ download_release() {
     cp "$acceptance_dir/$tarball_asset" "$tarball_path" || die 3 "failed to stage acceptance tarball"
   else
     log "Downloading $tarball_asset from GitHub Releases."
-    curl -fL "$base/$tarball_asset" -o "$tarball_path" || die 3 "failed to download release tarball"
+    curl -fL --connect-timeout 15 --speed-limit 1024 --speed-time 120 --retry 3 --retry-connrefused --retry-max-time 300 "$base/$tarball_asset" -o "$tarball_path" || die 3 "failed to download release tarball"
   fi
   asset_path="$tarball_path"
   asset_kind="tar"


### PR DESCRIPTION
## Problem (URGENT — blocks new-provider onboarding)

A brand-new provider's fresh install via Malibu hangs indefinitely at
**"Starting installer…"** ("the app just hangs here"). The same early step
gates the Repair path.

## Root cause

`latest_release_tag` and `download_release` in `phase3-binary/dist/install.sh`
call `curl` with **no connect or transfer timeout**:

- `install.sh` GitHub releases API query (`curl -fsSL "$api_url"`)
- checksums.txt / .sig / pkg / tarball downloads (`curl -fL "$base/…"`)

On a stalled socket (captive portal, black-holing proxy, GitHub API stall) these
block **forever**. The Malibu onboarding progress monitor
(`CLIInstallRunner.ActivityMonitor`) filters `ps` to lines containing
`macprovider-cli`, so the bare `curl`/`bash` install processes are invisible and
the stage stays pinned at "Starting installer…" — the hang looks like the app
froze. Verified: the installer's local pre-network path completes fast; the
stall is the first network `curl`.

## Fix

Add `--connect-timeout 15 --speed-limit 1024 --speed-time 120 --retry 3
--retry-connrefused` to the five network curls in the fresh-install path. A
stalled connection now fails fast with the existing `die 3` error (surfaced by
the app's `classifiedInstallError` as a real install error) instead of hanging.
`--speed-limit/--speed-time` aborts a mid-transfer stall without capping
legitimately slow-but-progressing large downloads (hence not `--max-time`).

## Delivery

Reaches GUI providers via the next Malibu.app release (regenerates the signed
install-contract manifest) and the public `get.malibu.tech/install.sh` on
release/site sync. Independent of the current release feed-gate block.

## Follow-up (not in this PR)

The onboarding monitor is blind to the pre-CLI network phase (tag resolve +
download + verify), so even a healthy install shows "Starting installer…" for
the whole download. A small monitor change to recognize that phase (via the
install log lines it already receives) would improve the UX. Tracked separately;
the curl timeout is the load-bearing hang fix.

## Tested

- `bash -n install.sh`
- `provider_upgrade_transaction.test.sh`, `test-install-config-token-preserve.sh`,
  `test-install-provider-id-preserve.sh`, `watchdog_rollback_paths.test.sh` — all pass
- `--dry-run` end-to-end still exits 0
- curl 8.7.1 accepts all flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R003"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "bash -n phase3-binary/dist/install.sh",
    "bash phase3-binary/dist/test/provider_upgrade_transaction.test.sh",
    "bash scripts/test-install-config-token-preserve.sh",
    "bash scripts/test-install-provider-id-preserve.sh",
    "bash phase3-binary/dist/test/watchdog_rollback_paths.test.sh"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END
