### PR TITLE
Add production-release CI signing for autotune feed renewal

### DIFF
--- a/.github/workflows/autotune-feed-freshness-alarm.yml
+++ b/.github/workflows/autotune-feed-freshness-alarm.yml
@@ -3,11 +3,12 @@ name: Autotune feed freshness alarm
 # Read-only backstop for the SPEC-023 signed autotune feed (rate-card /
 # candidate / demand). The client 30-day generated_at horizon fails closed
 # with rate_card_update_required and strands any provider that restarts.
-# Operator-local launchd runs scripts/renew-autotune-static-feed.sh weekly
-# (signing stays off CI — see docs/runbooks/autotune-feed-renewal.md); if that
-# run is skipped/late, this alarm fails (and notifies) BEFORE the feed ages
-# past 30 days. No secrets, no production-release environment, no signing,
-# no Pearl SSH — it only reads the public /v1/rate-card generated_at.
+# The Wednesday production-release workflow
+# (renew-autotune-static-feed-signed.yml) is the always-on signer. If that
+# run is skipped, late, or waiting on approval, this alarm fails (and
+# notifies) BEFORE the feed ages past 30 days. No secrets, no
+# production-release environment, no signing, no Pearl SSH — it only reads
+# the public /v1/rate-card generated_at.
 
 on:
   schedule:

--- a/.github/workflows/renew-autotune-static-feed-signed.yml
+++ b/.github/workflows/renew-autotune-static-feed-signed.yml
@@ -1,0 +1,102 @@
+name: Renew signed autotune static feed
+
+# Protected weekly freshness re-stamp for the SPEC-023 signed autotune feed.
+# Signs on a macos-15-intel runner (Swift CryptoKit + sealed OpenSSL 3 verify),
+# then rsyncs only signed bytes to Pearl and SIGHUPs the coordinator.
+#
+# The feed key MUST NOT live on Pearl. It is a production-release secret
+# (AUTOTUNE_STATIC_V4_PRIVATE_KEY_BASE64). Do not reuse the discovery-head
+# PEM or the download.malibu.tech SSH key. antfleet-ops approves each run.
+#
+# Tuesday watch (renew-autotune-static-feed.yml) and the 20-day alarm stay as
+# read-only backstops. A red Tuesday run means this Wednesday job missed or
+# is still waiting on production-release approval.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Wednesday 16:00 UTC: offset from Monday discovery-head and Tuesday watch.
+    - cron: "0 16 * * 3"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-release
+  cancel-in-progress: false
+
+jobs:
+  renew:
+    name: Re-stamp, sign, and hot-reload the autotune feed
+    runs-on: macos-15-intel
+    environment: production-release
+    timeout-minutes: 20
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Checkout reviewed renewal controls
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify protected GitHub release posture
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_POSTURE_TOKEN }}
+        run: bash scripts/verify-github-release-posture.sh "$GITHUB_REPOSITORY" production-release 28995904
+
+      - name: Seal reviewed OpenSSL 3
+        id: protected_openssl
+        shell: bash
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+        run: |
+          set -euo pipefail
+          sealed_bin="$(
+            bash scripts/install-sealed-release-openssl.sh \
+              /private/var/macprovider-openssl-autotune-renewal
+          )"
+          "$sealed_bin" version | grep -E '^OpenSSL 3\.'
+          printf 'bin=%s\n' "$sealed_bin" >> "$GITHUB_OUTPUT"
+
+      - name: Sign a freshness restamp and deploy to Pearl
+        shell: bash
+        env:
+          OPENSSL_BIN: ${{ steps.protected_openssl.outputs.bin }}
+          AUTOTUNE_STATIC_V4_PRIVATE_KEY_BASE64: ${{ secrets.AUTOTUNE_STATIC_V4_PRIVATE_KEY_BASE64 }}
+          PEARL_AUTOTUNE_DEPLOY_SSH_KEY: ${{ secrets.PEARL_AUTOTUNE_DEPLOY_SSH_KEY }}
+        run: |
+          set -euo pipefail
+          [ -n "$OPENSSL_BIN" ] || {
+            echo "::error::sealed OPENSSL_BIN is required" >&2
+            exit 1
+          }
+          [ -x "$OPENSSL_BIN" ] || {
+            echo "::error::sealed OPENSSL_BIN is not executable" >&2
+            exit 1
+          }
+          "$OPENSSL_BIN" version | grep -E '^OpenSSL 3\.'
+          [ -n "$AUTOTUNE_STATIC_V4_PRIVATE_KEY_BASE64" ] || {
+            echo "::error::AUTOTUNE_STATIC_V4_PRIVATE_KEY_BASE64 is required (production-release secret)" >&2
+            exit 1
+          }
+          [ -n "$PEARL_AUTOTUNE_DEPLOY_SSH_KEY" ] || {
+            echo "::error::PEARL_AUTOTUNE_DEPLOY_SSH_KEY is required (production-release secret)" >&2
+            exit 1
+          }
+          key="$(mktemp "$RUNNER_TEMP/autotune-static.XXXXXX.b64")"
+          ssh_key="$(mktemp "$RUNNER_TEMP/pearl-autotune-deploy.XXXXXX")"
+          trap 'rm -f "$key" "$ssh_key"' EXIT
+          umask 077
+          printf '%s\n' "$AUTOTUNE_STATIC_V4_PRIVATE_KEY_BASE64" > "$key"
+          printf '%s\n' "$PEARL_AUTOTUNE_DEPLOY_SSH_KEY" > "$ssh_key"
+          chmod 600 "$key" "$ssh_key"
+          unset AUTOTUNE_STATIC_V4_PRIVATE_KEY_BASE64 PEARL_AUTOTUNE_DEPLOY_SSH_KEY
+          export AUTOTUNE_STATIC_PRIVATE_KEY_PATH="$key"
+          export PEARL_SSH_IDENTITY="$ssh_key"
+          export PEARL_SSH_KNOWN_HOSTS="$GITHUB_WORKSPACE/scripts/dist/malibu-download-known_hosts"
+          export PEARL_SSH="root@159.223.165.194"
+          bash scripts/renew-autotune-static-feed.sh --deploy

--- a/.github/workflows/renew-autotune-static-feed.yml
+++ b/.github/workflows/renew-autotune-static-feed.yml
@@ -2,28 +2,24 @@ name: Renew autotune static feed
 
 # Weekly cadence gate for the SPEC-023 signed autotune feed.
 #
-# Signing stays on the operator machine (streamvc-autotune-static-v4 MUST NOT
-# be a CI secret and MUST NOT live on Pearl — see
-# docs/runbooks/autotune-feed-renewal.md). GitHub-hosted runners therefore
-# cannot call `scripts/renew-autotune-static-feed.sh --deploy`: that script
-# signs locally and rsyncs to Pearl over SSH. This workflow uses the same
-# 16:00 UTC weekly hour as renew-release-discovery-head.yml, offset to
-# Tuesday so it runs AFTER the Monday operator-local launchd renewal rather
-# than racing it. The 20-day autotune-feed-freshness-alarm.yml is the
-# last-line backstop.
+# Signing is the Wednesday production-release workflow
+# (.github/workflows/renew-autotune-static-feed-signed.yml). This job is
+# watch-only: no secrets, no Pearl SSH, no --deploy. Tuesday 16:00 UTC is
+# one day after Wednesday's signed run would have landed the previous week
+# (~6 days old, inside the 7-day SLA). Offset from Monday 16:00 UTC
+# discovery-head renewal.
 #
 # The job fetches the live /v1/rate-card and fails if generated_at is at
-# least 7 days old — the weekly SLA. On failure, run
-# `scripts/renew-autotune-static-feed.sh --deploy` on the signing host.
-# No secrets, no Pearl SSH, no --deploy from CI.
+# least 7 days old — the weekly SLA. On failure, inspect the Wednesday
+# signed workflow (missed run or production-release approval still pending).
+# The 20-day autotune-feed-freshness-alarm.yml is the last-line backstop.
 
 on:
   schedule:
