### PR TITLE
Add operator onboarding funnel join for #1267

### DIFF
--- a/phase4-coordinator/cmd/coordinator-cli/main.go
+++ b/phase4-coordinator/cmd/coordinator-cli/main.go
@@ -31,6 +31,8 @@ func main() {
 		err = revokeBootstrapIdentity(os.Args[2:])
 	case "list-bootstrap-identities":
 		err = listBootstrapIdentities(os.Args[2:])
+	case "list-onboarding":
+		err = listOnboarding(os.Args[2:])
 	case "list-tokens":
 		err = listTokens(os.Args[2:])
 	case "revoke-and-kick":
@@ -627,5 +629,5 @@ func preFlipAuditRun(args []string, stdout io.Writer) (stale bool, err error) {
 }
 
 func usage() {
-	fmt.Fprintln(os.Stderr, "usage: coordinator-cli <issue-token|revoke-token|revoke-bootstrap-identity|list-bootstrap-identities|list-tokens|revoke-and-kick|prune-tokens|list-pair-ot-mints|pre-flip-audit|create-seed-referral|adjust-seed-referral|replace-seed-referral|revoke-referral|trust-pool-admin|trust-pool-oncall|trust-pool-artifact-lifecycle> [flags]")
+	fmt.Fprintln(os.Stderr, "usage: coordinator-cli <issue-token|revoke-token|revoke-bootstrap-identity|list-bootstrap-identities|list-onboarding|list-tokens|revoke-and-kick|prune-tokens|list-pair-ot-mints|pre-flip-audit|create-seed-referral|adjust-seed-referral|replace-seed-referral|revoke-referral|trust-pool-admin|trust-pool-oncall|trust-pool-artifact-lifecycle> [flags]")
 }

--- a/phase4-coordinator/cmd/coordinator-cli/onboarding.go
+++ b/phase4-coordinator/cmd/coordinator-cli/onboarding.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/auth"
+	"github.com/augstar/macprovider-coordinator/internal/providerevents"
+)
+
+func listOnboarding(args []string) error {
+	fs := flag.NewFlagSet("list-onboarding", flag.ExitOnError)
+	dbPath := fs.String("db", "coordinator.db", "path to coordinator SQLite database")
+	eventsDBPath := fs.String("events-db", "", "path to provider_connection_events.db; defaults to the sibling of --db; omitted when the file is absent")
+	state := fs.String("state", "all", "filter: all|pending|confirmed|live|failed_expired|failed_revoked; live stays empty without a connected coordinator session, use GET /admin/onboarding")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	filter := strings.TrimSpace(*state)
+	if filter != "all" && !auth.ValidOnboardingState(filter) {
+		return fmt.Errorf("invalid --state %q", filter)
+	}
+	store, err := auth.OpenStore(*dbPath)
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+	ctx := context.Background()
+	records, err := store.ListOnboardingAttempts(ctx)
+	if err != nil {
+		return err
+	}
+	now := time.Now().UTC()
+	eventsStore, err := openOnboardingEventsStore(*dbPath, *eventsDBPath)
+	if err != nil {
+		return err
+	}
+	if eventsStore != nil {
+		defer eventsStore.Close()
+	}
+
+	all := make([]auth.OnboardingAttempt, 0, len(records))
+	for _, record := range records {
+		if providerevents.LooksLikeCredential(record.ProviderID) {
+			continue
+		}
+		presence, err := onboardingPresenceFromEvents(ctx, eventsStore, record.ProviderID)
+		if err != nil {
+			return err
+		}
+		all = append(all, auth.OverlayPresence(auth.AssembleOnboardingAttempt(record, now), presence, now, record))
+	}
+	summary := auth.SummarizeOnboardingAttempts(all)
+	matched := 0
+	for _, attempt := range all {
+		if filter != "all" && attempt.State != filter {
+			continue
+		}
+		fmt.Printf(
+			"provider_id=%s state=%s presence=%s redeemed_at=%s confirmed_at=%s expires_at=%s last_heartbeat_at=%s last_seen_at=%s last_event_kind=%s last_failure_reason=%s campaign=%s issuer_id=%s\n",
+			attempt.ProviderID,
+			attempt.State,
+			dashIfEmpty(attempt.Presence),
+			dashIfEmpty(attempt.RedeemedAt),
+			dashIfEmpty(attempt.ConfirmedAt),
+			dashIfEmpty(attempt.ExpiresAt),
+			dashIfEmpty(attempt.LastHeartbeatAt),
+			dashIfEmpty(attempt.LastSeenAt),
+			dashIfEmpty(attempt.LastEventKind),
+			dashIfEmpty(attempt.LastFailureReason),
+			dashIfEmpty(attempt.Campaign),
+			dashIfEmpty(attempt.IssuerID),
+		)
+		matched++
+	}
+	fmt.Printf(
+		"count=%d pending=%d confirmed=%d live=%d failed_expired=%d failed_revoked=%d\n",
+		matched, summary.Pending, summary.Confirmed, summary.Live, summary.FailedExpired, summary.FailedRevoked,
+	)
+	return nil
+}
+
+func openOnboardingEventsStore(authDBPath, eventsDBPath string) (*providerevents.SQLiteStore, error) {
+	path := strings.TrimSpace(eventsDBPath)
+	if path == "" {
+		path = providerevents.DefaultDBPath(authDBPath)
+	}
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return providerevents.Open(path)
+}
+
+func onboardingPresenceFromEvents(ctx context.Context, store *providerevents.SQLiteStore, providerID string) (auth.OnboardingPresence, error) {
+	if store == nil {
+		return auth.OnboardingPresence{}, nil
+	}
+	presence := auth.OnboardingPresence{}
+	snap, found, err := store.GetLastKnown(ctx, providerID)
+	if err != nil {
+		return auth.OnboardingPresence{}, err
+	}
+	if found {
+		if !snap.LastSeenAt.IsZero() {
+			presence.LastSeenAt = snap.LastSeenAt.UTC().Format(time.RFC3339)
+		}
+		if snap.LastHeartbeatAt != nil && !snap.LastHeartbeatAt.IsZero() {
+			presence.LastHeartbeatAt = snap.LastHeartbeatAt.UTC().Format(time.RFC3339)
+		}
+	}
+	ev, ok, err := store.LatestEventProvider(ctx, providerID)
+	if err != nil {
+		return auth.OnboardingPresence{}, err
+	}
+	if ok {
+		presence.LastEventKind = ev.Kind
+		presence.LastEventOutcome = ev.Outcome
+		presence.LastEventAt = ev.OccurredAt.UTC().Format(time.RFC3339)
+		presence.LastFailureReason = ev.FailureReason
+		if presence.LastSeenAt == "" && !ev.OccurredAt.IsZero() {
+			presence.LastSeenAt = ev.OccurredAt.UTC().Format(time.RFC3339)
+		}
+	}
+	return presence, nil
+}
+
+func dashIfEmpty(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return "-"
+	}
+	return value
+}

