### PR TITLE
Guard fresh-Mac installs against the python3 CLT stub (fixes the onboarding hang) — #1285

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,7 @@ test-dist:
 	bash scripts/test-tier2-enforcement-safety.sh
 	bash ops/pearl-updater/test_transaction_gate_systemd.sh
 	bash phase3-binary/dist/test/check_baked_static_feed_sync.test.sh
+	bash phase3-binary/dist/test/install_python3_clt_guard.test.sh
 	bash scripts/test-catalog-release.sh
 	bash scripts/test-autotune-gate-matrix.sh
 	bash -n phase4-coordinator/dist/deploy-pearl-vps.sh

--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,7 @@ test-dist:
 	bash ops/pearl-updater/test_transaction_gate_systemd.sh
 	bash phase3-binary/dist/test/check_baked_static_feed_sync.test.sh
 	bash phase3-binary/dist/test/install_python3_clt_guard.test.sh
+	bash phase3-binary/dist/test/install_1286_fresh_mac_e2e.test.sh
 	bash scripts/test-catalog-release.sh
 	bash scripts/test-autotune-gate-matrix.sh
 	bash -n phase4-coordinator/dist/deploy-pearl-vps.sh

--- a/phase3-binary/app/Sources/Malibu/Onboarding/CLIInstallRunner.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/CLIInstallRunner.swift
@@ -11,6 +11,7 @@ enum CLIInstallRunner {
         case referralFailure(ReferralFailure)
         case repairEvidenceMissing
         case bundledCLINotFound
+        case developerToolsRequired
         case nonZeroExit(Int32)
         case launchFailed(String)
 
@@ -52,6 +53,8 @@ enum CLIInstallRunner {
                 return "Provider software could not be verified for repair. Your provider identity was not changed."
             case .bundledCLINotFound:
                 return "Provider software for repair was not found in Malibu. Your provider identity was not changed."
+            case .developerToolsRequired:
+                return "This Mac needs Apple's Command Line Developer Tools to finish setup (they include python3). A system installer should have opened — click Install, wait for it to finish, then reopen Malibu."
             case let .nonZeroExit(code):
                 return "Provider software install failed (exit \(code)). Your provider identity was not changed."
             case .launchFailed(_):
@@ -69,6 +72,9 @@ enum CLIInstallRunner {
     ) -> Error? {
         if exitCode == 0 {
             return nil
+        }
+        if exitCode == 8 {
+            return Error.developerToolsRequired
         }
         if repairExistingInstall, exitCode == 20 || exitCode == 28 {
             return Error.repairEvidenceMissing

--- a/phase3-binary/app/Tests/MalibuTests/ReferralOnboardingTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/ReferralOnboardingTests.swift
@@ -250,6 +250,25 @@ final class ReferralOnboardingTests: XCTestCase {
         XCTAssertNil(CLIInstallRunner.classifiedInstallError(exitCode: 0, repairExistingInstall: true))
     }
 
+    func testExit8MapsToDeveloperToolsRequiredNotInvite() {
+        // install.sh die 8 = missing/unusable Command Line Developer Tools (python3
+        // CLT stub). It must surface an actionable "install developer tools" message,
+        // never the invite-required copy, in both new-join and repair flows. (#1285/#1286)
+        for repair in [false, true] {
+            switch CLIInstallRunner.classifiedInstallError(exitCode: 8, repairExistingInstall: repair) {
+            case .developerToolsRequired?:
+                break
+            default:
+                XCTFail("exit 8 must map to developerToolsRequired (repair=\(repair))")
+            }
+        }
+        let description = CLIInstallRunner.Error.developerToolsRequired.errorDescription ?? ""
+        XCTAssertTrue(
+            description.localizedCaseInsensitiveContains("Developer Tools"),
+            "developerToolsRequired message must name the Command Line Developer Tools"
+        )
+    }
+
     func testInstallerEnvironmentCarriesManifestSelectedInstallDirectory() throws {
         let home = FileManager.default.temporaryDirectory
             .appendingPathComponent("installer-custom-home-\(UUID().uuidString)")

--- a/phase3-binary/dist/install.sh
+++ b/phase3-binary/dist/install.sh
@@ -7232,19 +7232,37 @@ require_tool() {
 # with a hard time budget so a BROKEN or BLOCKING interpreter (e.g. a hung shim
 # earlier in PATH, or a python3 with a missing dylib) fails fast with die 8
 # instead of hanging the whole install at the first real python3 call. macOS has
-# no GNU `timeout`, so enforce the budget with a background job + kill. Returns 0
-# only if python3 exits 0 within the budget; non-zero on failure/crash; 124 on
-# timeout. (#1286)
+# no GNU `timeout`, so enforce the budget with a background job + kill.
+#
+# CRITICAL: probe with the SAME stdin-script style the installer actually uses
+# (`python3 - ...` fed a heredoc, e.g. validate_install_dir at the first real
+# call), NOT `python3 -c`. A shim can exit 0 for `-c` yet block reading stdin on
+# `python3 -`, which would let the probe pass and the installer still hang. (#1286)
+# Returns 0 only if python3 exits 0 within the budget; non-zero on failure/crash;
+# 124 on timeout.
 _python3_runs_quickly() {
-  local py="$1" budget="${MACPROVIDER_PY_PROBE_BUDGET:-8}" waited=0 pid
-  "$py" -c 'import sys; sys.exit(0)' >/dev/null 2>&1 &
+  local py="$1" budget waited=0 pid
+  # Validate/clamp the (normally-unset) budget override so a bogus or huge value
+  # can't defeat the "fast" guarantee.
+  budget="${MACPROVIDER_PY_PROBE_BUDGET:-8}"
+  case "$budget" in ''|*[!0-9]*) budget=8 ;; esac
+  [ "$budget" -ge 1 ] 2>/dev/null || budget=8
+  [ "$budget" -le 60 ] 2>/dev/null || budget=60
+  "$py" - >/dev/null 2>&1 <<'PYEOF' &
+import sys
+sys.exit(0)
+PYEOF
   pid=$!
   while kill -0 "$pid" 2>/dev/null; do
     sleep 1
     waited=$((waited + 1))
     [ "$waited" -lt "$budget" ] && continue
+    # Reap the interpreter AND any children it spawned (e.g. a shim's `sleep`),
+    # so a wedged probe leaves nothing behind.
+    pkill -P "$pid" 2>/dev/null || true
     kill -TERM "$pid" 2>/dev/null || true
     sleep 1
+    pkill -KILL -P "$pid" 2>/dev/null || true
     kill -KILL "$pid" 2>/dev/null || true
     wait "$pid" 2>/dev/null || true
     return 124

--- a/phase3-binary/dist/install.sh
+++ b/phase3-binary/dist/install.sh
@@ -7229,7 +7229,7 @@ require_tool() {
 # installer for the user (consumer/GUI only), and exit fast with a dedicated,
 # actionable code the app surfaces as a clear message. (#1285)
 ensure_python3_usable() {
-  local py
+  local py devdir
   py="$(command -v python3 2>/dev/null || true)"
   # Only /usr/bin/python3 is the CLT stub. A python3 anywhere else (Homebrew,
   # python.org, an active CLT/Xcode toolchain) is real and safe to use.
@@ -7237,9 +7237,15 @@ ensure_python3_usable() {
     [ -n "$py" ] || die 8 "This Mac is missing python3, which provider setup requires. Install Apple's Command Line Developer Tools (or Xcode), then try again."
     return 0
   fi
-  # /usr/bin/python3 present. If an active developer toolchain is selected, the
-  # stub resolves to a real python3 and works. If not, it is the bare stub.
-  if xcode-select -p >/dev/null 2>&1; then
+  # /usr/bin/python3 present. It resolves to a real python3 ONLY if a developer
+  # directory is selected AND that directory actually still contains a working
+  # python3. `xcode-select -p` alone is not enough: it just prints the selected
+  # path, which can be stale/removed, so its success would let a dangling stub
+  # through to the first real python3 call and hang. Verify the resolved tool
+  # exists and is executable — without invoking the stub (which is what triggers
+  # the CLT install dialog). (#1285/#1286)
+  devdir="$(xcode-select -p 2>/dev/null || true)"
+  if [ -n "$devdir" ] && [ -x "$devdir/usr/bin/python3" ]; then
     return 0
   fi
   if [ "${HEADLESS:-0}" != "1" ]; then

--- a/phase3-binary/dist/install.sh
+++ b/phase3-binary/dist/install.sh
@@ -12568,11 +12568,14 @@ main() {
   validate_repair_privilege_domain
   validate_headless_acceptance_source
   validate_port_value "$PORT"
-  for tool in curl tar shasum grep sed awk date hostname mktemp openssl find python3 lsof cmp diff readlink ps; do
+  for tool in curl tar shasum grep sed awk date hostname mktemp openssl find lsof cmp diff readlink ps; do
     require_tool "$tool"
   done
-  # python3 needs a functional check beyond command -v: on a stock Mac the CLT
-  # stub passes command -v but hangs the first real invocation. (#1285)
+  # python3 is intentionally NOT in the generic require_tool loop: on a stock Mac
+  # the only python3 is the CLT stub, which passes command -v but hangs the first
+  # real invocation, and a Mac with no python3 at all must surface the same
+  # actionable die 8 (not a generic "missing required tool: python3" exit 2).
+  # ensure_python3_usable is the sole authority for python3 presence+usability. (#1285)
   ensure_python3_usable
   validate_install_dir
   remediate_repair_home_write_acl

--- a/phase3-binary/dist/install.sh
+++ b/phase3-binary/dist/install.sh
@@ -7219,6 +7219,38 @@ require_tool() {
   command -v "$1" >/dev/null 2>&1 || die 2 "missing required tool: $1"
 }
 
+# The installer relies on python3 in dozens of places. On a stock, non-developer
+# Mac `command -v python3` still succeeds because /usr/bin/python3 exists as an
+# Xcode Command Line Tools *stub*. Invoking that stub triggers the OS
+# "Install Command Line Developer Tools" dialog, which appears BEHIND the Malibu
+# window and blocks the installer indefinitely (looks like a hang at
+# "Starting installer"). Detect the non-functional stub WITHOUT invoking it
+# (xcode-select -p does not trigger the install prompt), kick off the CLT
+# installer for the user (consumer/GUI only), and exit fast with a dedicated,
+# actionable code the app surfaces as a clear message. (#1285)
+ensure_python3_usable() {
+  local py
+  py="$(command -v python3 2>/dev/null || true)"
+  # Only /usr/bin/python3 is the CLT stub. A python3 anywhere else (Homebrew,
+  # python.org, an active CLT/Xcode toolchain) is real and safe to use.
+  if [ "$py" != "/usr/bin/python3" ]; then
+    [ -n "$py" ] || die 8 "This Mac is missing python3, which provider setup requires. Install Apple's Command Line Developer Tools (or Xcode), then try again."
+    return 0
+  fi
+  # /usr/bin/python3 present. If an active developer toolchain is selected, the
+  # stub resolves to a real python3 and works. If not, it is the bare stub.
+  if xcode-select -p >/dev/null 2>&1; then
+    return 0
+  fi
+  if [ "${HEADLESS:-0}" != "1" ]; then
+    # Best-effort: open the GUI Command Line Tools installer for the user. This
+    # is what the stub would have triggered, but now visibly and up front.
+    xcode-select --install >/dev/null 2>&1 || true
+    die 8 "This Mac needs Apple's Command Line Developer Tools to finish provider setup (they include python3). A system installer has been opened — click Install, wait for it to finish, then reopen Malibu."
+  fi
+  die 8 "This Mac is missing Apple's Command Line Developer Tools, which provider setup requires (they include python3). Install them with: xcode-select --install, then re-run the installer."
+}
+
 read_line() {
   REPLY=""
   # In curl-pipe-bash invocations, /dev/tty often exists as a character
@@ -12533,6 +12565,9 @@ main() {
   for tool in curl tar shasum grep sed awk date hostname mktemp openssl find python3 lsof cmp diff readlink ps; do
     require_tool "$tool"
   done
+  # python3 needs a functional check beyond command -v: on a stock Mac the CLT
+  # stub passes command -v but hangs the first real invocation. (#1285)
+  ensure_python3_usable
   validate_install_dir
   remediate_repair_home_write_acl
   repair_autoupdate_recovery_preflight

--- a/phase3-binary/dist/install.sh
+++ b/phase3-binary/dist/install.sh
@@ -7228,33 +7228,72 @@ require_tool() {
 # (xcode-select -p does not trigger the install prompt), kick off the CLT
 # installer for the user (consumer/GUI only), and exit fast with a dedicated,
 # actionable code the app surfaces as a clear message. (#1285)
+# Bounded "does this python3 actually run?" probe. Executes a trivial program
+# with a hard time budget so a BROKEN or BLOCKING interpreter (e.g. a hung shim
+# earlier in PATH, or a python3 with a missing dylib) fails fast with die 8
+# instead of hanging the whole install at the first real python3 call. macOS has
+# no GNU `timeout`, so enforce the budget with a background job + kill. Returns 0
+# only if python3 exits 0 within the budget; non-zero on failure/crash; 124 on
+# timeout. (#1286)
+_python3_runs_quickly() {
+  local py="$1" budget="${MACPROVIDER_PY_PROBE_BUDGET:-8}" waited=0 pid
+  "$py" -c 'import sys; sys.exit(0)' >/dev/null 2>&1 &
+  pid=$!
+  while kill -0 "$pid" 2>/dev/null; do
+    sleep 1
+    waited=$((waited + 1))
+    [ "$waited" -lt "$budget" ] && continue
+    kill -TERM "$pid" 2>/dev/null || true
+    sleep 1
+    kill -KILL "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+    return 124
+  done
+  wait "$pid"
+}
+
+# Confirm one python3 path is present AND genuinely usable, or die 8. For the CLT
+# stub at /usr/bin/python3 we must NOT execute it blindly (that pops the hidden
+# "Install Command Line Developer Tools" dialog and hangs), so we first prove the
+# selected developer directory actually contains a real python3; only then is it
+# safe to probe. Any other python3 is a real interpreter path we probe directly —
+# presence via `command -v` is not enough, since a broken/blocking python3 would
+# otherwise sail through and hang the next real call. (#1285/#1286)
+_python3_usable_or_die() {
+  local py="$1" ctx="$2" devdir
+  [ -n "$py" ] || die 8 "This Mac is missing python3, which provider setup requires ($ctx). Install Apple's Command Line Developer Tools (xcode-select --install) or a working python3, then try again."
+  if [ "$py" = "/usr/bin/python3" ]; then
+    # `xcode-select -p` only prints the selected path (no install prompt) and can
+    # be stale/removed, so require the resolved tool to actually exist+execute
+    # before we dare run /usr/bin/python3.
+    devdir="$(xcode-select -p 2>/dev/null || true)"
+    if [ -z "$devdir" ] || [ ! -x "$devdir/usr/bin/python3" ]; then
+      if [ "${HEADLESS:-0}" != "1" ]; then
+        # Best-effort: open the GUI Command Line Tools installer for the user.
+        xcode-select --install >/dev/null 2>&1 || true
+        die 8 "This Mac needs Apple's Command Line Developer Tools to finish provider setup (they include python3). A system installer has been opened — click Install, wait for it to finish, then reopen Malibu."
+      fi
+      die 8 "This Mac is missing Apple's Command Line Developer Tools, which provider setup requires (they include python3). Install them with: xcode-select --install, then re-run the installer."
+    fi
+    # CLT is selected and backed by a real python3 -> /usr/bin/python3 delegates
+    # to it and is safe to probe below.
+  fi
+  _python3_runs_quickly "$py" \
+    || die 8 "This Mac's python3 ($py) is present but did not run correctly ($ctx) — it may be broken or a stub. Install Apple's Command Line Developer Tools (xcode-select --install) or a working python3, then try again."
+}
+
 ensure_python3_usable() {
-  local py devdir
-  py="$(command -v python3 2>/dev/null || true)"
-  # Only /usr/bin/python3 is the CLT stub. A python3 anywhere else (Homebrew,
-  # python.org, an active CLT/Xcode toolchain) is real and safe to use.
-  if [ "$py" != "/usr/bin/python3" ]; then
-    [ -n "$py" ] || die 8 "This Mac is missing python3, which provider setup requires. Install Apple's Command Line Developer Tools (or Xcode), then try again."
-    return 0
+  # (1) The interpreter that user-context python3 calls resolve to (the first is
+  # validate_install_dir, immediately after this guard).
+  _python3_usable_or_die "$(command -v python3 2>/dev/null || true)" "user interpreter"
+  # (2) In headless mode, privileged root helpers ALWAYS run ROOT_PYTHON3_BIN
+  # (/usr/bin/python3) under sudo. When the resolved user interpreter is a
+  # different python3 (e.g. Homebrew), the check above does NOT prove the system
+  # interpreter is usable, so validate it independently. (#1286 MEDIUM)
+  if [ "${HEADLESS:-0}" = "1" ] \
+     && [ "$(command -v python3 2>/dev/null || true)" != "${ROOT_PYTHON3_BIN:-/usr/bin/python3}" ]; then
+    _python3_usable_or_die "${ROOT_PYTHON3_BIN:-/usr/bin/python3}" "system root interpreter"
   fi
-  # /usr/bin/python3 present. It resolves to a real python3 ONLY if a developer
-  # directory is selected AND that directory actually still contains a working
-  # python3. `xcode-select -p` alone is not enough: it just prints the selected
-  # path, which can be stale/removed, so its success would let a dangling stub
-  # through to the first real python3 call and hang. Verify the resolved tool
-  # exists and is executable — without invoking the stub (which is what triggers
-  # the CLT install dialog). (#1285/#1286)
-  devdir="$(xcode-select -p 2>/dev/null || true)"
-  if [ -n "$devdir" ] && [ -x "$devdir/usr/bin/python3" ]; then
-    return 0
-  fi
-  if [ "${HEADLESS:-0}" != "1" ]; then
-    # Best-effort: open the GUI Command Line Tools installer for the user. This
-    # is what the stub would have triggered, but now visibly and up front.
-    xcode-select --install >/dev/null 2>&1 || true
-    die 8 "This Mac needs Apple's Command Line Developer Tools to finish provider setup (they include python3). A system installer has been opened — click Install, wait for it to finish, then reopen Malibu."
-  fi
-  die 8 "This Mac is missing Apple's Command Line Developer Tools, which provider setup requires (they include python3). Install them with: xcode-select --install, then re-run the installer."
 }
 
 read_line() {

--- a/phase3-binary/dist/test/install_1286_fresh_mac_e2e.test.sh
+++ b/phase3-binary/dist/test/install_1286_fresh_mac_e2e.test.sh
@@ -64,5 +64,21 @@ r="$(run_installer "$INSTALL_SH" "$TMP/cltbin" 25)"
 [ "$r" = "EXIT:0" ] || { echo "FAIL: healthy Mac should complete dry-run (EXIT:0), got '$r'"; tail -5 "$TMP/out.log"; exit 1; }
 pass "healthy Mac (real python3 + CLT) proceeds normally — no false positive"
 
+# 4) HIGH (final-audit reproduction) — a BLOCKING non-system python3 earlier in
+#    PATH must make the CURRENT guarded installer EXIT:8 (bounded probe), NOT hang.
+#    This is the public-shell-installer bypass the security lane reproduced.
+mkdir -p "$TMP/blockbin"
+cp "$TMP/cltbin/xcode-select" "$TMP/blockbin/xcode-select"   # CLT present, irrelevant: python3 resolves here first
+cat > "$TMP/blockbin/python3" <<'EOF'
+#!/usr/bin/env bash
+sleep 3600
+EOF
+chmod +x "$TMP/blockbin/python3"
+export MACPROVIDER_PY_PROBE_BUDGET=3
+r="$(run_installer "$INSTALL_SH" "$TMP/blockbin" 12)"
+unset MACPROVIDER_PY_PROBE_BUDGET
+[ "$r" = "EXIT:8" ] || { echo "FAIL: blocking non-system python3 should EXIT:8 (bounded probe), got '$r'"; tail -5 "$TMP/out.log"; exit 1; }
+pass "blocking non-system python3 in PATH -> fast EXIT:8, no hang (public-installer bypass closed)"
+
 echo "== #1286 fresh-Mac e2e OK =="
 echo "NOTE: real notarized DMG + Malibu.app GUI on a genuinely CLT-free Mac/VM is the T3 canary before messaging providers; a sandbox cannot run the app bundle."

--- a/phase3-binary/dist/test/install_1286_fresh_mac_e2e.test.sh
+++ b/phase3-binary/dist/test/install_1286_fresh_mac_e2e.test.sh
@@ -14,10 +14,12 @@ pass(){ printf '  \342\234\223 %s\n' "$*"; }
 # echoes "EXIT:<code>" or "HANG" — never blocks the suite.
 run_installer() {  # $1=script  $2=extra PATH prefix  $3=timeout_s ; rest via env already set
   local script="$1" pathpref="$2" t="$3" home; home="$(mktemp -d)"
-  ( HOME="$home" MACPROVIDER_PORT=8899 PATH="$pathpref:/usr/bin:/bin:/usr/sbin:/sbin" \
+  ( set -m   # own process group per run so a HANG can be reaped whole (no orphan shims)
+    HOME="$home" MACPROVIDER_PORT=8899 PATH="$pathpref:/usr/bin:/bin:/usr/sbin:/sbin" \
       bash -s -- --dry-run < "$script" > "$TMP/out.log" 2>&1 & p=$!
     for _ in $(seq 1 "$t"); do kill -0 $p 2>/dev/null || break; sleep 1; done
-    if kill -0 $p 2>/dev/null; then echo HANG; kill -9 $p 2>/dev/null; else wait $p; echo "EXIT:$?"; fi )
+    if kill -0 $p 2>/dev/null; then echo HANG; kill -9 -"$p" 2>/dev/null || kill -9 "$p" 2>/dev/null
+    else wait $p; echo "EXIT:$?"; fi ) 2>/dev/null
 }
 
 # ---- Fresh-Mac simulation: no CLT. xcode-select -p fails; python3 resolves to
@@ -69,9 +71,11 @@ pass "healthy Mac (real python3 + CLT) proceeds normally — no false positive"
 #    This is the public-shell-installer bypass the security lane reproduced.
 mkdir -p "$TMP/blockbin"
 cp "$TMP/cltbin/xcode-select" "$TMP/blockbin/xcode-select"   # CLT present, irrelevant: python3 resolves here first
+# Adversarial shim: fast for `-c`, BLOCKS on `-` (stdin script mode the installer
+# actually uses). A naive `-c` probe would pass this and the installer would hang.
 cat > "$TMP/blockbin/python3" <<'EOF'
 #!/usr/bin/env bash
-sleep 3600
+case "${1:-}" in -c) exit 0 ;; *) sleep 3600 ;; esac
 EOF
 chmod +x "$TMP/blockbin/python3"
 export MACPROVIDER_PY_PROBE_BUDGET=3

--- a/phase3-binary/dist/test/install_1286_fresh_mac_e2e.test.sh
+++ b/phase3-binary/dist/test/install_1286_fresh_mac_e2e.test.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# End-to-end proof for #1286: on a fresh, non-developer Mac (python3 is only the
+# /usr/bin/python3 Command Line Tools stub, no CLT installed), the installer must
+# FAIL FAST with an actionable error instead of hanging on the hidden CLT dialog.
+# Drives install.sh exactly as Malibu does: `bash -s -- <flags>` fed on stdin.
+set -euo pipefail
+[ "$(uname -s)" = "Darwin" ] || { echo "SKIP: macOS only" >&2; exit 0; }
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+INSTALL_SH="$REPO_ROOT/phase3-binary/dist/install.sh"
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+pass(){ printf '  \342\234\223 %s\n' "$*"; }
+
+# run install.sh via bash -s (app's exact method) with a hard kill-timer.
+# echoes "EXIT:<code>" or "HANG" — never blocks the suite.
+run_installer() {  # $1=script  $2=extra PATH prefix  $3=timeout_s ; rest via env already set
+  local script="$1" pathpref="$2" t="$3" home; home="$(mktemp -d)"
+  ( HOME="$home" MACPROVIDER_PORT=8899 PATH="$pathpref:/usr/bin:/bin:/usr/sbin:/sbin" \
+      bash -s -- --dry-run < "$script" > "$TMP/out.log" 2>&1 & p=$!
+    for _ in $(seq 1 "$t"); do kill -0 $p 2>/dev/null || break; sleep 1; done
+    if kill -0 $p 2>/dev/null; then echo HANG; kill -9 $p 2>/dev/null; else wait $p; echo "EXIT:$?"; fi )
+}
+
+# ---- Fresh-Mac simulation: no CLT. xcode-select -p fails; python3 resolves to
+# ---- /usr/bin/python3 (exactly where the real CLT stub lives). ----
+mkdir -p "$TMP/nocltbin"
+cat > "$TMP/nocltbin/xcode-select" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in -p|--print-path) echo "xcode-select: error: no developer tools" >&2; exit 2;;
+  --install) exit 0;; *) exit 0;; esac
+EOF
+chmod +x "$TMP/nocltbin/xcode-select"
+
+echo "== #1286 fresh-Mac (no-CLT) e2e =="
+
+# 1) WITH the guard (this branch): must exit 8 fast, NOT hang, with the message.
+r="$(run_installer "$INSTALL_SH" "$TMP/nocltbin" 12)"
+[ "$r" = "EXIT:8" ] || { echo "FAIL: expected fast EXIT:8, got '$r'"; tail -5 "$TMP/out.log"; exit 1; }
+grep -qiE "Command Line Developer Tools" "$TMP/out.log" || { echo "FAIL: missing actionable CLT message"; tail -5 "$TMP/out.log"; exit 1; }
+pass "guarded installer FAILS FAST (exit 8, ~instant) with actionable CLT message — no hang"
+
+# 2) COUNTERFACTUAL — old installer (origin/main, pre-guard) with a BLOCKING
+#    python3 stub HANGS. Proves the guard fixes a real hang.
+git -C "$REPO_ROOT" show origin/main:phase3-binary/dist/install.sh > "$TMP/old-install.sh"
+mkdir -p "$TMP/hangbin"
+cp "$TMP/nocltbin/xcode-select" "$TMP/hangbin/xcode-select"
+cat > "$TMP/hangbin/python3" <<'EOF'
+#!/usr/bin/env bash
+# Simulate the CLT stub blocking on the hidden install dialog.
+sleep 3600
+EOF
+chmod +x "$TMP/hangbin/python3"
+r="$(run_installer "$TMP/old-install.sh" "$TMP/hangbin" 8)"
+[ "$r" = "HANG" ] || { echo "FAIL: expected OLD installer to HANG on blocking python3, got '$r'"; exit 1; }
+pass "pre-guard installer HANGS on a blocking python3 stub (the real bug) — guard prevents it"
+
+# 3) NO FALSE POSITIVE — real python3 + CLT present: installer proceeds (dry-run).
+mkdir -p "$TMP/cltbin"
+cat > "$TMP/cltbin/xcode-select" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in -p|--print-path) echo "/Library/Developer/CommandLineTools"; exit 0;; *) exit 0;; esac
+EOF
+chmod +x "$TMP/cltbin/xcode-select"
+r="$(run_installer "$INSTALL_SH" "$TMP/cltbin" 25)"
+[ "$r" = "EXIT:0" ] || { echo "FAIL: healthy Mac should complete dry-run (EXIT:0), got '$r'"; tail -5 "$TMP/out.log"; exit 1; }
+pass "healthy Mac (real python3 + CLT) proceeds normally — no false positive"
+
+echo "== #1286 fresh-Mac e2e OK =="
+echo "NOTE: real notarized DMG + Malibu.app GUI on a genuinely CLT-free Mac/VM is the T3 canary before messaging providers; a sandbox cannot run the app bundle."

--- a/phase3-binary/dist/test/install_python3_clt_guard.test.sh
+++ b/phase3-binary/dist/test/install_python3_clt_guard.test.sh
@@ -1,29 +1,46 @@
 #!/usr/bin/env bash
-# Verifies the #1285/#1286 python3/CLT-stub guard: a stock Mac whose only python3
-# is the non-functional Command Line Tools stub must FAIL FAST with exit 8
-# (mapped by Malibu to an actionable "install developer tools" message) instead
-# of hanging on the hidden CLT install dialog — and must NOT block a Mac that has
-# a real, working python3.
+# Verifies the #1285/#1286 python3/CLT guard. A stock Mac whose only python3 is
+# the non-functional Command Line Tools stub, OR a Mac whose python3 is broken or
+# blocking (e.g. a hung shim earlier in PATH — the public-installer bypass the
+# final audit reproduced), must FAIL FAST with exit 8 (mapped by Malibu to an
+# actionable "install developer tools" message) instead of hanging. A Mac with a
+# real, working python3 must NOT be blocked. In headless mode the system root
+# interpreter (/usr/bin/python3, run as root) must also be proven usable.
 set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 INSTALL_SH="$REPO_ROOT/phase3-binary/dist/install.sh"
 TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
 
-awk '/^ensure_python3_usable\(\)/{i=1} i{print} i&&/^}$/{exit}' "$INSTALL_SH" > "$TMP/guard.sh"
-[ -s "$TMP/guard.sh" ] || { echo "could not extract ensure_python3_usable" >&2; exit 1; }
+# Extract all three guard functions (probe + per-interpreter check + entrypoint).
+awk '/^_python3_runs_quickly\(\)/{cap=1}
+     cap{print}
+     /^ensure_python3_usable\(\)/{inlast=1}
+     cap && inlast && /^}$/{exit}' "$INSTALL_SH" > "$TMP/guard.sh"
+grep -q '^_python3_runs_quickly()' "$TMP/guard.sh" || { echo "could not extract _python3_runs_quickly" >&2; exit 1; }
+grep -q '^ensure_python3_usable()' "$TMP/guard.sh" || { echo "could not extract ensure_python3_usable" >&2; exit 1; }
 printf 'die() { echo "DIE:$1"; exit "$1"; }\n' >> "$TMP/guard.sh"
+
+# Real executable python3 shims the probe can actually run.
+GOOD="$TMP/good-python3"; printf '#!/bin/sh\nexit 0\n' > "$GOOD"; chmod +x "$GOOD"
+BROKEN="$TMP/broken-python3"; printf '#!/bin/sh\nexit 1\n' > "$BROKEN"; chmod +x "$BROKEN"
+BLOCK="$TMP/blocking-python3"; printf '#!/bin/sh\nsleep 3600\n' > "$BLOCK"; chmod +x "$BLOCK"
 
 # A real developer dir that actually contains an executable python3.
 DEVDIR="$TMP/devdir"; mkdir -p "$DEVDIR/usr/bin"
-printf '#!/bin/sh\n' > "$DEVDIR/usr/bin/python3"; chmod +x "$DEVDIR/usr/bin/python3"
+printf '#!/bin/sh\nexit 0\n' > "$DEVDIR/usr/bin/python3"; chmod +x "$DEVDIR/usr/bin/python3"
 
-# run_guard <py-path> <xcodeselect-p-output-or-empty> <xcodeselect-p-rc> [HEADLESS]
-# Echoes the guard's outcome: "OK" (returned 0) or "DIE:<code>".
+expect() { # <label> <actual> <expected>
+  [ "$2" = "$3" ] || { echo "$1: expected '$3', got '$2'" >&2; exit 1; }
+}
+
+# ── Part 1: path / CLT gating (probe stubbed OK to isolate the branch logic) ──
+# run_guard <py-path> <xcodeselect-p-output> <xcodeselect-p-rc> [HEADLESS] [ROOT_PY]
 run_guard() {
-  local pypath="$1" xp_out="$2" xp_rc="$3" hl="${4:-0}"
+  local pypath="$1" xp_out="$2" xp_rc="$3" hl="${4:-0}" rootpy="${5:-/usr/bin/python3}"
   (
     set +e
     source "$TMP/guard.sh"
+    _python3_runs_quickly() { return 0; }   # isolate gating from execution
     command() { if [ "${1:-}" = "-v" ] && [ "${2:-}" = "python3" ]; then printf '%s\n' "$pypath"; return 0; fi; builtin command "$@"; }
     xcode-select() {
       case "${1:-}" in
@@ -32,38 +49,59 @@ run_guard() {
         *) return 0 ;;
       esac
     }
-    HEADLESS="$hl"
+    HEADLESS="$hl"; ROOT_PYTHON3_BIN="$rootpy"
     ensure_python3_usable && echo "OK"
   )
 }
 
-expect() { # <label> <actual> <expected>
-  [ "$2" = "$3" ] || { echo "$1: expected '$3', got '$2'" >&2; exit 1; }
-}
-
-# A) real python3 elsewhere (Homebrew/python.org) -> accepted
-expect "A real-python3" "$(run_guard /opt/homebrew/bin/python3 "" 0)" "OK"
-
-# B) /usr/bin/python3 stub + NO developer dir selected -> die 8
-expect "B stub-no-CLT" "$(run_guard /usr/bin/python3 "" 2 1)" "DIE:8"
-
-# C) /usr/bin/python3 + a developer dir that actually contains python3 -> accepted
-expect "C CLT-backed" "$(run_guard /usr/bin/python3 "$DEVDIR" 0)" "OK"
-
-# D) /usr/bin/python3 + STALE developer dir (selected path has no python3) -> die 8
-expect "D stale-devdir" "$(run_guard /usr/bin/python3 "$TMP/gone-devdir" 0 1)" "DIE:8"
-
+# A) real python3 elsewhere -> accepted
+expect "A real-python3"      "$(run_guard "$GOOD" "" 0)"          "OK"
+# B) /usr/bin/python3 stub + NO developer dir -> die 8
+expect "B stub-no-CLT"       "$(run_guard /usr/bin/python3 "" 2 1)" "DIE:8"
+# C) /usr/bin/python3 + valid developer dir -> accepted
+expect "C CLT-backed"        "$(run_guard /usr/bin/python3 "$DEVDIR" 0)" "OK"
+# D) /usr/bin/python3 + STALE developer dir -> die 8
+expect "D stale-devdir"      "$(run_guard /usr/bin/python3 "$TMP/gone-devdir" 0 1)" "DIE:8"
 # E) no python3 at all -> die 8
-expect "E no-python3" "$(run_guard "" "" 2 1)" "DIE:8"
+expect "E no-python3"        "$(run_guard "" "" 2 1)"             "DIE:8"
 
-# F) main() calls the guard before the first python3 user (validate_install_dir)
-grep -Eq 'ensure_python3_usable' "$INSTALL_SH" || { echo "F: guard not wired into installer" >&2; exit 1; }
+# ── Part 2: the real bounded probe (good / broken / blocking) ────────────────
+probe_rc() { ( set +e; source "$TMP/guard.sh"; MACPROVIDER_PY_PROBE_BUDGET=2 _python3_runs_quickly "$1" 2>/dev/null; echo $? ) ; }
+expect "P good-exec"     "$(probe_rc "$GOOD")"   "0"
+expect "P broken-exec"   "$(probe_rc "$BROKEN")" "1"
+expect "P blocking-exec" "$(probe_rc "$BLOCK")"  "124"   # times out, not hangs
+
+# ── Part 3: HIGH — a blocking non-system python3 dies 8 (does NOT hang) ───────
+run_guard_probe() { # <py-path> [HEADLESS] [ROOT_PY]  (real probe, small budget)
+  local pypath="$1" hl="${2:-0}" rootpy="${3:-/usr/bin/python3}"
+  (
+    set +e
+    source "$TMP/guard.sh"
+    command() { if [ "${1:-}" = "-v" ] && [ "${2:-}" = "python3" ]; then printf '%s\n' "$pypath"; return 0; fi; builtin command "$@"; }
+    xcode-select() { case "${1:-}" in --install) return 0;; *) return 0;; esac; }
+    MACPROVIDER_PY_PROBE_BUDGET=2; HEADLESS="$hl"; ROOT_PYTHON3_BIN="$rootpy"
+    ensure_python3_usable 2>/dev/null && echo "OK"
+  )
+}
+expect "H1 blocking-nonsystem" "$(run_guard_probe "$BLOCK")" "DIE:8"
+expect "H2 good-nonsystem"     "$(run_guard_probe "$GOOD")"  "OK"
+
+# ── Part 4: MEDIUM — headless root interpreter validated independently ────────
+# User python3 is a good non-system interpreter, but the system root interpreter
+# (ROOT_PYTHON3_BIN) is blocking -> die 8 (would otherwise wedge root helpers).
+expect "M1 headless-root-blocking" "$(run_guard_probe "$GOOD" 1 "$BLOCK")" "DIE:8"
+expect "M2 headless-root-good"     "$(run_guard_probe "$GOOD" 1 "$GOOD")"  "OK"
+
+# ── Part 5: ordering — guard runs before validate_install_dir (first python3) ─
+grep -Eq 'ensure_python3_usable' "$INSTALL_SH" || { echo "guard not wired into installer" >&2; exit 1; }
 python3 - "$INSTALL_SH" <<'PY'
 import sys
 s = open(sys.argv[1]).read()
 main = s[s.rindex("\nmain() {"):]
 assert main.index("ensure_python3_usable") < main.index("validate_install_dir"), \
     "guard must run before validate_install_dir (first python3 user)"
+assert "python3" not in main[main.index("for tool in"):main.index("done", main.index("for tool in"))], \
+    "python3 must not be in the generic require_tool loop"
 print("order ok")
 PY
 

--- a/phase3-binary/dist/test/install_python3_clt_guard.test.sh
+++ b/phase3-binary/dist/test/install_python3_clt_guard.test.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Verifies the #1285 python3/CLT-stub guard: a stock Mac whose only python3 is
+# the non-functional Command Line Tools stub must FAIL FAST with exit 8 (mapped
+# by Malibu to an actionable "install developer tools" message) instead of
+# hanging on the hidden CLT install dialog.
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+INSTALL_SH="$REPO_ROOT/phase3-binary/dist/install.sh"
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+
+awk '/^ensure_python3_usable\(\)/{i=1} i{print} i&&/^}$/{exit}' "$INSTALL_SH" > "$TMP/guard.sh"
+[ -s "$TMP/guard.sh" ] || { echo "could not extract ensure_python3_usable" >&2; exit 1; }
+printf 'die() { echo "DIE:$1"; exit "$1"; }\n' >> "$TMP/guard.sh"
+
+# A) real python3 elsewhere (Homebrew/python.org) -> accepted, no die
+out="$(
+  source "$TMP/guard.sh"
+  command() { if [ "${1:-}" = "-v" ] && [ "${2:-}" = "python3" ]; then echo /opt/homebrew/bin/python3; return 0; fi; builtin command "$@"; }
+  ensure_python3_usable && echo "OK"
+)"
+[ "$out" = "OK" ] || { echo "A: real python3 was rejected: $out" >&2; exit 1; }
+
+# B) /usr/bin/python3 stub + NO developer tools -> die 8
+rc=0
+out="$(
+  source "$TMP/guard.sh"
+  command() { if [ "${1:-}" = "-v" ] && [ "${2:-}" = "python3" ]; then echo /usr/bin/python3; return 0; fi; builtin command "$@"; }
+  xcode-select() { return 1; }
+  HEADLESS=1
+  ensure_python3_usable
+)" || rc=$?
+[ "$rc" = "8" ] || { echo "B: expected exit 8 for CLT stub, got $rc ($out)" >&2; exit 1; }
+
+# C) /usr/bin/python3 + developer tools present -> accepted
+out="$(
+  source "$TMP/guard.sh"
+  command() { if [ "${1:-}" = "-v" ] && [ "${2:-}" = "python3" ]; then echo /usr/bin/python3; return 0; fi; builtin command "$@"; }
+  xcode-select() { return 0; }
+  ensure_python3_usable && echo "OK"
+)"
+[ "$out" = "OK" ] || { echo "C: CLT-backed python3 was rejected: $out" >&2; exit 1; }
+
+# D) main() calls the guard before the first python3 user (validate_install_dir)
+grep -Eq 'ensure_python3_usable' "$INSTALL_SH" || { echo "D: guard not wired into installer" >&2; exit 1; }
+python3 - "$INSTALL_SH" <<'PY'
+import sys, re
+s = open(sys.argv[1]).read()
+main = s[s.rindex("\nmain() {"):]
+gi = main.index("ensure_python3_usable")
+vi = main.index("validate_install_dir")
+assert gi < vi, "guard must run before validate_install_dir (first python3 user)"
+print("order ok")
+PY
+
+echo "python3/CLT guard ok"

--- a/phase3-binary/dist/test/install_python3_clt_guard.test.sh
+++ b/phase3-binary/dist/test/install_python3_clt_guard.test.sh
@@ -24,6 +24,11 @@ printf 'die() { echo "DIE:$1"; exit "$1"; }\n' >> "$TMP/guard.sh"
 GOOD="$TMP/good-python3"; printf '#!/bin/sh\nexit 0\n' > "$GOOD"; chmod +x "$GOOD"
 BROKEN="$TMP/broken-python3"; printf '#!/bin/sh\nexit 1\n' > "$BROKEN"; chmod +x "$BROKEN"
 BLOCK="$TMP/blocking-python3"; printf '#!/bin/sh\nsleep 3600\n' > "$BLOCK"; chmod +x "$BLOCK"
+# Adversarial shim: exits 0 for `-c` (what a naive probe uses) but BLOCKS on `-`
+# (stdin script mode — what the installer actually uses). Proves the probe must
+# match the real invocation style. (round-3 HIGH)
+STDINBLOCK="$TMP/stdinblock-python3"
+printf '#!/bin/sh\ncase "${1:-}" in -c) exit 0 ;; *) sleep 3600 ;; esac\n' > "$STDINBLOCK"; chmod +x "$STDINBLOCK"
 
 # A real developer dir that actually contains an executable python3.
 DEVDIR="$TMP/devdir"; mkdir -p "$DEVDIR/usr/bin"
@@ -67,9 +72,10 @@ expect "E no-python3"        "$(run_guard "" "" 2 1)"             "DIE:8"
 
 # ── Part 2: the real bounded probe (good / broken / blocking) ────────────────
 probe_rc() { ( set +e; source "$TMP/guard.sh"; MACPROVIDER_PY_PROBE_BUDGET=2 _python3_runs_quickly "$1" 2>/dev/null; echo $? ) ; }
-expect "P good-exec"     "$(probe_rc "$GOOD")"   "0"
-expect "P broken-exec"   "$(probe_rc "$BROKEN")" "1"
-expect "P blocking-exec" "$(probe_rc "$BLOCK")"  "124"   # times out, not hangs
+expect "P good-exec"       "$(probe_rc "$GOOD")"       "0"
+expect "P broken-exec"     "$(probe_rc "$BROKEN")"     "1"
+expect "P blocking-exec"   "$(probe_rc "$BLOCK")"      "124"   # times out, not hangs
+expect "P stdin-blocking"  "$(probe_rc "$STDINBLOCK")" "124"   # -c passes but stdin blocks -> caught
 
 # ── Part 3: HIGH — a blocking non-system python3 dies 8 (does NOT hang) ───────
 run_guard_probe() { # <py-path> [HEADLESS] [ROOT_PY]  (real probe, small budget)
@@ -83,8 +89,9 @@ run_guard_probe() { # <py-path> [HEADLESS] [ROOT_PY]  (real probe, small budget)
     ensure_python3_usable 2>/dev/null && echo "OK"
   )
 }
-expect "H1 blocking-nonsystem" "$(run_guard_probe "$BLOCK")" "DIE:8"
-expect "H2 good-nonsystem"     "$(run_guard_probe "$GOOD")"  "OK"
+expect "H1 blocking-nonsystem" "$(run_guard_probe "$BLOCK")"      "DIE:8"
+expect "H2 good-nonsystem"     "$(run_guard_probe "$GOOD")"       "OK"
+expect "H3 stdin-blocking"     "$(run_guard_probe "$STDINBLOCK")" "DIE:8"   # round-3 HIGH
 
 # ── Part 4: MEDIUM — headless root interpreter validated independently ────────
 # User python3 is a good non-system interpreter, but the system root interpreter

--- a/phase3-binary/dist/test/install_python3_clt_guard.test.sh
+++ b/phase3-binary/dist/test/install_python3_clt_guard.test.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
-# Verifies the #1285 python3/CLT-stub guard: a stock Mac whose only python3 is
-# the non-functional Command Line Tools stub must FAIL FAST with exit 8 (mapped
-# by Malibu to an actionable "install developer tools" message) instead of
-# hanging on the hidden CLT install dialog.
+# Verifies the #1285/#1286 python3/CLT-stub guard: a stock Mac whose only python3
+# is the non-functional Command Line Tools stub must FAIL FAST with exit 8
+# (mapped by Malibu to an actionable "install developer tools" message) instead
+# of hanging on the hidden CLT install dialog — and must NOT block a Mac that has
+# a real, working python3.
 set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 INSTALL_SH="$REPO_ROOT/phase3-binary/dist/install.sh"
@@ -12,43 +13,57 @@ awk '/^ensure_python3_usable\(\)/{i=1} i{print} i&&/^}$/{exit}' "$INSTALL_SH" > 
 [ -s "$TMP/guard.sh" ] || { echo "could not extract ensure_python3_usable" >&2; exit 1; }
 printf 'die() { echo "DIE:$1"; exit "$1"; }\n' >> "$TMP/guard.sh"
 
-# A) real python3 elsewhere (Homebrew/python.org) -> accepted, no die
-out="$(
-  source "$TMP/guard.sh"
-  command() { if [ "${1:-}" = "-v" ] && [ "${2:-}" = "python3" ]; then echo /opt/homebrew/bin/python3; return 0; fi; builtin command "$@"; }
-  ensure_python3_usable && echo "OK"
-)"
-[ "$out" = "OK" ] || { echo "A: real python3 was rejected: $out" >&2; exit 1; }
+# A real developer dir that actually contains an executable python3.
+DEVDIR="$TMP/devdir"; mkdir -p "$DEVDIR/usr/bin"
+printf '#!/bin/sh\n' > "$DEVDIR/usr/bin/python3"; chmod +x "$DEVDIR/usr/bin/python3"
 