-    # Tuesday 16:00 UTC: one day after the Monday operator-local renewal
-    # window, well inside the 30-day client freshness horizon. A missed
-    # Monday run then fails this check the next day rather than silently
-    # aging toward 30 days, and cannot false-fail while launchd is still
-    # deploying.
+    # Tuesday 16:00 UTC: after last week's Wednesday signed renewal, well
+    # inside the 30-day client freshness horizon. A missed/unapproved
+    # Wednesday run then fails this check rather than silently aging
+    # toward 30 days.
     - cron: "0 16 * * 2"
   workflow_dispatch:
     inputs:
@@ -64,6 +60,6 @@ jobs:
             exit 1
           }
           echo "Weekly SLA: live generated_at must be younger than ${MAX_AGE_DAYS}d."
-          echo "A failure means: run scripts/renew-autotune-static-feed.sh --deploy on the signing host."
+          echo "A failure means: inspect the Wednesday production-release workflow renew-autotune-static-feed-signed.yml (missed run or approval pending)."
           curl -fsS --proto '=https' --tlsv1.2 --max-time 20 -- "$url" \
             | python3 scripts/check-autotune-feed-freshness.py --max-age-days "$MAX_AGE_DAYS"

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,10 @@ test-dist:
 	bash scripts/test-select-public-discovery-transport.sh
 	bash scripts/test-renew-release-discovery-head.sh
 	bash scripts/test-autotune-feed-freshness-alarm.sh
+	bash scripts/test-renew-autotune-static-feed-signed.sh
+	bash -n scripts/renew-autotune-static-feed.sh
 	PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v scripts.tests.test_autotune_feed_freshness
+	PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v scripts.tests.test_pearl_autotune_deploy_lock
 	bash scripts/test-tier2-provider-artifact.sh
 	bash scripts/test-tier2-provider-release.sh
 	bash scripts/test-tier2-activation-safety.sh

--- a/docs/runbooks/autotune-feed-renewal.md
+++ b/docs/runbooks/autotune-feed-renewal.md
@@ -19,115 +19,111 @@ every provider WebSocket stays connected.
 ## Security model — signing stays off the production host
 
 The Ed25519 feed-signing key (`streamvc-autotune-static-v4`) is what protects
-clients from a compromised coordinator serving forged feeds. It MUST NOT live on
-Pearl. `renew-autotune-static-feed.sh` therefore:
+clients from a compromised coordinator serving forged feeds. It **MUST NOT**
+live on Pearl. A Pearl-root signer that mints client-trusted feeds and retargets
+`autotune/current` is the same mutation surface as `deploy-pearl-vps.sh`.
 
-- signs locally, on the operator machine where the key lives
-  (`~/.config/macprovider/keys/autotune-static-v4.private.base64`, `0600`),
-  deriving the public key in memory and comparing it to the committed trusted
-  keyring — **never printing private bytes**;
-- pushes only signed bytes to Pearl and does the symlink swap + `SIGHUP` over SSH.
+Primary always-on signer: GitHub Actions
+`.github/workflows/renew-autotune-static-feed-signed.yml` (Wednesday 16:00 UTC,
+`environment: production-release`, antfleet-ops approval). The runner signs with
+Swift CryptoKit, verifies with a sealed OpenSSL 3 bottle, and rsyncs **only
+signed bytes** to Pearl. The private key is a `production-release` secret, never
+a file on the coordinator host.
 
 A Pearl compromise therefore still cannot mint a validly-signed feed.
 
-## What the script does
+## Operator secrets (not in the repo)
 
-`scripts/renew-autotune-static-feed.sh` (default = dry-run, `--deploy` to publish):
+Place these on the `production-release` environment **before the first live
+`--deploy`**. Until they exist, the workflow is mergeable but a scheduled run
+fails closed on empty secrets. Do **not** commit key material.
 
-1. Builds an **ephemeral git worktree** off `origin/main` so it never dirties
-   your checkout (`generate`/`resign` rewrite tracked feed files + the ledger).
+| Secret | What it is |
+| --- | --- |
+| `AUTOTUNE_STATIC_V4_PRIVATE_KEY_BASE64` | Raw 32-byte Ed25519 seed, same contents as `~/.config/macprovider/keys/autotune-static-v4.private.base64`. Do not reuse the discovery-head release-signing PEM. |
+| `PEARL_AUTOTUNE_DEPLOY_SSH_KEY` | OpenSSH private key for `root@159.223.165.194`. Do not reuse the download.malibu.tech upload key (different blast radius). Host key is pinned via `scripts/dist/malibu-download-known_hosts` with `StrictHostKeyChecking=yes`. |
+
+## What the signed job does
+
+`scripts/renew-autotune-static-feed.sh --deploy` (default without `--deploy` is
+dry-run):
+
+1. Builds an **ephemeral git worktree**. On Actions, restamps `GITHUB_SHA`
+   (the approved workflow commit), not a floating `origin/main`. Locally,
+   restamps `origin/main`.
 2. Re-stamps `version` + `generated_at` on candidate/demand and `generated_at`
    only on rate-card (its `version` is a rows-hash — a freshness renewal must not
    change it). Content is otherwise byte-identical.
 3. `catalog-release.py generate` → canonical bytes + manifest + ledger, then
-   `resign-autotune-static.sh` signs the three feeds.
+   `resign-autotune-static.sh` signs the three feeds (Swift). `verify-directory`
+   uses `OPENSSL_BIN` when set (CI sealed bottle).
 4. Assembles the 9-file release dir and gates it with
    `catalog-release.py verify-directory`.
 5. **Dry-run stops here.** With `--deploy`:
-   - reads the live `current` target,
+   - refuses to run if the signing-host clock is skewed >120s vs Pearl;
+   - takes `.renew.lock` (no concurrent autotune publishes);
    - **content-continuity guard**: compares the new feed (dates stripped) against
      the live feed and ABORTS on any model/gate/rate-card-row difference — a real
      catalog change must go through a reviewed release, never this cron;
-   - rsyncs the signed dir into `releases/`, records the outgoing release as
-     `.previous-target` (so nodes still on it are admitted as `previous`),
-     atomically retargets `current`, and `SIGHUP`s the coordinator;
-   - verifies the served `/v1/rate-card` `generated_at` refreshed within
-     `FRESHNESS_MAX_AGE_SEC` (default 900s); **rolls the symlink back and re-HUPs
-     on regression.**
+   - rsyncs the signed dir into `releases/`;
+   - holds the same Pearl deploy locks as `deploy-pearl-vps.sh`
+     (`/run/lock/macprovider-pearl-updater.lock` then
+     `/opt/macprovider/.coordinator-deploy.lock`, non-blocking). Lock files
+     are validated first (`scripts/pearl_autotune_deploy_lock.py`: regular
+     file, root:root, `0600`, nlink 1, `O_NOFOLLOW`) and never created;
+   - re-checks content continuity **under those locks** so a coordinator
+     catalog deploy cannot be overwritten by this restamp;
+   - resolves coordinator `MainPID` before mutating, records the outgoing
+     release as `.previous-target`, atomically retargets `current`, `SIGHUP`s;
+   - verifies served `/v1/rate-card` `generated_at` **exactly** equals this
+     run's stamp. Rollback of `current` / `.previous-target` runs **only if
+     this run already swapped `current`**, and only while holding the same
+     locks. A lock-held or pre-swap failure does not rollback (that would be
+     the first mutation and can clobber an in-flight coordinator deploy).
 
