### PR TITLE
Add #1189 integrated repair reproduction test + T1-T3 fidelity runbook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -445,6 +445,9 @@ jobs:
       - name: Verify macOS upgrade rollback and manual process recovery
         run: bash phase3-binary/dist/test/install_upgrade_evidence_rollback.test.sh
 
+      - name: Verify #1189 repair reproduction (real ACLs, mocked launchd)
+        run: bash phase3-binary/dist/test/repair_1189_reproduction.test.sh
+
 
   spec-015-acceptance:
     name: spec-015-acceptance

--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,7 @@ test-dist:
 	bash scripts/test-watchdog-inline-drift.sh
 	bash phase3-binary/dist/test/watchdog_health_scope.test.sh
 	bash phase3-binary/dist/test/watchdog_rollback_paths.test.sh
+	bash phase3-binary/dist/test/repair_1189_reproduction.test.sh
 	bash ops/macprovider-watchdog/Scripts/test-ac-19-20-watchdog-recovery.sh
 	node --test test/e2e/canary-buyer/probe.test.mjs test/e2e/canary-buyer/safety.test.mjs
 	node --test frontdoor/provider-portal/mining-health.test.mjs

--- a/docs/runbooks/provider-repair-1189-e2e.md
+++ b/docs/runbooks/provider-repair-1189-e2e.md
@@ -1,0 +1,186 @@
+# Provider repair #1189 end-to-end reproduction
+
+Incident #1189 stranded an external provider: a stale watchdog running under
+the legacy label, plus a HOME ACL write barrier, plus a stale pending/rollback
+marker, together blocked repaired provider software from landing even after
+PR #1208 (`aee7d157`, Malibu Repair recovers stale watchdog + HOME ACL) and
+PR #1228 (`16b0fa4d`, watchdog no longer owns rollback — it defers) shipped to
+`main`. Before asking the real #1189 provider to download the new DMG and run
+Repair, we need graduated proof that the fix actually recovers their exact
+failure shape. This runbook is that fidelity ladder.
+
+## The fidelity ladder
+
+| Tier | What it runs | Real vs. mocked | Proves | Status |
+| --- | --- | --- | --- | --- |
+| T1 | `phase3-binary/dist/test/repair_1189_reproduction.test.sh` | Real macOS filesystem ACLs; launchd mocked | The four #1189 ingredients compose correctly in one sandbox HOME | Done, see below |
+| T2 | Full `install.sh` transaction against a mock coordinator + offline catalog | Real installer script; coordinator and catalog stubbed | Rejoin logic end-to-end without touching the live network | Follow-up, not yet built |
+| T3 | Malibu Repair button on a real, notarized DMG, on a spare canary Mac, against the live coordinator | Fully real | The actual last-mile path a sandbox cannot cover | **Required before messaging the real #1189 provider** |
+
+Each tier only earns the claims of the tier below it. T1 passing does not mean
+T2 or T3 passed. Do not message the real #1189 provider based on T1 or T2
+alone.
+
+## T1 — sandbox reproduction (this repo)
+
+`phase3-binary/dist/test/repair_1189_reproduction.test.sh` builds ONE sandbox
+`$HOME` containing all four #1189 ingredients at once:
+
+1. The installer-inline watchdog on disk, wired to both the current
+   (`live.malibu.provider-watchdog`) and legacy
+   (`live.streamvc.macprovider-watchdog`) launchd labels.
+2. A stale pending-autoupdate marker plus a rollback backup binary (the
+   #1228 trap: an armed but unresolved update/rollback transaction).
+3. A real macOS HOME ACL write barrier (`chmod +a "group:everyone allow
+   write,append"` plus a `deny delete` ACE), planted with the real `chmod
+   -a`/ACL syscalls — not simulated.
+4. Full provider identity: `config.yaml`, `provider_id`, `wallet.json`, and a
+   model weights file, fingerprinted before and after the run.
+
+It then runs the actual functions extracted from `phase3-binary/dist/install.sh`
+(`quiesce_repair_watchdogs_for_transaction`, `remediate_repair_home_write_acl`,
+`validate_install_dir`) and the actual watchdog script
+(`ops/macprovider-watchdog/watchdog.sh`'s installer-inline copy) — not
+reimplementations — through three phases:
+
+- **Phase A** — the stale watchdog ticks *before* repair runs, with the
+  pending marker and ACL barrier both still in place. It must defer (per
+  #1228): no rollback of the repaired binary, the pending marker survives, and
+  the tick makes no `bootout`/`bootstrap`/`kickstart` launchctl calls. The
+  sandbox gives the watchdog a resolvable, healthy-looking provider process (a
+  faked `lsof` matching `provider_process_pid`'s expectations) so the tick
+  takes the same "process present" path a real running #1189 provider would
+  have taken, rather than an unrelated missing-process restart path that has
+  nothing to do with the #1228 bug.
+- **Phase B** — the real repair preflight runs: it quiesces (bootouts) *both*
+  the current and legacy watchdog launchd labels, remediates the real HOME ACL
+  barrier via `chmod -a`, and the test fingerprints config/provider_id/
+  wallet/model bytes before and after to confirm the preflight is a pure
+  precondition step that mutates nothing about the provider's identity.
+- **Phase C** — the watchdog ticks again, post-repair. It must still be unable
+  to undo the repair (#1228 holds after cutover, not just before it).
+
+Real vs. mocked, precisely: filesystem ACLs (`chmod +a`/`chmod -a` on real
+directories) are **real**. `launchctl` is a **PATH-resolved fake** — the test
+does not set `MACPROVIDER_LAUNCHCTL`, so both the extracted repair functions
+and the watchdog script pick it up exactly the way they would resolve the real
+`launchctl` binary in production, just pointed at a script that logs and
+returns canned output instead of talking to the real `launchd`. There is no
+DMG, no Malibu.app, no GUI Repair button, and no coordinator in this tier.
+
+Run it directly:
+
+```bash
+bash phase3-binary/dist/test/repair_1189_reproduction.test.sh
+```
+
+It requires real macOS (it SKIPs with exit 0 on any non-Darwin `uname -s`,
+since it needs real filesystem ACL support) and is wired into
+`make test-dist` and into the `swift-tests` CI job (`macos-15` runner) so it
+runs for real on every PR that touches `phase3-binary/`.
+
+### What T1 proves
+
+- The four #1189 ingredients do not fight each other or produce a different
+  failure shape when combined in one HOME than they do in isolation.
+- The real repair functions (not test doubles of them) successfully quiesce
+  both watchdog labels and remediate the ACL barrier together.
+- Provider identity, config, wallet, and model bytes survive the repair
+  preflight untouched.
+- The #1228 no-rollback-ownership guarantee holds both before and after
+  cutover under the full combined trap, not just in the isolated
+  `watchdog_rollback_paths.test.sh` fixture.
+
+### What T1 does NOT prove
+
+- That the real, notarized DMG installer and Malibu.app Repair button perform
+  the same sequence of calls as the extracted shell functions.
+- That the real `launchd` behaves the way the mocked `launchctl` script
+  claims it does (real `launchd` bootout/bootstrap semantics, timing, and
+  failure modes are not exercised).
+- That a real coordinator will actually re-admit and rejoin the repaired
+  provider (no coordinator, no network, no catalog in this tier).
+- Anything about the specific machine state of the real #1189 provider beyond
+  the four ingredients this incident is documented to have hit.
+
+## T2 — full install.sh transaction against a mock coordinator (follow-up, not yet built)
+
+Run the real `install.sh` end-to-end (not just extracted functions) as a
+repair transaction against a mock coordinator and an offline/local catalog, to
+exercise the rejoin/re-admission logic that T1 does not touch. This closes
+the gap between "the repair functions work in isolation" and "the full
+installer transaction, as a real user would invoke it, gets a provider back
+onto a coordinator." Not implemented as part of this change; track it before
+relying on T1 alone for anything beyond the sandbox claims above.
+
+## T3 — canary Mac, real DMG, live coordinator (required before messaging the real provider)
+
+T3 is the last mile a sandbox cannot cover: real code signing/notarization,
+the real Malibu.app GUI, the real Repair button, real `launchd`, and a real
+rejoin against the **live** coordinator. It must run on a **spare canary Mac
+that is NOT the real #1189 provider**.
+
+### Preconditions
+
+- A spare Mac (any Apple Silicon Mac not currently in the #1189 provider's
+  hands) that you can freely wipe and reinstall.
+- The new, notarized provider DMG build that includes both #1208
+  (`aee7d157`) and #1228 (`16b0fa4d`).
+- Network access to the live coordinator (`coordinator.malibu.tech`).
+
+### Steps
+
+1. On the canary Mac, install a provider build **predating** #1208/#1228
+   (the last stable release before those two PRs) and let it fully onboard:
+   confirm it appears healthy in the coordinator/provider directory.
+2. Reproduce the #1189 failure shape on the canary Mac's real HOME, using the
+   real primitives (not the test's extracted-function shortcuts):
+   - Plant the real HOME ACL write barrier:
+     `chmod +a "group:everyone allow write,append" ~` (and the matching
+     `deny delete` ACE the incident showed).
+   - Leave the watchdog running under the **legacy** launchd label
+     (`live.streamvc.macprovider-watchdog`) if the installed build still uses
+     it, or bootstrap it under that label manually if it doesn't.
+   - Stage a stale `pending.json` autoupdate marker plus a rollback backup
+     binary under `~/.local/share/macprovider/autoupdate/` and
+     `~/.local/bin/`, matching the shape in
+     `phase3-binary/dist/test/watchdog_rollback_paths.test.sh`'s fixture.
+3. Confirm the canary Mac is now stuck the same way the real #1189 provider
+   is: repair/update attempts fail against the ACL barrier, and the stale
+   watchdog is present.
+4. Download the new, notarized DMG (the one with #1208 + #1228) onto the
+   canary Mac through the normal path (`get.malibu.tech/install.sh` or the
+   DMG directly) — do not sideload the installer script by hand.
+5. Launch Malibu.app and click the real **Repair** button in the GUI. Do not
+   invoke `install.sh --repair` from a terminal for this step; the point of
+   T3 is exercising the same code path a non-technical provider operator
+   would.
+6. Watch it through to completion.
+
+### Acceptance criteria
+
+T3 passes only if **all** of the following hold on the canary Mac after
+Repair completes:
+
+- The GUI Repair flow completes without requiring manual terminal
+  intervention.
+- The legacy watchdog launchd label is gone (or, if a compatibility bridge
+  intentionally leaves it registered, it is provably inert — no rollback,
+  no interference).
+- The HOME ACL write barrier is gone (`ls -lde ~` shows no lingering
+  `everyone allow write`/`add_file` ACE; the safe `deny delete` ACE, if any,
+  may remain per the documented safe-ACL shape).
+- The stale pending/rollback marker is resolved (consumed or cleanly
+  quarantined by the installer/CLI transaction owner) — not silently
+  rolled back by a watchdog.
+- Provider identity (`provider_id`), wallet, and any downloaded model weights
+  are byte-identical to before Repair ran.
+- The provider **actually rejoins the live coordinator**: it shows up as
+  healthy/routable in the coordinator's provider directory or admin view
+  within a reasonable window after Repair finishes, and a real buyer request
+  can be routed to it end-to-end.
+
+Only once T3 passes on the canary Mac should the real #1189 provider be asked
+to download the new DMG and run Repair. T1 (this repo's sandbox test) and any
+future T2 give confidence the fix is directionally correct; neither is a
+substitute for T3's live-coordinator rejoin proof.

--- a/phase3-binary/dist/test/repair_1189_reproduction.test.sh
+++ b/phase3-binary/dist/test/repair_1189_reproduction.test.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# Integrated reproduction of the #1189 stranded-provider failure.
+#
+# The component behaviors are already covered in isolation:
+#   - provider_upgrade_transaction.test.sh : quiesce (both labels), HOME ACL
+#     remediation, marker quarantine, cutover ordering.
+#   - watchdog_rollback_paths.test.sh       : #1228 — a stale watchdog cannot
+#     execute a rollback / restore an old release payload; it defers.
+#
+# What was NOT covered, and is exactly what gates asking a real provider to
+# "download the new DMG and run Repair", is the *composition*: all four #1189
+# ingredients present in ONE home at once, run through the real repair steps in
+# order, proving they neutralize the failure together while preserving the
+# provider's identity, models, and wallet. This test closes that gap on real
+# macOS (real filesystem ACLs; launchd is mocked — the real-launchd + DMG + live
+# coordinator rejoin remain a canary-Mac step, see the runbook).
+#
+# Fidelity: T1 (see docs/runbooks/provider-repair-1189-e2e.md). Not a substitute
+# for the canary-Mac T3 run.
+
+set -euo pipefail
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  echo "SKIP: #1189 reproduction requires real macOS ACLs (uname=$(uname -s))" >&2
+  exit 0
+fi
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+INSTALL_SH="$REPO_ROOT/phase3-binary/dist/install.sh"
+TMP="$(mktemp -d)"
+
+SBX="$TMP/home"
+# The extracted repair helpers (remediate_repair_home_write_acl,
+# validate_install_dir) read the real installer's $HOME directly, exactly as
+# install.sh does when it runs for the logged-in user. Point it at the
+# sandbox so those functions operate on $SBX instead of the operator's real
+# home directory.
+export HOME="$SBX"
+acl_cleanup() {
+  # Best-effort: strip any ACL we planted so teardown can remove the tree.
+  /bin/chmod -a "group:everyone allow write,append" "$SBX" 2>/dev/null || true
+  /bin/chmod -a "group:everyone deny delete" "$SBX" 2>/dev/null || true
+  /bin/chmod -R -N "$SBX" 2>/dev/null || true
+  rm -rf "$TMP"
+}
+trap acl_cleanup EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+note() { printf '  ✓ %s\n' "$*"; }
+
+# --- extract the real repair functions from install.sh -----------------------
+extract_function() {
+  awk -v start="$1() {" '
+    $0 == start { inside=1 }
+    inside { print }
+    inside && /^}$/ { exit }
+  ' "$INSTALL_SH"
+}
+
+HELPERS="$TMP/helpers.sh"
+for fn in \
+  validate_install_dir \
+  pid_is_live_non_zombie \
+  remediate_repair_home_write_acl \
+  quiesce_repair_watchdog_label_for_transaction \
+  quiesce_repair_watchdogs_for_transaction; do
+  extract_function "$fn" >> "$HELPERS"
+done
+# shellcheck source=/dev/null
+source "$HELPERS" || fail "could not source extracted repair functions"
+
+# --- extract the installer-inline watchdog (the adversary) -------------------
+extract_inline_watchdog() {
+  awk '
+    /write_atomic_install_file "\$WATCHDOG_PATH" 0755 <<.WATCHDOG_EOF./ { inside=1; next }
+    inside && /^WATCHDOG_EOF$/ { exit }
+    inside { print }
+  ' "$INSTALL_SH"
+}
+INLINE_WATCHDOG="$TMP/watchdog-inline.sh"
+extract_inline_watchdog > "$INLINE_WATCHDOG"
+[ -s "$INLINE_WATCHDOG" ] || fail "could not extract installer inline watchdog"
+chmod +x "$INLINE_WATCHDOG"
+
+# --- test doubles ------------------------------------------------------------
+log() { :; }
+die() { echo "die($1): ${2:-}" >&2; exit "$1"; }
+
+LAUNCHD_DOMAIN="gui/$(id -u)"
+WATCHDOG_LABEL="live.malibu.provider-watchdog"
+LEGACY_WATCHDOG_LABEL="live.streamvc.macprovider-watchdog"
+WATCHDOG_DIR="$SBX/.local/share/macprovider/watchdog"
+WATCHDOG_PATH="$WATCHDOG_DIR/watchdog.sh"
+WATCHDOG_BOOTSTRAP_PATH="$WATCHDOG_PATH"
+WATCHDOG_PLIST_BOOTSTRAP_PATH="$SBX/Library/LaunchAgents/$WATCHDOG_LABEL.plist"
+LEGACY_WATCHDOG_PLIST_BOOTSTRAP_PATH="$SBX/Library/LaunchAgents/$LEGACY_WATCHDOG_LABEL.plist"
+REPAIR_EXISTING_INSTALL=1
+
+QUIESCE_LOG="$TMP/quiesce.log"
+: > "$QUIESCE_LOG"
+
+# Mock launchd: both labels report as loaded (identity-valid) before bootout,
+# then unloaded afterwards. Mirrors the shape validated in
+# provider_upgrade_transaction.test.sh.
+launchctl_service() {
+  case "$*" in
+    "print $LAUNCHD_DOMAIN/$WATCHDOG_LABEL")
+      printf '    program = %s\n    path = %s\n' "$WATCHDOG_PATH" "$WATCHDOG_PLIST_BOOTSTRAP_PATH" ;;
+    "print $LAUNCHD_DOMAIN/$LEGACY_WATCHDOG_LABEL")
+      printf '    program = %s\n    path = %s\n' "$WATCHDOG_PATH" "$LEGACY_WATCHDOG_PLIST_BOOTSTRAP_PATH" ;;
+    "bootout $LAUNCHD_DOMAIN/$WATCHDOG_LABEL")
+      printf 'bootout %s\n' "$WATCHDOG_LABEL" >> "$QUIESCE_LOG" ;;
+    "bootout $LAUNCHD_DOMAIN/$LEGACY_WATCHDOG_LABEL")
+      printf 'bootout %s\n' "$LEGACY_WATCHDOG_LABEL" >> "$QUIESCE_LOG" ;;
+    *) return 0 ;;
+  esac
+}
+launchd_print_loaded() { return 1; }   # unloaded after bootout
+
+# --- build ONE home containing all four #1189 ingredients --------------------
+# `mkdir -p ... -m 700` only sets the mode on each leaf; $SBX itself (now also
+# $HOME, see above) needs its own chmod to match a real, non-world-readable
+# provider HOME.
+mkdir -p "$SBX" && chmod 700 "$SBX"
+mkdir -m 700 -p \
+  "$SBX/.config/macprovider" \
+  "$SBX/Library/Application Support/macprovider" \
+  "$SBX/Library/LaunchAgents" \
+  "$SBX/.local/bin" \
+  "$SBX/.local/share/macprovider/models/seed" \
+  "$SBX/.local/share/macprovider/autoupdate" \
+  "$WATCHDOG_DIR" \
+  "$SBX/logs"
+
+# identity / config / manifest / plist
+PROVIDER_ID="mp-0123456789abcdef0123456789abcdef"
+CONFIG_PATH="$SBX/.config/macprovider/config.yaml"
+PROVIDER_ID_PATH="$SBX/.config/macprovider/provider_id"
+WALLET_PATH="$SBX/.config/macprovider/wallet.json"
+MODEL_PATH="$SBX/.local/share/macprovider/models/seed/weights.bin"
+printf 'model: "seed"\nprovider_id: "%s"\ncoordinator_url: "wss://coordinator.example/ws/provider"\n' "$PROVIDER_ID" > "$CONFIG_PATH"
+printf '%s\n' "$PROVIDER_ID" > "$PROVIDER_ID_PATH"
+printf '{"address":"0xWALLET","rewards":"preserve-me"}\n' > "$WALLET_PATH"
+printf 'MODEL_WEIGHTS_DO_NOT_TOUCH' > "$MODEL_PATH"
+chmod 600 "$CONFIG_PATH" "$PROVIDER_ID_PATH" "$WALLET_PATH"
+
+# installer-inline watchdog on disk (identity target for quiesce)
+cp "$INLINE_WATCHDOG" "$WATCHDOG_PATH"; chmod 755 "$WATCHDOG_PATH"
+
+# both watchdog plists (current + legacy), owner-private
+for p in "$WATCHDOG_PLIST_BOOTSTRAP_PATH" "$LEGACY_WATCHDOG_PLIST_BOOTSTRAP_PATH"; do
+  printf '<plist><dict><key>Program</key><string>%s</string></dict></plist>\n' "$WATCHDOG_PATH" > "$p"
+  chmod 600 "$p"
+done
+
+# ingredient 3: stale pending marker + rollback backup binary (the #1228 trap)
+BIN_DIR="$SBX/.local/bin"
+NEW_BINARY="$BIN_DIR/macprovider-cli"
+ROLLBACK_UUID="123e4567-e89b-42d3-a456-426614174000"
+ROLLBACK_BACKUP="$BIN_DIR/.macprovider-cli.rollback-$ROLLBACK_UUID"
+printf 'REPAIRED_NEW_BINARY' > "$NEW_BINARY"
+printf 'OLD_STALE_BINARY'    > "$ROLLBACK_BACKUP"
+chmod 755 "$NEW_BINARY" "$ROLLBACK_BACKUP"
+ROLLBACK_HASH="$(shasum -a 256 "$ROLLBACK_BACKUP" | awk '{print $1}')"
+PENDING="$SBX/.local/share/macprovider/autoupdate/pending.json"
+cat > "$PENDING" <<EOF
+{"update_id":"$ROLLBACK_UUID","target_version":"1.8.10","target_path":"$NEW_BINARY","backup_path":"$ROLLBACK_BACKUP","size":16,"mode":493,"sha256":"$ROLLBACK_HASH","marker_deadline":"2000-01-01T00:00:00Z"}
+EOF
+
+# byte-level fingerprints of everything that MUST survive repair
+fingerprint() { shasum -a 256 "$CONFIG_PATH" "$PROVIDER_ID_PATH" "$WALLET_PATH" "$MODEL_PATH" | awk '{print $1}'; }
+IDENTITY_BEFORE="$(fingerprint)"
+
+INSTALL_DIR="$BIN_DIR"
+
+echo "== #1189 integrated reproduction =="
+
+# --- ingredient 4: the real HOME ACL barrier --------------------------------
+# Exactly the shape remediate_repair_home_write_acl recognizes.
+/bin/chmod +a "group:everyone deny delete" "$SBX" 2>/dev/null || true
+if ! /bin/chmod +a "group:everyone allow write,append" "$SBX" 2>/dev/null; then
+  echo "SKIP: cannot set test ACL on this filesystem" >&2
+  exit 0
+fi
+/bin/ls -lde "$SBX" | grep -q "everyone allow" || fail "ACL barrier did not apply"
+note "planted HOME ACL barrier + deny-delete (real filesystem ACL)"
+
+# ================= PHASE A: adversary is live, before repair =================
+# The stale watchdog runs while the pending/rollback trap is armed. It must
+# DEFER (not roll back), even with the ACL barrier present.
+# Fake launchctl resolved via PATH as `launchctl` (matching
+# watchdog_rollback_paths.test.sh). No MACPROVIDER_LAUNCHCTL override, so the
+# watchdog uses this fake and never the host launchd.
+mkdir -p "$TMP/wdbin"
+cat > "$TMP/wdbin/launchctl" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${MACPROVIDER_FAKE_LAUNCHCTL_LOG:-/dev/null}"
+case "${1:-}" in
+  list) printf -- '-\t0\tlive.malibu.provider-compatibility-reload\n' ;;
+  print) printf 'pid = 123\nlast exit status = 0\n' ;;
+  bootstrap|kickstart|bootout) exit 99 ;;
+esac
+EOF
+chmod +x "$TMP/wdbin/launchctl"
+
+# Fake `lsof`: the real #1189 provider process was up and healthy — only the
+# repair path (ACL/markers/stale watchdog label) was stuck. Reproduce that by
+# letting provider_process_pid() resolve the launchctl-reported pid to the
+# repaired binary, so the tick takes the "process is present" path instead of
+# the unrelated missing-process kickstart path (a different code path from the
+# #1228 rollback-deferral this phase exercises). No `port:` is set in the
+# sandbox config, so local_provider_health_ok() short-circuits before ever
+# needing a fake curl/health listener, and the watchdog's own "disarmed for
+# this boot" guard (fresh $STATE_DIR, no prior ARMED_FILE) exits clean without
+# any restart decision — so this does not launder a real health check.
+cat > "$TMP/wdbin/lsof" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+  *"-d txt -Fn"*) printf 'n%s\n' "${MACPROVIDER_FAKE_LSOF_TXT_PATH:?}" ;;
+  *) exit 1 ;;
+esac
+EOF
+chmod +x "$TMP/wdbin/lsof"
+
+run_watchdog() {
+  HOME="$SBX" \
+  MACPROVIDER_BINARY_PATH="$NEW_BINARY" \
+  MACPROVIDER_LOG_DIR="$SBX/logs" \
+  MACPROVIDER_FAKE_LAUNCHCTL_LOG="$TMP/wd-launchctl.log" \
+  MACPROVIDER_FAKE_LSOF_TXT_PATH="$NEW_BINARY" \
+  PATH="$TMP/wdbin:/usr/bin:/bin:/usr/sbin:/sbin" \
+  bash "$WATCHDOG_PATH" --reconcile-autoupdate
+}
+: > "$TMP/wd-launchctl.log"
+
+run_watchdog
+cmp -s "$NEW_BINARY"      <(printf 'REPAIRED_NEW_BINARY') || fail "A: watchdog rolled back the new binary"
+cmp -s "$ROLLBACK_BACKUP" <(printf 'OLD_STALE_BINARY')    || fail "A: watchdog mutated the rollback backup"
+[ -e "$PENDING" ] || fail "A: watchdog consumed the pending marker instead of deferring"
+grep -Fq "autoupdate recovery deferred: pending marker exists; transaction owner must resolve update/rollback state" "$SBX/logs/watchdog.log" \
+  || fail "A: watchdog did not log the #1228 deferral"
+if grep -Eq '(^| )(bootout|bootstrap|kickstart)( |$)' "$TMP/wd-launchctl.log"; then
+  fail "A: deferring watchdog must not touch launchctl"
+fi
+note "PHASE A: stale watchdog DEFERRED under the full trap (no rollback, marker preserved) — #1228"
+
+# ================= PHASE B: run the real repair preflight ====================
+quiesce_repair_watchdogs_for_transaction \
+  || fail "B: repair could not quiesce the watchdogs"
+grep -Fq "bootout $WATCHDOG_LABEL"        "$QUIESCE_LOG" || fail "B: current watchdog label not booted out"
+grep -Fq "bootout $LEGACY_WATCHDOG_LABEL" "$QUIESCE_LOG" || fail "B: legacy watchdog label not booted out"
+note "PHASE B1: quiesced BOTH current and legacy watchdog labels"
+
+remediate_repair_home_write_acl \
+  || fail "B: repair could not remediate the HOME ACL barrier"
+if /bin/ls -lde "$SBX" | grep -Eq "everyone allow (write|add_file)"; then
+  fail "B: HOME write ACL barrier survived remediation"
+fi
+note "PHASE B2: remediated the HOME ACL barrier (real chmod -a); write path restored"
+
+[ "$(fingerprint)" = "$IDENTITY_BEFORE" ] \
+  || fail "B: identity/config/wallet/model changed during repair preflight"
+note "PHASE B3: identity + config + wallet + model bytes UNCHANGED through preflight"
+
+# ================= PHASE C: post-repair undo-proof ==========================
+# A stale watchdog that wakes again after repair must not undo it.
+: > "$TMP/wd-launchctl.log"
+run_watchdog
+cmp -s "$NEW_BINARY"      <(printf 'REPAIRED_NEW_BINARY') || fail "C: post-repair watchdog reverted the repaired binary"
+cmp -s "$ROLLBACK_BACKUP" <(printf 'OLD_STALE_BINARY')    || fail "C: post-repair watchdog mutated the rollback backup"
+[ "$(fingerprint)" = "$IDENTITY_BEFORE" ] || fail "C: identity changed after post-repair watchdog tick"
+note "PHASE C: post-repair watchdog could NOT undo the repair — #1228 holds after cutover"
+
+echo "== #1189 integrated reproduction OK =="
+echo "NOTE: launchd is mocked here; real-launchd + DMG + live coordinator rejoin"
+echo "      remain a canary-Mac step (docs/runbooks/provider-repair-1189-e2e.md)."


