### PR TITLE
fix: fail closed on billing recovery and settlement jobs

### DIFF
--- a/phase4-coordinator/internal/billing/endpoints.go
+++ b/phase4-coordinator/internal/billing/endpoints.go
@@ -819,7 +819,9 @@ SELECT rl.request_id, rl.ts_utc, rl.model, COALESCE(rl.provider_assigned_id, '')
 			_, rewards, multiplier, share, err = h.store.snapshotAt(ctx, ts)
 		}
 		if err != nil {
-			continue
+			// Fail the reconcile run instead of skipping the row and still
+			// recording ledger_reconciliation_runs.status='complete'.
+			return 0, err
 		}
 		row := ComputeCreditsWithCache(pp, cachedP, cp, nil, usageFor(s.errorCode.String, nil), FaultNone, RateFor(rewards.RateCard, s.model), multiplier, share)
 		total += row.GrossCredits

--- a/phase4-coordinator/internal/billing/endpoints_test.go
+++ b/phase4-coordinator/internal/billing/endpoints_test.go
@@ -546,8 +546,38 @@ func TestReconcileEndpoint_CleanDelta(t *testing.T) {
 	}
 }
 
+func TestReconcileEndpoint_SnapshotAtErrorFailsRun(t *testing.T) {
+	reqStore, store := newRequestAndBillingStores(t)
+	ts := time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC)
+	prompt, completion := int64(1000), int64(2000)
+	if err := reqStore.Insert(context.Background(), requestlog.Row{
+		TSUtc: ts, RequestID: "reconcile-missing-snapshot", Model: "model-a", ProviderAssignedID: "assigned-a",
+		PromptTokens: &prompt, CompletionTokens: &completion, Status: 200, BuyerIP: "127.0.0.1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/admin/ledger/reconcile?from=2026-06-01&to=2026-06-08", nil)
+	req.Header.Set("Authorization", "Bearer operator")
+	w := httptest.NewRecorder()
+	store.Handlers("operator", fakeTokens{}, true, 60).ServeHTTP(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status=%d body=%s want 500 when snapshotAt fails", w.Code, w.Body.String())
+	}
+	var complete int
+	if err := store.db.QueryRow(`SELECT COUNT(*) FROM ledger_reconciliation_runs WHERE run_type = 'admin_reconcile' AND status = 'complete'`).Scan(&complete); err != nil {
+		t.Fatal(err)
+	}
+	if complete != 0 {
+		t.Fatalf("complete reconcile runs=%d want 0", complete)
+	}
+}
+
 func TestReconcileEndpointCountsFractionalRFC3339TimestampChronologically(t *testing.T) {
 	reqStore, store := newRequestAndBillingStores(t)
+	cfg := testRewards()
+	if _, err := store.InsertConfigSnapshot(context.Background(), cfg, time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)); err != nil {
+		t.Fatal(err)
+	}
 	ts := time.Date(2026, 6, 1, 0, 0, 0, 500*int(time.Millisecond), time.UTC)
 	if err := reqStore.Insert(context.Background(), requestlog.Row{
 		TSUtc: ts, RequestID: "fractional-rfc3339", Model: "model-a", ProviderAssignedID: "assigned-a",
@@ -717,6 +747,10 @@ func TestReconcileEndpoint_DetectsMissingOperatorSplit(t *testing.T) {
 
 func TestReconcileEndpoint_DuplicateByteEstimatedRowsDoNotHideDelta(t *testing.T) {
 	reqStore, store := newRequestAndBillingStores(t)
+	cfg := testRewards()
+	if _, err := store.InsertConfigSnapshot(context.Background(), cfg, time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)); err != nil {
+		t.Fatal(err)
+	}
 	ts := time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC)
 	if err := reqStore.Insert(context.Background(), requestlog.Row{
 		TSUtc: ts, RequestID: "dup-byte", Model: "model-a", ProviderAssignedID: "assigned-a",

--- a/phase4-coordinator/internal/billing/recovery.go
+++ b/phase4-coordinator/internal/billing/recovery.go
@@ -70,6 +70,8 @@ UPDATE ledger_request_credits
        quarantine_reason = COALESCE(quarantine_reason, 'missing_request_log'),
        updated_at_utc = ?
  WHERE quarantined = 0
+    AND settled = 0
+    AND settlement_id IS NULL
     AND `+sqliteTimeRange("ts_utc")+`
 	AND NOT EXISTS (
        SELECT 1
@@ -137,7 +139,26 @@ SELECT rl.id, rl.ts_utc, rl.request_id, rl.account_id, rl.model, rl.provider_ass
 		scanned++
 		ts, err := time.Parse(time.RFC3339Nano, tsText)
 		if err != nil {
-			ts = time.Now().UTC()
+			// Unparseable ts_utc must not select a rate-card snapshot from
+			// wall-clock now — that is nondeterministic across recovery runs.
+			affected, qErr := quarantineExistingLedgerForRequestAttemptTx(ctx, tx, requestID, attemptN, assignedID, "unparseable_ts_utc", now)
+			if qErr != nil {
+				return qErr
+			}
+			if affected == 0 {
+				exists, existsErr := ledgerRowExistsForRequestAttemptTx(ctx, tx, requestID, attemptN, assignedID)
+				if existsErr != nil {
+					return existsErr
+				}
+				if !exists {
+					if insErr := insertQuarantineTx(ctx, tx, requestID, attemptN, unresolvedProviderID(assignedID), assignedID, time.Unix(0, 0).UTC(), model, status, stream == 1, nil, nil, nil, errorCode.String, in.Source, "unparseable_ts_utc", now); insErr != nil {
+						return insErr
+					}
+					quarantined++
+				}
+			}
+			quarantined += affected
+			continue
 		}
 		invalidReason := ""
 		if invalidRecoveryToken(prompt) || invalidRecoveryEstimate(estimated) || invalidRecoveryCompletion(completion, estimated) {
@@ -424,7 +445,9 @@ func (s *Store) StartNightlyReconcile(ctx context.Context, cfg SettlementConfig)
 				}
 				to := time.Now().UTC().Add(-time.Duration(cfg.RecoveryGraceSeconds) * time.Second)
 				from := to.AddDate(0, 0, -cfg.NightlyReconcileWindowDays)
-				_ = s.RecoverLedger(ctx, RecoverInput{ScanFrom: from, ScanTo: to, Source: "nightly_reconcile"})
+				if err := s.RecoverLedger(ctx, RecoverInput{ScanFrom: from, ScanTo: to, Source: "nightly_reconcile"}); err != nil {
+					logBillingJobError("nightly_reconcile", err, from, to)
+				}
 			}
 		}
 	}()
@@ -719,6 +742,8 @@ UPDATE ledger_request_credits
  WHERE request_id = ?
    AND attempt_n = ?
    AND quarantined = 0
+   AND settled = 0
+   AND settlement_id IS NULL
    AND (
        provider_assigned_id = ?
        OR provider_id IN (

--- a/phase4-coordinator/internal/billing/settlement.go
+++ b/phase4-coordinator/internal/billing/settlement.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log/slog"
 	"time"
 )
 
@@ -258,7 +259,9 @@ func (s *Store) StartWeeklySettlement(ctx context.Context, cfg SettlementConfig)
 				}
 				end := next
 				start := end.AddDate(0, 0, -cfg.CadenceDays)
-				_ = s.RunSettlement(ctx, cfg, start, end)
+				if err := s.RunSettlement(ctx, cfg, start, end); err != nil {
+					logBillingJobError("weekly_settlement", err, start, end)
+				}
 			}
 		}
 	}()
