### PR TITLE
Add curl-channel install.sh parity gate

### DIFF
--- a/.github/workflows/install-sh-parity-alarm.yml
+++ b/.github/workflows/install-sh-parity-alarm.yml
@@ -1,0 +1,67 @@
+name: Install.sh curl-channel parity alarm
+
+# Read-only backstop for the public one-liner installer. The Malibu app bundles
+# its own signed install.sh, but `curl -fsSL https://get.malibu.tech/install.sh |
+# bash` is served as a static file on the coordinator host that nothing
+# republishes automatically on release. It has silently drifted stale before
+# (missing the python3-CLT guard and the donor-join fix). This alarm compares the
+# served bytes to the LATEST RELEASE's dist/install.sh every few hours and FAILS
+# (notifying) on drift, so a stale curl channel is caught here — not discovered
+# by a broken provider install. No secrets, no writes, no deploy.
+
+on:
+  schedule:
+    # Every 6 hours: frequent enough that a post-release republish miss is caught
+    # within a quarter day, long before it can strand a wave of new installs.
+    - cron: "0 */6 * * *"
+  workflow_dispatch:
+    inputs:
+      install_url:
+        description: "Override the served install.sh URL (default get.malibu.tech)"
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: install-sh-parity-alarm
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Alarm on a stale curl-channel install.sh
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Pin to latest release tag and compare served vs released install.sh
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INSTALL_URL_INPUT: ${{ github.event.inputs.install_url }}
+        run: |
+          set -euo pipefail
+          git fetch --tags --quiet || true
+          # The curl channel should serve the LATEST published release's
+          # install.sh. Comparing against main would false-alarm on install.sh
+          # changes that have merged but not yet shipped in a release.
+          latest_tag="$(
+            gh release list --repo "$GITHUB_REPOSITORY" --limit 50 \
+              --json tagName,isDraft,isPrerelease \
+              --jq '.[] | select(.isDraft==false and .isPrerelease==false) | .tagName' \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1
+          )"
+          [ -n "$latest_tag" ] || { echo "::error::no published vX.Y.Z release tag found"; exit 1; }
+          echo "Latest release tag: $latest_tag"
+          git checkout "$latest_tag" -- phase3-binary/dist/install.sh
+          if [ -n "${INSTALL_URL_INPUT:-}" ]; then
+            export INSTALL_SH_URL="$INSTALL_URL_INPUT"
+          fi
+          bash scripts/check-install-sh-parity.sh

--- a/docs/runbooks/provider-cli-release-verification.md
+++ b/docs/runbooks/provider-cli-release-verification.md
@@ -138,6 +138,39 @@ Do not enable the strict gate while the fleet still contains providers that
 cannot produce v2 evidence. A coordinator deployment that has not yet
 accepted v2 must remain on the previous provider recommendation.
 
+## Curl-channel install.sh republish (MANDATORY on release)
+
+The Malibu app bundles its own signed `install.sh`, but the public one-liner
+`curl -fsSL https://get.malibu.tech/install.sh | bash` is served as a **static
+file on the coordinator host** (`/var/www/get/install.sh`). Cutting a release
+updates the app bundle and the release assets but does **not** republish this
+static file, so it drifts stale silently — it once lagged ~2 weeks, serving an
+installer without the python3-CLT guard or the donor-join fix.
+
+On every release that changes `phase3-binary/dist/install.sh`, after immutable
+publication:
+
+1. Back up the current served file, then copy the released `dist/install.sh`
+   into the webroot (preserve `root:root 0755`):
+
+   ```bash
+   ts=$(date -u +%Y%m%dT%H%M%SZ)
+   ssh pearl "cp -p /var/www/get/install.sh /var/www/get/install.sh.bak-$ts"
+   scp phase3-binary/dist/install.sh pearl:/tmp/install.sh.new
+   ssh pearl "install -o root -g root -m 0755 /tmp/install.sh.new /var/www/get/install.sh && rm -f /tmp/install.sh.new"
+   ```
+
+2. Verify parity from a clean checkout of the release tag:
+
+   ```bash
+   bash scripts/check-install-sh-parity.sh   # exits 0 only when served == released
+   ```
+
+The scheduled `.github/workflows/install-sh-parity-alarm.yml` runs this check
+every 6 hours against the latest release tag and FAILS (notifying) on drift, so
+a missed republish surfaces within a quarter day instead of stranding new
+installs. Treat a red parity alarm as a release step that did not complete.
+
 ## What not to count as release proof
 
 - matching `macprovider-cli --version`

