### PR TITLE
Renew the discovery head's own target (freshness-only), not GitHub latest

### DIFF
--- a/.github/workflows/renew-release-discovery-head.yml
+++ b/.github/workflows/renew-release-discovery-head.yml
@@ -1,9 +1,12 @@
 name: Renew signed release discovery head
 
 # Protected recurring renewal for append-only discovery transports.
-# Signs a strictly greater sequence for the current latest stable target and
-# publishes one new immutable prerelease. Never mutates existing transports or
-# the permanently immutable fixed release-discovery tag.
+# Freshness-only: signs a strictly greater sequence for the target the CURRENT
+# signed head already points at (resolved from the live transport, not from
+# GitHub "latest", which legitimately runs ahead until an operator rolls the
+# coordinator forward) and publishes one new immutable prerelease. Never
+# advances the target, mutates existing transports, or touches the permanently
+# immutable fixed release-discovery tag.
 
 on:
   workflow_dispatch:
@@ -68,7 +71,7 @@ jobs:
           "$sealed_bin" version | grep -E '^OpenSSL 3\.'
           printf 'bin=%s\n' "$sealed_bin" >> "$GITHUB_OUTPUT"
 
-      - name: Resolve latest stable target and current discovery ceiling
+      - name: Resolve the current head's own target and discovery ceiling
         id: target
         shell: bash
         env:
@@ -76,8 +79,14 @@ jobs:
           VALIDITY_HOURS_INPUT: ${{ github.event.inputs.validity_hours || '168' }}
         run: |
           set -euo pipefail
+          # Freshness-only renewal: keep the CURRENT signed self-heal head fresh
+          # for the exact target it already points at. The GitHub "latest" release
+          # legitimately runs ahead of the signed head until an operator rolls the
+          # coordinator forward (verify-live-coordinator-release-rollout.yml). This
+          # renewal must NOT advance the target, so it resolves the target from the
+          # current live transport's signed head, never from the GitHub latest API.
           work="$RUNNER_TEMP/renew-discovery"
-          mkdir -p "$work/latest" "$work/current"
+          mkdir -p "$work/target" "$work/current"
           [[ "$VALIDITY_HOURS_INPUT" =~ ^[1-9][0-9]*$ ]] || {
             echo "::error::validity_hours must be a positive integer" >&2
             exit 1
@@ -86,30 +95,112 @@ jobs:
             echo "::error::validity_hours must be at most 168" >&2
             exit 1
           }
+          # 1) Resolve the renewal base, the append-only ceiling, and the minimal
+          #    next sequence, then fail closed unless the highest existing signal
+          #    is exactly the current public head:
+          #    - previous_transport: the highest PUBLIC IMMUTABLE prerelease
+          #      transport (with the three discovery assets) to renew FROM.
+          #    - previous_sequence: the append-only CEILING across every
+          #      release-discovery-v1-* signal — both published releases (public
+          #      OR leftover draft) AND git tag refs (which may exist without a
+          #      release after an interrupted publish). Folding tags in makes the
+          #      next sequence collision-proof.
+          #    - renewal_sequence: ceiling + 1, computed here (not in Bash, which
+          #      is signed-64-bit and would wrap a near-uint64 ceiling), bounded
+          #      by uint64. Minimal increment keeps the renewal from leapfrogging
+          #      a newer release's earlier-built, lower-sequence prebuilt head.
+          #    If the ceiling exceeds the public head, a higher-sequence draft,
+          #    orphan tag, or in-flight rollout is pending; renewing the older
+          #    base above it could dominate a newer target, so fail closed and let
+          #    the operator (backstopped by the freshness alarm) resolve it first.
+          gh api --paginate --slurp -H 'X-GitHub-Api-Version: 2026-03-10' \
+            "repos/$GITHUB_REPOSITORY/releases?per_page=100" \
+            > "$work/releases.json"
+          git ls-remote --tags origin 'release-discovery-v1-*' > "$work/discovery-tags.txt"
+          # Command substitution (not process substitution) so a fail-closed
+          # non-zero exit from the selector aborts the step under `set -e`.
+          selection="$(python3 scripts/select-discovery-renewal-base.py \
+            "$work/releases.json" "$work/discovery-tags.txt")"
+          read -r previous_sequence previous_transport renewal_sequence <<<"$selection"
+          [[ "$previous_sequence" =~ ^[1-9][0-9]*$ ]] || {
+            echo "::error::resolved discovery ceiling is invalid" >&2
+            exit 1
+          }
+          [[ "$previous_transport" =~ ^release-discovery-v1-[1-9][0-9]*$ ]] || {
+            echo "::error::resolved renewal base transport is invalid" >&2
+            exit 1
+          }
+          [[ "$renewal_sequence" =~ ^[1-9][0-9]*$ ]] || {
+            echo "::error::resolved renewal sequence is invalid" >&2
+            exit 1
+          }
+          # 2) Download the current head and read the exact target it is bound to.
           gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
-            "repos/$GITHUB_REPOSITORY/releases/latest" > "$work/latest/release.json"
-          read -r tag commit < <(
-            python3 - "$work/latest/release.json" <<'PY'
+            "repos/$GITHUB_REPOSITORY/releases/tags/$previous_transport" \
+            > "$work/current/release.json"
+          head_asset_id="$(
+            python3 - "$work/current/release.json" <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          release = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+          matches = [
+              asset for asset in release.get("assets", [])
+              if asset.get("name") == "macprovider-release-discovery.json"
+          ]
+          if len(matches) != 1 or type(matches[0].get("id")) is not int:
+              raise SystemExit("current discovery transport lacks one numeric head asset ID")
+          print(matches[0]["id"])
+          PY
+          )"
+          gh api -H 'Accept: application/octet-stream' \
+            -H 'X-GitHub-Api-Version: 2026-03-10' \
+            "repos/$GITHUB_REPOSITORY/releases/assets/$head_asset_id" \
+            > "$work/current/macprovider-release-discovery.json"
+          # `read < <(...)` does not propagate the resolver's exit status under
+          # `set -e`, so bind it to a checked command substitution first and
+          # re-validate the shape here before it reaches any API path.
+          target_identity="$(
+            python3 scripts/resolve-discovery-renewal-target.py \
+              "$work/current/macprovider-release-discovery.json" \
+              "$GITHUB_REPOSITORY"
+          )"
+          read -r tag commit <<<"$target_identity"
+          [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+            echo "::error::resolved renewal target tag is invalid" >&2
+            exit 1
+          }
+          [[ "$commit" =~ ^[0-9a-f]{40}$ ]] || {
+            echo "::error::resolved renewal target commit is invalid" >&2
+            exit 1
+          }
+          # 3) Fetch THAT target release (not "latest") and confirm it is a real,
+          #    immutable, stable release bound to the exact commit the head names.
+          gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
+            "repos/$GITHUB_REPOSITORY/releases/tags/$tag" > "$work/target/release.json"
+          python3 - "$work/target/release.json" "$tag" "$commit" <<'PY'
           import json
           import pathlib
           import re
           import sys
 
           release = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+          expected_tag, expected_commit = sys.argv[2], sys.argv[3]
           tag = release.get("tag_name")
           commit = release.get("target_commitish")
           if not isinstance(tag, str) or not re.fullmatch(r"v[0-9]+\.[0-9]+\.[0-9]+", tag):
