### PR TITLE
Add autotune-feed weekly cadence check + 20-day freshness alarm

### DIFF
--- a/.github/workflows/autotune-feed-freshness-alarm.yml
+++ b/.github/workflows/autotune-feed-freshness-alarm.yml
@@ -1,0 +1,57 @@
+name: Autotune feed freshness alarm
+
+# Read-only backstop for the SPEC-023 signed autotune feed (rate-card /
+# candidate / demand). The client 30-day generated_at horizon fails closed
+# with rate_card_update_required and strands any provider that restarts.
+# Operator-local launchd runs scripts/renew-autotune-static-feed.sh weekly
+# (signing stays off CI — see docs/runbooks/autotune-feed-renewal.md); if that
+# run is skipped/late, this alarm fails (and notifies) BEFORE the feed ages
+# past 30 days. No secrets, no production-release environment, no signing,
+# no Pearl SSH — it only reads the public /v1/rate-card generated_at.
+
+on:
+  schedule:
+    # Every 6 hours: far more often than the weekly renewal, so a stale feed
+    # is caught with well over a week of runway (alarm threshold is 20 days
+    # of a 30-day horizon).
+    - cron: "0 */6 * * *"
+  workflow_dispatch:
+    inputs:
+      max_age_days:
+        description: "Alarm if generated_at is this many days old (default 20; must be < 30)"
+        required: false
+        default: "20"
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: autotune-feed-freshness-alarm
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Alarm on a stale autotune rate-card feed
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout freshness check
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Fetch live /v1/rate-card and check generated_at age
+        shell: bash
+        env:
+          MAX_AGE_DAYS: ${{ github.event.inputs.max_age_days || '20' }}
+        run: |
+          set -euo pipefail
+          url="https://coordinator.malibu.tech/v1/rate-card"
+          [[ "$MAX_AGE_DAYS" =~ ^[0-9]+([.][0-9]+)?$ ]] || {
+            echo "::error::max_age_days must be a positive number" >&2
+            exit 1
+          }
+          curl -fsS --proto '=https' --tlsv1.2 --max-time 20 -- "$url" \
+            | python3 scripts/check-autotune-feed-freshness.py --max-age-days "$MAX_AGE_DAYS"

--- a/.github/workflows/renew-autotune-static-feed.yml
+++ b/.github/workflows/renew-autotune-static-feed.yml
@@ -1,0 +1,69 @@
+name: Renew autotune static feed
+
+# Weekly cadence gate for the SPEC-023 signed autotune feed.
+#
+# Signing stays on the operator machine (streamvc-autotune-static-v4 MUST NOT
+# be a CI secret and MUST NOT live on Pearl — see
+# docs/runbooks/autotune-feed-renewal.md). GitHub-hosted runners therefore
+# cannot call `scripts/renew-autotune-static-feed.sh --deploy`: that script
+# signs locally and rsyncs to Pearl over SSH. This workflow uses the same
+# 16:00 UTC weekly hour as renew-release-discovery-head.yml, offset to
+# Tuesday so it runs AFTER the Monday operator-local launchd renewal rather
+# than racing it. The 20-day autotune-feed-freshness-alarm.yml is the
+# last-line backstop.
+#
+# The job fetches the live /v1/rate-card and fails if generated_at is at
+# least 7 days old — the weekly SLA. On failure, run
+# `scripts/renew-autotune-static-feed.sh --deploy` on the signing host.
+# No secrets, no Pearl SSH, no --deploy from CI.
+
+on:
+  schedule:
+    # Tuesday 16:00 UTC: one day after the Monday operator-local renewal
+    # window, well inside the 30-day client freshness horizon. A missed
+    # Monday run then fails this check the next day rather than silently
+    # aging toward 30 days, and cannot false-fail while launchd is still
+    # deploying.
+    - cron: "0 16 * * 2"
+  workflow_dispatch:
+    inputs:
+      max_age_days:
+        description: "Fail if generated_at is this many days old (default 7; must be < 30)"
+        required: false
+        default: "7"
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: renew-autotune-static-feed
+  cancel-in-progress: false
+
+jobs:
+  cadence:
+    name: Confirm weekly autotune-feed renewal happened
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout cadence check
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Fail if live /v1/rate-card is older than the weekly SLA
+        shell: bash
+        env:
+          MAX_AGE_DAYS: ${{ github.event.inputs.max_age_days || '7' }}
+        run: |
+          set -euo pipefail
+          url="https://coordinator.malibu.tech/v1/rate-card"
+          [[ "$MAX_AGE_DAYS" =~ ^[0-9]+([.][0-9]+)?$ ]] || {
+            echo "::error::max_age_days must be a positive number" >&2
+            exit 1
+          }
+          echo "Weekly SLA: live generated_at must be younger than ${MAX_AGE_DAYS}d."
+          echo "A failure means: run scripts/renew-autotune-static-feed.sh --deploy on the signing host."
+          curl -fsS --proto '=https' --tlsv1.2 --max-time 20 -- "$url" \
+            | python3 scripts/check-autotune-feed-freshness.py --max-age-days "$MAX_AGE_DAYS"