-# B) /usr/bin/python3 stub + NO developer tools -> die 8
-rc=0
-out="$(
-  source "$TMP/guard.sh"
-  command() { if [ "${1:-}" = "-v" ] && [ "${2:-}" = "python3" ]; then echo /usr/bin/python3; return 0; fi; builtin command "$@"; }
-  xcode-select() { return 1; }
-  HEADLESS=1
-  ensure_python3_usable
-)" || rc=$?
-[ "$rc" = "8" ] || { echo "B: expected exit 8 for CLT stub, got $rc ($out)" >&2; exit 1; }
+# run_guard <py-path> <xcodeselect-p-output-or-empty> <xcodeselect-p-rc> [HEADLESS]
+# Echoes the guard's outcome: "OK" (returned 0) or "DIE:<code>".
+run_guard() {
+  local pypath="$1" xp_out="$2" xp_rc="$3" hl="${4:-0}"
+  (
+    set +e
+    source "$TMP/guard.sh"
+    command() { if [ "${1:-}" = "-v" ] && [ "${2:-}" = "python3" ]; then printf '%s\n' "$pypath"; return 0; fi; builtin command "$@"; }
+    xcode-select() {
+      case "${1:-}" in
+        -p|--print-path) [ -n "$xp_out" ] && printf '%s\n' "$xp_out"; return "$xp_rc" ;;
+        --install) return 0 ;;
+        *) return 0 ;;
+      esac
+    }
+    HEADLESS="$hl"
+    ensure_python3_usable && echo "OK"
+  )
+}
 