-              raise SystemExit("latest public release does not have a stable semantic tag")
+              raise SystemExit("current head target release does not have a stable semantic tag")
           if not isinstance(commit, str) or not re.fullmatch(r"[0-9a-f]{40}", commit):
-              raise SystemExit("latest public release is not bound to an exact commit")
+              raise SystemExit("current head target release is not bound to an exact commit")
+          if tag != expected_tag or commit != expected_commit:
+              raise SystemExit("current head target release identity differs from the signed head")
           if release.get("draft") is not False or release.get("prerelease") is not False:
-              raise SystemExit("latest public release is not stable")
+              raise SystemExit("current head target release is not stable")
           if release.get("immutable") is not True:
-              raise SystemExit("latest public release is not immutable")
-          print(tag, commit)
+              raise SystemExit("current head target release is not immutable")
           PY
-          )
-          python3 - "$work/latest/release.json" "$work/latest/assets.tsv" <<'PY'
+          python3 - "$work/target/release.json" "$work/target/assets.tsv" <<'PY'
           import json
           import pathlib
           import sys
@@ -125,49 +216,20 @@ jobs:
           for name in sorted(required):
               matches = [asset for asset in release.get("assets", []) if asset.get("name") == name]
               if len(matches) != 1 or type(matches[0].get("id")) is not int:
-                  raise SystemExit(f"latest immutable release does not have one numeric asset ID for {name}")
+                  raise SystemExit(f"target immutable release does not have one numeric asset ID for {name}")
               rows.append(f"{name}\t{matches[0]['id']}\n")
           pathlib.Path(sys.argv[2]).write_text("".join(rows), encoding="ascii")
           PY
           while IFS=$'\t' read -r name asset_id; do
             gh api -H 'Accept: application/octet-stream' \
               -H 'X-GitHub-Api-Version: 2026-03-10' \
-              "repos/$GITHUB_REPOSITORY/releases/assets/$asset_id" > "$work/latest/$name"
-          done < "$work/latest/assets.tsv"
-          gh api --paginate --slurp -H 'X-GitHub-Api-Version: 2026-03-10' \
-            "repos/$GITHUB_REPOSITORY/releases?per_page=100" \
-            > "$work/releases.json"
-          read -r previous_sequence previous_transport < <(
-            python3 - "$work/releases.json" <<'PY'
-          import json
-          import pathlib
-          import re
-          import sys
-
-          pages = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
-          candidates = []
-          for page in pages:
-              if not isinstance(page, list):
-                  continue
-              for release in page:
-                  if not isinstance(release, dict):
-                      continue
-                  match = re.fullmatch(
-                      r"release-discovery-v1-([1-9][0-9]*)",
-                      str(release.get("tag_name", "")),
-                  )
-                  if match:
-                      candidates.append((int(match.group(1)), release.get("tag_name")))
-          if not candidates:
-              raise SystemExit("no append-only discovery transport exists to renew from")
-          sequence, tag = max(candidates, key=lambda item: item[0])
-          print(sequence, tag)
-          PY
-          )
+              "repos/$GITHUB_REPOSITORY/releases/assets/$asset_id" > "$work/target/$name"
+          done < "$work/target/assets.tsv"
           printf 'tag=%s\n' "$tag" >> "$GITHUB_OUTPUT"
           printf 'commit=%s\n' "$commit" >> "$GITHUB_OUTPUT"
           printf 'previous_sequence=%s\n' "$previous_sequence" >> "$GITHUB_OUTPUT"
           printf 'previous_transport=%s\n' "$previous_transport" >> "$GITHUB_OUTPUT"
+          printf 'renewal_sequence=%s\n' "$renewal_sequence" >> "$GITHUB_OUTPUT"
           printf 'validity_hours=%s\n' "$VALIDITY_HOURS_INPUT" >> "$GITHUB_OUTPUT"
           printf 'work=%s\n' "$work" >> "$GITHUB_OUTPUT"
 
@@ -182,6 +244,7 @@ jobs:
           COMMIT: ${{ steps.target.outputs.commit }}
           PREVIOUS_SEQUENCE: ${{ steps.target.outputs.previous_sequence }}
           PREVIOUS_TRANSPORT: ${{ steps.target.outputs.previous_transport }}
+          RENEWAL_SEQUENCE: ${{ steps.target.outputs.renewal_sequence }}
           VALIDITY_HOURS: ${{ steps.target.outputs.validity_hours }}
           WORK: ${{ steps.target.outputs.work }}
         run: |
@@ -236,7 +299,7 @@ jobs:
             --allow-expired \
             --require-immutable \
             --openssl "$OPENSSL_BIN" >/dev/null
-          cmp "$WORK/latest/compatibility-artifact-index.json" \
+          cmp "$WORK/target/compatibility-artifact-index.json" \
             "$WORK/current/compatibility-artifact-index.json"
           # macos runners ship bash 3.2, where "${empty[@]}" is an unbound-variable
           # error under `set -u`. A head with no signed policy minimum and no
@@ -275,11 +338,20 @@ jobs:
           )
           PY
           )