--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,8 @@ test-dist:
 	bash scripts/test-release-discovery-transport.sh
 	bash scripts/test-select-public-discovery-transport.sh
 	bash scripts/test-renew-release-discovery-head.sh
+	bash scripts/test-autotune-feed-freshness-alarm.sh
+	PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v scripts.tests.test_autotune_feed_freshness
 	bash scripts/test-tier2-provider-artifact.sh
 	bash scripts/test-tier2-provider-release.sh
 	bash scripts/test-tier2-activation-safety.sh

--- a/docs/runbooks/autotune-feed-renewal.md
+++ b/docs/runbooks/autotune-feed-renewal.md
@@ -109,6 +109,33 @@ launchctl kickstart -p gui/$(id -u)/live.streamvc.autotune-feed-renewal   # opti
 Verify after a run: `curl -s https://coordinator.malibu.tech/v1/rate-card | python3 -c 'import sys,json;print(json.load(sys.stdin)["generated_at"])'`
 should show today; provider `pool_size` should be unchanged across the HUP.
 
+## GitHub Actions backstops (no signing, no Pearl SSH)
+
+GitHub-hosted runners cannot call `renew-autotune-static-feed.sh --deploy`:
+the Ed25519 feed key must not be a CI secret, and deploy is SSH to Pearl.
+Two read-only workflows make a missed launchd/manual run visible in Actions
+before the client 30-day horizon:
+
+1. **Weekly cadence** — `.github/workflows/renew-autotune-static-feed.yml`
+   (`cron: "0 16 * * 2"`, Tuesday 16:00 UTC — same hour as discovery-head
+   renewal, offset one day so it does not race Monday launchd). Fetches live
+   `/v1/rate-card` and fails if `generated_at` is ≥ 7 days old. A failure
+   means: run `--deploy` on the signing host this week.
+2. **20-day alarm** — `.github/workflows/autotune-feed-freshness-alarm.yml`
+   (every 6 hours). Fails if `generated_at` is ≥ 20 days old, leaving ~10
+   days of runway. Mirror of `discovery-head-freshness-alarm.yml`.
+
+Both call `scripts/check-autotune-feed-freshness.py` (stdin JSON, no
+network, no secrets). `workflow_dispatch` accepts a `max_age_days` override
+for a manual check after a local deploy. The live URL is pinned to
+`https://coordinator.malibu.tech/v1/rate-card` (no dispatch override).
+
+```bash
+curl -fsS --proto '=https' --tlsv1.2 --max-time 20 \
+  https://coordinator.malibu.tech/v1/rate-card \
+  | python3 scripts/check-autotune-feed-freshness.py --max-age-days 20
+```
+
 ## Rollback
 
 The prior release is retained as `.previous-target` and its directory is left in

