### PR TITLE
Fix recommendation adoption RAM fit for signed artifacts

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift
@@ -423,8 +423,9 @@ struct ModelsAdoptRecommendationCommand: AsyncParsableCommand {
         guard !Self.hasBlockingWarning(recommendation.warnings) else {
             try fail("blocked_warning", exitCode: 2)
         }
+        let signedAuthority: RecommendationAdoptionAuthority?
         do {
-            try await Self.validateSignedAuthority(recommendation, configPath: config)
+            signedAuthority = try await Self.validateSignedAuthority(recommendation, configPath: config)
         } catch {
             try fail("signed_authority_invalid", exitCode: 2)
         }
@@ -452,14 +453,16 @@ struct ModelsAdoptRecommendationCommand: AsyncParsableCommand {
         } catch {
             try fail("invalid_supported_models", exitCode: 2)
         }
-        switch ModelFit.evaluate(modelID: recommendation.targetModelID, ramGB: ModelFit.detectRAMGB()) {
+        switch Self.evaluateAdoptionRAMFit(
+            recommendation: recommendation,
+            signedCatalogRow: signedAuthority?.catalogRow,
+            ramGB: ModelFit.detectRAMGB()
+        ) {
         case .wontFit:
             try fail("ram_unfit", exitCode: 2)
-        case .unknown:
-            if recommendation.targetModelID.contains("/") {
-                try fail("fit_unknown", exitCode: 2)
-            }
-        case .fits, .tight:
+        case .unknown(_):
+            try fail("fit_unknown", exitCode: 2)
+        case .fits:
             break
         }
         let storePath = ControlSocketPaths.defaultSwitchStatePath(resolved.switchStatePath)
@@ -823,7 +826,17 @@ struct ParsedRecommendationAdoption {
     let hardwareBinaryVersion: String
 }
 
+fileprivate struct RecommendationAdoptionAuthority {
+    let catalogRow: CandidateCatalog.Row
+}
+
 extension ModelsAdoptRecommendationCommand {
+    enum AdoptionRAMFitDecision: Equatable {
+        case fits
+        case wontFit
+        case unknown(String)
+    }
+
     static func loadRecommendation(pathOrStdin: String) throws -> ParsedRecommendationAdoption {
         let data: Data
         if pathOrStdin == "-" {
@@ -973,11 +986,11 @@ extension ModelsAdoptRecommendationCommand {
     fileprivate static func validateSignedAuthority(
         _ recommendation: ParsedRecommendationAdoption,
         configPath: String? = nil
-    ) async throws {
+    ) async throws -> RecommendationAdoptionAuthority? {
         #if DEBUG
         if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
             || ProcessInfo.processInfo.processName.lowercased().contains("xctest") {
-            return
+            return nil
         }
         #endif
         let inputs = await AutotuneStaticInputs().loadRecommendationInputs()
@@ -1019,6 +1032,31 @@ extension ModelsAdoptRecommendationCommand {
             }
         }
         try validateSignedContextAuthority(recommendation: recommendation, row: row, artifact: artifact)
+        return RecommendationAdoptionAuthority(catalogRow: row)
+    }
+
+    static func evaluateAdoptionRAMFit(
+        recommendation: ParsedRecommendationAdoption,
+        signedCatalogRow: CandidateCatalog.Row?,
+        ramGB: Int
+    ) -> AdoptionRAMFitDecision {
+        if let signedCatalogRow {
+            return signedCatalogRow.minRAMGB <= ramGB - AutotuneRecommendEngine.safetyMarginGB
+                ? .fits
+                : .wontFit
+        }
+        guard let artifactModelID = recommendation.core.modelCatalogModelID,
+              !artifactModelID.isEmpty else {
+            return .unknown("missing signed catalog artifact model ID")
+        }
+        switch ModelFit.evaluate(modelID: artifactModelID, ramGB: ramGB) {
+        case .wontFit:
+            return .wontFit
+        case .unknown(let reason):
+            return artifactModelID.contains("/") ? .unknown(reason) : .fits
+        case .fits, .tight:
+            return .fits
+        }
     }
 
     static func validateSignedCatalogBinding(

--- a/phase3-binary/Tests/macprovider-cliTests/ModelsSubcommandTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ModelsSubcommandTests.swift
@@ -1,6 +1,7 @@
 import ArgumentParser
 import Darwin
 import Foundation
+import MacProviderCore
 import XCTest
 @testable import macprovider_cli
 
@@ -408,6 +409,78 @@ final class ModelsSubcommandTests: XCTestCase {
         )) { error in
             XCTAssertTrue(String(describing: error).contains("current signed catalog inputs"))
         }
+    }
+
+    func testAdoptRecommendationRAMFitUsesArtifactModelIDWhenSignedRowIsBypassed() throws {
+        let fixture = try AdoptionFixture(
+            current: "old-model",
+            target: "meta-llama/llama-3.1-8b-instruct",
+            catalogModelID: "mlx-community/Meta-Llama-3.1-8B-Instruct-4bit"
+        )
+        let recommendation = Self.parsedAdoption(
+            fixture: fixture,
+            maxContext: 4_000,
+            hardwareMemoryGB: 16
+        )
+
+        XCTAssertEqual(
+            ModelsAdoptRecommendationCommand.evaluateAdoptionRAMFit(
+                recommendation: recommendation,
+                signedCatalogRow: nil,
+                ramGB: 16
+            ),
+            .fits
+        )
+        XCTAssertEqual(
+            ModelFit.evaluate(modelID: recommendation.targetModelID, ramGB: 16),
+            .wontFit(estGB: 16, ramGB: 16)
+        )
+    }
+
+    func testAdoptRecommendationRAMFitUsesSignedCatalogMemoryFloor() throws {
+        let fixture = try AdoptionFixture(
+            current: "old-model",
+            target: "meta-llama/llama-3.1-8b-instruct",
+            catalogModelID: "mlx-community/Meta-Llama-3.1-8B-Instruct-4bit"
+        )
+        let recommendation = Self.parsedAdoption(
+            fixture: fixture,
+            maxContext: 4_000,
+            hardwareMemoryGB: 16
+        )
+        let row = fixture.catalogRow(minRAMGB: 12)
+
+        XCTAssertEqual(
+            ModelsAdoptRecommendationCommand.evaluateAdoptionRAMFit(
+                recommendation: recommendation,
+                signedCatalogRow: row,
+                ramGB: 16
+            ),
+            .fits
+        )
+    }
+
+    func testAdoptRecommendationRAMFitRejectsSignedCatalogFloorWithoutSafetyHeadroom() throws {
+        let fixture = try AdoptionFixture(
+            current: "old-model",
+            target: "meta-llama/llama-3.1-8b-instruct",
+            catalogModelID: "mlx-community/Meta-Llama-3.1-8B-Instruct-fp16"
+        )
+        let recommendation = Self.parsedAdoption(
+            fixture: fixture,
+            maxContext: 4_000,
+            hardwareMemoryGB: 16
+        )
+        let row = fixture.catalogRow(minRAMGB: 16)
+
+        XCTAssertEqual(
+            ModelsAdoptRecommendationCommand.evaluateAdoptionRAMFit(
+                recommendation: recommendation,
+                signedCatalogRow: row,
+                ramGB: 16
+            ),
+            .wontFit
+        )
     }
 
     func testAdoptRecommendationRollsBackOwnedConfigWhenSwitchFails() async throws {
@@ -1096,12 +1169,12 @@ private struct AdoptionFixture {
         )
     }
 
-    func catalogRow(modelID: String? = nil) -> CandidateCatalog.Row {
+    func catalogRow(modelID: String? = nil, minRAMGB: Int = 1) -> CandidateCatalog.Row {
         CandidateCatalog.Row(
             modelID: modelID ?? catalogModelID,
             modelRevision: String(repeating: "1", count: 40),
             modelSHA256: artifactSHA256,
-            minRAMGB: 1,
+            minRAMGB: minRAMGB,
             minBandwidthTier: .c,
             benchGate: CandidateCatalog.BenchGate(minSustainedTPS: 1, max4KTTFTMS: 1_000),
             runtimeStatus: "recommendable",


### PR DESCRIPTION
## Summary

- Route `models adopt-recommendation` RAM validation through the signed candidate catalog row, matching the recommendation engine's `min_ram_gb` plus safety-margin rule.
- Preserve a test-only fallback that evaluates the signed artifact `model_catalog_model_id` so quantized artifacts are not re-sized as their display/catalog key.
- Add regression coverage for the reported 16 GB Llama 3.1 8B 4-bit adoption case and for signed catalog memory floors.

## Tests

- `cd phase3-binary && swift test --filter ModelsSubcommandTests`
- `cd phase3-binary && swift test --filter ModelFitTests`
- `git diff --check`
- Full `cd phase3-binary && swift test` is not green in this checkout: it first stops on an unrelated local MLX default metallib load failure in `StageForwardParityTests`.
- `cd phase3-binary && swift test --skip StageForwardParityTests` still reports unrelated coordinator compatibility-set / token-recovery failures; the touched test suite remains green.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "issue": "https://github.com/Augustas11/macprovider/issues/1307",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-023"],
  "requirements": ["SPEC-023-R001"],
  "authority_domains": ["installer-autotune-policy", "autotune-recommendation", "model-catalog-identity"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "cd phase3-binary && swift test --filter ModelsSubcommandTests",
    "cd phase3-binary && swift test --filter ModelFitTests",
    "git diff --check"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END