+          # Mint the smallest sequence strictly greater than the append-only
+          # ceiling (RENEWAL_SEQUENCE = ceiling + 1, computed and uint64-bounded in
+          # the target step). This keeps the renewed head monotonic without
+          # leapfrogging a newer release's earlier-built, lower-sequence prebuilt
+          # head, so the coordinator-gated rollout transport still wins the
+          # client's greatest-sequence selection when an operator later advances.
+          [[ "$RENEWAL_SEQUENCE" =~ ^[1-9][0-9]*$ ]] || {
+            echo "::error::resolved renewal sequence is invalid" >&2
+            exit 1
+          }
           python3 scripts/build-release-discovery-head.py \
-            --sequence "$GITHUB_RUN_ID" \
-            --attempt "$GITHUB_RUN_ATTEMPT" \
-            --compatibility-manifest "$WORK/latest/compatibility-set.json" \
-            --target-artifact-index "$WORK/latest/compatibility-artifact-index.json" \
+            --release-sequence "$RENEWAL_SEQUENCE" \
+            --compatibility-manifest "$WORK/target/compatibility-set.json" \
+            --target-artifact-index "$WORK/target/compatibility-artifact-index.json" \
             ${policy_args[@]+"${policy_args[@]}"} \
             --issued-at "$issued_at" \
             --expires-at "$expires_at" \
@@ -304,7 +376,7 @@ jobs:
           verified_sequence="$(python3 scripts/verify-release-discovery-transport.py \
             --head "$WORK/macprovider-release-discovery.json" \
             --signature "$WORK/macprovider-release-discovery.json.sig" \
-            --artifact-index "$WORK/latest/compatibility-artifact-index.json" \
+            --artifact-index "$WORK/target/compatibility-artifact-index.json" \
             --public-key ops/pearl-updater/release-signing-public.pem \
             --repository "$GITHUB_REPOSITORY" \
             --transport-tag "$transport_tag" \
@@ -313,7 +385,7 @@ jobs:
             --minimum-sequence "$PREVIOUS_SEQUENCE" \
             --openssl "$OPENSSL_BIN")"
           [[ "$transport_tag" == "release-discovery-v1-$verified_sequence" ]]
-          cp "$WORK/latest/compatibility-artifact-index.json" \
+          cp "$WORK/target/compatibility-artifact-index.json" \
             "$WORK/compatibility-artifact-index.json"
           printf 'transport_tag=%s\n' "$transport_tag" >> "$GITHUB_OUTPUT"
 

--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,8 @@ test-dist:
 	bash scripts/test-release-discovery-head.sh
 	bash scripts/test-release-discovery-transport.sh
 	bash scripts/test-select-public-discovery-transport.sh
+	bash scripts/test-resolve-discovery-renewal-target.sh
+	bash scripts/test-select-discovery-renewal-base.sh
 	bash scripts/test-renew-release-discovery-head.sh
 	bash scripts/test-autotune-feed-freshness-alarm.sh
 	bash scripts/test-renew-autotune-static-feed-signed.sh

--- a/scripts/build-release-discovery-head.py
+++ b/scripts/build-release-discovery-head.py
@@ -137,7 +137,16 @@ def release_sequence(run_id: int, run_attempt: int) -> int:
 
 
 def build(args: argparse.Namespace) -> None:
-    sequence = release_sequence(args.sequence, args.attempt)
+    if args.release_sequence is not None:
+        if args.sequence is not None or args.attempt is not None:
+            fail("--release-sequence is mutually exclusive with --sequence/--attempt")
+        sequence = args.release_sequence
+        if type(sequence) is not int or sequence <= 0 or sequence > UINT64_MAX:
+            fail("release sequence must be a positive uint64")
+    else:
+        if args.sequence is None or args.attempt is None:
+            fail("--sequence and --attempt are required unless --release-sequence is given")
+        sequence = release_sequence(args.sequence, args.attempt)
     set_id = compatibility_set_id(args.compatibility_manifest)
     artifact_index_sha = hashlib.sha256(args.target_artifact_index.read_bytes()).hexdigest()
     if not HEX64.fullmatch(artifact_index_sha):
@@ -170,8 +179,13 @@ def build(args: argparse.Namespace) -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--sequence", type=int, required=True)
-    parser.add_argument("--attempt", type=int, required=True)
+    # Provenance sequencing (run_id<<16|attempt), used by release-build signing.
+    parser.add_argument("--sequence", type=int)
+    parser.add_argument("--attempt", type=int)
+    # Explicit sequence, used by the freshness-only renewal so it mints the
+    # smallest value greater than the existing ceiling and never leapfrogs a
+    # newer release's earlier-built (lower-sequence) prebuilt discovery head.
+    parser.add_argument("--release-sequence", type=int)
     parser.add_argument("--compatibility-manifest", type=pathlib.Path, required=True)
     parser.add_argument("--target-artifact-index", type=pathlib.Path, required=True)
     parser.add_argument("--signed-policy-minimum")

