### PR TITLE
Keep promoted-provider admission telemetry live after promotion

### DIFF
--- a/phase4-coordinator/internal/ws/admin_endpoints.go
+++ b/phase4-coordinator/internal/ws/admin_endpoints.go
@@ -42,12 +42,14 @@ func (s *Server) handleAdminProvisional(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	connected := map[string]bool{}
+	live := map[string]pool.Provider{}
 	for _, p := range s.pool.Snapshot() {
-		if p.Tier == pool.TierProvisional {
+		live[p.ProviderID] = p
+		if s.isProviderTransportConnected(p) {
 			connected[p.ProviderID] = true
 		}
 	}
-	records := s.admission.Records(connected)
+	records := overlayLiveAdmissionRecords(s.admission.Records(connected), live, connected)
 	summary := struct {
 		TotalProvisional   int `json:"total_provisional"`
 		CurrentlyConnected int `json:"currently_connected"`
@@ -62,6 +64,40 @@ func (s *Server) handleAdminProvisional(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"provisional": records, "summary": summary})
+}
+
+// overlayLiveAdmissionRecords prefers live pool identity/last-seen for
+// connected providers so /admin/provisional does not serve a frozen
+// promotion-time snapshot (issue #1311). Durable admission records still
+// refresh on heartbeat/reconnect; this overlay covers the in-memory gap
+// before the next persist.
+func overlayLiveAdmissionRecords(records []ProvisionalRecord, live map[string]pool.Provider, connected map[string]bool) []ProvisionalRecord {
+	for i := range records {
+		p, ok := live[records[i].ProviderID]
+		if !ok || !connected[records[i].ProviderID] {
+			continue
+		}
+		if p.BinaryVersion != "" {
+			records[i].BinaryVersion = p.BinaryVersion
+		}
+		if p.Hostname != "" {
+			records[i].Hostname = p.Hostname
+		}
+		if p.ModelID != "" {
+			records[i].ModelID = p.ModelID
+		}
+		seen := p.LastHeartbeatAt
+		if p.LastActivityAt.After(seen) {
+			seen = p.LastActivityAt
+		}
+		if seen.IsZero() {
+			seen = p.ConnectedAt
+		}
+		if !seen.IsZero() && seen.After(records[i].LastSeenAt) {
+			records[i].LastSeenAt = seen.UTC()
+		}
+	}
+	return records
 }
 
 func (s *Server) handleAdminPromote(w http.ResponseWriter, r *http.Request) {

--- a/phase4-coordinator/internal/ws/admission.go
+++ b/phase4-coordinator/internal/ws/admission.go
@@ -10,6 +10,11 @@ import (
 	gobwas "github.com/gobwas/ws"
 )
 
+// admissionTelemetryPersistInterval throttles last-seen-only SQLite rewrites
+// of the provisional_admission blob. Identity changes (binary_version,
+// hostname, model_id) persist immediately so dashboards survive a restart.
+const admissionTelemetryPersistInterval = time.Minute
+
 type AdmissionManager struct {
 	mu             sync.Mutex
 	cfg            config.AdmissionConfig
@@ -19,8 +24,13 @@ type AdmissionManager struct {
 	records        map[string]*ProvisionalRecord
 	rejected       map[string]string
 	requestWindows map[string][]time.Time
-	store          AdmissionStateStore
-	onStoreError   func(error)
+	// lastTelemetryPersist is in-process only. Last-seen-only heartbeat
+	// refreshes coalesce to one full-blob SQLite rewrite per interval for the
+	// whole manager (not per provider), so a connected fleet cannot convoy
+	// admission/quota behind N persistLocked calls per minute.
+	lastTelemetryPersist time.Time
+	store                AdmissionStateStore
+	onStoreError         func(error)
 }
 
 type ProvisionalRecord struct {
@@ -144,15 +154,64 @@ func (a *AdmissionManager) CommitReservedAdmission(hello Hello, pinned bool) poo
 
 func (a *AdmissionManager) CommitReservedAdmissionAs(hello Hello, tier pool.Tier) pool.Tier {
 	if tier == pool.TierPinned {
+		a.RefreshTelemetry(hello.ProviderID, hello.Hostname, hello.ModelID, hello.BinaryVersion)
 		return pool.TierPinned
 	}
 	if tier != pool.TierProvisional {
+		a.RefreshTelemetry(hello.ProviderID, hello.Hostname, hello.ModelID, hello.BinaryVersion)
 		return tier
 	}
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	a.recordAdmissionLocked(hello, a.now())
 	return pool.TierProvisional
+}
+
+// RefreshTelemetry updates version/last-seen on an existing admission record
+// without creating a new hourly admission or changing promotion/rejection.
+// No-op when the provider has no provisional record (never-admitted pinned).
+// Issue #1311: promoted providers otherwise freeze binary_version/last_seen
+// at Promote() time because recordAdmissionLocked only runs for provisional.
+//
+// LastSeenAt is the FR-P17 retention/liveness clock used by Prune. Refreshing
+// it from heartbeat/reconnect is intentional: a still-connected provider is
+// not stale, and must not be dropped from the snapshot (or have its rejection
+// TTL elapse) merely because it was promoted. After heartbeats stop, the
+// existing ProvisionalRetentionDays cutoff still applies.
+func (a *AdmissionManager) RefreshTelemetry(providerID, hostname, modelID, binaryVersion string) {
+	if a == nil {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.refreshTelemetryLocked(providerID, hostname, modelID, binaryVersion)
+}
+
+func (a *AdmissionManager) refreshTelemetryLocked(providerID, hostname, modelID, binaryVersion string) {
+	rec := a.records[providerID]
+	if rec == nil {
+		return
+	}
+	now := a.now()
+	identityChanged := false
+	if hostname != "" && rec.Hostname != hostname {
+		rec.Hostname = hostname
+		identityChanged = true
+	}
+	if modelID != "" && rec.ModelID != modelID {
+		rec.ModelID = modelID
+		identityChanged = true
+	}
+	if binaryVersion != "" && rec.BinaryVersion != binaryVersion {
+		rec.BinaryVersion = binaryVersion
+		identityChanged = true
+	}
+	rec.LastSeenAt = now
+	if !identityChanged && !a.lastTelemetryPersist.IsZero() && now.Sub(a.lastTelemetryPersist) < admissionTelemetryPersistInterval {
+		return
+	}
+	a.lastTelemetryPersist = now
+	a.persistLocked()
 }
 
 func requestedAdmissionTier(pinned bool) pool.Tier {
@@ -214,6 +273,7 @@ func (a *AdmissionManager) recordAdmissionLocked(hello Hello, now time.Time) {
 	rec.Hostname = hello.Hostname
 	rec.ModelID = hello.ModelID
 	rec.BinaryVersion = hello.BinaryVersion
+	a.lastTelemetryPersist = now
 	a.persistLocked()
 }
 

--- a/phase4-coordinator/internal/ws/admission_test.go
+++ b/phase4-coordinator/internal/ws/admission_test.go
@@ -73,6 +73,233 @@ func TestAdmissionManagerTiersRateLimitAndQuota(t *testing.T) {
 	}
 }
 
+func TestAdmissionRefreshTelemetryAfterPromote(t *testing.T) {
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	adm := NewAdmissionManager(config.AdmissionConfig{
+		ProvisionalAdmissionRatePerHour: 1,
+		ProvisionalPoolMax:              10,
+	}, func() time.Time { return now })
+
+	hello := Hello{ProviderID: "new-1", Hostname: "host", ModelID: "model", BinaryVersion: "1.8.115"}
+	if tier, code, reason := adm.Admit(hello, false, 0); tier != pool.TierProvisional || code != 0 || reason != "" {
+		t.Fatalf("admit = tier:%s code:%d reason:%q", tier, code, reason)
+	}
+	if _, ok := adm.Promote("new-1"); !ok {
+		t.Fatal("promote failed")
+	}
+
+	now = now.Add(2 * time.Minute)
+	adm.RefreshTelemetry("new-1", "host", "model", "1.8.117")
+	adm.RefreshTelemetry("unknown", "other", "model", "9.9.9")
+
+	recs := adm.Records(nil)
+	if len(recs) != 1 {
+		t.Fatalf("records=%d want 1 (unknown provider must not mint a row)", len(recs))
+	}
+	if recs[0].BinaryVersion != "1.8.117" {
+		t.Fatalf("binary_version=%q want 1.8.117", recs[0].BinaryVersion)
+	}
+	if !recs[0].LastSeenAt.Equal(now) {
+		t.Fatalf("last_seen=%s want %s", recs[0].LastSeenAt, now)
+	}
+	if recs[0].PromotedAt == nil {
+		t.Fatal("promoted_at cleared by telemetry refresh")
+	}
+
+	if _, code, _ := adm.Admit(Hello{ProviderID: "new-2"}, false, 0); code != CloseProvisionalRateLimited {
+		t.Fatalf("second provisional code = %d, want rate-limited %d (refresh must not consume a rate-limit slot)", code, CloseProvisionalRateLimited)
+	}
+}
+
+func TestCommitReservedAdmissionAsPinnedRefreshesExistingRecord(t *testing.T) {
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	adm := NewAdmissionManager(config.AdmissionConfig{
+		ProvisionalAdmissionRatePerHour: 1,
+		ProvisionalPoolMax:              10,
+	}, func() time.Time { return now })
+
+	hello := Hello{ProviderID: "new-1", Hostname: "host", ModelID: "model", BinaryVersion: "1.8.115"}
+	if _, code, _ := adm.Admit(hello, false, 0); code != 0 {
+		t.Fatalf("admit code=%d", code)
+	}
+	if _, ok := adm.Promote("new-1"); !ok {
+		t.Fatal("promote failed")
+	}
+
+	now = now.Add(2 * time.Minute)
+	rehello := Hello{ProviderID: "new-1", Hostname: "host-2", ModelID: "model-b", BinaryVersion: "1.8.117"}
+	if got := adm.CommitReservedAdmissionAs(rehello, pool.TierPinned); got != pool.TierPinned {
+		t.Fatalf("commit pinned = %s", got)
+	}
+
+	recs := adm.Records(nil)
+	if len(recs) != 1 || recs[0].BinaryVersion != "1.8.117" || recs[0].Hostname != "host-2" || recs[0].ModelID != "model-b" {
+		t.Fatalf("pinned reconnect did not refresh snapshot: %#v", recs)
+	}
+	if !recs[0].LastSeenAt.Equal(now) {
+		t.Fatalf("last_seen=%s want %s", recs[0].LastSeenAt, now)
+	}
+	if _, code, _ := adm.Admit(Hello{ProviderID: "new-2"}, false, 0); code != CloseProvisionalRateLimited {
+		t.Fatalf("pinned reconnect consumed a rate-limit slot, code=%d", code)
+	}
+}
+
+func TestAdmissionRefreshTelemetryDoesNotCreateRecord(t *testing.T) {
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	adm := NewAdmissionManager(config.AdmissionConfig{
+		ProvisionalAdmissionRatePerHour: 1,
+		ProvisionalPoolMax:              10,
+	}, func() time.Time { return now })
+
+	adm.RefreshTelemetry("never-admitted", "host", "model", "1.8.117")
+	if recs := adm.Records(nil); len(recs) != 0 {
+		t.Fatalf("records=%d want 0", len(recs))
+	}
+	if tier, code, _ := adm.Admit(Hello{ProviderID: "new-1", Hostname: "host", ModelID: "model", BinaryVersion: "1.8.115"}, false, 0); tier != pool.TierProvisional || code != 0 {
+		t.Fatalf("first real admit blocked after no-op refresh: tier=%s code=%d", tier, code)
+	}
+}
+
+func TestAdmissionRefreshTelemetryPersistsVersionImmediatelyAndThrottlesLastSeen(t *testing.T) {
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	store := &countingAdmissionStore{}
+	adm := NewAdmissionManager(config.AdmissionConfig{
+		ProvisionalAdmissionRatePerHour: 1,
+		ProvisionalPoolMax:              10,
+	}, func() time.Time { return now })
+	adm.SetPersistence(store, nil)
+
+	hello := Hello{ProviderID: "new-1", Hostname: "host", ModelID: "model", BinaryVersion: "1.8.115"}
+	if _, code, _ := adm.Admit(hello, false, 0); code != 0 {
+		t.Fatalf("admit code=%d", code)
+	}
+	if _, ok := adm.Promote("new-1"); !ok {
+		t.Fatal("promote failed")
+	}
+	afterPromote := store.saves
+
+	now = now.Add(10 * time.Second)
+	adm.RefreshTelemetry("new-1", "host", "model", "1.8.115")
+	if store.saves != afterPromote {
+		t.Fatalf("last-seen-only refresh inside interval persisted, saves=%d want %d", store.saves, afterPromote)
+	}
+
+	adm.RefreshTelemetry("new-1", "host", "model", "1.8.117")
+	if store.saves != afterPromote+1 {
+		t.Fatalf("version change did not persist immediately, saves=%d want %d", store.saves, afterPromote+1)
+	}
+
+	now = now.Add(10 * time.Second)
+	adm.RefreshTelemetry("new-1", "host", "model", "1.8.117")
+	if store.saves != afterPromote+1 {
+		t.Fatalf("last-seen-only refresh after version persist wrote again, saves=%d", store.saves)
+	}
+
+	now = now.Add(admissionTelemetryPersistInterval + time.Second)
+	adm.RefreshTelemetry("new-1", "host", "model", "1.8.117")
+	if store.saves != afterPromote+2 {
+		t.Fatalf("last-seen refresh after interval did not persist, saves=%d want %d", store.saves, afterPromote+2)
+	}
+}
+
+func TestOverlayLiveAdmissionRecordsPrefersLivePool(t *testing.T) {
+	frozen := time.Date(2026, 9, 1, 10, 0, 0, 0, time.UTC)
+	liveAt := frozen.Add(2 * time.Hour)
+	records := []ProvisionalRecord{{
+		ProviderID:    "provider-a",
+		BinaryVersion: "1.8.115",
+		LastSeenAt:    frozen,
+		Hostname:      "old-host",
+		ModelID:       "old-model",
+	}}
+	live := map[string]pool.Provider{
+		"provider-a": {
+			ProviderID:      "provider-a",
+			BinaryVersion:   "1.8.117",
+			Hostname:        "new-host",
+			ModelID:         "new-model",
+			LastHeartbeatAt: liveAt,
+			Tier:            pool.TierPinned,
+		},
+	}
+	connected := append([]ProvisionalRecord(nil), records...)
+	out := overlayLiveAdmissionRecords(connected, live, map[string]bool{"provider-a": true})
+	if out[0].BinaryVersion != "1.8.117" || out[0].Hostname != "new-host" || out[0].ModelID != "new-model" {
+		t.Fatalf("overlay identity: %+v", out[0])
+	}
+	if !out[0].LastSeenAt.Equal(liveAt) {
+		t.Fatalf("last_seen=%s want %s", out[0].LastSeenAt, liveAt)
+	}
+
+	offline := overlayLiveAdmissionRecords(append([]ProvisionalRecord(nil), records...), live, map[string]bool{})
+	if offline[0].BinaryVersion != "1.8.115" {
+		t.Fatalf("offline overlay mutated frozen snapshot: %q", offline[0].BinaryVersion)
+	}
+}
+
+func TestPromotedAdmissionTelemetryDoesNotBypassRetentionAfterDisconnect(t *testing.T) {
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	adm := NewAdmissionManager(config.AdmissionConfig{
+		ProvisionalAdmissionRatePerHour: 1,
+		ProvisionalPoolMax:              10,
+		ProvisionalRetentionDays:        30,
+	}, func() time.Time { return now })
+
+	hello := Hello{ProviderID: "new-1", Hostname: "host", ModelID: "model", BinaryVersion: "1.8.115"}
+	if _, code, _ := adm.Admit(hello, false, 0); code != 0 {
+		t.Fatalf("admit code=%d", code)
+	}
+	if _, ok := adm.Promote("new-1"); !ok {
+		t.Fatal("promote failed")
+	}
+	now = now.Add(2 * time.Minute)
+	adm.RefreshTelemetry("new-1", "host", "model", "1.8.117")
+
+	if deleted, _, _ := adm.Prune(now.Add(-time.Second)); deleted != 0 {
+		t.Fatalf("fresh last_seen pruned immediately, deleted=%d", deleted)
+	}
+
+	now = now.Add(31 * 24 * time.Hour)
+	cutoff := now.Add(-30 * 24 * time.Hour)
+	deleted, _, _ := adm.Prune(cutoff)
+	if deleted != 1 {
+		t.Fatalf("disconnected promoted record survived retention, deleted=%d", deleted)
+	}
+	if recs := adm.Records(nil); len(recs) != 0 {
+		t.Fatalf("records after retention prune = %+v", recs)
+	}
+}
+
+func TestAdmissionRefreshTelemetryCoalescesPersistsAcrossProviders(t *testing.T) {
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	store := &countingAdmissionStore{}
+	adm := NewAdmissionManager(config.AdmissionConfig{
+		ProvisionalAdmissionRatePerHour: 10,
+		ProvisionalPoolMax:              10,
+	}, func() time.Time { return now })
+	adm.SetPersistence(store, nil)
+
+	if _, code, _ := adm.Admit(Hello{ProviderID: "a", Hostname: "h", ModelID: "m", BinaryVersion: "1.8.115"}, false, 0); code != 0 {
+		t.Fatalf("admit a code=%d", code)
+	}
+	if _, code, _ := adm.Admit(Hello{ProviderID: "b", Hostname: "h", ModelID: "m", BinaryVersion: "1.8.115"}, false, 0); code != 0 {
+		t.Fatalf("admit b code=%d", code)
+	}
+	afterAdmit := store.saves
+
+	now = now.Add(10 * time.Second)
+	adm.RefreshTelemetry("a", "h", "m", "1.8.115")
+	adm.RefreshTelemetry("b", "h", "m", "1.8.115")
+	if store.saves != afterAdmit {
+		t.Fatalf("last-seen-only refreshes persisted per provider, saves=%d want %d", store.saves, afterAdmit)
+	}
+
+	recs := adm.Records(nil)
+	if len(recs) != 2 || recs[0].LastSeenAt.IsZero() {
+		t.Fatalf("in-memory last_seen not updated: %+v", recs)
+	}
+}
+
 func TestAdmissionManagerTrustedTierBypassesProvisionalQuotaByDefault(t *testing.T) {
 	now := time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC)
 	adm := NewAdmissionManager(config.AdmissionConfig{
@@ -845,6 +1072,19 @@ func TestAdmissionManagerPruneShrinksStateBeyondCutoff(t *testing.T) {
 
 type failingAdmissionStateStore struct {
 	err error
+}
+
+type countingAdmissionStore struct {
+	saves int
+}
+
+func (c *countingAdmissionStore) LoadAdmissionState(context.Context) (AdmissionState, error) {
+	return AdmissionState{}, nil
+}
+
+func (c *countingAdmissionStore) SaveAdmissionState(context.Context, AdmissionState) error {
+	c.saves++
+	return nil
 }
 
 type fakeRewardsTrustStore struct {

--- a/phase4-coordinator/internal/ws/heartbeat_telemetry_test.go
+++ b/phase4-coordinator/internal/ws/heartbeat_telemetry_test.go
@@ -254,3 +254,56 @@ func TestHeartbeatAutoupdateOutcomeRecordsDistinctEvents(t *testing.T) {
 		t.Fatalf("unexpected outcomes: %+v", calls)
 	}
 }
+
+func TestHeartbeatRefreshesPromotedAdmissionTelemetry(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	registry := pool.NewRegistry(nil)
+	server := NewServer(capacityTestConfig(0), registry, zerolog.Nop(),
+		WithNow(func() time.Time { return now }))
+
+	hello := capacityTestHello(4)
+	hello.BinaryVersion = "1.8.115"
+	if tier, code, reason := server.admission.Admit(hello, false, 0); tier != pool.TierProvisional || code != 0 {
+		t.Fatalf("admit = %s code=%d reason=%q", tier, code, reason)
+	}
+	if _, ok := server.admission.Promote("provider-a"); !ok {
+		t.Fatal("promote failed")
+	}
+
+	entry := &pool.Provider{
+		ProviderID:      "provider-a",
+		AssignedID:      "assigned-a",
+		Hostname:        hello.Hostname,
+		ModelID:         hello.ModelID,
+		BinaryVersion:   "1.8.117",
+		State:           pool.StateReady,
+		Tier:            pool.TierPinned,
+		MaxConcurrency:  4,
+		SlotsFree:       4,
+		SlotsTotal:      4,
+		ConnectedAt:     now,
+		LastHeartbeatAt: now,
+	}
+	if _, ok := registry.RegisterAt(entry, nil, now); !ok {
+		t.Fatal("register failed")
+	}
+
+	now = now.Add(2 * time.Minute)
+	payload := []byte(`{"type":"heartbeat","status":"ready","model_id":"model-a","model_params_b":7.0,"ram_gb":16,"max_context_tokens":32768,"max_concurrency":4,"slots_free":4,"slots_total":4,"throughput_tps_estimate":19.8,"requests_served_since_last":0,"avg_latency_ms_since_last":0.0,"throughput_tps_since_last":0.0}`)
+	server.handleHeartbeat(nil, "provider-a", "assigned-a", payload)
+
+	recs := server.admission.Records(nil)
+	if len(recs) != 1 {
+		t.Fatalf("records=%d want 1", len(recs))
+	}
+	if recs[0].BinaryVersion != "1.8.117" {
+		t.Fatalf("binary_version=%q want 1.8.117", recs[0].BinaryVersion)
+	}
+	if !recs[0].LastSeenAt.Equal(now) {
+		t.Fatalf("last_seen=%s want %s", recs[0].LastSeenAt, now)
+	}
+	if recs[0].PromotedAt == nil {
+		t.Fatal("promoted_at cleared")
+	}
+}

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -5041,6 +5041,9 @@ func (s *Server) handleHeartbeat(conn net.Conn, providerID, assignedID string, p
 	s.rememberProviderSnapshotCoalesced(*entry)
 	s.refreshHardwareProfileHeartbeatAsync(providerID, entry.BinaryVersion, s.now())
 	s.recordAutoupdateOutcomeIfChanged(providerID, hb.LastAutoupdateEvent, s.now())
+	if s.admission != nil {
+		s.admission.RefreshTelemetry(providerID, entry.Hostname, entry.ModelID, entry.BinaryVersion)
+	}
 	threshold := s.cfg.HeartbeatInterval() + s.cfg.HeartbeatInterval()/2
 	if gap > threshold {
 		s.log.Warn().Str("provider_id", providerID).Dur("gap", gap).Dur("threshold", threshold).Msg("provider heartbeat stale")


### PR DESCRIPTION
## Summary
- Promoted providers froze `binary_version` / `last_seen` in the `provisional_admission` snapshot because those fields only updated on provisional admit. `/admin/provisional` therefore showed stale versions (live: 1.8.115 vs serving 1.8.117). `/admin/providers` (connected) and the Malibu app were already live/local and are unchanged.
- Heartbeat and pinned/trusted reconnect now refresh existing admission records without consuming rate-limit slots. Last-seen-only SQLite writes coalesce globally to one blob rewrite per minute; identity changes persist immediately. `/admin/provisional` also overlays live pool identity for currently connected providers of any tier.
- Retention still uses `LastSeenAt` (SPEC-002 FR-P17): a still-connected provider is not stale; after heartbeats stop, `ProvisionalRetentionDays` still prunes.

## Test plan
- [x] `cd phase4-coordinator && go test ./internal/ws -count=1`
- [x] Targeted #1311 tests: promote→refresh version, pinned reconnect, no rate-limit slot, persist throttle, overlay, retention after disconnect, heartbeat path
- [x] Three Codex audit lanes (code / security / architect) to 0 CRITICAL / 0 HIGH / 0 MEDIUM

Closes #1311

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "issue": "https://github.com/Augustas11/macprovider/issues/1311",
  "specs": ["SPEC-002"],
  "requirements": ["SPEC-002-R002"],
  "authority_domains": ["coordinator-admission-routing"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "cd phase4-coordinator && go test ./internal/ws -count=1",
    "TestAdmissionRefreshTelemetryAfterPromote",
    "TestCommitReservedAdmissionAsPinnedRefreshesExistingRecord",
    "TestHeartbeatRefreshesPromotedAdmissionTelemetry",
    "TestPromotedAdmissionTelemetryDoesNotBypassRetentionAfterDisconnect"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END

Made with [Cursor](https://cursor.com)