@@ -287,4 +290,16 @@ func nullIntFromRow(row *sql.Row) (int64, error) {
 
 func idempotencyKey(providerID string, start, end time.Time) string {
 	return fmt.Sprintf("%s|%s|%s", providerID, sqliteTimeText(start), sqliteTimeText(end))
+}
+
+func logBillingJobError(job string, err error, windowStart, windowEnd time.Time) {
+	if err == nil {
+		return
+	}
+	slog.Error("billing background job failed",
+		"job", job,
+		"err", err,
+		"window_start", sqliteTimeText(windowStart),
+		"window_end", sqliteTimeText(windowEnd),
+	)
 }

--- a/phase4-coordinator/internal/billing/settlement_jobs_test.go
+++ b/phase4-coordinator/internal/billing/settlement_jobs_test.go
@@ -1,0 +1,47 @@
+package billing
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLogBillingJobErrorEmitsStructuredError(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	start := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	end := start.AddDate(0, 0, 7)
+	logBillingJobError("weekly_settlement", errors.New("boom"), start, end)
+	got := buf.String()
+	for _, want := range []string{"billing background job failed", "weekly_settlement", "boom"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("log %q missing %q", got, want)
+		}
+	}
+}
+
+func TestRunSettlementCancelledContextFailsClosed(t *testing.T) {
+	_, store := newRequestAndBillingStores(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	start := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	err := store.RunSettlement(ctx, SettlementConfig{CadenceDays: 7, MinPayoutCredits: 1}, start, start.AddDate(0, 0, 7))
+	if err == nil {
+		t.Fatal("expected cancelled context to fail RunSettlement")
+	}
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	logBillingJobError("weekly_settlement", err, start, start.AddDate(0, 0, 7))
+	if !strings.Contains(buf.String(), "weekly_settlement") {
+		t.Fatalf("log=%q", buf.String())
+	}
+}

--- a/phase4-coordinator/internal/billing/store_test.go
+++ b/phase4-coordinator/internal/billing/store_test.go
@@ -1084,6 +1084,22 @@ func TestRecoverLedger_QuarantinesOrphanLedgerRows(t *testing.T) {
 	}
 }
 