--- a/scripts/resolve-discovery-renewal-target.py
+++ b/scripts/resolve-discovery-renewal-target.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Resolve the renewal target from the CURRENT signed discovery head.
+
+The discovery-head renewal keeps the *current* self-heal head fresh; it never
+advances the target (advancing is the coordinator-gated rollout workflow). The
+target it must re-sign is therefore whatever the current live transport already
+points at -- NOT whatever GitHub currently marks "latest", which legitimately
+runs ahead of the signed head until an operator rolls the coordinator forward.
+
+This reads the current signed head JSON and prints the exact target it is bound
+to, so the renewal fetches THAT release's compatibility manifests and re-signs
+the same target with a fresh sequence and expiry. It never trusts the head's
+signature (the caller re-verifies that against the pinned public key); it only
+parses the self-declared target identity so the renewal cannot silently drift
+onto a different release than the head it is renewing.
+
+Usage:
+  resolve-discovery-renewal-target.py CURRENT_HEAD_JSON REPOSITORY
+Prints: "<tag> <commit>" for a well-formed head bound to REPOSITORY.
+Exit 1 (fail closed) for any malformed, missing, or off-repository target.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+import sys
+
+
+def fail(message: str) -> "NoReturn":  # type: ignore[name-defined]
+    print(f"resolve-discovery-renewal-target: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def reject_duplicates(pairs: list[tuple[str, object]]) -> dict:
+    result: dict = {}
+    for key, value in pairs:
+        if key in result:
+            fail(f"current head contains duplicate key {key!r}")
+        result[key] = value
+    return result
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        fail("usage: resolve-discovery-renewal-target.py CURRENT_HEAD_JSON REPOSITORY")
+    head_path, repository = argv
+    if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository):
+        fail("repository is invalid")
+    path = pathlib.Path(head_path)
+    if not path.is_file() or path.is_symlink():
+        fail(f"current head is absent or unsafe: {path}")
+    try:
+        envelope = json.loads(path.read_bytes().decode("utf-8"), object_pairs_hook=reject_duplicates)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        fail(f"current head is invalid: {exc}")
+    if not isinstance(envelope, dict):
+        fail("current head must be an object")
+    signed = envelope.get("signed")
+    if not isinstance(signed, dict):
+        fail("current head has no signed object")
+    set_id = signed.get("target_compatibility_set_id")
+    if not isinstance(set_id, str):
+        fail("current head has no target_compatibility_set_id")
+    match = re.fullmatch(
+        r"(?P<repo>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+):(?P<tag>v[0-9]+\.[0-9]+\.[0-9]+)@(?P<commit>[0-9a-f]{40})",
+        set_id,
+    )
+    if match is None:
+        fail("current head target_compatibility_set_id is malformed")
+    if match.group("repo") != repository:
+        fail("current head target is bound to a different repository")
+    print(match.group("tag"), match.group("commit"))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/select-discovery-renewal-base.py
+++ b/scripts/select-discovery-renewal-base.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Select the freshness-only renewal base, ceiling, and next sequence.
+
+Inputs:
+  RELEASES_JSON  a `gh api --paginate --slurp releases?per_page=100` array of
+                 pages (list of lists of release objects).
+  TAGS_FILE      `git ls-remote --tags origin 'release-discovery-v1-*'` output,
+                 one "<sha>\trefs/tags/<name>" line per ref (may be empty).
+
+Prints "<ceiling> <base_tag> <renewal_sequence>" where:
+  - base_tag is the highest PUBLIC IMMUTABLE prerelease transport (carrying the
+    three discovery assets) to renew FROM;
+  - ceiling is the highest release-discovery-v1-<n> sequence across BOTH
+    published releases (public OR leftover draft) AND git tag refs (which can
+    exist without a release after an interrupted publish);
+  - renewal_sequence is ceiling + 1, bounded by uint64.
+
+Fails closed (exit 1) unless the ceiling equals the public head. A higher
+ceiling means a higher-sequence draft, orphan tag, or in-flight rollout is
+pending; minting the older base above it could dominate a newer target's
+transport in the client's greatest-sequence selection, so the operator (backed
+by the freshness alarm) must resolve it before a renewal proceeds.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+import sys
+
+
+UINT64_MAX = (1 << 64) - 1
+TRANSPORT_RE = re.compile(r"release-discovery-v1-([1-9][0-9]*)")
+TAG_REF_RE = re.compile(r"refs/tags/release-discovery-v1-([1-9][0-9]*)(?:\^\{\})?")
+DISCOVERY_ASSETS = {
+    "compatibility-artifact-index.json",
+    "macprovider-release-discovery.json",
+    "macprovider-release-discovery.json.sig",
+}
+
+
+def fail(message: str) -> "NoReturn":  # type: ignore[name-defined]
+    print(f"select-discovery-renewal-base: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        fail("usage: select-discovery-renewal-base.py RELEASES_JSON TAGS_FILE")
+    releases_path, tags_path = argv
+    try:
+        pages = json.loads(pathlib.Path(releases_path).read_bytes().decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        fail(f"release listing is invalid: {exc}")
+    if not isinstance(pages, list):
+        fail("release listing must be an array of pages")
+
+    all_sequences: list[int] = []
+    public: list[tuple[int, str]] = []
+    for page in pages:
+        if not isinstance(page, list):
+            continue
+        for release in page:
+            if not isinstance(release, dict):
+                continue
+            match = TRANSPORT_RE.fullmatch(str(release.get("tag_name", "")))
+            if not match:
+                continue
+            sequence = int(match.group(1))
+            all_sequences.append(sequence)
+            names = {
+                asset.get("name")
+                for asset in release.get("assets", [])
+                if isinstance(asset, dict)
+            }
+            if (
+                release.get("draft") is False
+                and release.get("prerelease") is True
+                and release.get("immutable") is True
+                and DISCOVERY_ASSETS <= names
+            ):
+                public.append((sequence, release.get("tag_name")))
+
+    tags_file = pathlib.Path(tags_path)
+    if tags_file.exists():
+        for line in tags_file.read_text(encoding="utf-8").splitlines():
+            fields = line.split()
+            if len(fields) != 2:
+                continue
+            ref = TAG_REF_RE.fullmatch(fields[1])
+            if ref:
+                all_sequences.append(int(ref.group(1)))
+
+    if not all_sequences:
+        fail("no append-only discovery transport exists to renew from")
+    if not public:
+        fail("no public immutable discovery transport to renew from")
+
+    ceiling = max(all_sequences)
+    base_sequence, base_tag = max(public, key=lambda item: item[0])
+    if ceiling != base_sequence:
+        fail(
+            "a higher-sequence discovery signal exists above the current public head "
+            f"(ceiling={ceiling}, public_head={base_sequence}); resolve the pending "
+            "rollout, leftover draft, or orphan tag before renewing so the renewal "
+            "cannot dominate a newer target"
+        )
+    renewal_sequence = ceiling + 1
+    if renewal_sequence > UINT64_MAX:
+        fail("append-only discovery sequence space is exhausted")
+    print(ceiling, base_tag, renewal_sequence)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/test-release-discovery-head.sh
+++ b/scripts/test-release-discovery-head.sh
@@ -102,4 +102,47 @@ assert renewal["signed"]["release_sequence"] > original["signed"]["release_seque
 assert renewal["signed"]["expires_at"] != original["signed"]["expires_at"]
 PY
 
+# --release-sequence mints an exact value (the freshness-only renewal path uses
+# this to emit ceiling+1) and is mutually exclusive with --sequence/--attempt.
+python3 "$root/scripts/build-release-discovery-head.py" \
+  --release-sequence 2176955688681474 \
+  --compatibility-manifest "$work/compatibility-set.json" \
+  --target-artifact-index "$work/compatibility-artifact-index.json" \
+  --issued-at 2026-07-18T00:00:00Z \
+  --expires-at 2026-07-19T00:00:00Z \
+  --private-key "$work/private.pem" \
+  --public-key "$work/public.pem" \
+  --output "$work/macprovider-release-discovery-explicit.json" \
+  --signature "$work/macprovider-release-discovery-explicit.json.sig"
+python3 - "$work" <<'PY'
+import json
+import pathlib
+import sys
+
+work = pathlib.Path(sys.argv[1])
+explicit = json.loads(work.joinpath("macprovider-release-discovery-explicit.json").read_bytes())
+assert explicit["signed"]["release_sequence"] == 2176955688681474
+PY
+if python3 "$root/scripts/build-release-discovery-head.py" \
+    --release-sequence 5 --sequence 1 --attempt 1 \
+    --compatibility-manifest "$work/compatibility-set.json" \
+    --target-artifact-index "$work/compatibility-artifact-index.json" \
+    --private-key "$work/private.pem" \
+    --public-key "$work/public.pem" \
+    --output "$work/mutex.json" \
+    --signature "$work/mutex.json.sig" >/dev/null 2>&1; then
+  printf '[test-release-discovery-head] ERROR: --release-sequence with --sequence was accepted\n' >&2
+  exit 1
+fi
+if python3 "$root/scripts/build-release-discovery-head.py" \
+    --compatibility-manifest "$work/compatibility-set.json" \
+    --target-artifact-index "$work/compatibility-artifact-index.json" \
+    --private-key "$work/private.pem" \
+    --public-key "$work/public.pem" \
+    --output "$work/noseq.json" \
+    --signature "$work/noseq.json.sig" >/dev/null 2>&1; then
+  printf '[test-release-discovery-head] ERROR: missing sequence arguments were accepted\n' >&2
+  exit 1
+fi
+
 printf '[test-release-discovery-head] PASS\n'

--- a/scripts/test-renew-release-discovery-head.sh
+++ b/scripts/test-renew-release-discovery-head.sh
@@ -46,11 +46,35 @@ for requirement in (
     "--latest=false",
     "scripts/verify-anonymous-release-discovery.sh",
     "Verify renewed discovery without protected credentials",
+    # Freshness-only renewal: the target is resolved from the CURRENT signed
+    # head (the live transport), never from GitHub "latest", so a legitimately
+    # diverged latest cannot fail the Monday renewal closed.
+    "scripts/resolve-discovery-renewal-target.py",
+    "releases/tags/$previous_transport",
+    "releases/tags/$tag",
+    "current head target release is not immutable",
+    "current head target release identity differs from the signed head",
+    # Minimal-increment sequencing: the ceiling folds git tag refs (collision
+    # proof) and the renewal fails closed unless the ceiling equals the public
+    # head, so it can never leapfrog a pending newer target's transport.
+    "git ls-remote --tags origin 'release-discovery-v1-*'",
+    "scripts/select-discovery-renewal-base.py",
+    '--release-sequence "$RENEWAL_SEQUENCE"',
 ):
     if requirement not in workflow:
         raise SystemExit(f"renewal workflow omits: {requirement}")
 if "--clobber" in workflow:
     raise SystemExit("renewal workflow must never overwrite discovery assets")
+if "releases/latest" in workflow:
+    raise SystemExit(
+        "renewal must not resolve its target from GitHub 'latest'; it renews the "
+        "current head's own target (advancing is the coordinator-gated rollout)"
+    )
+if "PREVIOUS_SEQUENCE + 1" in workflow or "renewal_sequence=$((" in workflow:
+    raise SystemExit(
+        "renewal must not compute the next sequence with signed Bash arithmetic; "
+        "ceiling+1 is computed and uint64-bounded in Python"
+    )
 for requirement in (
     "- name: Seal reviewed OpenSSL 3",
     "id: protected_openssl",

--- a/scripts/test-resolve-discovery-renewal-target.sh
+++ b/scripts/test-resolve-discovery-renewal-target.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Fail-closed checks for the freshness-only renewal target resolver. A renewal
+# must re-sign the target the CURRENT head already points at (even when GitHub
+# "latest" has diverged forward), and must reject any malformed/off-repository
+# target rather than silently drift onto a different release.
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+resolver="$root/scripts/resolve-discovery-renewal-target.py"
+work="$(mktemp -d "${TMPDIR:-/tmp}/resolve-renewal-target.XXXXXX")"
+trap 'rm -rf "$work"' EXIT
+
+fail() {
+  printf '[test-resolve-discovery-renewal-target] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+repository="Augustas11/macprovider"
+commit="$(printf 'e%.0s' {1..40})"
+
+write_head() {
+  local path="$1" set_id="$2"
+  python3 - "$path" "$set_id" <<'PY'
+import json
+import pathlib
+import sys
+
+path, set_id = sys.argv[1:]
+signed = {
+    "expires_at": "2026-09-04T23:14:00Z",
+    "issued_at": "2026-08-28T23:14:00Z",
+    "release_sequence": 2176955688681473,
+    "schema_version": "macprovider.release-discovery.v1",
+    "signed_policy_minimum": None,
+    "signed_policy_revoked": [],
+    "target_artifact_index_sha256": "a" * 64,
+    "target_compatibility_set_id": set_id,
+}
+envelope = {"schema_version": "macprovider.release-discovery-envelope.v1", "signed": signed}
+pathlib.Path(path).write_bytes(
+    (json.dumps(envelope, sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
+)
+PY
+}
+
+# 1) A well-formed head whose target (v1.8.111) is BEHIND GitHub "latest"
+#    (v1.8.117) still resolves cleanly — this is the divergent-latest case the
+#    Monday cron must survive.
+write_head "$work/diverged.json" "$repository:v1.8.111@$commit"
+result="$(python3 "$resolver" "$work/diverged.json" "$repository")"
+[[ "$result" == "v1.8.111 $commit" ]] || fail "divergent-latest target did not resolve: '$result'"
+
+expect_reject() {
+  local label="$1"
+  shift
+  if "$@" >"$work/$label.out" 2>&1; then
+    fail "$label was accepted: $(cat "$work/$label.out")"
+  fi
+}
+
+# 2) A malformed set id must fail closed.
+write_head "$work/malformed.json" "not-a-valid-set-id"
+expect_reject malformed python3 "$resolver" "$work/malformed.json" "$repository"
+
+# 3) A short (non-40-hex) commit must fail closed.
+write_head "$work/shortcommit.json" "$repository:v1.8.111@abc123"
+expect_reject shortcommit python3 "$resolver" "$work/shortcommit.json" "$repository"
+
+# 4) A non-semantic tag must fail closed.
+write_head "$work/badtag.json" "$repository:latest@$commit"
+expect_reject badtag python3 "$resolver" "$work/badtag.json" "$repository"
+
+# 5) A target bound to a DIFFERENT repository must fail closed (no cross-repo drift).
+write_head "$work/otherrepo.json" "attacker/macprovider:v1.8.111@$commit"
+expect_reject otherrepo python3 "$resolver" "$work/otherrepo.json" "$repository"
+
+# 6) A head missing the signed object must fail closed.
+printf '{"schema_version":"macprovider.release-discovery-envelope.v1"}\n' > "$work/nosigned.json"
+expect_reject nosigned python3 "$resolver" "$work/nosigned.json" "$repository"
+
+# 7) A duplicate key must fail closed (canonical-JSON hardening parity).
+printf '{"signed":{"target_compatibility_set_id":"%s:v1.8.111@%s"},"signed":{}}\n' \
+  "$repository" "$commit" > "$work/dupkey.json"
+expect_reject dupkey python3 "$resolver" "$work/dupkey.json" "$repository"
+
+printf '[test-resolve-discovery-renewal-target] ok: freshness-only target resolver fails closed\n'

--- a/scripts/test-select-discovery-renewal-base.sh
+++ b/scripts/test-select-discovery-renewal-base.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Fail-closed checks for the freshness-only renewal base/ceiling selector.
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+selector="$root/scripts/select-discovery-renewal-base.py"
+work="$(mktemp -d "${TMPDIR:-/tmp}/select-renewal-base.XXXXXX")"
+trap 'rm -rf "$work"' EXIT
+
+fail() {
+  printf '[test-select-discovery-renewal-base] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+# Build a one-page releases listing from "seq:draft:prerelease:immutable:assets"
+# specs (assets=1 includes the three discovery assets, 0 omits them).
+write_releases() {
+  local path="$1"
+  shift
+  python3 - "$path" "$@" <<'PY'
+import json
+import pathlib
+import sys
+
+path = sys.argv[1]
+assets = [
+    {"name": "compatibility-artifact-index.json"},
+    {"name": "macprovider-release-discovery.json"},
+    {"name": "macprovider-release-discovery.json.sig"},
+]
+releases = []
+for spec in sys.argv[2:]:
+    seq, draft, prerelease, immutable, has_assets = spec.split(":")
+    releases.append({
+        "tag_name": f"release-discovery-v1-{seq}",
+        "draft": draft == "1",
+        "prerelease": prerelease == "1",
+        "immutable": immutable == "1",
+        "assets": assets if has_assets == "1" else [],
+    })
+pathlib.Path(path).write_text(json.dumps([releases]), encoding="utf-8")
+PY
+}
+
+write_tags() {
+  local path="$1"
+  shift
+  : > "$path"
+  for seq in "$@"; do
+    printf 'deadbeef\trefs/tags/release-discovery-v1-%s\n' "$seq" >> "$path"
+  done
+}
+
+expect_reject() {
+  local label="$1"
+  shift
+  if "$@" >"$work/$label.out" 2>&1; then
+    fail "$label was accepted: $(cat "$work/$label.out")"
+  fi
+}
+
+# 1) Divergent-latest normal case: the public head IS the ceiling; renew ceil+1.
+write_releases "$work/normal.json" "2176955688681473:0:1:1:1"
+write_tags "$work/empty-tags.txt"
+result="$(python3 "$selector" "$work/normal.json" "$work/empty-tags.txt")"
+[[ "$result" == "2176955688681473 release-discovery-v1-2176955688681473 2176955688681474" ]] \
+  || fail "normal renewal did not resolve ceil+1: '$result'"
+
+# 2) A same-sequence git tag alongside the public release is fine (ceiling==head).
+write_tags "$work/same-tag.txt" 2176955688681473
+result="$(python3 "$selector" "$work/normal.json" "$work/same-tag.txt")"
+[[ "$result" == "2176955688681473 release-discovery-v1-2176955688681473 2176955688681474" ]] \
+  || fail "same-sequence tag changed selection: '$result'"
+
+# 3) DOMINATION GUARD: a higher-sequence DRAFT (pending rollout of a newer
+#    target) above the public head must fail closed, not mint ceiling+1.
+write_releases "$work/draft.json" \
+  "2176955688681473:0:1:1:1" "2186103947198465:1:1:0:1"
+expect_reject draft-above python3 "$selector" "$work/draft.json" "$work/empty-tags.txt"
+grep -q "higher-sequence discovery signal exists above the current public head" \
+  "$work/draft-above.out" || fail "draft-above did not report the domination guard"
+
+# 4) COLLISION/GUARD: a higher-sequence ORPHAN git tag (no release) must fail closed.
+write_tags "$work/orphan-tag.txt" 2186103947198465
+expect_reject orphan-tag python3 "$selector" "$work/normal.json" "$work/orphan-tag.txt"
+
+# 5) No public immutable transport (only a draft) must fail closed.
+write_releases "$work/draft-only.json" "2176955688681473:1:1:0:1"
+expect_reject no-public python3 "$selector" "$work/draft-only.json" "$work/empty-tags.txt"
+
+# 6) A public release missing the discovery assets is not a valid base.
+write_releases "$work/no-assets.json" "2176955688681473:0:1:1:0"
+expect_reject no-assets python3 "$selector" "$work/no-assets.json" "$work/empty-tags.txt"
+
+# 7) No transports at all must fail closed.
+printf '[[]]\n' > "$work/none.json"
+expect_reject none python3 "$selector" "$work/none.json" "$work/empty-tags.txt"
+
+# 8) A PEELED (^{}) higher orphan tag must be counted (annotated-tag refs), so it
+#    trips the domination guard exactly like an unpeeled ref.
+printf 'deadbeef\trefs/tags/release-discovery-v1-2186103947198465^{}\n' > "$work/peeled-tag.txt"
+expect_reject peeled-tag python3 "$selector" "$work/normal.json" "$work/peeled-tag.txt"
+grep -q "higher-sequence discovery signal exists above the current public head" \
+  "$work/peeled-tag.out" || fail "peeled orphan tag was not counted in the ceiling"
+
+# 9) A public head at UINT64_MAX exhausts the append-only sequence space (ceil+1
+#    would overflow uint64) and must fail closed.
+write_releases "$work/exhausted.json" "18446744073709551615:0:1:1:1"
+expect_reject exhausted python3 "$selector" "$work/exhausted.json" "$work/empty-tags.txt"
+grep -q "sequence space is exhausted" "$work/exhausted.out" \
+  || fail "uint64-exhausted ceiling did not fail closed"
+
+printf '[test-select-discovery-renewal-base] ok: renewal base/ceiling selector fails closed\n'

--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -561,7 +561,7 @@
     {
       "spec_id": "SPEC-020",
       "title": "Provider autoupdate",
-      "version": "v0.1.14",
+      "version": "v0.1.15",
       "path": "specs/SPEC-020-provider-autoupdate.md",
       "status": "normative",
       "owner": "@Augustas11",

--- a/specs/README.md
+++ b/specs/README.md
@@ -28,7 +28,7 @@ it can no longer drift. Do not hand-edit the table; edit each spec's
 | SPEC-017 | Network Stats API | 0.2.0 | normative | pending | pending: 1 | [SPEC-017-network-stats-api.md](SPEC-017-network-stats-api.md) |
 | SPEC-018 | Agentic tool calling (provider-side response synthesis) | 0.2.7 | normative | pending | conformant: 1, pending: 1 | [SPEC-018-agentic-tool-calling.md](SPEC-018-agentic-tool-calling.md) |
 | SPEC-019 | Structured output (`response_format: json_schema`) | 0.2.5 | normative | pending | pending corpus migration | [SPEC-019-structured-output.md](SPEC-019-structured-output.md) |
-| SPEC-020 | Provider autoupdate | v0.1.14 | normative | pending | pending: 5 | [SPEC-020-provider-autoupdate.md](SPEC-020-provider-autoupdate.md) |
+| SPEC-020 | Provider autoupdate | v0.1.15 | normative | pending | pending: 5 | [SPEC-020-provider-autoupdate.md](SPEC-020-provider-autoupdate.md) |
 | SPEC-021 | MALIBU rewards emission ledger | 0.4.0 | draft | complete | pending: 10 | [SPEC-021-malibu-emission-ledger.md](SPEC-021-malibu-emission-ledger.md) |
 | SPEC-022 | Verified model settlement | v0.1.7 | draft | complete | conformant: 11 | [SPEC-022-verified-model-settlement.md](SPEC-022-verified-model-settlement.md) |
 | SPEC-023 | Installer-Integrated Autotune Recommend | v0.9.4 | normative | pending | conformant: 2 | [SPEC-023-installer-autotune-recommend.md](SPEC-023-installer-autotune-recommend.md) |

--- a/specs/SPEC-020-provider-autoupdate.md
+++ b/specs/SPEC-020-provider-autoupdate.md
@@ -1,6 +1,6 @@
 # SPEC-020 - Provider autoupdate
 
-Version: v0.1.14
+Version: v0.1.15
 Status: Normative; coordinator-independent recovery is reconciled and
 implementation remains nonconformant under issue #610. The production path ran
 the 2026-07-10 incident-recovery
@@ -308,10 +308,16 @@ A head renewal MUST use a newly signed, strictly greater sequence and append a
 new immutable transport even when the numeric target is unchanged. No existing
 transport may be refreshed in place. The protected
 `renew-release-discovery-head.yml` workflow is the recurring signer for that
-append-only renewal path: it binds the current latest immutable stable target,
-requires the new sequence to exceed the greatest public transport sequence,
-publishes exactly one new immutable prerelease, and anonymously proves the
-same-target CLI still discovers the renewed head. The client MUST fail closed
+append-only renewal path. It is freshness-only: it binds the exact immutable
+stable target that the current signed head already points at — resolved from the
+live transport head, never from mutable GitHub `latest` ordering, which the
+separate coordinator-gated rollout (`verify-live-coordinator-release-rollout.yml`)
+advances — so a renewal keeps the head fresh without advancing the target. It
+mints the smallest sequence strictly greater than every existing append-only
+transport, so the renewal never leapfrogs a newer target's earlier-signed,
+lower-sequence discovery head and thereby blocks a later rollout. It publishes
+exactly one new immutable prerelease and anonymously proves the same-target CLI
+still discovers the renewed head. The client MUST fail closed
 when the greatest located transport is mutable, malformed, expired, incorrectly
 signed, or inconsistent with its sequence-bound tag; it MUST NOT silently fall
 back to an older located transport.
@@ -1411,6 +1417,16 @@ Deferred to v0.3.0 or later:
 
 ## Change log
 
+- v0.1.15 (2026-08-31): Corrected the append-only head renewal description to
+  freshness-only. The `renew-release-discovery-head.yml` signer binds the target
+  the current signed head already points at (resolved from the live transport
+  head), never mutable GitHub `latest`; advancing to a newer stable target
+  remains the separate coordinator-gated rollout's job. The renewal mints the
+  smallest sequence strictly greater than every existing transport so it never
+  leapfrogs a newer target's earlier-signed, lower-sequence prebuilt head and
+  blocks a later rollout. This reconciles the renewal prose with SPEC-020-R001
+  (discovery MUST NOT derive its target from mutable `latest` ordering); no
+  requirement, conformance, or authority binding changed.
 - v0.1.14 (2026-08-28): Added SPEC-020-R005, accepted-but-stuck session recovery.
   v0.1.8 scoped coordinator-independent recovery to providers that cannot
   establish a session; R005 closes the residual gap where an admitted provider


### PR DESCRIPTION
## Summary

Fixes the signed release-discovery **head renewal** so the coordinator-independent
self-heal rail does not go dark fleet-wide.

`renew-release-discovery-head.yml` is a **freshness-only** renewal: it re-signs a
strictly-greater sequence with a fresh expiry for the target the **current** signed head
already points at. Advancing the target to a newer release is a **separate,
coordinator-gated** workflow (`verify-live-coordinator-release-rollout.yml`).

**Bug:** the renewal resolved its target from GitHub `releases/latest` and rebuilt the
head against *latest's* manifests. When `latest` legitimately runs ahead of the signed
head — it does now: the live head targets **v1.8.111** while GitHub-latest is **v1.8.117**,
because advancing requires an operator coordinator flip that has not happened — the sign
step's `verify-release-discovery-transport.py --target-tag <latest>` and the
latest-vs-current `cmp` all fail closed. The Monday `0 16 * * 1` cron would therefore
**fail**, and the live head **expires 2026-09-04T23:14Z**, after which clients fail closed
(`discoveryHeadExpired`) and the signed self-heal rail is dark fleet-wide.

This is exactly the mutable-`latest` coupling **SPEC-020-R001** forbids ("Discovery MUST
begin from a signature-authenticated monotonic discovery head under the pinned release
trust root, not from mutable GitHub `latest` ordering"). SPEC-020's renewal prose had
mandated binding "the current latest immutable stable target" — that prose was the
normative root cause and is corrected here.

## Fix

- **`scripts/resolve-discovery-renewal-target.py`** (new) parses the **current** live
  transport head's `signed.target_compatibility_set_id` to resolve the exact `tag@commit`
  the head is bound to, with strict `re.fullmatch` validation and repository binding
  (fails closed on any malformed / off-repository target).
- **`renew-release-discovery-head.yml`** now: (1) selects the renewal base + append-only
  ceiling via the new selector, (2) downloads the current head and resolves **its own**
  target, (3) fetches **that** target release's `compatibility-set.json` +
  `compatibility-artifact-index.json` (via `releases/tags/<tag>`, never `releases/latest`)
  and re-validates it is a real, stable, immutable release bound to the exact commit the
  head names, then (4) re-signs. Succeeds even when GitHub-latest has moved.
- **`scripts/select-discovery-renewal-base.py`** (new) picks the renewal base from
  **public immutable** transports only (so a leftover draft is never the base), computes
  the ceiling across **both** published releases **and** git tag refs
  (`git ls-remote --tags`, collision-proof), and mints the **smallest** sequence above it
  (`ceiling + 1`, computed in Python and uint64-bounded — not signed-64-bit Bash) via the
  new `build-release-discovery-head.py --release-sequence`. It **fails closed unless the
  ceiling equals the public head**, so a renewal of the older target can never dominate a
  newer target's coordinator-gated rollout (which republishes a prebuilt, higher-sequence
  head). Verified against live state: current ceiling `2176955688681473` → mints
  `2176955688681474`; v1.8.117's prebuilt head is `2186103947198465`, so a later rollout
  still wins the client's greatest-sequence selection.

## Security invariants preserved (unchanged)

- ECDSA signature over canonical JSON verified with the pinned public key
  (`ops/pearl-updater/release-signing-public.pem`) before and after signing.
- Current head re-verified with `--allow-expired --require-immutable` against its own
  resolved target; new head verified with `--minimum-sequence`.
- Sequence monotonicity, 7-day expiry cap, canonical-JSON / duplicate-key rejection,
  append-only transport tags (no `--clobber`), and the immutable fixed `release-discovery`
  tag are untouched.
- `scripts/verify-release-discovery-transport.py` needed **no change** — it is already
  target-agnostic; the bug was purely the workflow's target resolution.

## Tests

- New `scripts/test-resolve-discovery-renewal-target.sh`: a **divergent-latest** target
  resolves cleanly; malformed set-id, short commit, non-semver tag, cross-repository
  target, missing `signed`, and duplicate-key inputs all fail closed.
- New `scripts/test-select-discovery-renewal-base.sh`: normal ceiling+1; a higher draft or
  orphan tag (incl. peeled `^{}` refs) fails the domination guard; uint64 exhaustion,
  missing-public, and missing-assets cases fail closed.
- `scripts/test-release-discovery-head.sh` extended for `--release-sequence` + mutual
  exclusion; `scripts/test-renew-release-discovery-head.sh` asserts no `releases/latest`
  target, current-head derivation, git-tag ceiling folding, and no signed-Bash arithmetic.
- Registered in `make test-dist`. Local: full discovery suite passes; workflow YAML
  validates; `py_compile` / `shellcheck` / `bash -n` clean; SPEC governance passes for
  SPEC-020.

## Audit

Full-fix diff reviewed by a three-lane codex audit (code / security / architecture);
**0 CRITICAL / 0 HIGH / 0 MEDIUM** on the final diff (one LOW test-coverage note closed
with committed cases). The audit caught and drove fixes for a sequence-domination HIGH (a
run-id-based renewal of the old target would leapfrog a newer release's earlier-built
prebuilt head) and two MEDIUMs (draft base selection, Bash uint64 overflow, tag collision).

## OPERATOR ACTION REQUIRED — deadline 2026-09-04T23:14Z

After this merges, an operator MUST run the fixed **Renew signed release discovery head**
workflow (with `production-release` approval) **before 2026-09-04T23:14Z**, or the live
signed head expires and the self-heal rail goes dark fleet-wide. This PR only fixes the
renewal logic; it does **not** sign, publish, or dispatch anything, and it does **not**
advance the target (that remains the coordinator-gated rollout's job).

Refs #1235.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R001"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "scripts/test-resolve-discovery-renewal-target.sh",
    "scripts/test-select-discovery-renewal-base.sh",
    "scripts/test-renew-release-discovery-head.sh"
  ],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/1235"
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