-# C) /usr/bin/python3 + developer tools present -> accepted
-out="$(
-  source "$TMP/guard.sh"
-  command() { if [ "${1:-}" = "-v" ] && [ "${2:-}" = "python3" ]; then echo /usr/bin/python3; return 0; fi; builtin command "$@"; }
-  xcode-select() { return 0; }
-  ensure_python3_usable && echo "OK"
-)"
-[ "$out" = "OK" ] || { echo "C: CLT-backed python3 was rejected: $out" >&2; exit 1; }
+expect() { # <label> <actual> <expected>
+  [ "$2" = "$3" ] || { echo "$1: expected '$3', got '$2'" >&2; exit 1; }
+}
 
-# D) main() calls the guard before the first python3 user (validate_install_dir)
-grep -Eq 'ensure_python3_usable' "$INSTALL_SH" || { echo "D: guard not wired into installer" >&2; exit 1; }
+# A) real python3 elsewhere (Homebrew/python.org) -> accepted
+expect "A real-python3" "$(run_guard /opt/homebrew/bin/python3 "" 0)" "OK"
+
+# B) /usr/bin/python3 stub + NO developer dir selected -> die 8
+expect "B stub-no-CLT" "$(run_guard /usr/bin/python3 "" 2 1)" "DIE:8"
+
+# C) /usr/bin/python3 + a developer dir that actually contains python3 -> accepted
+expect "C CLT-backed" "$(run_guard /usr/bin/python3 "$DEVDIR" 0)" "OK"
+
+# D) /usr/bin/python3 + STALE developer dir (selected path has no python3) -> die 8
+expect "D stale-devdir" "$(run_guard /usr/bin/python3 "$TMP/gone-devdir" 0 1)" "DIE:8"
+
+# E) no python3 at all -> die 8
+expect "E no-python3" "$(run_guard "" "" 2 1)" "DIE:8"
+
+# F) main() calls the guard before the first python3 user (validate_install_dir)
+grep -Eq 'ensure_python3_usable' "$INSTALL_SH" || { echo "F: guard not wired into installer" >&2; exit 1; }
 python3 - "$INSTALL_SH" <<'PY'