+func TestRecoverLedger_DoesNotQuarantineSettledOrphanRows(t *testing.T) {
+	_, store := newRequestAndBillingStores(t)
+	ts := time.Unix(200, 0).UTC()
+	insertCreditWithRequest(t, store.db, "settled-orphan", "provider-a", ts, 500)
+	if _, err := store.db.Exec(`UPDATE ledger_request_credits SET settled = 1, settlement_id = 99 WHERE request_id = 'settled-orphan'`); err != nil {
+		t.Fatal(err)
+	}
+	in := RecoverInput{ScanFrom: ts.Add(-time.Minute), ScanTo: ts.Add(time.Minute), Source: "startup_scan"}
+	if err := store.RecoverLedger(context.Background(), in); err != nil {
+		t.Fatal(err)
+	}
+	if got := scalar(t, store.db, `SELECT quarantined FROM ledger_request_credits WHERE request_id = 'settled-orphan'`); got != 0 {
+		t.Fatalf("settled orphan quarantined=%d want 0", got)
+	}
+}
+
 func TestRecoverLedger_QuarantinesLedgerRowsWithoutMatchingAttemptProviderEvidence(t *testing.T) {
 	reqStore, store := newRequestAndBillingStores(t)
 	ts := time.Unix(200, 0).UTC()
@@ -1159,6 +1175,60 @@ func TestRecoverLedger_InvalidUsageQuarantinesExistingActiveRows(t *testing.T) {
 	}
 	if got := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_request_credits WHERE request_id = 'invalid-existing' AND provider_id LIKE '__unresolved__%'`); got != 0 {
 		t.Fatalf("unresolved placeholder rows=%d want 0", got)
+	}
+}
+
+func TestRecoverLedger_DoesNotQuarantineSettledRowsOnInvalidUsage(t *testing.T) {
+	reqStore, store := newRequestAndBillingStores(t)
+	cfg := testRewards()
+	if _, err := store.InsertConfigSnapshot(context.Background(), cfg, time.Unix(100, 0).UTC()); err != nil {
+		t.Fatal(err)
+	}
+	ts := time.Unix(200, 0).UTC()
+	prompt, completion := int64(-1), int64(1000)
+	if err := reqStore.Insert(context.Background(), requestlog.Row{
+		TSUtc: ts, RequestID: "settled-invalid", Model: "model-a", ProviderAssignedID: "assigned-a",
+		PromptTokens: &prompt, CompletionTokens: &completion, Status: 200, BuyerIP: "127.0.0.1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.Exec(`INSERT INTO ledger_provider_identity_snapshots (request_id, attempt_n, provider_assigned_id, provider_id, resolved_from, created_at_utc) VALUES ('settled-invalid', 0, 'assigned-a', 'provider-a', 'pool_entry', ?)`, ts.Format(time.RFC3339Nano)); err != nil {
+		t.Fatal(err)
+	}
+	insertCreditWithRequest(t, store.db, "settled-invalid", "provider-a", ts, 500)
+	if _, err := store.db.Exec(`UPDATE ledger_request_credits SET settled = 1, settlement_id = 99 WHERE request_id = 'settled-invalid'`); err != nil {
+		t.Fatal(err)
+	}
+	in := RecoverInput{ScanFrom: ts.Add(-time.Minute), ScanTo: ts.Add(time.Minute), Source: "startup_scan"}
+	if err := store.RecoverLedger(context.Background(), in); err != nil {
+		t.Fatal(err)
+	}
+	if got := scalar(t, store.db, `SELECT quarantined FROM ledger_request_credits WHERE request_id = 'settled-invalid'`); got != 0 {
+		t.Fatalf("settled row quarantined=%d want 0", got)
+	}
+	if got := scalar(t, store.db, `SELECT settled FROM ledger_request_credits WHERE request_id = 'settled-invalid'`); got != 1 {
+		t.Fatalf("settled flag=%d want 1", got)
+	}
+}
+
+func TestRecoverLedger_QuarantinesUnparseableTSUtc(t *testing.T) {
+	reqStore, store := newRequestAndBillingStores(t)
+	ts := time.Unix(200, 0).UTC()
+	if err := reqStore.Insert(context.Background(), requestlog.Row{
+		TSUtc: ts, RequestID: "bad-ts", Model: "model-a", ProviderAssignedID: "assigned-a",
+		Status: 200, BuyerIP: "127.0.0.1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.Exec(`UPDATE request_log SET ts_utc = ? WHERE request_id = 'bad-ts'`, ts.UTC().Format(time.RFC3339Nano)+"bogus"); err != nil {
+		t.Fatal(err)
+	}
+	in := RecoverInput{ScanFrom: ts.Add(-time.Minute), ScanTo: ts.Add(time.Minute), Source: "startup_scan"}
+	if err := store.RecoverLedger(context.Background(), in); err != nil {
+		t.Fatal(err)
+	}
+	if got := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_request_credits WHERE request_id = 'bad-ts' AND quarantined = 1 AND quarantine_reason = 'unparseable_ts_utc'`); got != 1 {
+		t.Fatalf("unparseable ts quarantine rows=%d want 1", got)
 	}
 }
 

