### PR TITLE
Fix Malibu app install hang (beachball) — ps pipe deadlock + off-main progress polling

### DIFF
--- a/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
@@ -304,7 +304,7 @@ final class MalibuAgent: ObservableObject {
                     try await AutotuneRecommendationRunner.runHardwareAdmissionRecovery(cliURL: cliURL)
                 }
                 guard !Task.isCancelled, !self.isShuttingDown else {
-                    self.restoreLaunchdIfCorrectiveRecoveryOwned(attemptedCorrectiveRecovery)
+                    await self.restoreLaunchdIfCorrectiveRecoveryOwned(attemptedCorrectiveRecovery)
                     return
                 }
                 self.hardwareRecoveryOwnsLaunchdRestore = false
@@ -314,10 +314,10 @@ final class MalibuAgent: ObservableObject {
                     await self.applyProviderSnapshot(port: port)
                 }
             } catch is CancellationError {
-                self.restoreLaunchdIfCorrectiveRecoveryOwned(attemptedCorrectiveRecovery)
+                await self.restoreLaunchdIfCorrectiveRecoveryOwned(attemptedCorrectiveRecovery)
                 return
             } catch {
-                self.restoreLaunchdIfCorrectiveRecoveryOwned(attemptedCorrectiveRecovery)
+                await self.restoreLaunchdIfCorrectiveRecoveryOwned(attemptedCorrectiveRecovery)
                 guard !Task.isCancelled, !self.isShuttingDown else { return }
                 self.snapshot.hardwareVerificationRetryLastError =
                     AgentSnapshotPresenter.publicErrorDetail(error.localizedDescription)
@@ -327,13 +327,13 @@ final class MalibuAgent: ObservableObject {
         await hardwareVerificationRetryTask?.value
     }
 
-    private func restoreLaunchdIfCorrectiveRecoveryOwned(_ attemptedCorrectiveRecovery: Bool) {
+    private func restoreLaunchdIfCorrectiveRecoveryOwned(_ attemptedCorrectiveRecovery: Bool) async {
         guard AutotuneRecommendationRunner.shouldBestEffortBootstrapLaunchd(
             attemptedCorrectiveRecovery: attemptedCorrectiveRecovery
         ) || hardwareRecoveryOwnsLaunchdRestore else {
             return
         }
-        AutotuneRecommendationRunner.bestEffortBootstrapLaunchdProvider()
+        await AutotuneRecommendationRunner.bestEffortBootstrapLaunchdProvider()
         hardwareRecoveryOwnsLaunchdRestore = false
     }
 
@@ -578,7 +578,7 @@ final class MalibuAgent: ObservableObject {
         // Only restore when corrective recovery may have drained launchd.
         // Ordinary quit must not re-bootstrap an intentionally unloaded job.
         if hardwareRecoveryOwnsLaunchdRestore {
-            AutotuneRecommendationRunner.bestEffortBootstrapLaunchdProvider()
+            await AutotuneRecommendationRunner.bestEffortBootstrapLaunchdProvider()
             hardwareRecoveryOwnsLaunchdRestore = false
         }
         let admissionRecoveryTask = admissionIdentityRecoveryTask

--- a/phase3-binary/app/Sources/Malibu/Onboarding/AutotuneRecommendationRunner.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/AutotuneRecommendationRunner.swift
@@ -163,19 +163,49 @@ enum AutotuneRecommendationRunner {
         launchctlURL: URL = URL(fileURLWithPath: "/bin/launchctl"),
         plistURL: URL = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent("Library/LaunchAgents/live.malibu.provider.plist")
-    ) {
-        let process = Process()
-        process.executableURL = launchctlURL
-        process.arguments = ["bootstrap", "gui/\(uid)", plistURL.path]
-        process.standardOutput = FileHandle.nullDevice
-        process.standardError = FileHandle.nullDevice
-        do {
-            try process.run()
-            process.waitUntilExit()
-        } catch {
-            return
+    ) async {
+        // Async + off-main: the caller (MalibuAgent) is @MainActor, so the
+        // launchctl subprocess must never run on the main actor. The await
+        // suspends the caller's actor without blocking it.
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            DispatchQueue.global(qos: .utility).async {
+                let process = Process()
+                process.executableURL = launchctlURL
+                process.arguments = ["bootstrap", "gui/\(uid)", plistURL.path]
+                process.standardOutput = FileHandle.nullDevice
+                process.standardError = FileHandle.nullDevice
+                do {
+                    try process.run()
+                    // Bounded wait: this restore is awaited on the cancel/shutdown
+                    // path, so an unbounded waitUntilExit() would let a wedged
+                    // `launchctl bootstrap` hang app shutdown indefinitely. Cap the
+                    // wait and terminate a stuck launchctl; the restore is
+                    // best-effort so we resume regardless of the outcome. We do NOT
+                    // key off Task cancellation here: the restore must still run
+                    // during shutdown so a corrective-recovery bootout is not left
+                    // stranded — we only bound how long it may block.
+                    let deadline = Date().addingTimeInterval(bestEffortBootstrapTimeout)
+                    while process.isRunning && Date() < deadline {
+                        Thread.sleep(forTimeInterval: 0.05)
+                    }
+                    if process.isRunning {
+                        process.terminate()
+                        let terminateDeadline = Date().addingTimeInterval(1)
+                        while process.isRunning && Date() < terminateDeadline {
+                            Thread.sleep(forTimeInterval: 0.05)
+                        }
+                    }
+                } catch {
+                }
+                continuation.resume()
+            }
         }
     }
+
+    /// Upper bound on how long the best-effort launchd bootstrap may block the
+    /// awaiting caller (including the shutdown/cancel path) before the stuck
+    /// `launchctl` child is terminated and control returns.
+    static let bestEffortBootstrapTimeout: TimeInterval = 10
 
     private final class ProcessHold: @unchecked Sendable {
         private let lock = NSLock()

--- a/phase3-binary/app/Sources/Malibu/Onboarding/CLIInstallRunner.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/CLIInstallRunner.swift
@@ -376,13 +376,18 @@ enum CLIInstallRunner {
 
     /// Human-readable hint for onboarding UI while `install.sh` runs long silent phases.
     enum ActivityMonitor {
-        static func snapshot(logLines: [String] = []) -> InstallProgress {
-            progress(
-                processLines: macproviderProcessLines(),
+        /// Async so the progress poller never runs a subprocess on the caller's
+        /// actor. The subprocess + pipe drain happen on a background executor;
+        /// callers `await` this and assign the result on their own actor.
+        static func snapshot(logLines: [String] = []) async -> InstallProgress {
+            let processLines = await macproviderProcessLines()
+            let cliInstalled = FileManager.default.isExecutableFile(
+                atPath: NSHomeDirectory() + "/macprovider/macprovider-cli"
+            )
+            return progress(
+                processLines: processLines,
                 logLines: logLines,
-                cliInstalled: FileManager.default.isExecutableFile(
-                    atPath: NSHomeDirectory() + "/macprovider/macprovider-cli"
-                )
+                cliInstalled: cliInstalled
             )
         }
 
@@ -493,25 +498,61 @@ enum CLIInstallRunner {
             }
         }
 
-        private static func macproviderProcessLines() -> [String] {
-            let process = Process()
-            let pipe = Pipe()
-            process.executableURL = URL(fileURLWithPath: "/bin/ps")
-            process.arguments = ["-ax", "-o", "command="]
-            process.standardOutput = pipe
-            process.standardError = Pipe()
-            do {
-                try process.run()
-            } catch {
-                return []
-            }
-            process.waitUntilExit()
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            let text = String(decoding: data, as: UTF8.self)
+        private static func macproviderProcessLines() async -> [String] {
+            let text = await capturedProcessOutput(
+                executableURL: URL(fileURLWithPath: "/bin/ps"),
+                arguments: ["-ax", "-o", "command="]
+            )
             return text
                 .split(whereSeparator: \.isNewline)
                 .map(String.init)
                 .filter { $0.contains("macprovider-cli") && !$0.contains("/bin/ps") }
+        }
+
+        /// Run a subprocess off the caller's actor and return its stdout.
+        ///
+        /// The pipe is drained to EOF BEFORE `waitUntilExit()`. Draining after
+        /// waiting is a classic deadlock: a child whose stdout exceeds the
+        /// ~64KB pipe buffer (e.g. `ps -ax` on a Mac with many processes) blocks
+        /// on write into the full, undrained pipe and never exits, so
+        /// `waitUntilExit()` hangs forever. Reading to EOF first keeps the pipe
+        /// draining so the child can finish; `waitUntilExit()` then returns
+        /// immediately. stderr is discarded (nullDevice) so it cannot fill and
+        /// wedge either. A watchdog bounds a stuck child. `internal` so tests
+        /// can prove the >64KB path does not deadlock.
+        static func capturedProcessOutput(
+            executableURL: URL,
+            arguments: [String],
+            timeout: TimeInterval = 5
+        ) async -> String {
+            await withCheckedContinuation { (continuation: CheckedContinuation<String, Never>) in
+                DispatchQueue.global(qos: .utility).async {
+                    let process = Process()
+                    let pipe = Pipe()
+                    process.executableURL = executableURL
+                    process.arguments = arguments
+                    process.standardOutput = pipe
+                    process.standardError = FileHandle.nullDevice
+                    let watchdog = DispatchWorkItem {
+                        if process.isRunning { process.terminate() }
+                    }
+                    DispatchQueue.global(qos: .utility)
+                        .asyncAfter(deadline: .now() + timeout, execute: watchdog)
+                    do {
+                        try process.run()
+                    } catch {
+                        watchdog.cancel()
+                        continuation.resume(returning: "")
+                        return
+                    }
+                    // Drain to EOF (returns when the child closes stdout on exit,
+                    // or when the watchdog terminates it) BEFORE waiting.
+                    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+                    process.waitUntilExit()
+                    watchdog.cancel()
+                    continuation.resume(returning: String(decoding: data, as: UTF8.self))
+                }
+            }
         }
 
         private static func extractFlag(_ flag: String, from command: String) -> String? {

--- a/phase3-binary/app/Sources/Malibu/Onboarding/LaunchProviderController.swift
+++ b/phase3-binary/app/Sources/Malibu/Onboarding/LaunchProviderController.swift
@@ -451,9 +451,13 @@ final class LaunchProviderController: ObservableObject {
         installProgressTask = Task { @MainActor [weak self] in
             while !Task.isCancelled {
                 guard let self else { return }
-                self.installProgress = CLIInstallRunner.ActivityMonitor.snapshot(
-                    logLines: self.installLogLines
-                )
+                // snapshot() runs the `ps` subprocess off the main actor; the
+                // await suspends (never blocks) the main actor, and we hop back
+                // only to assign installProgress.
+                let logLines = self.installLogLines
+                let next = await CLIInstallRunner.ActivityMonitor.snapshot(logLines: logLines)
+                guard !Task.isCancelled else { return }
+                self.installProgress = next
                 try? await Task.sleep(nanoseconds: 2_000_000_000)
             }
         }

--- a/phase3-binary/app/Tests/MalibuTests/CLIInstallActivityMonitorTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/CLIInstallActivityMonitorTests.swift
@@ -77,4 +77,40 @@ final class CLIInstallActivityMonitorTests: XCTestCase {
         XCTAssertEqual(progress.detail, "Install in progress…")
         XCTAssertFalse(OnboardingCopy.installingFallback.contains("little visible progress"))
     }
+
+    // Regression for the beachball: `ps -ax` on a busy Mac can emit >64KB, more
+    // than the pipe buffer. Draining to EOF before waitUntilExit must not
+    // deadlock. This helper emits ~220KB (>128KB); if the old
+    // waitUntilExit-then-read ordering regressed, this test would hang and fail.
+    func testCapturedProcessOutputDrainsLargeOutputWithoutDeadlock() async {
+        let output = await CLIInstallRunner.ActivityMonitor.capturedProcessOutput(
+            executableURL: URL(fileURLWithPath: "/bin/sh"),
+            arguments: ["-c", "for i in $(seq 1 20000); do echo 0123456789; done"]
+        )
+        XCTAssertGreaterThan(
+            output.utf8.count, 128 * 1024,
+            "large subprocess output must be fully drained without deadlock"
+        )
+    }
+
+    // A launch failure returns empty rather than hanging or throwing.
+    func testCapturedProcessOutputReturnsEmptyOnLaunchFailure() async {
+        let output = await CLIInstallRunner.ActivityMonitor.capturedProcessOutput(
+            executableURL: URL(fileURLWithPath: "/nonexistent/definitely-not-a-binary"),
+            arguments: []
+        )
+        XCTAssertEqual(output, "")
+    }
+
+    // The progress poller path is async (runs its subprocess off the caller's
+    // actor) and still returns a usable InstallProgress. Driven from @MainActor
+    // to prove the await suspends rather than blocks the main actor.
+    @MainActor
+    func testSnapshotIsAsyncAndReturnsProgressFromMainActor() async {
+        let progress = await CLIInstallRunner.ActivityMonitor.snapshot(
+            logLines: ["Fetching model weights 42%"]
+        )
+        // With no macprovider-cli process running, the log lines drive the stage.
+        XCTAssertNotNil(progress.detail)
+    }
 }


### PR DESCRIPTION
## Summary

Fixes the Malibu app hanging with a spinning-rainbow beachball at **"Starting installer"** (elapsed 0:00) the instant a provider enters the invite and presses Next — the reason new providers could not onboard through the app.

**Root cause (verified):** the install-progress poller ran `ps -ax -o command=` via `macproviderProcessLines()` and called `waitUntilExit()` **before** draining the output pipe. macOS pipe buffers are ~64KB; when `ps` output exceeds that, `ps` blocks writing into the full undrained pipe and never exits → `waitUntilExit()` hangs forever. It ran on the `@MainActor` progress loop, so the UI froze. Measured: **99KB** of `ps` output on a Mac running Electron apps (deadlock) vs **18KB** on a plain Mac (no hang) — explaining why it hit some Macs and not others, independent of macOS version, model cache, or the install itself.

## Fix

- New `capturedProcessOutput(...)` drains stdout to EOF and routes stderr to `nullDevice`, with a bounded watchdog — a >64KB writer can no longer deadlock. `macproviderProcessLines()` uses it.
- `ActivityMonitor.snapshot()` is now `async` and runs the subprocess **off the main actor**; `installProgress` is assigned back on `@MainActor` only.
- `bestEffortBootstrapLaunchdProvider()` / `restoreLaunchdIfCorrectiveRecoveryOwned()` made async/off-main; the `launchctl bootstrap` wait is **bounded** (10s + terminate, resumes once) so a wedged launchctl cannot hang shutdown, while still performing the restore on shutdown/cancel (not skipped on Task cancellation).
- Swept the onboarding path; the main install runner already drains via `readabilityHandler` and is unchanged.

## Testing

- App build + **478 MalibuTests pass** (incl. `testCapturedProcessOutputDrainsLargeOutputWithoutDeadlock`, emitting >128KB).
- 3-lane audit (code / concurrency / architecture) — 0 CRITICAL/HIGH/MEDIUM on the changed surface.

## Follow-up (pre-existing, not in this diff)

`CLIInstallTeardown.runBundledUninstall` and `PayoutWalletFlow.runCLI` use the same read-after-wait subprocess-capture shape and should migrate to a shared bounded helper. Carried as a LOW: `capturedProcessOutput` is SIGTERM-only (fine for the cooperative `ps` caller).

<!-- SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-003"],
  "requirements": ["SPEC-003-R001"],
  "authority_domains": ["provider-onboarding-identity"],
  "arbitration": ["CODE_BUG"],
  "tests": ["phase3-binary/app/Tests/MalibuTests/CLIInstallActivityMonitorTests.swift"],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END -->