-## Manual run
+## Weekly schedule
+
+| When (UTC) | What |
+| --- | --- |
+| Monday 16:00 | discovery-head renewal (`renew-release-discovery-head.yml`) — different key, different artifact. Do not share this slot. |
+| Wednesday 16:00 | **signed autotune renew** (`renew-autotune-static-feed-signed.yml`, `production-release`) |
+| Tuesday 16:00 | **watch** (`renew-autotune-static-feed.yml`) — fails if live `generated_at` is ≥ 7 days old (~6 days after a successful Wednesday) |
+| every 6 hours | **20-day alarm** (`autotune-feed-freshness-alarm.yml`) |
+
+A red Tuesday watch means: inspect the Wednesday `production-release` run
+(missed schedule or approval still pending). Do **not** install a laptop
+LaunchAgent as the SLA — a closed laptop misses the week. Do **not** put the
+feed key on Pearl.
+
+## Laptop fallback (not the SLA)
+
+If the Actions signer cannot run, an operator at a machine that already holds
+the key can:
 
 ```bash
-# From any repo checkout (it uses its own ephemeral worktree):
 scripts/renew-autotune-static-feed.sh            # build + verify, no prod contact
 scripts/renew-autotune-static-feed.sh --deploy   # publish + hot-reload + verify
 ```
 
-Env overrides: `PEARL_SSH`, `REMOTE_AUTOTUNE_DIR`, `COORDINATOR_UNIT`,
-`COORDINATOR_HEALTH_URL`, `AUTOTUNE_STATIC_KEY_ID`.
+Env overrides: `PEARL_SSH` (default `pearl`), `PEARL_SSH_IDENTITY`,
+`PEARL_SSH_KNOWN_HOSTS`, `REMOTE_AUTOTUNE_DIR`, `COORDINATOR_UNIT`,
+`COORDINATOR_HEALTH_URL`, `AUTOTUNE_STATIC_KEY_ID`,
+`AUTOTUNE_STATIC_PRIVATE_KEY_PATH`, `OPENSSL_BIN`.
 
-Deploy is fail-closed and hardened: it takes an atomic remote lock (no concurrent
-publishes), guards against signing-host clock skew, verifies the served
-`generated_at` **exactly** equals this run's stamp (not a freshness window), and
-on any post-swap regression rolls back **both** `current` and `.previous-target`
-and re-HUPs.
-
-## Weekly schedule (operator-local, macOS launchd)
-
-Run weekly — `generated_at` is then never more than ~7 days old, leaving ~23
-days of slack, so a missed run (laptop asleep) is safe. Install as a **user
-LaunchAgent** on the machine that holds the signing key. This plist is
-operator-local (it names local paths + the key); keep it OUT of the repo.
-
-`~/Library/LaunchAgents/live.streamvc.autotune-feed-renewal.plist`:
-
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
-  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0"><dict>
-  <key>Label</key><string>live.streamvc.autotune-feed-renewal</string>
-  <key>ProgramArguments</key>
-  <array>
-    <string>/bin/bash</string>
-    <string>-lc</string>
-    <string>cd "$HOME/macprovider-poc" &amp;&amp; scripts/renew-autotune-static-feed.sh --deploy &gt;&gt; "$HOME/Library/Logs/autotune-feed-renewal.log" 2>&amp;1</string>
-  </array>
-  <!-- Mondays 16:00 UTC-ish; launchd runs once on wake if the machine was asleep. -->
-  <key>StartCalendarInterval</key>
-  <dict><key>Weekday</key><integer>1</integer><key>Hour</key><integer>16</integer><key>Minute</key><integer>0</integer></dict>
-  <key>StandardErrorPath</key><string>/tmp/autotune-feed-renewal.err</string>
-  <key>RunAtLoad</key><false/>
-</dict></plist>
-```
+Verify after a run:
 
 ```bash
-launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/live.streamvc.autotune-feed-renewal.plist
-launchctl kickstart -p gui/$(id -u)/live.streamvc.autotune-feed-renewal   # optional: run once now
+curl -s https://coordinator.malibu.tech/v1/rate-card \
+  | python3 -c 'import sys,json;print(json.load(sys.stdin)["generated_at"])'
 ```
 
-Verify after a run: `curl -s https://coordinator.malibu.tech/v1/rate-card | python3 -c 'import sys,json;print(json.load(sys.stdin)["generated_at"])'`
-should show today; provider `pool_size` should be unchanged across the HUP.
+`pool_size` should be unchanged across the HUP.
 
 ## GitHub Actions backstops (no signing, no Pearl SSH)
 
-GitHub-hosted runners cannot call `renew-autotune-static-feed.sh --deploy`:
-the Ed25519 feed key must not be a CI secret, and deploy is SSH to Pearl.
-Two read-only workflows make a missed launchd/manual run visible in Actions
-before the client 30-day horizon:
-
-1. **Weekly cadence** — `.github/workflows/renew-autotune-static-feed.yml`
-   (`cron: "0 16 * * 2"`, Tuesday 16:00 UTC — same hour as discovery-head
-   renewal, offset one day so it does not race Monday launchd). Fetches live
-   `/v1/rate-card` and fails if `generated_at` is ≥ 7 days old. A failure
-   means: run `--deploy` on the signing host this week.
-2. **20-day alarm** — `.github/workflows/autotune-feed-freshness-alarm.yml`
-   (every 6 hours). Fails if `generated_at` is ≥ 20 days old, leaving ~10
-   days of runway. Mirror of `discovery-head-freshness-alarm.yml`.
-
-Both call `scripts/check-autotune-feed-freshness.py` (stdin JSON, no
-network, no secrets). `workflow_dispatch` accepts a `max_age_days` override
-for a manual check after a local deploy. The live URL is pinned to
+The Tuesday cadence and 20-day alarm remain **read-only**. They fetch live
+`/v1/rate-card` and call `scripts/check-autotune-feed-freshness.py` (stdin JSON,
+no network, no secrets). The live URL is pinned to
 `https://coordinator.malibu.tech/v1/rate-card` (no dispatch override).
 
 ```bash
@@ -139,10 +135,43 @@ curl -fsS --proto '=https' --tlsv1.2 --max-time 20 \
 ## Rollback
 
 The prior release is retained as `.previous-target` and its directory is left in
-`releases/`. To revert manually:
+`releases/`. Automated rollback holds the Pearl deploy locks, then:
+
+- restores `current` and `.previous-target` if `current` still points at the
+  failed renewal;
+- restores `.previous-target` only if `current` never moved;
+- does nothing if `current` already points at a newer release.
+
+Manual rollback must do the same. Replace `<failed-release-id>` with the
+renewal directory that should be undone:
 
 ```bash