### PR DESCRIPTION
## Summary

- Adds `phase3-binary/dist/test/repair_1189_reproduction.test.sh`: an
  integrated reproduction of the #1189 stranded-provider failure that stacks
  all four ingredients (stale watchdog under both current + legacy launchd
  labels, a stale pending-autoupdate/rollback marker, a real macOS HOME ACL
  write barrier, and full provider identity/config/wallet/model bytes) in
  ONE sandbox HOME, then runs the real extracted repair functions from
  `phase3-binary/dist/install.sh` and the real watchdog script
  (`ops/macprovider-watchdog/watchdog.sh`, launchd mocked via `PATH`) through
  pre-repair defer (#1228), repair preflight, and post-repair undo-proof
  phases.
- Wires the new test into `make test-dist` and into the `swift-tests`
  (`macos-15`) CI job so it actually executes with real assertions on PRs
  touching `phase3-binary/` (it SKIPs cleanly, exit 0, on non-Darwin, so its
  presence in `make test-dist` is inert on the Ubuntu `dist-tooling` job).
- Adds `docs/runbooks/provider-repair-1189-e2e.md` documenting the T1/T2/T3
  fidelity ladder: T1 is this sandbox test; T2 (follow-up, not built here) is
  a full `install.sh` transaction against a mock coordinator; T3 is the
  required canary-Mac run (real notarized DMG, real Malibu Repair button,
  real live-coordinator rejoin) that must pass before the real #1189
  provider is asked to run Repair.

## What this proves vs. does not prove

Proves (T1, this PR): the four #1189 ingredients compose correctly in one
sandbox HOME; the real repair functions quiesce both watchdog labels and
remediate the real ACL barrier together; provider identity/wallet/model bytes
survive the repair preflight untouched; the #1228 no-rollback guarantee holds
both before and after cutover under the full combined trap.

Does NOT prove: that the real notarized DMG / Malibu.app GUI Repair button
performs the same sequence; that real `launchd` (vs. the mocked `launchctl`)
behaves as assumed; that a real coordinator actually re-admits and routes to
the repaired provider. That is exactly the T3 canary-Mac gap documented in
the runbook, and it has not been run as part of this change.

## Test plan

- [x] `bash phase3-binary/dist/test/repair_1189_reproduction.test.sh` — PASS
      (all phases: A stale-watchdog-defers, B1 both-labels-quiesced, B2
      ACL-remediated, B3 identity-unchanged, C post-repair-undo-proof)
- [x] `bash phase3-binary/dist/test/provider_upgrade_transaction.test.sh` —
      PASS (no regression)
- [x] `bash phase3-binary/dist/test/watchdog_rollback_paths.test.sh` — PASS
      (no regression)
- [ ] T3 canary-Mac run (tracked in the new runbook; required before
      messaging the real #1189 provider, out of scope for this PR)

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R004"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "phase3-binary/dist/test/repair_1189_reproduction.test.sh",
    "phase3-binary/dist/test/provider_upgrade_transaction.test.sh",
    "phase3-binary/dist/test/watchdog_rollback_paths.test.sh"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