--- a/phase4-coordinator/cmd/coordinator-cli/onboarding_test.go
+++ b/phase4-coordinator/cmd/coordinator-cli/onboarding_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/auth"
+	"github.com/augstar/macprovider-coordinator/internal/providerevents"
+)
+
+func TestListOnboardingMarksExpiredUnconfirmedAsFailed(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "coordinator.db")
+	store, err := auth.OpenStore(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	now := time.Now().UTC().Add(-2 * time.Minute)
+	policy := auth.ReferralPolicy{
+		RequireForRegistration: true,
+		Campaign:               "prebeta_test",
+		PolicyVersion:          "v1",
+		CurrentKeyID:           "k1",
+		HMACKeys:               map[string]string{"k1": strings.Repeat("s", 32)},
+		ProviderBaseUses:       1,
+	}
+	if _, err := store.DB().Exec(`
+INSERT INTO referral_issuers (
+    issuer_id, code_type, key_id, campaign, provider_id,
+    base_capacity, bonus_capacity, created_at, first_serving_at
+) VALUES ('seedcli', 'S', ?, ?, NULL, 1, 0, ?, ?)`,
+		policy.CurrentKeyID, policy.Campaign, now.Format(time.RFC3339), now.Format(time.RFC3339),
+	); err != nil {
+		t.Fatal(err)
+	}
+	code, err := auth.EncodeReferralCode(policy, auth.ReferralTypeSeed, policy.CurrentKeyID, "seedcli")
+	if err != nil {
+		t.Fatal(err)
+	}
+	providerID := "mp-00000000000000000000000000000093"
+	mint, err := store.MintBootstrapToken(ctx, auth.BootstrapMintRequest{
+		ProviderID: providerID, ProviderName: "expired funnel", SourceIP: "192.0.2.93",
+		ReceiptPubkey: bytes.Repeat([]byte{0x93}, 32), Now: now, TTL: time.Minute,
+		PerIPLimitPerHour: 8, PerProviderPerHour: 3, GlobalLimitPerHour: 128,
+		UnconfirmedIDMax: 64, OutstandingTokenMax: 64, IdentityRetention: 7 * 24 * time.Hour,
+		ReferralCode: code, ReferralPolicy: policy,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	eventsPath := providerevents.DefaultDBPath(dbPath)
+	events, err := providerevents.Open(eventsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := events.Record(ctx, providerevents.Event{
+		ProviderID:    providerID,
+		Kind:          providerevents.KindAuthRejected,
+		Outcome:       providerevents.OutcomeFailure,
+		FailureReason: providerevents.ReasonInvalidToken,
+		OccurredAt:    now.Add(30 * time.Second),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := events.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	listed := captureStdout(t, func() {
+		if err := listOnboarding([]string{"--db", dbPath, "--state", "failed_expired"}); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if !strings.Contains(listed, "provider_id="+providerID+" state=failed_expired") {
+		t.Fatalf("output=%q", listed)
+	}
+	if !strings.Contains(listed, "last_failure_reason=invalid_token") || !strings.Contains(listed, "redeemed_at=") {
+		t.Fatalf("missing join fields: %q", listed)
+	}
+	if !strings.Contains(listed, "failed_expired=1") {
+		t.Fatalf("summary missing: %q", listed)
+	}
+	if strings.Contains(listed, code) || strings.Contains(listed, mint.ProviderToken) || strings.Contains(listed, "code_digest") {
+		t.Fatalf("leaked secret material: %q", listed)
+	}
+}

--- a/phase4-coordinator/internal/auth/onboarding_funnel.go
+++ b/phase4-coordinator/internal/auth/onboarding_funnel.go
@@ -1,0 +1,285 @@
+package auth
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"time"
+)
+
+// Operator-facing onboarding funnel states. These join referral redemption,
+// bootstrap identity, and (when the caller supplies it) live presence.
+// Redeemed is never a success state.
+const (
+	OnboardingStatePending       = "pending"
+	OnboardingStateConfirmed     = "confirmed"
+	OnboardingStateLive          = "live"
+	OnboardingStateFailedExpired = "failed_expired"
+	OnboardingStateFailedRevoked = "failed_revoked"
+
+	OnboardingPresenceConnected = "connected"
+	OnboardingPresenceOffline   = "offline"
+	OnboardingPresenceUnknown   = "unknown"
+)
+
+// OnboardingAttemptRecord is the durable auth-SQLite side of one invite or
+// bootstrap onboarding attempt. It never includes invite codes, code digests,
+// tokens, or receipt public keys.
+type OnboardingAttemptRecord struct {
+	ProviderID         string
+	Campaign           string
+	IssuerID           string
+	RedeemedAt         sql.NullString
+	BootstrapCreatedAt sql.NullString
+	ExpiresAt          sql.NullString
+	ConfirmedAt        sql.NullString
+	OperatorRevokedAt  sql.NullString
+}
+
+// OnboardingPresence is the optional live/last-known overlay supplied by the
+// connection-event journal and/or the in-process pool. Empty timestamps mean
+// the caller did not observe that signal.
+type OnboardingPresence struct {
+	Connected         bool
+	LastSeenAt        string
+	LastHeartbeatAt   string
+	LastEventKind     string
+	LastEventOutcome  string
+	LastEventAt       string
+	LastFailureReason string
+}
+
+// OnboardingAttempt is the operator-safe joined funnel row.
+type OnboardingAttempt struct {
+	ProviderID         string `json:"provider_id"`
+	State              string `json:"onboarding_state"`
+	Campaign           string `json:"campaign,omitempty"`
+	IssuerID           string `json:"issuer_id,omitempty"`
+	RedeemedAt         string `json:"redeemed_at,omitempty"`
+	BootstrapCreatedAt string `json:"bootstrap_created_at,omitempty"`
+	ExpiresAt          string `json:"expires_at,omitempty"`
+	ConfirmedAt        string `json:"confirmed_at,omitempty"`
+	OperatorRevokedAt  string `json:"operator_revoked_at,omitempty"`
+	Presence           string `json:"presence"`
+	LastSeenAt         string `json:"last_seen_at,omitempty"`
+	LastHeartbeatAt    string `json:"last_heartbeat_at,omitempty"`
+	LastEventKind      string `json:"last_event_kind,omitempty"`
+	LastEventOutcome   string `json:"last_event_outcome,omitempty"`
+	LastEventAt        string `json:"last_event_at,omitempty"`
+	LastFailureReason  string `json:"last_failure_reason,omitempty"`
+}
+
+// OnboardingFunnelSummary counts exclusive funnel states.
+type OnboardingFunnelSummary struct {
+	Pending       int `json:"pending"`
+	Confirmed     int `json:"confirmed"`
+	Live          int `json:"live"`
+	FailedExpired int `json:"failed_expired"`
+	FailedRevoked int `json:"failed_revoked"`
+}
+
+var validOnboardingStates = map[string]bool{
+	OnboardingStatePending:       true,
+	OnboardingStateConfirmed:     true,
+	OnboardingStateLive:          true,
+	OnboardingStateFailedExpired: true,
+	OnboardingStateFailedRevoked: true,
+}
+
+// ValidOnboardingState reports whether state is one of the exclusive funnel
+// labels operators may filter on.
+func ValidOnboardingState(state string) bool {
+	return validOnboardingStates[strings.TrimSpace(state)]
+}
+
+// ListOnboardingAttempts returns every referral redemption and bootstrap
+// identity row, outer-joined on provider_id. Callers overlay presence
+// separately. The query never selects invite codes, digests, or key material.
+func (s *Store) ListOnboardingAttempts(ctx context.Context) ([]OnboardingAttemptRecord, error) {
+	rows, err := s.db.QueryContext(ctx, `
+SELECT provider_id, campaign, issuer_id, redeemed_at,
+       bootstrap_created_at, expires_at, confirmed_at, operator_revoked_at
+  FROM (
+    SELECT i.provider_id AS provider_id,
+           r.campaign AS campaign,
+           r.issuer_id AS issuer_id,
+           r.redeemed_at AS redeemed_at,
+           i.created_at AS bootstrap_created_at,
+           i.expires_at AS expires_at,
+           i.confirmed_at AS confirmed_at,
+           i.operator_revoked_at AS operator_revoked_at
+      FROM provider_bootstrap_identities i
+      LEFT JOIN referral_redemptions r ON r.provider_id = i.provider_id
+    UNION ALL
+    SELECT r.provider_id,
+           r.campaign,
+           r.issuer_id,
+           r.redeemed_at,
+           i.created_at,
+           i.expires_at,
+           i.confirmed_at,
+           i.operator_revoked_at
+      FROM referral_redemptions r
+      LEFT JOIN provider_bootstrap_identities i ON i.provider_id = r.provider_id
+     WHERE i.provider_id IS NULL
+  )
+ ORDER BY COALESCE(redeemed_at, bootstrap_created_at) DESC, provider_id ASC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var records []OnboardingAttemptRecord
+	for rows.Next() {
+		var (
+			record             OnboardingAttemptRecord
+			campaign, issuerID sql.NullString
+		)
+		if err := rows.Scan(
+			&record.ProviderID,
+			&campaign,
+			&issuerID,
+			&record.RedeemedAt,
+			&record.BootstrapCreatedAt,
+			&record.ExpiresAt,
+			&record.ConfirmedAt,
+			&record.OperatorRevokedAt,
+		); err != nil {
+			return nil, err
+		}
+		record.Campaign = nullStringValue(campaign)
+		record.IssuerID = nullStringValue(issuerID)
+		records = append(records, record)
+	}
+	return records, rows.Err()
+}
+
+// AssembleOnboardingAttempt derives the exclusive funnel state and copies
+// non-secret timestamps. Presence defaults to unknown until OverlayPresence.
+func AssembleOnboardingAttempt(record OnboardingAttemptRecord, now time.Time) OnboardingAttempt {
+	attempt := OnboardingAttempt{
+		ProviderID:         strings.TrimSpace(record.ProviderID),
+		Campaign:           strings.TrimSpace(record.Campaign),
+		IssuerID:           strings.TrimSpace(record.IssuerID),
+		RedeemedAt:         nullStringValue(record.RedeemedAt),
+		BootstrapCreatedAt: nullStringValue(record.BootstrapCreatedAt),
+		ExpiresAt:          nullStringValue(record.ExpiresAt),
+		ConfirmedAt:        nullStringValue(record.ConfirmedAt),
+		OperatorRevokedAt:  nullStringValue(record.OperatorRevokedAt),
+		Presence:           OnboardingPresenceUnknown,
+	}
+	attempt.State = DeriveOnboardingState(record, now, false)
+	return attempt
+}
+
+// DeriveOnboardingState maps durable identity/redemption facts onto one
+// exclusive operator state. connected only promotes a confirmed attempt to live.
+func DeriveOnboardingState(record OnboardingAttemptRecord, now time.Time, connected bool) string {
+	if record.OperatorRevokedAt.Valid && strings.TrimSpace(record.OperatorRevokedAt.String) != "" {
+		return OnboardingStateFailedRevoked
+	}
+	if record.ConfirmedAt.Valid && strings.TrimSpace(record.ConfirmedAt.String) != "" {
+		if connected {
+			return OnboardingStateLive
+		}
+		return OnboardingStateConfirmed
+	}
+	if record.ExpiresAt.Valid {
+		if expiresAt, err := time.Parse(time.RFC3339, record.ExpiresAt.String); err == nil && expiresAt.After(now) {
+			return OnboardingStatePending
+		}
+	}
+	return OnboardingStateFailedExpired
+}
+
+// OverlayPresence applies live/last-known signals. A confirmed connected
+// provider becomes live. Unconfirmed attempts stay pending/expired even if a
+// stale last-known row exists.
+func OverlayPresence(attempt OnboardingAttempt, presence OnboardingPresence, now time.Time, record OnboardingAttemptRecord) OnboardingAttempt {
+	if presence.Connected {
+		attempt.Presence = OnboardingPresenceConnected
+	} else if strings.TrimSpace(presence.LastSeenAt) != "" || strings.TrimSpace(presence.LastHeartbeatAt) != "" || strings.TrimSpace(presence.LastEventAt) != "" {
+		attempt.Presence = OnboardingPresenceOffline
+	} else {
+		attempt.Presence = OnboardingPresenceUnknown
+	}
+	attempt.LastSeenAt = strings.TrimSpace(presence.LastSeenAt)
+	attempt.LastHeartbeatAt = strings.TrimSpace(presence.LastHeartbeatAt)
+	attempt.LastEventKind = strings.TrimSpace(presence.LastEventKind)
+	attempt.LastEventOutcome = strings.TrimSpace(presence.LastEventOutcome)
+	attempt.LastEventAt = strings.TrimSpace(presence.LastEventAt)
+	attempt.LastFailureReason = strings.TrimSpace(presence.LastFailureReason)
+	attempt.State = DeriveOnboardingState(record, now, presence.Connected)
+	return attempt
+}
+
+// SummarizeOnboardingAttempts counts exclusive states across the full set.
+func SummarizeOnboardingAttempts(attempts []OnboardingAttempt) OnboardingFunnelSummary {
+	var summary OnboardingFunnelSummary
+	for _, attempt := range attempts {
+		switch attempt.State {
+		case OnboardingStatePending:
+			summary.Pending++
+		case OnboardingStateConfirmed:
+			summary.Confirmed++
+		case OnboardingStateLive:
+			summary.Live++
+		case OnboardingStateFailedExpired:
+			summary.FailedExpired++
+		case OnboardingStateFailedRevoked:
+			summary.FailedRevoked++
+		}
+	}
+	return summary
+}
+
+// OnboardingSortKey is the list order: newest redemption/bootstrap first, then
+// provider_id ascending. It matches ListOnboardingAttempts SQL ORDER BY.
+func OnboardingSortKey(attempt OnboardingAttempt) (ts, id string) {
+	ts = strings.TrimSpace(attempt.RedeemedAt)
+	if ts == "" {
+		ts = strings.TrimSpace(attempt.BootstrapCreatedAt)
+	}
+	return ts, strings.TrimSpace(attempt.ProviderID)
+}
+
+func onboardingAfterCursor(attempt OnboardingAttempt, afterTS, afterID string) bool {
+	ts, id := OnboardingSortKey(attempt)
+	if ts < afterTS {
+		return true
+	}
+	return ts == afterTS && id > afterID
+}
+
+// PageOnboardingAttempts applies an exclusive-state filter, then a stable
+// (after_ts, after_id) cursor, then limit. nextTS/nextID are set when more
+// matching rows remain.
+func PageOnboardingAttempts(attempts []OnboardingAttempt, filter string, limit int, afterTS, afterID string) (page []OnboardingAttempt, nextTS, nextID string) {
+	if limit <= 0 {
+		return nil, "", ""
+	}
+	filter = strings.TrimSpace(filter)
+	afterTS = strings.TrimSpace(afterTS)
+	afterID = strings.TrimSpace(afterID)
+	page = make([]OnboardingAttempt, 0, limit)
+	for _, attempt := range attempts {
+		if filter != "" && filter != "all" && attempt.State != filter {
+			continue
+		}
+		if afterTS != "" && afterID != "" && !onboardingAfterCursor(attempt, afterTS, afterID) {
+			continue
+		}
+		if len(page) == limit {
+			ts, id := OnboardingSortKey(page[len(page)-1])
+			return page, ts, id
+		}
+		page = append(page, attempt)
+	}
+	return page, "", ""
+}
+
+func nullStringValue(value sql.NullString) string {
+	if !value.Valid {
+		return ""
+	}
+	return strings.TrimSpace(value.String)
+}

--- a/phase4-coordinator/internal/auth/onboarding_funnel_test.go
+++ b/phase4-coordinator/internal/auth/onboarding_funnel_test.go
@@ -1,0 +1,201 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestListOnboardingAttemptsJoinsRedemptionAndBootstrapIdentity(t *testing.T) {
+	store, err := OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+	now := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
+	policy := coreReferralPolicy()
+	code := seedCoreReferral(t, store, policy, "seedfunnel")
+	providerID := "mp-00000000000000000000000000000081"
+	if _, err := store.MintBootstrapToken(ctx, BootstrapMintRequest{
+		ProviderID: providerID, ProviderName: "funnel pending", SourceIP: "192.0.2.81",
+		ReceiptPubkey: bytes.Repeat([]byte{0x81}, 32), Now: now, TTL: time.Hour,
+		PerIPLimitPerHour: 8, PerProviderPerHour: 3, GlobalLimitPerHour: 128,
+		UnconfirmedIDMax: 64, OutstandingTokenMax: 64, IdentityRetention: 7 * 24 * time.Hour,
+		ReferralCode: code, ReferralPolicy: policy,
+	}); err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+
+	records, err := store.ListOnboardingAttempts(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("attempts=%d want 1", len(records))
+	}
+	got := records[0]
+	if got.ProviderID != providerID {
+		t.Fatalf("provider_id=%q", got.ProviderID)
+	}
+	if got.Campaign != policy.Campaign || got.IssuerID != "seedfunnel" {
+		t.Fatalf("campaign=%q issuer_id=%q", got.Campaign, got.IssuerID)
+	}
+	if !got.RedeemedAt.Valid || !got.BootstrapCreatedAt.Valid || !got.ExpiresAt.Valid {
+		t.Fatalf("missing timestamps: %+v", got)
+	}
+	if got.ConfirmedAt.Valid {
+		t.Fatal("pending attempt unexpectedly confirmed")
+	}
+	attempt := AssembleOnboardingAttempt(got, now.Add(time.Second))
+	if attempt.State != OnboardingStatePending {
+		t.Fatalf("state=%q want pending", attempt.State)
+	}
+	if strings.Contains(attempt.RedeemedAt, code) || strings.Contains(got.IssuerID, code) {
+		t.Fatalf("invite code leaked: %+v", attempt)
+	}
+}
+
+func TestOnboardingFunnelStatesCoverExpiredConfirmedLiveAndRevoked(t *testing.T) {
+	now := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
+
+	t.Run("failed_expired unconfirmed past ttl", func(t *testing.T) {
+		record := OnboardingAttemptRecord{
+			ProviderID: "mp-expired",
+			RedeemedAt: sql.NullString{String: timeText(now.Add(-2 * time.Minute)), Valid: true},
+			ExpiresAt:  sql.NullString{String: timeText(now.Add(-time.Minute)), Valid: true},
+		}
+		if got := DeriveOnboardingState(record, now, false); got != OnboardingStateFailedExpired {
+			t.Fatalf("state=%q", got)
+		}
+	})
+
+	t.Run("failed_expired after identity collection", func(t *testing.T) {
+		record := OnboardingAttemptRecord{
+			ProviderID: "mp-collected",
+			Campaign:   "prebeta_test",
+			IssuerID:   "seed-funnel",
+			RedeemedAt: sql.NullString{String: timeText(now.Add(-8 * 24 * time.Hour)), Valid: true},
+		}
+		attempt := AssembleOnboardingAttempt(record, now)
+		if attempt.State != OnboardingStateFailedExpired {
+			t.Fatalf("state=%q want failed_expired", attempt.State)
+		}
+		if attempt.RedeemedAt == "" || attempt.BootstrapCreatedAt != "" {
+			t.Fatalf("collected identity row=%+v", attempt)
+		}
+	})
+
+	t.Run("confirmed offline is not live", func(t *testing.T) {
+		record := OnboardingAttemptRecord{
+			ProviderID:  "mp-confirmed",
+			ConfirmedAt: sql.NullString{String: timeText(now), Valid: true},
+		}
+		attempt := OverlayPresence(AssembleOnboardingAttempt(record, now), OnboardingPresence{
+			LastSeenAt:      timeText(now),
+			LastHeartbeatAt: timeText(now),
+		}, now, record)
+		if attempt.State != OnboardingStateConfirmed || attempt.Presence != OnboardingPresenceOffline {
+			t.Fatalf("state=%q presence=%q", attempt.State, attempt.Presence)
+		}
+	})
+
+	t.Run("confirmed connected is live", func(t *testing.T) {
+		record := OnboardingAttemptRecord{
+			ProviderID:  "mp-live",
+			ConfirmedAt: sql.NullString{String: timeText(now), Valid: true},
+		}
+		attempt := OverlayPresence(AssembleOnboardingAttempt(record, now), OnboardingPresence{
+			Connected:       true,
+			LastHeartbeatAt: timeText(now),
+		}, now, record)
+		if attempt.State != OnboardingStateLive || attempt.Presence != OnboardingPresenceConnected {
+			t.Fatalf("state=%q presence=%q", attempt.State, attempt.Presence)
+		}
+	})
+
+	t.Run("operator revoked beats live overlay", func(t *testing.T) {
+		record := OnboardingAttemptRecord{
+			ProviderID:        "mp-revoked",
+			OperatorRevokedAt: sql.NullString{String: timeText(now), Valid: true},
+			ConfirmedAt:       sql.NullString{String: timeText(now), Valid: true},
+		}
+		attempt := OverlayPresence(AssembleOnboardingAttempt(record, now), OnboardingPresence{Connected: true}, now, record)
+		if attempt.State != OnboardingStateFailedRevoked {
+			t.Fatalf("state=%q", attempt.State)
+		}
+	})
+}
+
+func TestListOnboardingAttemptsKeepsRedemptionAfterIdentityDelete(t *testing.T) {
+	store, err := OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+	now := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
+	policy := coreReferralPolicy()
+	code := seedCoreReferral(t, store, policy, "seedgc")
+	providerID := "mp-00000000000000000000000000000082"
+	if _, err := store.MintBootstrapToken(ctx, BootstrapMintRequest{
+		ProviderID: providerID, ProviderName: "funnel gc", SourceIP: "192.0.2.82",
+		ReceiptPubkey: bytes.Repeat([]byte{0x82}, 32), Now: now, TTL: time.Hour,
+		PerIPLimitPerHour: 8, PerProviderPerHour: 3, GlobalLimitPerHour: 128,
+		UnconfirmedIDMax: 64, OutstandingTokenMax: 64, IdentityRetention: 7 * 24 * time.Hour,
+		ReferralCode: code, ReferralPolicy: policy,
+	}); err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, `DELETE FROM provider_bootstrap_identities WHERE provider_id = ?`, providerID); err != nil {
+		t.Fatal(err)
+	}
+	records, err := store.ListOnboardingAttempts(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 1 || records[0].ProviderID != providerID || !records[0].RedeemedAt.Valid || records[0].BootstrapCreatedAt.Valid {
+		t.Fatalf("gc join=%+v", records)
+	}
+	if AssembleOnboardingAttempt(records[0], now).State != OnboardingStateFailedExpired {
+		t.Fatalf("state=%q", AssembleOnboardingAttempt(records[0], now).State)
+	}
+	if AssembleOnboardingAttempt(records[0], now).ExpiresAt != "" {
+		t.Fatalf("collected identity still has expires_at=%q", AssembleOnboardingAttempt(records[0], now).ExpiresAt)
+	}
+}
+
+func TestSummarizeOnboardingAttempts(t *testing.T) {
+	summary := SummarizeOnboardingAttempts([]OnboardingAttempt{
+		{State: OnboardingStatePending},
+		{State: OnboardingStatePending},
+		{State: OnboardingStateConfirmed},
+		{State: OnboardingStateLive},
+		{State: OnboardingStateFailedExpired},
+		{State: OnboardingStateFailedRevoked},
+	})
+	if summary.Pending != 2 || summary.Confirmed != 1 || summary.Live != 1 || summary.FailedExpired != 1 || summary.FailedRevoked != 1 {
+		t.Fatalf("summary=%+v", summary)
+	}
+}
+
+func TestPageOnboardingAttemptsEmitsCursorWhenTruncated(t *testing.T) {
+	ts := "2026-08-31T12:00:00Z"
+	attempts := []OnboardingAttempt{
+		{ProviderID: "mp-a", State: OnboardingStatePending, RedeemedAt: ts},
+		{ProviderID: "mp-b", State: OnboardingStateConfirmed, RedeemedAt: ts},
+		{ProviderID: "mp-c", State: OnboardingStatePending, RedeemedAt: ts},
+	}
+	page, nextTS, nextID := PageOnboardingAttempts(attempts, "pending", 1, "", "")
+	if len(page) != 1 || page[0].ProviderID != "mp-a" || nextID != "mp-a" || nextTS != ts {
+		t.Fatalf("first page=%+v next=%s %s", page, nextTS, nextID)
+	}
+	page, nextTS, nextID = PageOnboardingAttempts(attempts, "pending", 1, nextTS, nextID)
+	if len(page) != 1 || page[0].ProviderID != "mp-c" || nextID != "" {
+		t.Fatalf("second page=%+v next=%s %s", page, nextTS, nextID)
+	}
+}

--- a/phase4-coordinator/internal/ws/admin_onboarding.go
+++ b/phase4-coordinator/internal/ws/admin_onboarding.go
@@ -1,0 +1,155 @@
+package ws
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/auth"
+	"github.com/augstar/macprovider-coordinator/internal/providerevents"
+)
+
+const defaultOnboardingListCap = providerevents.DefaultListPageCap
+
+func (s *Server) handleAdminOnboarding(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !s.authorizedOperator(r) {
+		writeJSON(w, http.StatusUnauthorized, map[string]any{"error": map[string]any{"message": "unauthorized", "code": "invalid_operator_token"}})
+		return
+	}
+	if s.authStore == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{"error": map[string]any{"message": "onboarding attempt store unavailable", "code": "onboarding_store_unavailable"}})
+		return
+	}
+	filter := strings.TrimSpace(r.URL.Query().Get("state"))
+	if filter != "" && filter != "all" && !auth.ValidOnboardingState(filter) {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": map[string]any{"message": "invalid state", "code": "invalid_request"}})
+		return
+	}
+	limit := defaultOnboardingListCap
+	if raw := strings.TrimSpace(r.URL.Query().Get("limit")); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n <= 0 {
+			writeJSON(w, http.StatusBadRequest, map[string]any{"error": map[string]any{"message": "invalid limit", "code": "invalid_request"}})
+			return
+		}
+		limit = n
+	}
+	if limit > defaultOnboardingListCap {
+		limit = defaultOnboardingListCap
+	}
+	afterID := strings.TrimSpace(r.URL.Query().Get("after"))
+	afterTS := strings.TrimSpace(r.URL.Query().Get("after_ts"))
+	if (afterID == "") != (afterTS == "") {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": map[string]any{"message": "after and after_ts must be supplied together", "code": "invalid_request"}})
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
+	defer cancel()
+	records, err := s.authStore.ListOnboardingAttempts(ctx)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": map[string]any{"message": "list onboarding attempts failed", "code": "onboarding_store_error"}})
+		return
+	}
+
+	now := s.now().UTC()
+	live := s.onboardingLivePresence()
+	all := make([]auth.OnboardingAttempt, 0, len(records))
+	for _, record := range records {
+		if providerevents.LooksLikeCredential(record.ProviderID) {
+			continue
+		}
+		presence, err := s.onboardingPresenceFor(ctx, record.ProviderID, live)
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]any{"error": map[string]any{"message": "onboarding presence lookup failed", "code": "events_store_error"}})
+			return
+		}
+		all = append(all, auth.OverlayPresence(auth.AssembleOnboardingAttempt(record, now), presence, now, record))
+	}
+
+	summary := auth.SummarizeOnboardingAttempts(all)
+	out, nextTS, nextID := auth.PageOnboardingAttempts(all, filter, limit, afterTS, afterID)
+	resp := map[string]any{
+		"attempts": out,
+		"summary": map[string]any{
+			"returned":       len(out),
+			"pending":        summary.Pending,
+			"confirmed":      summary.Confirmed,
+			"live":           summary.Live,
+			"failed_expired": summary.FailedExpired,
+			"failed_revoked": summary.FailedRevoked,
+			"limit":          limit,
+		},
+	}
+	if nextID != "" {
+		resp["next_after"] = nextID
+		resp["next_after_ts"] = nextTS
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) onboardingLivePresence() map[string]struct{} {
+	live := map[string]struct{}{}
+	if s.pool == nil {
+		return live
+	}
+	for _, p := range s.pool.Snapshot() {
+		if s.isProviderTransportConnected(p) {
+			live[p.ProviderID] = struct{}{}
+		}
+	}
+	return live
+}
+
+func (s *Server) onboardingPresenceFor(ctx context.Context, providerID string, live map[string]struct{}) (auth.OnboardingPresence, error) {
+	presence := auth.OnboardingPresence{}
+	if _, ok := live[providerID]; ok {
+		presence.Connected = true
+		if p, ok := s.pool.Resolve(providerID, ""); ok {
+			if !p.LastHeartbeatAt.IsZero() {
+				presence.LastHeartbeatAt = p.LastHeartbeatAt.UTC().Format(time.RFC3339)
+			}
+			if !p.LastActivityAt.IsZero() {
+				presence.LastSeenAt = p.LastActivityAt.UTC().Format(time.RFC3339)
+			} else if !p.ConnectedAt.IsZero() {
+				presence.LastSeenAt = p.ConnectedAt.UTC().Format(time.RFC3339)
+			}
+		}
+	}
+	if s.connectionEvents == nil {
+		return presence, nil
+	}
+	snap, found, err := s.connectionEvents.GetLastKnown(ctx, providerID)
+	if err != nil {
+		return auth.OnboardingPresence{}, err
+	}
+	if found {
+		if presence.LastSeenAt == "" && !snap.LastSeenAt.IsZero() {
+			presence.LastSeenAt = snap.LastSeenAt.UTC().Format(time.RFC3339)
+		}
+		if presence.LastHeartbeatAt == "" && snap.LastHeartbeatAt != nil && !snap.LastHeartbeatAt.IsZero() {
+			presence.LastHeartbeatAt = snap.LastHeartbeatAt.UTC().Format(time.RFC3339)
+		}
+	}
+	ev, ok, err := s.connectionEvents.LatestEventProvider(ctx, providerID)
+	if err != nil {
+		return auth.OnboardingPresence{}, err
+	}
+	if ok {
+		presence.LastEventKind = ev.Kind
+		presence.LastEventOutcome = ev.Outcome
+		presence.LastEventAt = ev.OccurredAt.UTC().Format(time.RFC3339)
+		presence.LastFailureReason = ev.FailureReason
+		if presence.LastSeenAt == "" && !ev.OccurredAt.IsZero() {
+			presence.LastSeenAt = ev.OccurredAt.UTC().Format(time.RFC3339)
+		}
+	}
+	return presence, nil
+}

--- a/phase4-coordinator/internal/ws/admin_onboarding_test.go
+++ b/phase4-coordinator/internal/ws/admin_onboarding_test.go
@@ -1,0 +1,294 @@
+package ws_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/auth"
+	"github.com/augstar/macprovider-coordinator/internal/config"
+	"github.com/augstar/macprovider-coordinator/internal/pool"
+	"github.com/augstar/macprovider-coordinator/internal/providerevents"
+	providerws "github.com/augstar/macprovider-coordinator/internal/ws"
+)
+
+func TestAdminOnboardingRequiresOperatorAuth(t *testing.T) {
+	h := newProviderHarnessWithServerOptions(t, nil, nil)
+	defer h.HTTP.Close()
+
+	resp, err := http.Get(h.HTTP.URL + "/admin/onboarding")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status=%d want 401", resp.StatusCode)
+	}
+}
+
+func TestAdminOnboardingUnavailableWithoutAuthStore(t *testing.T) {
+	h := newProviderHarnessWithServerOptions(t, nil, nil)
+	defer h.HTTP.Close()
+
+	req, err := http.NewRequest(http.MethodGet, h.HTTP.URL+"/admin/onboarding", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer test-operator-key")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d want 503", resp.StatusCode)
+	}
+}
+
+func TestAdminOnboardingJoinsInviteBootstrapAndLivePresence(t *testing.T) {
+	authStore, err := auth.OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = authStore.Close() })
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Second)
+	policy := auth.ReferralPolicy{
+		RequireForRegistration: true,
+		Campaign:               "prebeta_test",
+		PolicyVersion:          "v1",
+		CurrentKeyID:           "k1",
+		HMACKeys:               map[string]string{"k1": strings.Repeat("s", 32)},
+		ProviderBaseUses:       2,
+	}
+	if _, err := authStore.DB().Exec(`
+INSERT INTO referral_issuers (
+    issuer_id, code_type, key_id, campaign, provider_id,
+    base_capacity, bonus_capacity, created_at, first_serving_at
+) VALUES ('seedadmin', 'S', ?, ?, NULL, 2, 0, ?, ?)`,
+		policy.CurrentKeyID, policy.Campaign, now.Format(time.RFC3339), now.Format(time.RFC3339),
+	); err != nil {
+		t.Fatal(err)
+	}
+	code, err := auth.EncodeReferralCode(policy, auth.ReferralTypeSeed, policy.CurrentKeyID, "seedadmin")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pendingID := "mp-00000000000000000000000000000091"
+	liveID := "mp-00000000000000000000000000000092"
+	pendingMint, err := authStore.MintBootstrapToken(ctx, auth.BootstrapMintRequest{
+		ProviderID: pendingID, ProviderName: "pending host", SourceIP: "192.0.2.91",
+		ReceiptPubkey: bytes.Repeat([]byte{0x91}, 32), Now: now, TTL: time.Hour,
+		PerIPLimitPerHour: 8, PerProviderPerHour: 3, GlobalLimitPerHour: 128,
+		UnconfirmedIDMax: 64, OutstandingTokenMax: 64, IdentityRetention: 7 * 24 * time.Hour,
+		ReferralCode: code, ReferralPolicy: policy,
+	})
+	if err != nil {
+		t.Fatalf("pending mint: %v", err)
+	}
+	liveMint, err := authStore.MintBootstrapToken(ctx, auth.BootstrapMintRequest{
+		ProviderID: liveID, ProviderName: "live host", SourceIP: "192.0.2.92",
+		ReceiptPubkey: bytes.Repeat([]byte{0x92}, 32), Now: now, TTL: time.Hour,
+		PerIPLimitPerHour: 8, PerProviderPerHour: 3, GlobalLimitPerHour: 128,
+		UnconfirmedIDMax: 64, OutstandingTokenMax: 64, IdentityRetention: 7 * 24 * time.Hour,
+		ReferralCode: code, ReferralPolicy: policy,
+	})
+	if err != nil {
+		t.Fatalf("live mint: %v", err)
+	}
+	if err := authStore.MarkTokenUsed(ctx, liveMint.ProviderToken); err != nil {
+		t.Fatalf("confirm live: %v", err)
+	}
+
+	events := newConnectionEventStore(t)
+	if err := events.Record(ctx, providerevents.Event{
+		ProviderID:    pendingID,
+		Kind:          providerevents.KindAuthRejected,
+		Outcome:       providerevents.OutcomeFailure,
+		FailureReason: providerevents.ReasonInvalidToken,
+		OccurredAt:    now.Add(30 * time.Second),
+		Diagnostic:    "Authorization: Bearer mpk_should_redact",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	h := newProviderHarnessWithServerOptions(t, nil, []providerws.Option{
+		providerws.WithGitHubAuthStore(authStore),
+		providerws.WithConnectionEventStore(events),
+		providerws.WithNow(func() time.Time { return now.Add(time.Minute) }),
+	})
+	defer h.HTTP.Close()
+
+	if _, ok := h.Registry.Register(&pool.Provider{
+		ProviderID:      liveID,
+		AssignedID:      "asg-live",
+		State:           pool.StateReady,
+		LastHeartbeatAt: now.Add(45 * time.Second),
+		ConnectedAt:     now.Add(40 * time.Second),
+	}, nil); !ok {
+		t.Fatal("register live provider failed")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, h.HTTP.URL+"/admin/onboarding", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer test-operator-key")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+	if strings.Contains(string(body), code) || strings.Contains(string(body), pendingMint.ProviderToken) ||
+		strings.Contains(string(body), liveMint.ProviderToken) || strings.Contains(string(body), "code_digest") ||
+		strings.Contains(string(body), "invite_code") || strings.Contains(string(body), "receipt_pubkey") {
+		t.Fatalf("response leaked secret material: %s", body)
+	}
+
+	var decoded struct {
+		Attempts []map[string]any `json:"attempts"`
+		Summary  map[string]any   `json:"summary"`
+	}
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatalf("decode: %v body=%s", err, body)
+	}
+	if decoded.Summary["pending"] != float64(1) || decoded.Summary["live"] != float64(1) {
+		t.Fatalf("summary=%v", decoded.Summary)
+	}
+	byID := map[string]map[string]any{}
+	for _, attempt := range decoded.Attempts {
+		id, _ := attempt["provider_id"].(string)
+		byID[id] = attempt
+	}
+	if byID[pendingID]["onboarding_state"] != "pending" || byID[pendingID]["last_failure_reason"] != providerevents.ReasonInvalidToken {
+		t.Fatalf("pending=%v", byID[pendingID])
+	}
+	if byID[liveID]["onboarding_state"] != "live" || byID[liveID]["presence"] != "connected" {
+		t.Fatalf("live=%v", byID[liveID])
+	}
+
+	filterReq, err := http.NewRequest(http.MethodGet, h.HTTP.URL+"/admin/onboarding?state=failed_expired", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	filterReq.Header.Set("Authorization", "Bearer test-operator-key")
+	filterResp, err := http.DefaultClient.Do(filterReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer filterResp.Body.Close()
+	var filtered struct {
+		Attempts []map[string]any `json:"attempts"`
+		Summary  map[string]any   `json:"summary"`
+	}
+	if err := json.NewDecoder(filterResp.Body).Decode(&filtered); err != nil {
+		t.Fatal(err)
+	}
+	if len(filtered.Attempts) != 0 {
+		t.Fatalf("filtered attempts=%v", filtered.Attempts)
+	}
+	if filtered.Summary["pending"] != float64(1) {
+		t.Fatalf("filter should keep unfiltered summary: %v", filtered.Summary)
+	}
+
+	pageReq, err := http.NewRequest(http.MethodGet, h.HTTP.URL+"/admin/onboarding?limit=1", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pageReq.Header.Set("Authorization", "Bearer test-operator-key")
+	pageResp, err := http.DefaultClient.Do(pageReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pageResp.Body.Close()
+	var firstPage struct {
+		Attempts    []map[string]any `json:"attempts"`
+		NextAfter   string           `json:"next_after"`
+		NextAfterTS string           `json:"next_after_ts"`
+	}
+	if err := json.NewDecoder(pageResp.Body).Decode(&firstPage); err != nil {
+		t.Fatal(err)
+	}
+	if len(firstPage.Attempts) != 1 || firstPage.NextAfter == "" || firstPage.NextAfterTS == "" {
+		t.Fatalf("first page=%+v", firstPage)
+	}
+	secondQuery := url.Values{}
+	secondQuery.Set("limit", "1")
+	secondQuery.Set("after", firstPage.NextAfter)
+	secondQuery.Set("after_ts", firstPage.NextAfterTS)
+	secondReq, err := http.NewRequest(http.MethodGet, h.HTTP.URL+"/admin/onboarding?"+secondQuery.Encode(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondReq.Header.Set("Authorization", "Bearer test-operator-key")
+	secondResp, err := http.DefaultClient.Do(secondReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer secondResp.Body.Close()
+	var secondPage struct {
+		Attempts  []map[string]any `json:"attempts"`
+		NextAfter string           `json:"next_after"`
+	}
+	if err := json.NewDecoder(secondResp.Body).Decode(&secondPage); err != nil {
+		t.Fatal(err)
+	}
+	if len(secondPage.Attempts) != 1 {
+		t.Fatalf("second page=%+v", secondPage)
+	}
+	firstID, _ := firstPage.Attempts[0]["provider_id"].(string)
+	secondID, _ := secondPage.Attempts[0]["provider_id"].(string)
+	if firstID == "" || firstID == secondID {
+		t.Fatalf("pages overlapped: %q %q", firstID, secondID)
+	}
+
+	incompleteReq, err := http.NewRequest(http.MethodGet, h.HTTP.URL+"/admin/onboarding?after="+url.QueryEscape(firstID), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	incompleteReq.Header.Set("Authorization", "Bearer test-operator-key")
+	incompleteResp, err := http.DefaultClient.Do(incompleteReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer incompleteResp.Body.Close()
+	if incompleteResp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("incomplete cursor status=%d want 400", incompleteResp.StatusCode)
+	}
+}
+
+func TestAdminOnboardingRejectsGatewayServiceToken(t *testing.T) {
+	h := newProviderHarnessWithServerOptions(t, nil, nil, func(cfg *config.Config) {
+		cfg.Auth.GatewayServiceToken = "service-secret"
+	})
+	defer h.HTTP.Close()
+
+	req, err := http.NewRequest(http.MethodGet, h.HTTP.URL+"/admin/onboarding", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer service-secret")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status=%d want 401", resp.StatusCode)
+	}
+}

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -1313,6 +1313,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/admin/blacklist", s.handleBlacklist)
 	mux.HandleFunc("/admin/providers", s.handleAdminProviders)
 	mux.HandleFunc("/admin/providers/", s.handleAdminProviders)
+	mux.HandleFunc("/admin/onboarding", s.handleAdminOnboarding)
 	mux.HandleFunc("/admin/compute-integrity", s.handleAdminComputeIntegrity)
 	mux.HandleFunc("/admin/compute-integrity/", s.handleAdminComputeIntegrity)
 	mux.HandleFunc("/admin/provisional", s.handleAdminProvisional)

--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -997,7 +997,7 @@
     {
       "spec_id": "SPEC-035",
       "title": "Provider connection diagnostics and failure history",
-      "version": "v0.4.0",
+      "version": "v0.4.1",
       "path": "specs/SPEC-035-provider-connection-diagnostics.md",
       "status": "draft",
       "owner": "@Augustas11",
@@ -2361,10 +2361,18 @@
       "state": "pending",
       "implementation": [
         "phase4-coordinator/internal/ws/admin_providers.go:func (s *Server) handleAdminProviders",
+        "phase4-coordinator/internal/ws/admin_onboarding.go:func (s *Server) handleAdminOnboarding",
+        "phase4-coordinator/cmd/coordinator-cli/onboarding.go:func listOnboarding",
         "phase4-coordinator/internal/ws/server.go:func (s *Server) authorizedOperator"
       ],
       "tests": [
-        "phase4-coordinator/internal/ws/admin_providers_test.go:TestAdminProvidersRequireOperatorAuth"
+        "phase4-coordinator/internal/ws/admin_providers_test.go:TestAdminProvidersRequireOperatorAuth",
+        "phase4-coordinator/internal/ws/admin_onboarding_test.go:TestAdminOnboardingRequiresOperatorAuth",
+        "phase4-coordinator/internal/ws/admin_onboarding_test.go:TestAdminOnboardingJoinsInviteBootstrapAndLivePresence",
+        "phase4-coordinator/internal/ws/admin_onboarding_test.go:TestAdminOnboardingRejectsGatewayServiceToken",
+        "phase4-coordinator/cmd/coordinator-cli/onboarding_test.go:TestListOnboardingMarksExpiredUnconfirmedAsFailed",
+        "phase4-coordinator/internal/auth/onboarding_funnel_test.go:TestOnboardingFunnelStatesCoverExpiredConfirmedLiveAndRevoked",
+        "phase4-coordinator/internal/auth/onboarding_funnel_test.go:TestPageOnboardingAttemptsEmitsCursorWhenTruncated"
       ],
       "journeys": [],
       "evidence": [],
@@ -2372,7 +2380,7 @@
         "verdict": "UNKNOWN",
         "owner": "@Augustas11",
         "issue": "https://github.com/Augustas11/macprovider/issues/535",
-        "rationale": "Operator-only admin GETs: coordinator Partial implemented under unit tests; production Pearl deploy and remaining #535 stages are pending."
+        "rationale": "Operator-only admin GETs including the #1267 onboarding funnel join: coordinator Partial implemented under unit tests; production Pearl deploy and remaining #535 stages are pending."
       }
     },
     {

--- a/specs/README.md
+++ b/specs/README.md
@@ -43,7 +43,7 @@ it can no longer drift. Do not hand-edit the table; edit each spec's
 | SPEC-032 | Autotune Hardware-Evidence Admission Gate, OPoI & Proof-of-Weights Boundary | v0.2.5 | draft | complete | pending: 3 | [SPEC-032-proof-of-weights-hello-gate.md](SPEC-032-proof-of-weights-hello-gate.md) |
 | SPEC-033 | Hardware-Evidence Verifier (`hardware-verifier.v2`) | v0.6.2 | draft | pending | conformant: 1 | [SPEC-033-hardware-verifier.md](SPEC-033-hardware-verifier.md) |
 | SPEC-034 | Referral admission, provider invites, and advocacy rewards | v0.4.7 | normative | pending | conformant: 1 | [SPEC-034-referral-gated-prebeta.md](SPEC-034-referral-gated-prebeta.md) |
-| SPEC-035 | Provider connection diagnostics and failure history | v0.4.0 | draft | complete | pending: 9 | [SPEC-035-provider-connection-diagnostics.md](SPEC-035-provider-connection-diagnostics.md) |
+| SPEC-035 | Provider connection diagnostics and failure history | v0.4.1 | draft | complete | pending: 9 | [SPEC-035-provider-connection-diagnostics.md](SPEC-035-provider-connection-diagnostics.md) |
 | SPEC-036 | Compute-Integrity Receipt Companion | v0.1.1 | draft | complete | pending: 17 | [SPEC-036-compute-integrity-receipt.md](SPEC-036-compute-integrity-receipt.md) |
 | SPEC-037 | KV survival across provider restarts (encrypted provider-local disk tier) | v0.1.1 | draft | complete | pending: 13 | [SPEC-037-kv-survival-restart.md](SPEC-037-kv-survival-restart.md) |
 | SPEC-038 | Continuous batching for concurrent provider inference | v0.2 | draft | complete | pending: 17 | [SPEC-038-continuous-batching.md](SPEC-038-continuous-batching.md) |

--- a/specs/SPEC-035-provider-connection-diagnostics.md
+++ b/specs/SPEC-035-provider-connection-diagnostics.md
@@ -1,9 +1,22 @@
 # SPEC-035 — Provider connection diagnostics and failure history
 
-Version: v0.4.0
-Status: draft (Partial #535 coordinator journal + provider diagnostic snapshot + monitor alerts + admission-ceiling drift diagnostics)
+Version: v0.4.1
+Status: draft (Partial #535 coordinator journal + provider diagnostic snapshot + monitor alerts + admission-ceiling drift diagnostics; #1267 operator onboarding funnel join)
 Owner: coordinator operator observability
 Issue: https://github.com/Augustas11/macprovider/issues/535
+
+Changelog:
+
+- v0.4.1 (2026-08-31): adds the operator onboarding funnel join for
+  [#1267](https://github.com/Augustas11/macprovider/issues/1267). `GET /admin/onboarding`
+  and `coordinator-cli list-onboarding` project exclusive pending / confirmed /
+  live / failed_expired / failed_revoked states from referral redemptions,
+  bootstrap identities, last-known/events, and live pool presence. Redeemed is
+  not a success marker. Invite codes, code digests, tokens, and receipt keys
+  MUST NOT appear in the projection. The admin GET is page-capped with a
+  `next_after` / `next_after_ts` cursor. After bootstrap-identity collection,
+  a leftover redemption still projects as `failed_expired` with its redemption
+  timestamp; expiry MAY be omitted.
 
 ## 1. Purpose and scope
 
@@ -30,6 +43,10 @@ In scope for v0.2 (this Partial):
   coordinator admin endpoints.
 - Coordinator-observed proof-of-weights admission-ceiling drift diagnostics on
   heartbeat model changes.
+- Operator onboarding funnel join (`GET /admin/onboarding` and
+  `coordinator-cli list-onboarding`) that distinguishes pending, confirmed,
+  live, expired-unconfirmed, and revoked attempts without treating redemption
+  as a successful join.
 
 Out of scope (later Partials of #535):
 
@@ -64,11 +81,28 @@ the closed set: `invalid_token`, `invalid_auth_request`, `no_common_aead_suite`,
 `unrecognized_auth_message`, `pool_full`, `other`.
 
 **SPEC-035-R003 — Operator-only admin GETs.** The coordinator MUST expose
-`GET /admin/providers`, `GET /admin/providers/{provider_id}`, and
-`GET /admin/providers/{provider_id}/events` only to requests that pass the
-existing human-operator bearer check. Missing/invalid operator credentials MUST
-fail closed with `401`. These routes MUST NOT accept gateway service tokens and
-MUST NOT be reachable on buyer/gateway public APIs.
+`GET /admin/providers`, `GET /admin/providers/{provider_id}`,
+`GET /admin/providers/{provider_id}/events`, and `GET /admin/onboarding`
+only to requests that pass the existing human-operator bearer check.
+Missing/invalid operator credentials MUST fail closed with `401`. These
+routes MUST NOT accept gateway service tokens and MUST NOT be reachable on
+buyer/gateway public APIs. `GET /admin/onboarding` MUST join referral
+redemptions, bootstrap identities, last-known/events, and live pool presence
+into exclusive operator states `pending`, `confirmed`, `live`,
+`failed_expired`, and `failed_revoked`. A redeemed-but-unconfirmed identity
+that has passed bootstrap token expiry MUST surface as `failed_expired` with
+its redemption timestamp and, while the bootstrap identity row remains, its
+expiry timestamp. After identity collection removes the bootstrap row, the
+redemption MUST still appear as `failed_expired` with the redemption
+timestamp; expiry MAY be omitted because it is no longer durably present.
+The list MUST be page-capped and MUST emit a stable cursor (`next_after`,
+`next_after_ts`) when more matching rows remain. The projection MUST NOT
+include invite codes, code digests, provider tokens, or receipt public keys.
+The Pearl-local `coordinator-cli list-onboarding` command is the offline
+sibling of this GET and MUST apply the same exclusive states and redaction
+rules, except that `live` requires an in-process connected session and
+therefore remains `confirmed` on the CLI unless a later operator HTTP overlay
+supplies presence.
 
 **SPEC-035-R004 — Offline last-known representation.** A provider that is not
 currently connected MUST be represented as `presence=offline` with its last-known
@@ -140,5 +174,7 @@ Authorization values, local paths, or buyer-visible diagnostics.
 
 v0.4 ships coordinator-side journal/admin GETs, provider `status --json`,
 authenticated WSS `diagnostic_status` snapshots, Pearl monitor diagnostic
-alerts, and coordinator observe-only admission-ceiling drift events. CLI inspect
-wrappers and any HTTPS beacon remain deferred under #535.
+alerts, and coordinator observe-only admission-ceiling drift events. v0.4.1
+adds the operator onboarding funnel join (`GET /admin/onboarding` and
+`coordinator-cli list-onboarding`). CLI inspect wrappers and any HTTPS beacon
+remain deferred under #535.


### PR DESCRIPTION
## Summary

Slice 1 of #1267: join existing redemption, bootstrap-identity, last-known/events, and live pool facts into exclusive operator onboarding states. Redeemed is not a successful join.

- Adds `GET /admin/onboarding` behind the same operator bearer as `/admin/providers`.
- Adds `coordinator-cli list-onboarding` as the offline sibling (cannot mark `live`).
- Projects `pending` / `confirmed` / `live` / `failed_expired` / `failed_revoked` without invite codes, code digests, tokens, or receipt keys.
- Page-caps the admin GET with `next_after` / `next_after_ts`. After identity GC, leftover redemptions stay `failed_expired` with redemption time; expiry may be omitted.

Does not add admission-reason persistence, Malibu/CLI copy, or a Pearl overlay.

## Test plan

- [x] `cd phase4-coordinator && GOTOOLCHAIN=local go test ./internal/auth ./internal/ws ./cmd/coordinator-cli -count=1 -run 'TestListOnboarding|TestOnboardingFunnel|TestSummarizeOnboarding|TestPageOnboarding|TestAdminOnboarding'`
- [x] Three-lane Codex audits (`omc ask codex` code / security / architect): 0 CRITICAL, 0 HIGH, 0 MEDIUM
- [ ] CI `ci-required` green

Carried LOW/INFO: campaign fan-out is attempt-level; CLI `--events-db` missing file stays silent for the default sibling path; handler still loads the full join before paging.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "issue": "https://github.com/Augustas11/macprovider/issues/1267",
  "specs": ["SPEC-035"],
  "requirements": ["SPEC-035-R003"],
  "authority_domains": ["provider-connection-diagnostics"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "cd phase4-coordinator && GOTOOLCHAIN=local go test ./internal/auth ./internal/ws ./cmd/coordinator-cli -count=1 -run 'TestListOnboarding|TestOnboardingFunnel|TestSummarizeOnboarding|TestPageOnboarding|TestAdminOnboarding'"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END