-ssh pearl 'cd /opt/macprovider/autotune && ln -sfn "$(cat .previous-target)" .current.rb && mv -Tf .current.rb current && kill -HUP "$(systemctl show -p MainPID --value macprovider-coordinator)"'
+expected='releases/<failed-renewal-id>'
+orig_prev='releases/<pre-renewal-previous-id>'  # or __EMPTY__ if there was none
+ssh pearl bash -s -- "$expected" "$orig_prev" <<'RB'
+set -euo pipefail
+root=/opt/macprovider/autotune
+expected="$1"
+orig_prev="$2"
+[ "$orig_prev" = "__EMPTY__" ] && orig_prev=""
+exec 8</run/lock/macprovider-pearl-updater.lock
+flock -n 8 || { echo "Pearl updater lock held; not mutating" >&2; exit 1; }
+exec 9</opt/macprovider/.coordinator-deploy.lock
+flock -n 9 || { echo "coordinator deploy lock held; not mutating" >&2; exit 1; }
+live="$(readlink "$root/current")"
+live="${live#./}"
+[ "$live" = "$expected" ] || {
+  echo "current is $live, not $expected; not mutating" >&2
+  exit 0
+}
+prev="$(cat "$root/.previous-target")"
+ln -sfn "$prev" "$root/.current.rb"
+mv -Tf "$root/.current.rb" "$root/current"
+if [ -n "$orig_prev" ]; then printf '%s\n' "$orig_prev" > "$root/.previous-target"; else rm -f "$root/.previous-target"; fi
+pid="$(systemctl show -p MainPID --value macprovider-coordinator)"
+[ -n "$pid" ] && [ "$pid" != "0" ] && kill -HUP "$pid"
+echo "rolled back current away from $expected"
+RB
 ```
 
 See also `autotune-feed-30day-freshness-expiry-fleetwide` (incident + manual

--- a/scripts/check-autotune-feed-freshness.py
+++ b/scripts/check-autotune-feed-freshness.py
@@ -10,7 +10,7 @@ check is the read-only backstop that fires *before* that happens.
 
 Read-only: no secrets, no network, no signature trust decision (that is the
 client's job) — this only reads the self-asserted `generated_at`. Intended
-to run on a schedule far more often than the weekly operator-local renewal.
+to run on a schedule far more often than the weekly CI-signed renewal.
 
 Usage:
   curl -fsS --proto '=https' --tlsv1.2 --max-time 20 \\
@@ -77,15 +77,19 @@ def check_rate_card(
         fail(
             f"live /v1/rate-card generated_at is EXPIRED "
             f"({-remaining_days:.1f}d past the client 30-day horizon) — "
-            "providers that restart cannot rejoin; run "
-            "scripts/renew-autotune-static-feed.sh --deploy on the signing host now."
+            "providers that restart cannot rejoin; inspect "
+            "Actions workflow renew-autotune-static-feed-signed.yml "
+            "(production-release) or run "
+            "scripts/renew-autotune-static-feed.sh --deploy on a signing host now."
         )
     if age_days >= max_age_days:
         fail(
             f"live /v1/rate-card generated_at is {age_days:.1f}d old "
             f"(>= {max_age_days:.1f}d) — {remaining_days:.1f}d remain before the "
-            "client 30-day fail-closed. Run "
-            "scripts/renew-autotune-static-feed.sh --deploy on the signing host."
+            "client 30-day fail-closed. Inspect "
+            "Actions workflow renew-autotune-static-feed-signed.yml "
+            "(production-release) or run "
+            "scripts/renew-autotune-static-feed.sh --deploy on a signing host."
         )
     print("[autotune-feed-freshness] OK")
 

--- a/scripts/pearl_autotune_deploy_lock.py
+++ b/scripts/pearl_autotune_deploy_lock.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Validate Pearl coordinator-deploy lock files.
+
+Matches the deploy-pearl-vps.sh contract: existing regular files, root:root,
+0600, nlink==1, opened with O_NOFOLLOW. Does not create lock files and does
+not chmod /run/lock. flock stays in the caller so the lease is held across
+the bash mutation window.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import sys
+
+UPDATER_LOCK = "/run/lock/macprovider-pearl-updater.lock"
+COORDINATOR_LOCK = "/opt/macprovider/.coordinator-deploy.lock"
+NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
+
+
+def validate_lock_file(path: str, *, require_root: bool = True) -> None:
+    try:
+        fd = os.open(path, os.O_RDONLY | NOFOLLOW)
+    except FileNotFoundError as exc:
+        raise SystemExit(f"missing lock file: {path}") from exc
+    except OSError as exc:
+        raise SystemExit(f"cannot open lock file {path}: {exc}") from exc
+    try:
+        info = os.fstat(fd)
+        if not stat.S_ISREG(info.st_mode):
+            raise SystemExit(f"unsafe lock (not a regular file): {path}")
+        if require_root and (info.st_uid != 0 or info.st_gid != 0):
+            raise SystemExit(f"unsafe lock (not root:root): {path}")
+        if stat.S_IMODE(info.st_mode) != 0o600:
+            raise SystemExit(f"unsafe lock (mode not 0600): {path}")
+        if info.st_nlink != 1:
+            raise SystemExit(f"unsafe lock (nlink != 1): {path}")
+    finally:
+        os.close(fd)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if args == ["validate"]:
+        validate_lock_file(UPDATER_LOCK)
+        validate_lock_file(COORDINATOR_LOCK)
+        return 0
+    if len(args) >= 1 and args[0] == "validate-path":
+        require_root = True
+        paths = args[1:]
+        if paths and paths[0] == "--no-require-root":
+            require_root = False
+            paths = paths[1:]
+        if len(paths) != 1:
+            raise SystemExit("usage: validate-path [--no-require-root] PATH")
+        validate_lock_file(paths[0], require_root=require_root)
+        return 0
+    raise SystemExit("usage: pearl_autotune_deploy_lock.py validate | validate-path [--no-require-root] PATH")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/renew-autotune-static-feed.sh
+++ b/scripts/renew-autotune-static-feed.sh
@@ -9,8 +9,13 @@
 # SIGNING STAYS OFF THE PRODUCTION HOST. The Ed25519 feed-signing key is the
 # thing that protects clients from a compromised coordinator serving forged
 # feeds; putting it on Pearl would defeat that. This script signs locally (where
-# the key lives), pushes only signed bytes to Pearl, and does the symlink swap +
-# SIGHUP over SSH.
+# the key lives — operator laptop or a production-release GitHub Actions runner),
+# pushes only signed bytes to Pearl, and does the symlink swap + SIGHUP over SSH.
+#
+# Primary always-on signer: .github/workflows/renew-autotune-static-feed-signed.yml
+# (Wednesday 16:00 UTC, production-release). This script is that job's deploy
+# path and the laptop fallback. Do not install a Pearl systemd signer and do
+# not install a laptop LaunchAgent as the SLA.
 #
 # Default is DRY-RUN: build + verify a re-dated release locally and stop. Pass
 # --deploy to push to the coordinator host. --deploy is fail-closed and atomic,
@@ -23,13 +28,18 @@
 #
 # Env:
 #   PEARL_SSH                ssh target for the coordinator host (default: pearl)
+#   PEARL_SSH_IDENTITY       optional OpenSSH private-key file (CI deploy; 0600/0400)
+#   PEARL_SSH_KNOWN_HOSTS    pinned known_hosts when PEARL_SSH_IDENTITY is set
+#                            (default: scripts/dist/malibu-download-known_hosts)
 #   REMOTE_AUTOTUNE_DIR      remote autotune root (default: /opt/macprovider/autotune)
 #   COORDINATOR_UNIT         systemd unit name (default: macprovider-coordinator)
 #   COORDINATOR_HEALTH_URL   URL that returns the served rate-card (default: https://coordinator.malibu.tech/v1/rate-card)
 #   AUTOTUNE_STATIC_KEY_ID   signing key id (default: streamvc-autotune-static-v4)
 #   AUTOTUNE_STATIC_PRIVATE_KEY_PATH  override key path (default: ~/.config/macprovider/keys/autotune-static-<ver>.private.base64)
+#   OPENSSL_BIN              optional absolute OpenSSL 3 path (CI sealed bottle)
 #   RELEASE_ID_PREFIX        version prefix (default: published)
 #   RELEASE_ID_SUFFIX        version suffix (default: inband-provenance-v1)
+#   GITHUB_SHA               when set (Actions), restamp that commit instead of origin/main
 
 set -euo pipefail
 
@@ -50,16 +60,53 @@ DEPLOY=0
 WORKTREE=""
 STAGING=""
 LOCK_HELD=""
+LOCK_HELPER=""
+LOCK_HELPER_DIR=""
 
 log()   { printf '[renew-autotune] %s\n' "$*"; }
 fatal() { printf '[renew-autotune] ERROR: %s\n' "$*" >&2; exit 1; }
+
+# SSH options: laptop uses the operator ssh config (alias `pearl`). CI passes
+# PEARL_SSH_IDENTITY + a pinned known_hosts file and must not fall back to
+# ssh-agent identities or TOFU.
+SSH_OPTS=(-o ConnectTimeout=15 -o BatchMode=yes)
+if [ -n "${PEARL_SSH_IDENTITY:-}" ]; then
+  case "$PEARL_SSH_IDENTITY" in ""|*[!A-Za-z0-9._/+=@-]*) fatal "unsafe PEARL_SSH_IDENTITY path" ;; esac
+  [ -f "$PEARL_SSH_IDENTITY" ] || fatal "PEARL_SSH_IDENTITY is not a file"
+  identity_mode="$(stat -f '%A' "$PEARL_SSH_IDENTITY" 2>/dev/null || stat -c '%a' "$PEARL_SSH_IDENTITY" 2>/dev/null || echo '')"
+  case "$identity_mode" in
+    600|400) ;;
+    *) fatal "PEARL_SSH_IDENTITY $PEARL_SSH_IDENTITY has permissions $identity_mode; expected 0600 or 0400" ;;
+  esac
+  PEARL_SSH_KNOWN_HOSTS="${PEARL_SSH_KNOWN_HOSTS:-$SCRIPT_DIR/dist/malibu-download-known_hosts}"
+  case "$PEARL_SSH_KNOWN_HOSTS" in ""|*[!A-Za-z0-9._/+=@-]*) fatal "unsafe PEARL_SSH_KNOWN_HOSTS path" ;; esac
+  [ -f "$PEARL_SSH_KNOWN_HOSTS" ] || fatal "PEARL_SSH_KNOWN_HOSTS is not a file"
+  SSH_OPTS+=(
+    -i "$PEARL_SSH_IDENTITY"
+    -o IdentitiesOnly=yes
+    -o "UserKnownHostsFile=$PEARL_SSH_KNOWN_HOSTS"
+    -o StrictHostKeyChecking=yes
+    -p 22
+  )
+fi
+case "$PEARL_SSH" in ""|*[!A-Za-z0-9._@-]*) fatal "unsafe PEARL_SSH: $PEARL_SSH" ;; esac
+
+SSH() { ssh "${SSH_OPTS[@]}" "$PEARL_SSH" "$@"; }
+RSYNC_RSH="ssh"
+for _ssh_opt in "${SSH_OPTS[@]}"; do
+  RSYNC_RSH="$RSYNC_RSH $_ssh_opt"
+done
 
 cleanup() {
   local rc=$?
   # Release the remote publish lock if this run acquired it (MED-3).
   if [ -n "$LOCK_HELD" ]; then
-    ssh -o ConnectTimeout=15 -o BatchMode=yes "$PEARL_SSH" \
-      "rmdir '$REMOTE_AUTOTUNE_DIR/.renew.lock'" >/dev/null 2>&1 || true
+    SSH "rmdir '$REMOTE_AUTOTUNE_DIR/.renew.lock'" >/dev/null 2>&1 || true
+  fi
+  if [ -n "$LOCK_HELPER_DIR" ]; then
+    SSH "rm -rf '$LOCK_HELPER_DIR'" >/dev/null 2>&1 || true
+  elif [ -n "$LOCK_HELPER" ]; then
+    SSH "rm -f '$LOCK_HELPER'" >/dev/null 2>&1 || true
   fi
   [ -n "$STAGING" ] && [ -d "$STAGING" ] && rm -rf "$STAGING"
   if [ -n "$WORKTREE" ] && [ -d "$WORKTREE" ]; then
@@ -84,9 +131,21 @@ RELEASE_ID="${RELEASE_ID_PREFIX}-${TODAY}-${RELEASE_ID_SUFFIX}"
 
 WORKTREE="$(mktemp -d -t macprovider-feed-renew.XXXXXXXX)"
 rm -rf "$WORKTREE"
-git -C "$REPO_ROOT" fetch --quiet origin
-git -C "$REPO_ROOT" worktree add --quiet --detach "$WORKTREE" origin/main
-log "built ephemeral worktree at $WORKTREE (origin/main $(git -C "$WORKTREE" rev-parse --short HEAD))"
+if [ -n "${GITHUB_SHA:-}" ]; then
+  # Actions: restamp the approved workflow commit, not a floating origin/main.
+  case "$GITHUB_SHA" in
+    *[!0-9a-fA-F]*) fatal "unsafe GITHUB_SHA" ;;
+  esac
+  [ "${#GITHUB_SHA}" -eq 40 ] || fatal "GITHUB_SHA must be a 40-character commit"
+  git -C "$REPO_ROOT" cat-file -e "${GITHUB_SHA}^{commit}" \
+    || fatal "GITHUB_SHA $GITHUB_SHA is not in this checkout"
+  git -C "$REPO_ROOT" worktree add --quiet --detach "$WORKTREE" "$GITHUB_SHA"
+  log "built ephemeral worktree at $WORKTREE (GITHUB_SHA ${GITHUB_SHA:0:12})"
+else
+  git -C "$REPO_ROOT" fetch --quiet origin
+  git -C "$REPO_ROOT" worktree add --quiet --detach "$WORKTREE" origin/main
+  log "built ephemeral worktree at $WORKTREE (origin/main $(git -C "$WORKTREE" rev-parse --short HEAD))"
+fi
 
 CAT_DIR="$WORKTREE/phase3-binary/catalog/autotune"
 STATIC_DIR="$WORKTREE/phase3-binary/dist/static"
@@ -151,8 +210,6 @@ fi
 # 3. Deploy: push the signed dir, verify content continuity, atomically retarget
 #    `current`, keep the prior release as `.previous-target`, SIGHUP, verify.
 # ---------------------------------------------------------------------------
-SSH() { ssh -o ConnectTimeout=15 -o BatchMode=yes "$PEARL_SSH" "$@"; }
-
 # Allowlist every value interpolated into a remote shell string (MED-1). These are
 # operator-supplied, but a stray quote must never reach the remote shell.
 case "$REMOTE_AUTOTUNE_DIR" in ""|*[!A-Za-z0-9._/-]*) fatal "unsafe REMOTE_AUTOTUNE_DIR: $REMOTE_AUTOTUNE_DIR" ;; esac
@@ -236,42 +293,114 @@ done
 log "content continuity confirmed (dates-only delta)"
 
 # Rollback restores the EXACT prior state — current AND .previous-target — then
-# re-HUPs (HIGH-2, MED-2). Idempotent: if the deploy failed before mutating, this
-# just rewrites current/previous-target to the values they already hold.
+# re-HUPs. Only call this after this run has swapped `current` (remote exit 1).
+# Pre-mutation failures (remote exit 2) must not rollback: that would be the
+# first mutation and can clobber an in-flight coordinator deploy. Rollback
+# itself takes the same Pearl deploy locks; if they are held, skip mutation.
 rollback() {
   log "ROLLBACK: restoring current -> $CURRENT_TARGET, .previous-target -> ${ORIG_PREVIOUS_TARGET:-<none>}, re-HUPing"
-  SSH bash -s -- "$REMOTE_AUTOTUNE_DIR" "$CURRENT_TARGET" "$ORIG_PREVIOUS_TARGET" "$COORDINATOR_UNIT" <<'RB' || true
+  PREV_ARG="${ORIG_PREVIOUS_TARGET:-__EMPTY__}"
+  SSH bash -s -- "$REMOTE_AUTOTUNE_DIR" "$CURRENT_TARGET" "$PREV_ARG" "$COORDINATOR_UNIT" "$LOCK_HELPER" "releases/$RELEASE_DIRNAME" <<'RB' || true
 set -euo pipefail
-root="$1"; cur="$2"; prev="$3"; unit="$4"
-ln -sfn "$cur" "$root/.current.rollback"
-mv -Tf "$root/.current.rollback" "$root/current"
-if [ -n "$prev" ]; then printf '%s\n' "$prev" > "$root/.previous-target"; else rm -f "$root/.previous-target"; fi
-pid="$(systemctl show -p MainPID --value "$unit")"
-[ -n "$pid" ] && [ "$pid" != "0" ] && kill -HUP "$pid" || true
-echo "rolled back to $cur"
+root="$1"; cur="$2"; prev="$3"; unit="$4"; helper="$5"; expected="$6"
+[ "$prev" = "__EMPTY__" ] && prev=""
+python3 "$helper" validate || { echo "rollback: lock validation failed; not mutating" >&2; exit 1; }
+exec 8</run/lock/macprovider-pearl-updater.lock || { echo "rollback: cannot open updater lock; not mutating" >&2; exit 1; }
+flock -n 8 || { echo "rollback: Pearl updater lock held; not mutating" >&2; exit 1; }
+exec 9</opt/macprovider/.coordinator-deploy.lock || { echo "rollback: cannot open coordinator lock; not mutating" >&2; exit 1; }
+flock -n 9 || { echo "rollback: coordinator deploy lock held; not mutating" >&2; exit 1; }
+live="$(readlink "$root/current")" || { echo "rollback: cannot read current; not mutating" >&2; exit 1; }
+live="${live#./}"
+if [ "$live" = "$expected" ]; then
+  ln -sfn "$cur" "$root/.current.rollback"
+  mv -Tf "$root/.current.rollback" "$root/current"
+  if [ -n "$prev" ]; then printf '%s\n' "$prev" > "$root/.previous-target"; else rm -f "$root/.previous-target"; fi
+  pid="$(systemctl show -p MainPID --value "$unit")"
+  [ -n "$pid" ] && [ "$pid" != "0" ] && kill -HUP "$pid" || true
+  echo "rolled back to $cur"
+elif [ "$live" = "$cur" ]; then
+  if [ -n "$prev" ]; then printf '%s\n' "$prev" > "$root/.previous-target"; else rm -f "$root/.previous-target"; fi
+  echo "rollback: restored .previous-target only (current still $cur)"
+else
+  echo "rollback: current is $live, not $expected; not mutating"
+  exit 0
+fi
 RB
 }
 
 # Push the new release dir under a staging name first, then move into place.
 REMOTE_TMP=".incoming-$RELEASE_DIRNAME.$$"
+LOCK_HELPER_DIR="$(SSH 'umask 077 && mktemp -d /tmp/macprovider-autotune-lock.XXXXXXXX')" \
+  || fatal "cannot create remote lock-helper directory"
+LOCK_HELPER_DIR="${LOCK_HELPER_DIR//$'\n'/}"
+case "$LOCK_HELPER_DIR" in
+  /tmp/macprovider-autotune-lock.[A-Za-z0-9]*) ;;
+  *) fatal "unsafe LOCK_HELPER_DIR: $LOCK_HELPER_DIR" ;;
+esac
+case "$LOCK_HELPER_DIR" in *[!A-Za-z0-9._/-]*) fatal "unsafe LOCK_HELPER_DIR: $LOCK_HELPER_DIR" ;; esac
+LOCK_HELPER="$LOCK_HELPER_DIR/pearl_autotune_deploy_lock.py"
+log "installing Pearl lock validator"
+SSH "cat >'$LOCK_HELPER' && chown root:root '$LOCK_HELPER' && chmod 0700 '$LOCK_HELPER'" \
+  < "$SCRIPT_DIR/pearl_autotune_deploy_lock.py" \
+  || fatal "cannot install pearl_autotune_deploy_lock.py on $PEARL_SSH"
+
 log "uploading signed release bytes"
-rsync -e "ssh -o ConnectTimeout=15 -o BatchMode=yes" -a --delete \
+rsync -e "$RSYNC_RSH" -a --delete \
   "$RELEASE_STAGE/" "$PEARL_SSH:$REMOTE_AUTOTUNE_DIR/releases/$REMOTE_TMP/" \
   || fatal "rsync failed"
 
-# Remote publish. The coordinator PID is resolved FIRST so a missing daemon aborts
-# BEFORE any mutation (HIGH-2). .previous-target is written verbatim — CURRENT_TARGET
+# Remote publish. Exit 2 = aborted before swapping current (do not rollback).
+# Exit 1 = swapped current then failed (rollback under locks).
+# The coordinator PID is resolved FIRST so a missing daemon aborts BEFORE any
+# mutation (HIGH-2). .previous-target is written verbatim — CURRENT_TARGET
 # already carries the `releases/<id>` prefix, so it must NOT be re-prefixed (HIGH-1).
-if ! SSH bash -s -- "$REMOTE_AUTOTUNE_DIR" "$REMOTE_TMP" "$RELEASE_DIRNAME" "$CURRENT_TARGET" "$COORDINATOR_UNIT" <<'REMOTE'
+# Hold deploy-pearl-vps.sh locks for the swap window so a coordinator deploy
+# cannot clobber `current`. Validate existing lock files; do not create them
+# (a 0644 create would fail the coordinator deploy's 0600 root:root check).
+set +e
+SSH bash -s -- "$REMOTE_AUTOTUNE_DIR" "$REMOTE_TMP" "$RELEASE_DIRNAME" "$CURRENT_TARGET" "$COORDINATOR_UNIT" "$LOCK_HELPER" <<'REMOTE'
 set -euo pipefail
-root="$1"; incoming="$2"; final="$3"; prev="$4"; unit="$5"
+root="$1"; incoming="$2"; final="$3"; prev="$4"; unit="$5"; helper="$6"
+incoming_path="$root/releases/$incoming"
+mutated=0
+abort_pre_mutation() {
+  echo "$1" >&2
+  rm -rf "$incoming_path" >/dev/null 2>&1 || true
+  exit 2
+}
+trap 'if [ "$mutated" -eq 1 ]; then exit 1; else rm -rf "$incoming_path" >/dev/null 2>&1 || true; exit 2; fi' ERR
 # Resolve the reload target BEFORE mutating anything, so a dead daemon aborts clean.
 pid="$(systemctl show -p MainPID --value "$unit")"
-[ -n "$pid" ] && [ "$pid" != "0" ] || { echo "coordinator MainPID unavailable; not mutating" >&2; exit 1; }
+[ -n "$pid" ] && [ "$pid" != "0" ] || abort_pre_mutation "coordinator MainPID unavailable; not mutating"
+python3 "$helper" validate || abort_pre_mutation "Pearl deploy lock files failed validation; not mutating"
+exec 8</run/lock/macprovider-pearl-updater.lock || abort_pre_mutation "cannot open /run/lock/macprovider-pearl-updater.lock; not mutating"
+flock -n 8 || abort_pre_mutation "Pearl updater lock held; not mutating"
+exec 9</opt/macprovider/.coordinator-deploy.lock || abort_pre_mutation "cannot open /opt/macprovider/.coordinator-deploy.lock; not mutating"
+flock -n 9 || abort_pre_mutation "coordinator deploy lock held; not mutating"
+live_current="$(readlink "$root/current")" || abort_pre_mutation "cannot read current under lock"
+live_current="${live_current#./}"
+[ "$live_current" = "$prev" ] || abort_pre_mutation "current moved under lock ($live_current != $prev); not mutating"
+# Re-check dates-only continuity under the lock so a coordinator catalog deploy
+# that landed after the pre-lock read cannot be overwritten by this restamp.
+python3 - "$incoming_path" "$root/current" <<'PY'
+import json, pathlib, sys
+incoming, current = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
+def norm(path):
+    obj = json.loads(path.read_text())
+    obj.pop("version", None)
+    obj.pop("generated_at", None)
+    return json.dumps(obj, sort_keys=True)
+for name in ("autotune-candidates.json", "demand-rank.json", "rate-card.json"):
+    if norm(incoming / name) != norm(current / name):
+        raise SystemExit(f"content drift under lock in {name}")
+PY
 cd "$root/releases"
 chown -R root:macprovider "$incoming"
 chmod 0750 "$incoming"; chmod 0640 "$incoming"/*
 mv "$incoming" "$final"
+# Persistent autotune metadata starts here. Set mutated before the first write so
+# a failure after .previous-target (and before current swap) still rollbacks.
+mutated=1
 # Record the outgoing release (verbatim; already prefixed) so the coordinator admits
 # it as `previous` and already-joined nodes on it stay routable across the swap.
 printf '%s\n' "$prev" > "$root/.previous-target"
@@ -283,9 +412,15 @@ echo "retargeted current -> releases/$final (previous-target=$prev)"
 kill -HUP "$pid"
 echo "sent SIGHUP to $unit (pid $pid)"
 REMOTE
-then
+publish_rc=$?
+set -e
+if [ "$publish_rc" -eq 0 ]; then
+  :
+elif [ "$publish_rc" -eq 1 ]; then
   rollback
-  fatal "remote publish failed"
+  fatal "remote publish failed after mutating current"
+else
+  fatal "remote publish aborted before mutating current (rc=$publish_rc)"
 fi
 
 log "waiting for hot-reload to apply"

--- a/scripts/test-autotune-feed-freshness-alarm.sh
+++ b/scripts/test-autotune-feed-freshness-alarm.sh
@@ -73,9 +73,11 @@ if "|| '20'" not in alarm:
     raise SystemExit("alarm default max-age must be 20 days")
 
 if 'cron: "0 16 * * 2"' not in renew:
-    raise SystemExit("weekly cadence must run Tuesday 16:00 UTC (after Monday launchd)")
+    raise SystemExit("weekly cadence must run Tuesday 16:00 UTC (after Wednesday signed renewal)")
 if 'cron: "0 16 * * 1"' in renew:
-    raise SystemExit("weekly cadence must not share Monday 16:00 UTC with operator launchd")
+    raise SystemExit("weekly cadence must not share Monday 16:00 UTC with discovery-head")
+if 'cron: "0 16 * * 3"' in renew:
+    raise SystemExit("weekly cadence must not share Wednesday 16:00 UTC with the signed renewal")
 if "RATE_CARD_URL" in alarm or "RATE_CARD_URL" in renew:
     raise SystemExit("workflows must pin coordinator.malibu.tech; no URL override")
 if "group: renew-autotune-static-feed" not in renew:

--- a/scripts/test-renew-autotune-static-feed-signed.sh
+++ b/scripts/test-renew-autotune-static-feed-signed.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# Fail-closed structural checks for protected autotune-feed signed renewal.
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+workflow="$root/.github/workflows/renew-autotune-static-feed-signed.yml"
+script="$root/scripts/renew-autotune-static-feed.sh"
+helper="$root/scripts/pearl_autotune_deploy_lock.py"
+runbook="$root/docs/runbooks/autotune-feed-renewal.md"
+[[ -f "$workflow" ]] || {
+  printf '[test-renew-autotune-static-feed-signed] ERROR: missing signed renewal workflow\n' >&2
+  exit 1
+}
+[[ -f "$script" ]] || {
+  printf '[test-renew-autotune-static-feed-signed] ERROR: missing renew script\n' >&2
+  exit 1
+}
+[[ -f "$helper" ]] || {
+  printf '[test-renew-autotune-static-feed-signed] ERROR: missing Pearl lock validator\n' >&2
+  exit 1
+}
+[[ -f "$runbook" ]] || {
+  printf '[test-renew-autotune-static-feed-signed] ERROR: missing renewal runbook\n' >&2
+  exit 1
+}
+
+python3 - "$workflow" "$script" "$runbook" <<'PY'
+import pathlib
+import sys
+
+workflow = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+script = pathlib.Path(sys.argv[2]).read_text(encoding="utf-8")
+runbook = pathlib.Path(sys.argv[3]).read_text(encoding="utf-8")
+SEALED_OUTPUT = 'OPENSSL_BIN: ${{ steps.protected_openssl.outputs.bin }}'
+SEALED_RUNNER = "    runs-on: macos-15-intel"
+
+if workflow.count(SEALED_RUNNER) != 1:
+    raise SystemExit("signed renewal runner must match the reviewed Intel OpenSSL bottle")
+
+for requirement in (
+    "name: Renew signed autotune static feed",
+    "workflow_dispatch:",
+    "concurrency:",
+    "group: production-release",
+    "cancel-in-progress: false",
+    "environment: production-release",
+    "scripts/install-sealed-release-openssl.sh",
+    "/private/var/macprovider-openssl-autotune-renewal",
+    "AUTOTUNE_STATIC_V4_PRIVATE_KEY_BASE64",
+    "PEARL_AUTOTUNE_DEPLOY_SSH_KEY",
+    "AUTOTUNE_STATIC_PRIVATE_KEY_PATH",
+    "PEARL_SSH_IDENTITY",
+    "PEARL_SSH_KNOWN_HOSTS",
+    'export PEARL_SSH="root@159.223.165.194"',
+    "scripts/dist/malibu-download-known_hosts",
+    "bash scripts/renew-autotune-static-feed.sh --deploy",
+    "persist-credentials: false",
+    "uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10",
+    "timeout-minutes: 20",
+    "unset AUTOTUNE_STATIC_V4_PRIVATE_KEY_BASE64 PEARL_AUTOTUNE_DEPLOY_SSH_KEY",
+    'chmod 600 "$key" "$ssh_key"',
+    """trap 'rm -f "$key" "$ssh_key"' EXIT""",
+    "scripts/verify-github-release-posture.sh",
+    "RELEASE_POSTURE_TOKEN",
+    'cron: "0 16 * * 3"',
+):
+    if requirement not in workflow:
+        raise SystemExit(f"signed renewal workflow omits: {requirement}")
+
+before_secrets = workflow.split("- name: Sign a freshness restamp and deploy to Pearl", 1)[0]
+if "scripts/verify-github-release-posture.sh" not in before_secrets:
+    raise SystemExit("posture check must run before the secret-bearing deploy step")
+if "AUTOTUNE_STATIC_V4_PRIVATE_KEY_BASE64: ${{ secrets.AUTOTUNE_STATIC_V4_PRIVATE_KEY_BASE64 }}" in before_secrets:
+    raise SystemExit("feed key must not be in env before the deploy step")
+seal_idx = workflow.find("- name: Seal reviewed OpenSSL 3")
+posture_idx = workflow.find("- name: Verify protected GitHub release posture")
+if posture_idx < 0 or seal_idx < 0 or posture_idx > seal_idx:
+    raise SystemExit("posture check must run before OpenSSL seal")
+
+if 'cron: "0 16 * * 1"' in workflow:
+    raise SystemExit("signed renewal must not share Monday 16:00 UTC with discovery-head")
+if 'cron: "0 16 * * 2"' in workflow:
+    raise SystemExit("signed renewal must not share Tuesday 16:00 UTC with the watch workflow")
+
+for forbidden in (
+    "MACPROVIDER_RELEASE_SIGNING_KEY_PEM",
+    "MALIBU_DOWNLOAD_SSH_KEY",
+    "contents: write",
+    "/etc/macprovider/keys",
+    "brew install openssl@3",
+    "brew --prefix openssl@3",
+    "GITHUB_ENV",
+    "autotune-feed-renewal.service",
+    "install-autotune-feed-renewal-pearl.sh",
+):
+    if forbidden in workflow:
+        raise SystemExit(f"signed renewal workflow must not contain {forbidden!r}")
+
+if "OPENSSL_BIN=" in workflow:
+    raise SystemExit("signed renewal must not publish mutable OpenSSL environment state")
+if workflow.count(SEALED_OUTPUT) != 1:
+    raise SystemExit("the deploy crypto consumer must bind the sealed step output once")
+
+for requirement in (
+    "- name: Seal reviewed OpenSSL 3",
+    "id: protected_openssl",
+    "printf 'bin=%s\\n' \"$sealed_bin\" >> \"$GITHUB_OUTPUT\"",
+):
+    if requirement not in workflow:
+        raise SystemExit(f"signed renewal OpenSSL seal omits: {requirement}")
+
+deploy = workflow.split("- name: Sign a freshness restamp and deploy to Pearl", 1)[1]
+if deploy.count(SEALED_OUTPUT) != 1:
+    raise SystemExit("deploy step does not bind the sealed OpenSSL output")
+if "cat \"$key\"" in deploy or "cat \"$ssh_key\"" in deploy:
+    raise SystemExit("deploy step must not print key material")
+if 'printf \'%s\\n\' "$AUTOTUNE_STATIC_V4_PRIVATE_KEY_BASE64" > "$key"' not in deploy:
+    raise SystemExit("deploy step must materialize the feed key to a 0600 file")
+
+top_level, _, rest = workflow.partition("\njobs:\n")
+if "contents: write" in top_level or "contents: write" in rest:
+    raise SystemExit("signed autotune renewal must remain contents: read (no GitHub release publish)")
+if "contents: read" not in rest:
+    raise SystemExit("protected renewal job must request contents: read")
+
+for requirement in (
+    "PEARL_SSH_IDENTITY",
+    "IdentitiesOnly=yes",
+    "UserKnownHostsFile",
+    "StrictHostKeyChecking=yes",
+    "GITHUB_SHA",
+    "flock -n 8",
+    "flock -n 9",
+    "/run/lock/macprovider-pearl-updater.lock",
+    "/opt/macprovider/.coordinator-deploy.lock",
+    "exec 8</run/lock/macprovider-pearl-updater.lock",
+    "exec 9</opt/macprovider/.coordinator-deploy.lock",
+    "do not create them",
+    "pearl_autotune_deploy_lock.py",
+    "mutated=1",
+    'elif [ "$publish_rc" -eq 1 ]; then',
+    "aborted before mutating current",
+    "content drift under lock",
+    "rollback: Pearl updater lock held",
+    "python3 \"$helper\" validate",
+    "mktemp -d /tmp/macprovider-autotune-lock.XXXXXXXX",
+    "abort_pre_mutation",
+    "chown root:root",
+    "rollback: current is",
+    '"releases/$RELEASE_DIRNAME"',
+    "restored .previous-target only",
+    "__EMPTY__",
+    "current moved under lock",
+):
+    if requirement not in script:
+        raise SystemExit(f"renew script omits: {requirement}")
+rollback = script.split("rollback() {", 1)[1].split("\n}", 1)[0]
+if "flock -n 8" not in rollback or "flock -n 9" not in rollback:
+    raise SystemExit("rollback must take Pearl deploy locks before mutating current")
+if 'readlink "$root/current"' not in rollback:
+    raise SystemExit("rollback must re-read current under lock before restoring")
+if "not $expected" not in rollback:
+    raise SystemExit("rollback must skip unless current still points at this renewal")
+if "restored .previous-target only" not in rollback:
+    raise SystemExit("rollback must restore .previous-target when current never swapped")
+if 'elif [ "$publish_rc" -eq 1 ]; then' in script:
+    after = script.split('elif [ "$publish_rc" -eq 1 ]; then', 1)[1]
+    else_branch = after.split("else", 1)[1].split("fi", 1)[0]
+    if "rollback" in else_branch:
+        raise SystemExit("pre-mutation publish failure must not rollback")
+if "/tmp/macprovider-autotune-lock-validate." in script:
+    raise SystemExit("lock helper must not use a predictable /tmp/$$ path")
+if "/etc/macprovider/keys" in script:
+    raise SystemExit("renew script must not place the feed key on Pearl")
+remote = script.split("<<'REMOTE'", 1)[1].split("\nREMOTE", 1)[0]
+if remote.find("mutated=1") > remote.find('printf \'%s\\n\' "$prev" > "$root/.previous-target"'):
+    raise SystemExit("mutated=1 must be set before writing .previous-target")
+if "rsync" in script and ".private.base64" in script.split("rsync", 1)[1][:800]:
+    raise SystemExit("renew script must not rsync the private key to Pearl")
+if 'ln -sfn "$(cat .previous-target)"' in runbook:
+    raise SystemExit("runbook must not use unguarded manual rollback")
+if "flock -n 8" not in runbook or "flock -n 9" not in runbook:
+    raise SystemExit("runbook manual rollback must take Pearl deploy locks")
+if "not $expected" not in runbook:
+    raise SystemExit("runbook manual rollback must skip unless current matches the failed renewal")
+if "orig_prev" not in runbook:
+    raise SystemExit("runbook manual rollback must restore the pre-renewal .previous-target")
+PY
+
+python3 -m py_compile "$helper"
+bash -n "$script"
+
+printf '[test-renew-autotune-static-feed-signed] ok: protected autotune renewal fails closed\n'

--- a/scripts/tests/test_pearl_autotune_deploy_lock.py
+++ b/scripts/tests/test_pearl_autotune_deploy_lock.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Local tests for scripts/pearl_autotune_deploy_lock.py (no Pearl, no root)."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+import importlib.util
+
+SPEC = importlib.util.spec_from_file_location(
+    "pearl_autotune_deploy_lock",
+    REPO / "scripts" / "pearl_autotune_deploy_lock.py",
+)
+assert SPEC is not None and SPEC.loader is not None
+lockmod = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(lockmod)
+
+
+class PearlAutotuneDeployLockTests(unittest.TestCase):
+    def _touch(self, path: Path, mode: int) -> None:
+        path.write_bytes(b"lock")
+        os.chmod(path, mode)
+
+    def test_accepts_0600_regular_file_without_root_requirement(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "lock"
+            self._touch(path, 0o600)
+            lockmod.validate_lock_file(str(path), require_root=False)
+
+    def test_rejects_missing_file(self) -> None:
+        with self.assertRaises(SystemExit) as ctx:
+            lockmod.validate_lock_file("/tmp/macprovider-missing-lock-test", require_root=False)
+        self.assertIn("missing lock file", str(ctx.exception))
+
+    def test_rejects_world_readable_mode(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "lock"
+            self._touch(path, 0o644)
+            with self.assertRaises(SystemExit) as ctx:
+                lockmod.validate_lock_file(str(path), require_root=False)
+            self.assertIn("mode not 0600", str(ctx.exception))
+
+    def test_rejects_symlink(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "target"
+            link = Path(tmp) / "lock"
+            self._touch(target, 0o600)
+            os.symlink(target, link)
+            with self.assertRaises(SystemExit) as ctx:
+                lockmod.validate_lock_file(str(link), require_root=False)
+            self.assertTrue(
+                "cannot open lock file" in str(ctx.exception)
+                or "not a regular file" in str(ctx.exception)
+                or "nlink" in str(ctx.exception),
+                msg=str(ctx.exception),
+            )
+
+    def test_rejects_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "lockdir"
+            path.mkdir(mode=0o700)
+            with self.assertRaises(SystemExit) as ctx:
+                lockmod.validate_lock_file(str(path), require_root=False)
+            self.assertTrue(
+                "not a regular file" in str(ctx.exception)
+                or "cannot open lock file" in str(ctx.exception),
+                msg=str(ctx.exception),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Closes the remaining #1268 ops gap: keep the SPEC-023 signed autotune feed inside the client 30-day `generated_at` horizon without putting the signing key on Pearl and without relying on a laptop that can be closed.

- **Signed weekly renew** (`.github/workflows/renew-autotune-static-feed-signed.yml`): Wednesday 16:00 UTC, `production-release` (antfleet-ops approval), macos-15-intel + sealed OpenSSL 3, Swift restamp via `scripts/renew-autotune-static-feed.sh --deploy`. Feed key stays a CI secret; Pearl gets signed bytes only.
- **Watch backstops stay**: Tuesday 7-day cadence and 20-day alarm remain read-only. A red Tuesday run means the Wednesday signed job missed or is waiting on approval.
- Deploy path fail-closes against in-flight coordinator deploys (Pearl lock validation + under-lock CAS) and rolls back only when this renewal still owns `current`.

Operator-only before the first live `--deploy`: set `production-release` secrets `AUTOTUNE_STATIC_V4_PRIVATE_KEY_BASE64` and `PEARL_AUTOTUNE_DEPLOY_SSH_KEY`. Until then the workflow is mergeable but live runs fail closed on empty secrets.

## Test plan
- [x] `bash scripts/test-renew-autotune-static-feed-signed.sh`
- [x] `bash scripts/test-autotune-feed-freshness-alarm.sh`
- [x] `python3 -m unittest -v scripts.tests.test_autotune_feed_freshness scripts.tests.test_pearl_autotune_deploy_lock`
- [x] Codex 3-lane audit (code / security / architect) 0 CRITICAL / 0 HIGH / 0 MEDIUM
- [ ] After merge: place the two `production-release` secrets, then `workflow_dispatch` the signed job (or wait for Wednesday)

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-023"],
  "requirements": ["SPEC-023-R001"],
  "authority_domains": ["installer-autotune-policy"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "scripts/tests/test_autotune_feed_freshness.py",
    "scripts/tests/test_pearl_autotune_deploy_lock.py",
    "scripts/test-autotune-feed-freshness-alarm.sh",
    "scripts/test-renew-autotune-static-feed-signed.sh"
  ],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/1268"
}
SPEC-GOVERNANCE-DECLARATION-END

Made with [Cursor](https://cursor.com)