-import sys, re
+import sys
 s = open(sys.argv[1]).read()
 main = s[s.rindex("\nmain() {"):]
-gi = main.index("ensure_python3_usable")
-vi = main.index("validate_install_dir")
-assert gi < vi, "guard must run before validate_install_dir (first python3 user)"
+assert main.index("ensure_python3_usable") < main.index("validate_install_dir"), \
+    "guard must run before validate_install_dir (first python3 user)"
 print("order ok")
 PY
 


### PR DESCRIPTION
## Problem (P0 — the real new-provider onboarding blocker; issue #1285)

A brand-new, non-developer Mac hangs at **"Starting installer…"** on first
provider install. Root cause: `install.sh` hard-depends on `python3` (71 calls),
but a stock Mac's only `python3` is the **Xcode Command Line Tools stub** at
`/usr/bin/python3`. `require_tool` passed it via `command -v`, and the first real
`python3` call (`validate_install_dir`) triggered the OS **"Install Command Line
Developer Tools"** dialog — which appears **behind the Malibu window** and blocks
the installer forever. Deterministic for every fresh non-developer Mac → explains
multiple independent providers with the identical hang. (Not a network issue;
not fixed by #1281.)

## Fix (short-term guardrail from #1285)

`ensure_python3_usable` runs right after the tool-presence loop, before the first
`python3` use. It detects the non-functional stub **without invoking it**
(`xcode-select -p` does not pop the install dialog): the stub is only
`/usr/bin/python3` **and** only when no developer toolchain is selected. In
consumer/GUI mode it opens the Command Line Tools installer for the user, then
exits with a dedicated **code 8**; Malibu maps 8 → `developerToolsRequired` with
an actionable message instead of a hidden hang. A real `python3` (Homebrew,
python.org, or an active CLT/Xcode toolchain) is accepted unchanged.

Converts a hidden-dialog hang into clear, self-service recovery: "click Install,
wait, then reopen Malibu."

## Not in this PR (durable follow-up, #1285)

Removing the 71-site `python3` dependency from `install.sh` (or bundling a
self-contained Python in Malibu.app) so consumer onboarding never needs Apple
developer tools at all.

## Tested

- `bash -n install.sh`
- `phase3-binary/dist/test/install_python3_clt_guard.test.sh` (new): real-python3
  accepted / stub+no-CLT → exit 8 / stub+CLT accepted / guard precedes first
  python3 use — all pass; wired into `make test-dist`
- `--dry-run` end-to-end still exits 0 on a real-python3 Mac (no success-path change)

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "issue": "https://github.com/Augustas11/macprovider/issues/1285",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-003"],
  "requirements": ["SPEC-003-R001"],
  "authority_domains": ["provider-onboarding-identity"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "bash -n phase3-binary/dist/install.sh",
    "bash phase3-binary/dist/test/install_python3_clt_guard.test.sh"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END