--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -3901,10 +3901,10 @@
       ],
       "evidence": [
         {
-          "artifact": "commit:caa6ae4aec712c5d6353a3d307aab551911bea65",
+          "artifact": "commit:f5a4e1d1ec9f42e0f718ad0e82f95e62e91b1e17",
           "source": null,
-          "captured_at": "2026-08-18",
-          "expires_at": "2026-09-17"
+          "captured_at": "2026-08-31",
+          "expires_at": "2026-09-30"
         },
         {
           "artifact": "sha256:553f8eb085674daa557277cf4aaf476ad8269e50e5c7f9b89dcf77bf5587706b",
@@ -4642,10 +4642,10 @@
       ],
       "evidence": [
         {
-          "artifact": "commit:caa6ae4aec712c5d6353a3d307aab551911bea65",
+          "artifact": "commit:f5a4e1d1ec9f42e0f718ad0e82f95e62e91b1e17",
           "source": null,
-          "captured_at": "2026-08-18",
-          "expires_at": "2026-09-17"
+          "captured_at": "2026-08-31",
+          "expires_at": "2026-09-30"
         },
         {
           "artifact": "sha256:5ede794fefc03470f1e3e5c0c401e95c8b9842c2c4aa0ac0fb7fcefd0ee39e14",


### PR DESCRIPTION
## Summary
- Fail admin ledger reconcile closed when snapshot lookup errors, instead of skipping rows and still recording status=complete.
- Keep settled and settlement-linked ledger rows out of recovery quarantine (shared helper and orphan sweep).
- Quarantine unparseable request_log.ts_utc instead of substituting wall-clock time.
- Log weekly settlement and nightly reconcile job errors instead of discarding them.

Coordinator-only. No CLI or Malibu.app change. Deploy is a coordinator restart.

## Test plan
- [x] `cd phase4-coordinator && go test ./internal/billing -count=1`
- [x] Codex code / security / architect re-audit after orphan-sweep guard: 0 CRITICAL / 0 HIGH / 0 MEDIUM (LOW carried: failed admin-reconcile run rows not recorded; malformed timestamps outside the scan window still unswept)

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": ["SPEC-005", "SPEC-022"],
  "requirements": ["SPEC-005-R003", "SPEC-005-R005", "SPEC-005-R007", "SPEC-005-R009", "SPEC-022-R009"],
  "authority_domains": ["billing-settlement-formula"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "cd phase4-coordinator && go test ./internal/billing -count=1"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END