### PR TITLE
Remove retired v1.8.105 headless-smoke acceptance bridge

### DIFF
--- a/phase3-binary/dist/install.sh
+++ b/phase3-binary/dist/install.sh
@@ -11750,50 +11750,8 @@ PY
       )" || die 7 "installed compatibility set returned invalid preflight identity"
       installed_tag="v$installed_version"
     else
-      installed_preflight_status="$?"
-      # Some pre-release headless smoke CLIs expose release-payload-preflight
-      # but fail inside that command because their legacy credentials parser
-      # rejects the modern --config argument. Acceptance upgrades may recover
-      # only from that exact exit/status shape and only for the one-shot
-      # v1.8.105 -> v1.8.108 acceptance bridge tracked by issue #1201. Remove
-      # this branch after that signed acceptance release has drained the smoke
-      # fleet. The
-      # common comparison below still requires the signed candidate to be
-      # strictly newer, and staged candidate signature/identity validation is
-      # unchanged and occurs before any live cutover.
-      if [ "${HEADLESS:-0}" != "1" ]; then
-        rm -f "$installed_preflight_error_file"
-        die 7 "legacy headless smoke compatibility fallback requires headless mode"
-      fi
-      if [ "$target" != "v1.8.108" ]; then
-        rm -f "$installed_preflight_error_file"
-        die 7 "legacy headless smoke compatibility fallback is limited to acceptance target v1.8.108"
-      fi
-      python3 - "$installed_preflight_error_file" "$installed_preflight_status" <<'PY' \
-        || {
-import sys
-
-expected = (
-    b"Error: Unknown option '--config'\n"
-    b"Usage: macprovider-cli credentials <subcommand>\n"
-    b"  See 'macprovider-cli credentials --help' for more information.\n"
-)
-if sys.argv[2] != "2" or open(sys.argv[1], "rb").read() != expected:
-    raise SystemExit(1)
-PY
-        rm -f "$installed_preflight_error_file"
-        die 7 "installed compatibility preflight failed outside the legacy headless smoke signature"
-      }
       rm -f "$installed_preflight_error_file"
-      installed_version="$(installed_provider_binary_version "$installed_binary")" \
-        || die 7 "installed provider CLI version fallback failed before acceptance upgrade"
-      case "$installed_version" in
-        v*) installed_tag="$installed_version" ;;
-        *) installed_tag="v$installed_version" ;;
-      esac
-      [ "$installed_tag" = "v1.8.105" ] \
-        || die 7 "legacy headless smoke compatibility fallback requires incumbent v1.8.105"
-      log "Installed compatibility preflight failed; using bounded legacy incumbent version check for acceptance upgrade."
+      die 7 "installed compatibility set failed preflight before acceptance upgrade"
     fi
   else
     installed_version="$(installed_provider_binary_version "$installed_binary")" \

--- a/scripts/test-install-version-pin.sh
+++ b/scripts/test-install-version-pin.sh
@@ -744,26 +744,21 @@ report "case21b-mismatched-preflight-identity-version-rejected" 7 "$rc"
 unset MOCK_SUCCESSFUL_PREFLIGHT_JSON
 
 ################################################################
-# Case 21b2 — a legacy headless smoke incumbent whose compatibility
-# preflight fails may fall back to its bounded semantic version, but
-# only a strictly newer signed acceptance candidate is accepted.
+# Case 21b2 — incumbent compatibility preflight failure is
+# fail-closed. There is no version-fallback upgrade path, including
+# the retired v1.8.105 headless smoke hop.
 ################################################################
 cat > "$REAL_INSTALLED_BINARY" <<'SCRIPT'
 #!/usr/bin/env bash
 case "${1:-}" in
   --version)
-    printf '%s\n' "${MOCK_LEGACY_VERSION:-1.8.40}"
+    printf '1.8.105\n'
     ;;
   release-payload-preflight)
-    if [ "${MOCK_LEGACY_PREFLIGHT_VARIANT:-exact}" = "altered" ]; then
-      printf "Error: Unknown option '--config'\n" >&2
-      printf 'Usage: macprovider-cli credentials <subcommand>\n' >&2
-    else
-      printf "Error: Unknown option '--config'\n" >&2
-      printf 'Usage: macprovider-cli credentials <subcommand>\n' >&2
-      printf "  See 'macprovider-cli credentials --help' for more information.\n" >&2
-    fi
-    exit "${MOCK_LEGACY_PREFLIGHT_EXIT:-2}"
+    printf "Error: Unknown option '--config'\n" >&2
+    printf 'Usage: macprovider-cli credentials <subcommand>\n' >&2
+    printf "  See 'macprovider-cli credentials --help' for more information.\n" >&2
+    exit 2
     ;;
   *)
     exit 2
@@ -771,55 +766,24 @@ case "${1:-}" in
 esac
 SCRIPT
 chmod +x "$REAL_INSTALLED_BINARY"