--- a/scripts/check-install-sh-parity.sh
+++ b/scripts/check-install-sh-parity.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Curl-channel parity gate.
+#
+# The Malibu app bundles its own copy of install.sh (verified against the signed
+# compatibility set at release time), but the public one-liner
+# `curl -fsSL https://get.malibu.tech/install.sh | bash` is served as a static
+# file from the coordinator host. Cutting a release updates the app bundle and
+# the release assets, but nothing republishes that static file automatically, so
+# it can silently drift stale (it once lagged ~2 weeks behind, missing the
+# python3-CLT guard and the donor-join fix). This check compares the served
+# bytes against the repository's dist/install.sh so drift is caught, not shipped.
+#
+# Semantics: it compares the served file to the dist/install.sh of the CURRENT
+# checkout. In the scheduled alarm workflow the checkout is pinned to the latest
+# release tag, so "served must equal the released install.sh". Run locally to
+# confirm a republish landed. Read-only: no secrets, no writes, no deploy.
+#
+# Exit codes: 0 = parity (or --allow-ahead and served is a known older release),
+#             1 = drift (served != expected), 2 = usage/fetch error.
+set -euo pipefail
+
+INSTALL_URL="${INSTALL_SH_URL:-https://get.malibu.tech/install.sh}"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DIST_INSTALL="$REPO_ROOT/phase3-binary/dist/install.sh"
+
+sha256() {
+  # Portable across the GNU (Linux CI) and BSD (macOS) toolchains.
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+[ -f "$DIST_INSTALL" ] || { echo "error: $DIST_INSTALL not found" >&2; exit 2; }
+expected="$(sha256 "$DIST_INSTALL")"
+
+case "$INSTALL_URL" in
+  https://*) ;;
+  *) echo "error: INSTALL_SH_URL must be an https:// URL (got: $INSTALL_URL)" >&2; exit 2 ;;
+esac
+
+served_file="$(mktemp "${TMPDIR:-/tmp}/served-install.XXXXXX")"
+trap 'rm -f "$served_file"' EXIT
+# `--` before the URL so a value that begins with '-' can never be parsed as a
+# curl flag (the URL can be overridden via INSTALL_SH_URL / workflow input).
+if ! curl -fsSL --proto '=https' --tlsv1.2 --max-time 30 -o "$served_file" -- "$INSTALL_URL"; then
+  echo "error: could not fetch $INSTALL_URL" >&2
+  exit 2
+fi
+served="$(sha256 "$served_file")"
+
+echo "expected (repo dist/install.sh): $expected"
+echo "served   ($INSTALL_URL): $served"
+
+if [ "$served" = "$expected" ]; then
+  echo "OK: curl-channel install.sh matches the repository install.sh."
+  exit 0
+fi
+
+cat >&2 <<EOF
+DRIFT: the curl-channel install.sh does NOT match the repository install.sh.
+
+The public 'curl -fsSL $INSTALL_URL | bash' path is serving stale or divergent
+bytes. Republish the current release's dist/install.sh to the coordinator webroot
+(see docs/runbooks/provider-cli-release-verification.md), then re-run this check.
+EOF
+exit 1


### PR DESCRIPTION
## What

The public one-liner installer `curl -fsSL https://get.malibu.tech/install.sh | bash` is served as a static file on the coordinator host that nothing republishes on release, so it silently drifts stale (it lagged ~2 weeks, shipping an installer without the python3-CLT guard). This adds a read-only parity gate so drift is caught, not shipped.

- `scripts/check-install-sh-parity.sh` — compares the served bytes to the repo `dist/install.sh` (https-only URL, `--`-guarded curl, GNU/BSD sha256).
- `.github/workflows/install-sh-parity-alarm.yml` — scheduled every 6h + manual dispatch; compares the served file to the latest release tag's `dist/install.sh` and FAILS on drift.
- `docs/runbooks/provider-cli-release-verification.md` — documents the mandatory post-release republish + parity-verify step.

## Why

Cutting a release updates the app bundle and release assets but does not republish the curl-channel static file, so the `curl | bash` path can serve a stale installer. This is a read-only backstop (no secrets, no deploy, `permissions: contents: read`) that alarms on drift.

## Testing

- `bash -n` on the script; validated live (reports parity when served == released, drift otherwise).
- Workflow YAML parses.

CI/ops + docs only — no spec, manifest, product-behavior, schema, release, catalog, rate-card, or runtime-affecting changes.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-003"],
  "requirements": ["SPEC-003-R001"],
  "authority_domains": ["provider-onboarding-identity"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "bash -n scripts/check-install-sh-parity.sh",
    "bash scripts/check-install-sh-parity.sh"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