--- a/scripts/check-autotune-feed-freshness.py
+++ b/scripts/check-autotune-feed-freshness.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Alarm check for the live SPEC-023 autotune rate-card freshness.
+
+Reads a rate-card JSON object on stdin and fails (exit 1) when `generated_at`
+is missing, unparseable, more than 10 minutes in the future, or at least
+`--max-age-days` old (default 20; inclusive). The client 30-day horizon
+(`AutotuneRecommend.swift` `loadSignedStatic`) fails closed with
+`rate_card_update_required` and strands any provider that restarts; this
+check is the read-only backstop that fires *before* that happens.
+
+Read-only: no secrets, no network, no signature trust decision (that is the
+client's job) — this only reads the self-asserted `generated_at`. Intended
+to run on a schedule far more often than the weekly operator-local renewal.
+
+Usage:
+  curl -fsS --proto '=https' --tlsv1.2 --max-time 20 \\
+    https://coordinator.malibu.tech/v1/rate-card \\
+    | python3 scripts/check-autotune-feed-freshness.py --max-age-days 20
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sys
+
+
+CLIENT_HORIZON_DAYS = 30.0
+FUTURE_SKEW_MINUTES = 10.0
+
+
+def fail(message: str) -> "NoReturn":  # type: ignore[name-defined]
+    print(f"[autotune-feed-freshness] ALARM: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def parse_rfc3339_z(value: str, label: str) -> dt.datetime:
+    try:
+        parsed = dt.datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(
+            tzinfo=dt.timezone.utc
+        )
+    except ValueError as exc:
+        fail(f"unparseable {label} {value!r}: {exc}")
+    return parsed
+
+
+def check_rate_card(
+    payload: dict[str, object],
+    *,
+    now: dt.datetime,
+    max_age_days: float,
+) -> None:
+    generated_raw = payload.get("generated_at")
+    if not isinstance(generated_raw, str) or not generated_raw:
+        fail("rate-card 'generated_at' is missing")
+    generated = parse_rfc3339_z(generated_raw, "generated_at")
+
+    skew_seconds = (generated - now).total_seconds()
+    if skew_seconds > FUTURE_SKEW_MINUTES * 60.0:
+        fail(
+            f"rate-card generated_at is {skew_seconds / 60.0:.1f}min in the future "
+            f"(> {FUTURE_SKEW_MINUTES:.0f}min) — clients reject future-dated feeds; "
+            "do not publish until clocks agree."
+        )
+
+    age_days = (now - generated).total_seconds() / 86400.0
+    remaining_days = CLIENT_HORIZON_DAYS - age_days
+    print(
+        f"[autotune-feed-freshness] generated_at={generated_raw} "
+        f"age={age_days:.1f}d remaining_to_30d={remaining_days:.1f}d "
+        f"threshold={max_age_days:.1f}d"
+    )
+    # Client accepts age == 30d (`timeIntervalSince <= 30 * 24 * 3600`) and
+    # rejects only once age exceeds that. Reserve EXPIRED for the strict past.
+    if remaining_days < 0:
+        fail(
+            f"live /v1/rate-card generated_at is EXPIRED "
+            f"({-remaining_days:.1f}d past the client 30-day horizon) — "
+            "providers that restart cannot rejoin; run "
+            "scripts/renew-autotune-static-feed.sh --deploy on the signing host now."
+        )
+    if age_days >= max_age_days:
+        fail(
+            f"live /v1/rate-card generated_at is {age_days:.1f}d old "
+            f"(>= {max_age_days:.1f}d) — {remaining_days:.1f}d remain before the "
+            "client 30-day fail-closed. Run "
+            "scripts/renew-autotune-static-feed.sh --deploy on the signing host."
+        )
+    print("[autotune-feed-freshness] OK")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--max-age-days",
+        type=float,
+        default=20.0,
+        help="alarm if generated_at is this many days old (default 20; must be < 30)",
+    )
+    parser.add_argument(
+        "--now",
+        default=None,
+        help="RFC3339 UTC timestamp ending in Z; override wall clock (tests only)",
+    )
+    args = parser.parse_args(argv)
+    if args.max_age_days <= 0:
+        fail("--max-age-days must be positive")
+    if args.max_age_days >= CLIENT_HORIZON_DAYS:
+        fail(
+            "--max-age-days must be < 30 (the client fail-closed horizon); "
+            "an alarm at or past 30d fires too late to protect the fleet"
+        )
+
+    if args.now is None:
+        now = dt.datetime.now(dt.timezone.utc)
+    else:
+        now = parse_rfc3339_z(args.now, "--now")
+
+    raw = sys.stdin.read()
+    if not raw.strip():
+        fail("no rate-card on stdin (could not fetch /v1/rate-card?)")
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        fail(f"rate-card is not valid JSON: {exc}")
+    if not isinstance(payload, dict):
+        fail("rate-card must be a JSON object")
+
+    check_rate_card(payload, now=now, max_age_days=args.max_age_days)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test-autotune-feed-freshness-alarm.sh
+++ b/scripts/test-autotune-feed-freshness-alarm.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Fail-closed structural checks for autotune-feed cadence + freshness alarm.
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+alarm="$root/.github/workflows/autotune-feed-freshness-alarm.yml"
+renew="$root/.github/workflows/renew-autotune-static-feed.yml"
+checker="$root/scripts/check-autotune-feed-freshness.py"
+
+[[ -f "$alarm" ]] || {
+  printf '[test-autotune-feed-freshness-alarm] ERROR: missing alarm workflow\n' >&2
+  exit 1
+}
+[[ -f "$renew" ]] || {
+  printf '[test-autotune-feed-freshness-alarm] ERROR: missing weekly cadence workflow\n' >&2
+  exit 1
+}
+[[ -f "$checker" ]] || {
+  printf '[test-autotune-feed-freshness-alarm] ERROR: missing freshness checker\n' >&2
+  exit 1
+}
+
+python3 - "$alarm" "$renew" "$checker" <<'PY'
+import pathlib
+import sys
+
+alarm = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+renew = pathlib.Path(sys.argv[2]).read_text(encoding="utf-8")
+checker = pathlib.Path(sys.argv[3]).read_text(encoding="utf-8")
+CHECKOUT = "uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10"
+CHECKER = "python3 scripts/check-autotune-feed-freshness.py"
+
+for name, workflow in (("alarm", alarm), ("renew", renew)):
+    for requirement in (
+        "workflow_dispatch:",
+        "permissions:",
+        "contents: read",
+        CHECKOUT,
+        "persist-credentials: false",
+        "https://coordinator.malibu.tech/v1/rate-card",
+        CHECKER,
+        "--max-age-days",
+        "--proto '=https'",
+        "--tlsv1.2",
+        "timeout-minutes: 5",
+        "runs-on: ubuntu-latest",
+    ):
+        if requirement not in workflow:
+            raise SystemExit(f"{name} workflow omits: {requirement}")
+    for forbidden in (
+        "MACPROVIDER_RELEASE_SIGNING_KEY_PEM",
+        "AUTOTUNE_STATIC",
+        "secrets.",
+        "environment: production-release",
+        "PEARL_SSH",
+        "contents: write",
+        "bash scripts/renew-autotune-static-feed.sh",
+    ):
+        if forbidden in workflow:
+            raise SystemExit(f"{name} workflow must not contain {forbidden!r}")
+    if workflow.count(CHECKER) != 1:
+        raise SystemExit(f"{name} must invoke the checker exactly once")
+
+if 'cron: "0 */6 * * *"' not in alarm:
+    raise SystemExit("alarm must run every 6 hours")
+if "group: autotune-feed-freshness-alarm" not in alarm:
+    raise SystemExit("alarm must use its own concurrency group")
+if "cancel-in-progress: true" not in alarm:
+    raise SystemExit("alarm may cancel superseded runs")
+if '--max-age-days "$MAX_AGE_DAYS"' not in alarm:
+    raise SystemExit("alarm must pass the max-age input through to the checker")
+if "|| '20'" not in alarm:
+    raise SystemExit("alarm default max-age must be 20 days")
+
+if 'cron: "0 16 * * 2"' not in renew:
+    raise SystemExit("weekly cadence must run Tuesday 16:00 UTC (after Monday launchd)")
+if 'cron: "0 16 * * 1"' in renew:
+    raise SystemExit("weekly cadence must not share Monday 16:00 UTC with operator launchd")
+if "RATE_CARD_URL" in alarm or "RATE_CARD_URL" in renew:
+    raise SystemExit("workflows must pin coordinator.malibu.tech; no URL override")
+if "group: renew-autotune-static-feed" not in renew:
+    raise SystemExit("weekly cadence must use its own concurrency group")
+if "cancel-in-progress: false" not in renew:
+    raise SystemExit("weekly cadence must not cancel an in-flight Tuesday run")
+if "|| '7'" not in renew:
+    raise SystemExit("weekly cadence default max-age must be 7 days")
+
+for requirement in (
+    "CLIENT_HORIZON_DAYS = 30.0",
+    "FUTURE_SKEW_MINUTES = 10.0",
+    "rate_card_update_required",
+    "scripts/renew-autotune-static-feed.sh --deploy",
+    "--max-age-days must be < 30",
+):
+    if requirement not in checker:
+        raise SystemExit(f"freshness checker omits: {requirement}")
+if "requests." in checker or "urllib" in checker:
+    raise SystemExit("freshness checker must not open a network connection")
+PY
+
+# Workflow YAML is not a shell script; do not bash -n it.
+python3 -m py_compile "$checker"
+
+printf '[test-autotune-feed-freshness-alarm] ok: cadence + alarm workflows fail closed\n'

--- a/scripts/tests/test_autotune_feed_freshness.py
+++ b/scripts/tests/test_autotune_feed_freshness.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/check-autotune-feed-freshness.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "scripts" / "check-autotune-feed-freshness.py"
+SPEC = importlib.util.spec_from_file_location("check_autotune_feed_freshness", SCRIPT)
+freshness = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(freshness)
+
+NOW = "2026-08-31T04:00:00Z"
+
+
+def _run(payload: object, argv: list[str]) -> tuple[int, str, str]:
+    stdin = json.dumps(payload) if not isinstance(payload, str) else payload
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    old_stdin = sys.stdin
+    sys.stdin = io.StringIO(stdin)
+    try:
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            try:
+                code = freshness.main(argv)
+            except SystemExit as exc:
+                code = int(exc.code or 0)
+    finally:
+        sys.stdin = old_stdin
+    return code, stdout.getvalue(), stderr.getvalue()
+
+
+class AutotuneFeedFreshnessTests(unittest.TestCase):
+    def test_fresh_feed_is_ok(self) -> None:
+        code, out, err = _run(
+            {"generated_at": "2026-08-28T11:07:13Z", "version": "x"},
+            ["--max-age-days", "20", "--now", NOW],
+        )
+        self.assertEqual(code, 0, err)
+        self.assertIn("[autotune-feed-freshness] OK", out)
+        self.assertIn("age=2.7d", out)
+
+    def test_age_at_threshold_alarms(self) -> None:
+        code, _, err = _run(
+            {"generated_at": "2026-08-11T04:00:00Z"},
+            ["--max-age-days", "20", "--now", NOW],
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("ALARM:", err)
+        self.assertIn("20.0d old", err)
+        self.assertIn("renew-autotune-static-feed.sh --deploy", err)
+
+    def test_age_past_threshold_alarms(self) -> None:
+        code, _, err = _run(
+            {"generated_at": "2026-08-06T04:00:00Z"},
+            ["--max-age-days", "20", "--now", NOW],
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("25.0d old", err)
+        self.assertNotIn("EXPIRED", err)
+
+    def test_exact_horizon_is_stale_not_expired(self) -> None:
+        code, _, err = _run(
+            {"generated_at": "2026-08-01T04:00:00Z"},
+            ["--max-age-days", "20", "--now", NOW],
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("30.0d old", err)
+        self.assertNotIn("EXPIRED", err)
+
+    def test_past_client_horizon_uses_expired_wording(self) -> None:
+        code, _, err = _run(
+            {"generated_at": "2026-07-01T04:00:00Z"},
+            ["--max-age-days", "20", "--now", NOW],
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("EXPIRED", err)
+        self.assertIn("30-day horizon", err)
+
+    def test_weekly_sla_fails_at_seven_days(self) -> None:
+        code, _, err = _run(
+            {"generated_at": "2026-08-24T04:00:00Z"},
+            ["--max-age-days", "7", "--now", NOW],
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("7.0d old", err)
+
+    def test_weekly_sla_passes_inside_seven_days(self) -> None:
+        code, out, err = _run(
+            {"generated_at": "2026-08-25T04:00:01Z"},
+            ["--max-age-days", "7", "--now", NOW],
+        )
+        self.assertEqual(code, 0, err)
+        self.assertIn("OK", out)
+
+    def test_future_dated_feed_alarms(self) -> None:
+        code, _, err = _run(
+            {"generated_at": "2026-08-31T05:00:00Z"},
+            ["--max-age-days", "20", "--now", NOW],
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("in the future", err)
+
+    def test_ten_minute_future_skew_is_tolerated(self) -> None:
+        code, out, err = _run(
+            {"generated_at": "2026-08-31T04:10:00Z"},
+            ["--max-age-days", "20", "--now", NOW],
+        )
+        self.assertEqual(code, 0, err)
+        self.assertIn("OK", out)
+
+    def test_missing_generated_at_fails_closed(self) -> None:
+        code, _, err = _run({"version": "x"}, ["--now", NOW])
+        self.assertEqual(code, 1)
+        self.assertIn("generated_at", err)
+
+    def test_empty_stdin_fails_closed(self) -> None:
+        code, _, err = _run("  \n", ["--now", NOW])
+        self.assertEqual(code, 1)
+        self.assertIn("no rate-card on stdin", err)
+
+    def test_non_object_json_fails_closed(self) -> None:
+        code, _, err = _run("[1, 2]", ["--now", NOW])
+        self.assertEqual(code, 1)
+        self.assertIn("JSON object", err)
+
+    def test_invalid_json_fails_closed(self) -> None:
+        code, _, err = _run("{not-json", ["--now", NOW])
+        self.assertEqual(code, 1)
+        self.assertIn("not valid JSON", err)
+
+    def test_unparseable_timestamp_fails_closed(self) -> None:
+        code, _, err = _run(
+            {"generated_at": "2026-08-28T11:07:13+00:00"},
+            ["--now", NOW],
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("unparseable generated_at", err)
+
+    def test_rejects_max_age_at_or_past_horizon(self) -> None:
+        code, _, err = _run({"generated_at": NOW}, ["--max-age-days", "30", "--now", NOW])
+        self.assertEqual(code, 1)
+        self.assertIn("must be < 30", err)
+
+    def test_rejects_non_positive_max_age(self) -> None:
+        code, _, err = _run({"generated_at": NOW}, ["--max-age-days", "0", "--now", NOW])
+        self.assertEqual(code, 1)
+        self.assertIn("must be positive", err)
+
+    def test_invalid_now_override_fails_closed(self) -> None:
+        code, _, err = _run({"generated_at": NOW}, ["--now", "yesterday"])
+        self.assertEqual(code, 1)
+        self.assertIn("unparseable --now", err)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Closes the remaining #1268 ops gap: a missed operator-local autotune-feed renewal currently ages out invisibly until providers fail to rejoin (`rate_card_update_required` at the 30-day `generated_at` horizon).

SIGHUP hot-reload (#1272) and `scripts/renew-autotune-static-feed.sh` (#1276) already landed. Signing stays on the operator machine (the Ed25519 feed key must not be a CI secret and must not live on Pearl), so GitHub-hosted runners cannot `--deploy`. This slice adds the GitHub-visible backstops:

- **Weekly cadence** (`.github/workflows/renew-autotune-static-feed.yml`): Tuesday 16:00 UTC — same hour as discovery-head renewal, offset one day so it does not race Monday launchd. Fails if live `/v1/rate-card` `generated_at` is ≥ 7 days old.
- **20-day alarm** (`.github/workflows/autotune-feed-freshness-alarm.yml`): every 6 hours. Fails if `generated_at` is ≥ 20 days old (~10 days of runway).
- **`scripts/check-autotune-feed-freshness.py`**: stdin-only, no network, fail-closed. URL pinned to `https://coordinator.malibu.tech/v1/rate-card` (no dispatch override).

On failure: run `scripts/renew-autotune-static-feed.sh --deploy` on the signing host.

## Test plan
- [x] `python3 -m unittest -v scripts.tests.test_autotune_feed_freshness` (17 tests)
- [x] `bash scripts/test-autotune-feed-freshness-alarm.sh` (workflow structure)
- [x] Live `/v1/rate-card` currently 2.7d old; both 7d and 20d checks pass
- [ ] After merge, confirm the two scheduled workflows appear under Actions

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-023"],
  "requirements": ["SPEC-023-R001"],
  "authority_domains": ["installer-autotune-policy"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "scripts/tests/test_autotune_feed_freshness.py",
    "scripts/test-autotune-feed-freshness-alarm.sh"
  ],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/1268"
}
SPEC-GOVERNANCE-DECLARATION-END

Made with [Cursor](https://cursor.com)