-MOCK_LEGACY_VERSION="1.8.105"
-export MOCK_LEGACY_VERSION
-rc=0
-( validate_acceptance_upgrade_target v1.8.108 ) >/dev/null 2>&1 || rc=$?
-report "case21b2-non-headless-legacy-smoke-rejected" 7 "$rc"
 HEADLESS=1
 rc=0
 ( validate_acceptance_upgrade_target v1.8.108 ) >/dev/null 2>&1 || rc=$?
-report "case21b2-legacy-smoke-older-version-accepted" 0 "$rc"
-MOCK_LEGACY_VERSION="1.8.104"
-rc=0
-( validate_acceptance_upgrade_target v1.8.108 ) >/dev/null 2>&1 || rc=$?
-report "case21b2-unrelated-older-incumbent-rejected" 7 "$rc"
-MOCK_LEGACY_VERSION="1.8.105"
-rc=0
-( validate_acceptance_upgrade_target v1.8.109 ) >/dev/null 2>&1 || rc=$?
-report "case21b2-later-acceptance-target-rejected" 7 "$rc"
-MOCK_LEGACY_VERSION="1.8.108"
-rc=0
-( validate_acceptance_upgrade_target v1.8.108 ) >/dev/null 2>&1 || rc=$?
-report "case21b2-legacy-smoke-equal-version-rejected" 7 "$rc"
-MOCK_LEGACY_VERSION="1.8.109"
-rc=0
-( validate_acceptance_upgrade_target v1.8.108 ) >/dev/null 2>&1 || rc=$?
-report "case21b2-legacy-smoke-newer-version-rejected" 7 "$rc"
-MOCK_LEGACY_VERSION="not-a-version"
-rc=0
-( validate_acceptance_upgrade_target v1.8.108 ) >/dev/null 2>&1 || rc=$?
-report "case21b2-legacy-smoke-malformed-version-rejected" 7 "$rc"
-MOCK_LEGACY_VERSION="1.8."$'\n'"105"
-rc=0
-( validate_acceptance_upgrade_target v1.8.108 ) >/dev/null 2>&1 || rc=$?
-report "case21b2-legacy-smoke-multiline-version-rejected" 7 "$rc"
-MOCK_LEGACY_VERSION="1.8.105"
-MOCK_LEGACY_PREFLIGHT_EXIT="99"
-export MOCK_LEGACY_PREFLIGHT_EXIT
-rc=0
-( validate_acceptance_upgrade_target v1.8.108 ) >/dev/null 2>&1 || rc=$?
-report "case21b2-arbitrary-preflight-failure-rejected" 7 "$rc"
-unset MOCK_LEGACY_PREFLIGHT_EXIT
-MOCK_LEGACY_PREFLIGHT_VARIANT="altered"
-export MOCK_LEGACY_PREFLIGHT_VARIANT
-rc=0
-( validate_acceptance_upgrade_target v1.8.108 ) >/dev/null 2>&1 || rc=$?
-report "case21b2-altered-preflight-error-rejected" 7 "$rc"
-unset MOCK_LEGACY_PREFLIGHT_VARIANT
+report "case21b2-failed-preflight-rejected" 7 "$rc"
 unset HEADLESS
-unset MOCK_LEGACY_VERSION
 rm -f "$INSTALL_DIR/compatibility-set.json"
+cat > "$REAL_INSTALLED_BINARY" <<'SCRIPT'
+#!/usr/bin/env bash
+case "${1:-}" in
+  --version)
+    printf '1.8.40\n'
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+SCRIPT
+chmod +x "$REAL_INSTALLED_BINARY"
 
 ################################################################
 # Case 21c — an independent provider component may stay equal or advance,


### PR DESCRIPTION
## Summary

- Remove the one-shot v1.8.105 → v1.8.108 headless-smoke acceptance-upgrade fallback from `validate_acceptance_upgrade_target()`.
- Failed incumbent `release-payload-preflight` now fail-closes again before any version comparison.
- Keep `MACPROVIDER_MIN_HEADLESS_VERSION=v1.8.108`. No CLI version bump; this rides the next real 1.8.x cut.

The hop only recovered exact smoke `v1.8.105` against a signed `v1.8.108` candidate. Current main is 1.8.117, so the branch was already inert on any candidate we still ship.

## Test plan

- [x] `bash scripts/test-install-version-pin.sh` — 90/90 checks passed
- [x] `bash -n phase3-binary/dist/install.sh`
- [x] Codex code / security / architecture audits — 0 CRITICAL / 0 HIGH / 0 MEDIUM

Relates to #1201.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020", "SPEC-026"],
  "requirements": ["SPEC-020-R001", "SPEC-020-R002", "SPEC-020-R003", "SPEC-020-R004"],
  "authority_domains": ["browserless-onboarding"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "scripts/test-install-version-pin.sh"
  ],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/1201"
}
SPEC-GOVERNANCE-DECLARATION-END
