### PR TITLE
Align provider diagnostics with SPEC-035 taxonomy

### DIFF
--- a/phase3-binary/app/Sources/Malibu/Agent/AgentSnapshot.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/AgentSnapshot.swift
@@ -27,6 +27,12 @@ struct AgentSnapshot: Equatable {
     }
     var state: State
     var currentModelID: String?
+    var currentModelIDFromStatus: Bool = false
+    var currentModelLoaded: Bool?
+    var modelHash: String?
+    var modelHashAlgorithm: String?
+    var weightsManifestSHA256: String?
+    var weightsManifestAlgorithm: String?
     var earningsUsdcToday: Double?
     var malibuAccruedToday: Double?
     var unpaidLedgerBacklogUSDC: Double?
@@ -286,6 +292,37 @@ struct AgentSnapshot: Equatable {
         return isLocalStatusObservationCurrent(at: now)
     }
 
+    func hasFreshContractValidatedStatusObservation(at now: Date = Date()) -> Bool {
+        localStatusContractCompatible == true
+            && localStatusCapabilities.contains("status_observation_v1")
+            && rawStatusObservationFresh(at: now)
+    }
+
+    func hasFreshServeOwnedCredentialState(at now: Date = Date()) -> Bool {
+        hasFreshContractValidatedStatusObservation(at: now)
+            && !credentialStatusFromDiagnostic
+            && credentialState != nil
+    }
+
+    func hasFreshServeOwnedModelStatus(at now: Date = Date()) -> Bool {
+        hasFreshContractValidatedStatusObservation(at: now)
+            && localStatusCapabilities.contains("model_status_v1")
+            && currentModelIDFromStatus
+    }
+
+    private func rawStatusObservationFresh(at now: Date) -> Bool {
+        guard statusObservationFresh != false,
+              let observationID = statusObservationID,
+              !observationID.isEmpty,
+              let observedAt = statusObservedAt,
+              let validForMS = statusObservationValidForMS,
+              (1...60_000).contains(validForMS) else {
+            return false
+        }
+        return observedAt <= now.addingTimeInterval(1)
+            && observedAt.addingTimeInterval(Double(validForMS) / 1_000) >= now
+    }
+
     func hasTrustedReferralBoundary() -> Bool {
         localStatusContractCompatible == true
             && localStatusLifecycleOwner == "macprovider_cli"
@@ -324,6 +361,15 @@ struct AgentSnapshot: Equatable {
         lifecycleLeaseKind = nil
         lifecycleLeaseOperationID = nil
         lifecycleLeaseExpiresWallMS = nil
+        if currentModelIDFromStatus {
+            currentModelID = nil
+        }
+        currentModelIDFromStatus = false
+        currentModelLoaded = nil
+        modelHash = nil
+        modelHashAlgorithm = nil
+        weightsManifestSHA256 = nil
+        weightsManifestAlgorithm = nil
         credentialSource = nil
         credentialState = nil
         credentialRestartSafe = nil

--- a/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
@@ -719,6 +719,15 @@ final class MalibuAgent: ObservableObject {
             snapshot.lifecycleLeaseKind = status.lifecycleLeaseKind
             snapshot.lifecycleLeaseOperationID = status.lifecycleLeaseOperationID
             snapshot.lifecycleLeaseExpiresWallMS = status.lifecycleLeaseExpiresWallMS
+            if status.modelStatusTrusted {
+                snapshot.currentModelID = status.modelID
+                snapshot.currentModelIDFromStatus = true
+                snapshot.currentModelLoaded = status.modelLoaded
+                snapshot.modelHash = status.modelHash
+                snapshot.modelHashAlgorithm = status.modelHashAlgorithm
+                snapshot.weightsManifestSHA256 = status.weightsManifestSHA256
+                snapshot.weightsManifestAlgorithm = status.weightsManifestAlgorithm
+            }
             snapshot.credentialSource = status.credentialSource
             snapshot.credentialState = status.credentialState
             snapshot.credentialRestartSafe = status.credentialRestartSafe
@@ -786,7 +795,9 @@ final class MalibuAgent: ObservableObject {
                 configURL: ProviderPaths.current.configFile,
                 expectedProviderID: expectedProviderID
             )
-            applyCredentialSnapshot(result)
+            if !snapshot.hasFreshServeOwnedCredentialState() {
+                applyCredentialSnapshot(result)
+            }
         } catch {
             snapshot.credentialRepairLastError = snapshot.credentialRepairLastError
                 ?? error.localizedDescription
@@ -829,8 +840,14 @@ final class MalibuAgent: ObservableObject {
     @discardableResult
     private func applyHealthSnapshot(port: Int) async -> Bool {
         guard let health = await InstalledProviderMonitor.fetchHealth(port: port) else { return false }
-        if let model = health.model, !model.isEmpty {
+        if let model = health.model, !model.isEmpty, !snapshot.hasFreshServeOwnedModelStatus() {
             snapshot.currentModelID = model
+            snapshot.currentModelIDFromStatus = false
+            snapshot.currentModelLoaded = nil
+            snapshot.modelHash = nil
+            snapshot.modelHashAlgorithm = nil
+            snapshot.weightsManifestSHA256 = nil
+            snapshot.weightsManifestAlgorithm = nil
         }
         if let total = health.requestsTotal {
             snapshot.requestsServedAllTime = total
@@ -1321,7 +1338,15 @@ final class MalibuAgent: ObservableObject {
     func consume(_ frame: ControlFrame) {
         switch frame {
         case let .statusResponse(model, state):
-            snapshot.currentModelID = model
+            if !model.isEmpty, !snapshot.hasFreshServeOwnedModelStatus() {
+                snapshot.currentModelID = model
+                snapshot.currentModelIDFromStatus = false
+                snapshot.currentModelLoaded = nil
+                snapshot.modelHash = nil
+                snapshot.modelHashAlgorithm = nil
+                snapshot.weightsManifestSHA256 = nil
+                snapshot.weightsManifestAlgorithm = nil
+            }
             // CLI's `SwapState` (`RuntimeStateMachine.swift:public enum SwapState`)
             // has only `.loading` / `.ready` / `.draining`; there is no
             // `.serving`. `.ready` = model loaded + accepting requests, which

--- a/phase3-binary/app/Sources/Malibu/MalibuApp.swift
+++ b/phase3-binary/app/Sources/Malibu/MalibuApp.swift
@@ -296,7 +296,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 snapshot: agent.snapshot,
                 providerLogLines: agent.logLines,
                 watchdogLogURL: ProviderPaths.current.watchdogLog,
-                appVersion: appVersion
+                appVersion: appVersion,
+                launchdNeedsRepair: StartupState.launchdInstallEvidenceExists()
+                    && InstalledProviderMonitor.launchdServiceRepairState().needsRepair
             )
             try data.write(to: destination, options: [.atomic])
         } catch {

--- a/phase3-binary/app/Sources/Malibu/System/InstalledProviderMonitor.swift
+++ b/phase3-binary/app/Sources/Malibu/System/InstalledProviderMonitor.swift
@@ -66,6 +66,13 @@ enum InstalledProviderMonitor {
         let lifecycleLeaseKind: String?
         let lifecycleLeaseOperationID: String?
         let lifecycleLeaseExpiresWallMS: Int64?
+        let modelStatusTrusted: Bool
+        let modelID: String?
+        let modelLoaded: Bool?
+        let modelHash: String?
+        let modelHashAlgorithm: String?
+        let weightsManifestSHA256: String?
+        let weightsManifestAlgorithm: String?
         let recommendedVersion: String?
         let coordinatorConnected: Bool
         let coordinatorTier: String?
@@ -764,6 +771,7 @@ enum InstalledProviderMonitor {
         let trustLifecycleEvents = capabilities.contains("lifecycle_significant_events_v1")
         let trustLifecycleLease = capabilities.contains("lifecycle_lease_v1")
         let trustCompatibilitySet = capabilities.contains("compatibility_set_v1")
+        let trustModel = capabilities.contains("model_status_v1")
         let decodedObservationID = stringValue(observation["id"])
         let decodedObservedAt = dateValue(observation["observed_at"])
         let decodedObservationValidity = intValue(observation["valid_for_ms"])
@@ -896,6 +904,17 @@ enum InstalledProviderMonitor {
             lifecycleLeaseKind: trustTypedFields && trustLifecycleLease ? stringValue(lifecycleLease["kind"]) : nil,
             lifecycleLeaseOperationID: trustTypedFields && trustLifecycleLease ? stringValue(lifecycleLease["operation_id"]) : nil,
             lifecycleLeaseExpiresWallMS: trustTypedFields && trustLifecycleLease ? int64Value(lifecycleLease["expires_wall_ms"]) : nil,
+            modelStatusTrusted: trustTypedFields && trustModel,
+            modelID: trustTypedFields && trustModel ? stringValue(object["model"]) : nil,
+            modelLoaded: trustTypedFields && trustModel ? object["model_loaded"] as? Bool : nil,
+            modelHash: trustTypedFields && trustModel ? stringValue(object["model_hash"]) : nil,
+            modelHashAlgorithm: trustTypedFields && trustModel ? stringValue(object["model_hash_algorithm"]) : nil,
+            weightsManifestSHA256: trustTypedFields && trustModel
+                ? stringValue(object["weights_manifest_sha256"])
+                : nil,
+            weightsManifestAlgorithm: trustTypedFields && trustModel
+                ? stringValue(object["weights_manifest_algorithm"])
+                : nil,
             recommendedVersion: trustTypedFields
                 ? stringValue(coordinator["recommended_binary_version"])
                 : nil,

--- a/phase3-binary/app/Sources/Malibu/System/LogTailReader.swift
+++ b/phase3-binary/app/Sources/Malibu/System/LogTailReader.swift
@@ -22,6 +22,14 @@ struct LogTailBuffer: Equatable {
     }
 
     static func redacted(_ line: String) -> String {
+        let sanitized = scrubNonSecretIdentifiers(line)
+        if containsSecret(line) || containsSecret(sanitized) {
+            return "[redacted]"
+        }
+        return sanitized
+    }
+
+    private static func containsSecret(_ line: String) -> Bool {
         let lower = line.lowercased()
         let normalizedIdentifierText = lower.filter { $0.isLetter || $0.isNumber }
         if lower.contains("provider_token")
@@ -49,14 +57,15 @@ struct LogTailBuffer: Equatable {
             || normalizedIdentifierText.contains("tokenhash")
             || (lower.contains("-----begin") && lower.contains("private key-----"))
             || Self.matchesSecretPattern(line) {
-            return "[redacted]"
+            return true
         }
-        return line
+        return false
     }
 
     private static func matchesSecretPattern(_ line: String) -> Bool {
         let patterns = [
             #"(?i)\bbearer\s+[A-Za-z0-9._~+/\-=]{12,}"#,
+            #"(?i)(^|[^A-Za-z0-9_-])["']?authorization["']?\s*[:=]\s*["']?\S+"#,
             #"(?i)\b(provider|identity|auth|access|refresh|session)[_-]?token\b\s*[:=]\s*\S+"#,
             #"(?i)\b(api[_-]?key|client[_-]?secret|password|cookie)\b\s*[:=]\s*\S+"#,
             #"(?i)https?://\S+\?\S+"#
@@ -64,6 +73,265 @@ struct LogTailBuffer: Equatable {
         return patterns.contains { pattern in
             line.range(of: pattern, options: .regularExpression) != nil
         }
+    }
+
+    private static func scrubNonSecretIdentifiers(_ line: String) -> String {
+        scrubNonSecretIdentifiers(
+            line,
+            usernameCandidates: [
+                NSUserName(),
+                FileManager.default.homeDirectoryForCurrentUser.lastPathComponent,
+            ],
+            hostnameCandidates: currentHostnameCandidates()
+        )
+    }
+
+    static func redactedForTest(
+        _ line: String,
+        usernameCandidates: [String],
+        hostnameCandidates: [String?] = []
+    ) -> String {
+        let sanitized = scrubNonSecretIdentifiers(
+            line,
+            usernameCandidates: usernameCandidates,
+            hostnameCandidates: hostnameCandidates
+        )
+        if containsSecret(line) || containsSecret(sanitized) {
+            return "[redacted]"
+        }
+        return sanitized
+    }
+
+    private static func currentHostnameCandidates() -> [String?] {
+        var candidates: [String?] = [
+            ProcessInfo.processInfo.hostName,
+            ProcessInfo.processInfo.hostName.components(separatedBy: ".").first,
+        ]
+        var buffer = [CChar](repeating: 0, count: Int(MAXHOSTNAMELEN) + 1)
+        if gethostname(&buffer, buffer.count) == 0 {
+            let hostname = String(cString: buffer)
+            candidates.append(hostname)
+            candidates.append(hostname.components(separatedBy: ".").first)
+        }
+        return candidates
+    }
+
+    private static func scrubNonSecretIdentifiers(
+        _ line: String,
+        usernameCandidates rawUsernameCandidates: [String],
+        hostnameCandidates rawHostnameCandidates: [String?]
+    ) -> String {
+        var output = String(line.unicodeScalars.filter { scalar in
+            let value = scalar.value
+            return !(value <= 0x1F || (0x7F...0x9F).contains(value))
+        })
+
+        let usernameCandidates = rawUsernameCandidates
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { $0.count >= 2 }
+        for username in orderedIdentifierCandidates(usernameCandidates) {
+            output = output.replacingOccurrences(of: username, with: "[user]")
+        }
+
+        let hostnameCandidates = rawHostnameCandidates
+            .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { $0.count >= 2 }
+        for hostname in orderedIdentifierCandidates(hostnameCandidates) {
+            output = output.replacingOccurrences(of: hostname, with: "[host]")
+        }
+
+        let replacements: [(String, String)] = [
+            (#"(?i)\b(user(?:name)?|login|account)=([^\s,;]+)"#, "$1=[user]"),
+            (#"(?i)\b(host(?:name)?|computer[_-]?name|machine|nodename)=([^\s,;]+)"#, "$1=[host]"),
+            (#"\b[A-Za-z0-9][A-Za-z0-9-]*(?:\.[A-Za-z0-9][A-Za-z0-9-]*)*\.local\b"#, "[host]"),
+            (#"\b(?:(?:25[0-5]|2[0-4]\d|1?\d?\d)\.){3}(?:25[0-5]|2[0-4]\d|1?\d?\d)(?::\d{1,5})?\b"#, "[ip]"),
+        ]
+        for (pattern, template) in replacements {
+            output = output.replacingOccurrences(
+                of: pattern,
+                with: template,
+                options: .regularExpression
+            )
+        }
+        return scrubAbsolutePaths(scrubIPAddresses(output))
+    }
+
+    private static func orderedIdentifierCandidates(_ candidates: [String]) -> [String] {
+        Array(Set(candidates)).sorted { lhs, rhs in
+            if lhs.count != rhs.count {
+                return lhs.count > rhs.count
+            }
+            return lhs < rhs
+        }
+    }
+
+    private static func scrubAbsolutePaths(_ line: String) -> String {
+        let line = line.replacingOccurrences(of: #"\/"#, with: "/")
+        var output = ""
+        var index = line.startIndex
+        while index < line.endIndex {
+            if line.lowercasedRange(from: index, hasPrefix: "file:///") {
+                let pathStart = line.index(index, offsetBy: "file://".count)
+                output += "file://[path]"
+                index = line.indexAfterAbsolutePath(startingAt: pathStart)
+                continue
+            }
+            let character = line[index]
+            if character == "/", isPathBoundary(before: index, in: line) {
+                output += "[path]"
+                index = line.indexAfterAbsolutePath(startingAt: index)
+            } else {
+                output.append(character)
+                index = line.index(after: index)
+            }
+        }
+        return output
+    }
+
+    private static func scrubIPAddresses(_ line: String) -> String {
+        var output = ""
+        var token = ""
+
+        func flushToken() {
+            guard !token.isEmpty else { return }
+            output += redactedIPToken(token) ?? token
+            token = ""
+        }
+
+        for character in line {
+            if isIPTokenCharacter(character) {
+                token.append(character)
+            } else {
+                flushToken()
+                output.append(character)
+            }
+        }
+        flushToken()
+        return output
+    }
+
+    private static func isIPTokenCharacter(_ character: Character) -> Bool {
+        character.isLetter
+            || character.isNumber
+            || character == "."
+            || character == ":"
+            || character == "%"
+            || character == "["
+            || character == "]"
+    }
+
+    private static func redactedIPToken(_ token: String) -> String? {
+        guard token.contains(".") || token.contains(":") else { return nil }
+        let split = splitTrailingPunctuation(from: token)
+        let candidate = split.candidate
+        if candidate.hasPrefix("["),
+           let closeBracket = candidate.firstIndex(of: "]") {
+            let addressStart = candidate.index(after: candidate.startIndex)
+            let address = String(candidate[addressStart..<closeBracket])
+            let suffix = candidate[candidate.index(after: closeBracket)...]
+            guard suffix.isEmpty || isPortSuffix(suffix),
+                  isIPAddress(address) else {
+                return nil
+            }
+            return "[ip]" + split.trailing
+        }
+        if isIPAddress(candidate) {
+            return "[ip]" + split.trailing
+        }
+        if let colon = candidate.lastIndex(of: ":") {
+            let suffix = candidate[colon...]
+            let prefix = String(candidate[..<colon])
+            if isPortSuffix(suffix), isIPAddress(prefix) {
+                return "[ip]" + split.trailing
+            }
+        }
+        return nil
+    }
+
+    private static func splitTrailingPunctuation(from token: String) -> (candidate: String, trailing: String) {
+        var candidate = token
+        var trailing = ""
+        while let last = candidate.last,
+              last == "." || last == "," || last == ";" {
+            trailing.insert(last, at: trailing.startIndex)
+            candidate.removeLast()
+        }
+        return (candidate, trailing)
+    }
+
+    private static func isPortSuffix(_ suffix: Substring) -> Bool {
+        guard suffix.first == ":" else { return false }
+        let digits = suffix.dropFirst()
+        return (1...5).contains(digits.count) && digits.allSatisfy(\.isNumber)
+    }
+
+    private static func isIPAddress(_ rawAddress: String) -> Bool {
+        let address = rawAddress.split(separator: "%", maxSplits: 1, omittingEmptySubsequences: false).first
+            .map(String.init) ?? rawAddress
+        guard !address.isEmpty else { return false }
+        var ipv4 = in_addr()
+        if address.withCString({ inet_pton(AF_INET, $0, &ipv4) }) == 1 {
+            return true
+        }
+        var ipv6 = in6_addr()
+        return address.withCString { inet_pton(AF_INET6, $0, &ipv6) } == 1
+    }
+
+    private static func isPathBoundary(before index: String.Index, in line: String) -> Bool {
+        guard index > line.startIndex else { return true }
+        let previous = line[line.index(before: index)]
+        if previous == ":" {
+            let next = line.index(after: index)
+            return next == line.endIndex || line[next] != "/"
+        }
+        return previous.isWhitespace || #""'(<[{="#.contains(previous)
+    }
+}
+
+private extension String {
+    func lowercasedRange(from index: String.Index, hasPrefix prefix: String) -> Bool {
+        let end = self.index(index, offsetBy: prefix.count, limitedBy: endIndex) ?? endIndex
+        guard distance(from: index, to: end) == prefix.count else { return false }
+        return self[index..<end].lowercased() == prefix
+    }
+
+    func indexAfterAbsolutePath(startingAt start: String.Index) -> String.Index {
+        var index = self.index(after: start)
+        while index < endIndex {
+            let character = self[index]
+            if #""'`<>|;,"#.contains(character) {
+                break
+            }
+            if character.isWhitespace {
+                let next = self.index(after: index)
+                if next == endIndex || tokenAfterWhitespaceStartsKeyValue(at: next) {
+                    break
+                }
+            }
+            index = self.index(after: index)
+        }
+        return index
+    }
+
+    private func tokenAfterWhitespaceStartsKeyValue(at start: String.Index) -> Bool {
+        var index = start
+        guard index < endIndex,
+              self[index].isLetter || self[index] == "_" else {
+            return false
+        }
+        index = self.index(after: index)
+        while index < endIndex {
+            let character = self[index]
+            if character == "=" || character == ":" {
+                return true
+            }
+            if character.isLetter || character.isNumber || character == "_" || character == "-" || character == "." {
+                index = self.index(after: index)
+            } else {
+                return false
+            }
+        }
+        return false
     }
 }
 

--- a/phase3-binary/app/Sources/Malibu/System/ProviderDiagnosticFinding.swift
+++ b/phase3-binary/app/Sources/Malibu/System/ProviderDiagnosticFinding.swift
@@ -1,0 +1,303 @@
+import Foundation
+
+enum ProviderDiagnosticSignatureID: String, CaseIterable, Comparable {
+    case staleLaunchAgent = "stale_launch_agent"
+    case staleModelCatalog = "stale_model_catalog"
+    case catalogAdmission = "catalog_admission"
+    case rateCardAdmission = "rate_card_admission"
+    case catalogKeyMismatch = "catalog_key_mismatch"
+    case artifactHashMismatch = "artifact_hash_mismatch"
+    case artifactVerificationFailed = "artifact_verification_failed"
+    case missingCatalogProvenance = "missing_catalog_provenance"
+    case missingArtifactSHA = "missing_artifact_sha"
+    case snapshotPathMismatch = "snapshot_path_mismatch"
+    case autoupdateHomeACLRejected = "autoupdate_home_acl_rejected"
+    case credentialStoreUnavailable = "credential_store_unavailable"
+    case serveUnresponsive = "serve_unresponsive"
+    case admissionIdentityBlocked = "admission_identity_blocked"
+    case autoupdateInProgress = "autoupdate_in_progress"
+    case autoupdateDisabled = "autoupdate_disabled"
+
+    static func < (lhs: ProviderDiagnosticSignatureID, rhs: ProviderDiagnosticSignatureID) -> Bool {
+        lhs.rank < rhs.rank
+    }
+
+    var rank: Int {
+        switch self {
+        case .credentialStoreUnavailable: return 0
+        case .admissionIdentityBlocked: return 1
+        case .autoupdateInProgress: return 2
+        case .serveUnresponsive: return 3
+        case .staleLaunchAgent: return 4
+        case .staleModelCatalog: return 5
+        case .catalogAdmission: return 6
+        case .rateCardAdmission: return 7
+        case .catalogKeyMismatch: return 8
+        case .artifactHashMismatch: return 9
+        case .artifactVerificationFailed: return 10
+        case .missingCatalogProvenance: return 11
+        case .missingArtifactSHA: return 12
+        case .snapshotPathMismatch: return 13
+        case .autoupdateHomeACLRejected: return 14
+        case .autoupdateDisabled: return 15
+        }
+    }
+}
+
+struct ProviderDiagnosticFinding: Equatable {
+    enum Source: String, Comparable {
+        case status = "status"
+        case providerLogDiagnostics = "provider_log_diagnostics"
+        case doctorReport = "doctor_report"
+        case appPollingHistory = "app_polling_history"
+        case credentialsStatus = "credentials_status"
+
+        static func < (lhs: Source, rhs: Source) -> Bool {
+            lhs.rank < rhs.rank
+        }
+
+        var rank: Int {
+            switch self {
+            case .status: return 0
+            case .providerLogDiagnostics: return 1
+            case .doctorReport: return 2
+            case .appPollingHistory: return 3
+            case .credentialsStatus: return 4
+            }
+        }
+    }
+
+    let signatureID: ProviderDiagnosticSignatureID
+    let source: Source
+    let userMessage: String
+    let evidence: String?
+    let observedAt: Date?
+
+    var jsonObject: [String: Any] {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return [
+            "signature_id": signatureID.rawValue,
+            "source": source.rawValue,
+            "message": LogTailBuffer.redacted(userMessage),
+            "evidence": evidence.map(LogTailBuffer.redacted) ?? NSNull(),
+            "observed_at": observedAt.map(formatter.string(from:)) ?? NSNull(),
+        ]
+    }
+}
+
+enum ProviderDiagnosticFindingAggregator {
+    static func aggregate(
+        snapshot: AgentSnapshot,
+        providerLogLines: [String],
+        watchdogLogLines: [String],
+        launchdNeedsRepair: Bool = false,
+        doctorReportFindings: [ProviderDiagnosticFinding] = [],
+        appPollingHistoryFindings: [ProviderDiagnosticFinding] = [],
+        credentialsStatusFindings: [ProviderDiagnosticFinding] = [],
+        now: Date = Date()
+    ) -> [ProviderDiagnosticFinding] {
+        let hasFreshStatus = snapshot.hasFreshContractValidatedStatusObservation(at: now)
+        let hasFreshServeOwnedCredentialState = snapshot.hasFreshServeOwnedCredentialState(at: now)
+        var findings: [ProviderDiagnosticFinding] = []
+        findings.append(contentsOf: statusFindings(snapshot, hasFreshStatus: hasFreshStatus, now: now))
+        findings.append(contentsOf: diagnosticCredentialFindings(snapshot, now: now))
+        findings.append(contentsOf: logFindings(
+            providerLogLines: providerLogLines,
+            watchdogLogLines: watchdogLogLines,
+            launchdNeedsRepair: launchdNeedsRepair,
+            now: now
+        ))
+        if !hasFreshStatus {
+            findings.append(contentsOf: doctorReportFindings.filter { $0.signatureID == .serveUnresponsive })
+            findings.append(contentsOf: appPollingHistoryFindings)
+        }
+        if !hasFreshServeOwnedCredentialState {
+            findings.append(contentsOf: credentialsStatusFindings)
+        }
+        return findings.sorted { lhs, rhs in
+            if lhs.source != rhs.source { return lhs.source < rhs.source }
+            if lhs.signatureID != rhs.signatureID {
+                return lhs.signatureID < rhs.signatureID
+            }
+            return (lhs.observedAt ?? .distantPast) > (rhs.observedAt ?? .distantPast)
+        }
+    }
+
+    static func decodeBundleFindings(_ data: Data) -> [ProviderDiagnosticFinding] {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let minimumReaderVersion = root["minimum_reader_version"] as? Int,
+              minimumReaderVersion <= ProviderDiagnosticsBundle.supportedReaderVersion,
+              let rawFindings = root["diagnostic_findings"] as? [[String: Any]] else {
+            return []
+        }
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return rawFindings.compactMap { raw in
+            guard let rawID = raw["signature_id"] as? String,
+                  let signatureID = ProviderDiagnosticSignatureID(rawValue: rawID),
+                  let rawSource = raw["source"] as? String,
+                  let source = ProviderDiagnosticFinding.Source(rawValue: rawSource),
+                  let message = raw["message"] as? String else {
+                return nil
+            }
+            let observedAt = (raw["observed_at"] as? String).flatMap(formatter.date(from:))
+            return ProviderDiagnosticFinding(
+                signatureID: signatureID,
+                source: source,
+                userMessage: message,
+                evidence: raw["evidence"] as? String,
+                observedAt: observedAt
+            )
+        }
+    }
+
+    private static func statusFindings(
+        _ snapshot: AgentSnapshot,
+        hasFreshStatus: Bool,
+        now: Date
+    ) -> [ProviderDiagnosticFinding] {
+        guard hasFreshStatus else {
+            return [
+                ProviderDiagnosticFinding(
+                    signatureID: .serveUnresponsive,
+                    source: .status,
+                    userMessage: "Provider local status is unavailable or stale.",
+                    evidence: snapshot.statusObservationID.map { "observation.id=\($0)" },
+                    observedAt: snapshot.statusObservedAt ?? now
+                )
+            ] + localUpdateRepairFindings(snapshot, now: now)
+        }
+        var findings: [ProviderDiagnosticFinding] = []
+        if let credentialState = snapshot.credentialState,
+           !snapshot.credentialStatusFromDiagnostic,
+           credentialUnavailableStates.contains(credentialState) {
+            findings.append(ProviderDiagnosticFinding(
+                signatureID: .credentialStoreUnavailable,
+                source: .status,
+                userMessage: AgentSnapshotPresenter.credentialLine(snapshot),
+                evidence: "credential.state=\(credentialState)",
+                observedAt: snapshot.statusObservedAt ?? now
+            ))
+        }
+        if let admissionState = snapshot.admissionIdentityState,
+           admissionIdentityBlockedStates.contains(admissionState) {
+            findings.append(ProviderDiagnosticFinding(
+                signatureID: .admissionIdentityBlocked,
+                source: .status,
+                userMessage: AgentSnapshotPresenter.admissionIdentityLine(snapshot),
+                evidence: "admission_identity.state=\(admissionState)",
+                observedAt: snapshot.statusObservedAt ?? now
+            ))
+        }
+        if snapshot.lifecycleState == "update_in_progress"
+            || snapshot.lifecycleState == "rollback_in_progress"
+            || snapshot.cliUpdateInProgress
+            || snapshot.providerSoftwareRepairInProgress {
+            findings.append(ProviderDiagnosticFinding(
+                signatureID: .autoupdateInProgress,
+                source: .status,
+                userMessage: "Provider software update is in progress.",
+                evidence: snapshot.lifecycleState.map { "lifecycle.state=\($0)" }
+                    ?? localUpdateRepairEvidence(snapshot),
+                observedAt: snapshot.statusObservedAt ?? now
+            ))
+        }
+        switch snapshot.networkState {
+        case "not_buyer_serving", "buyer_serving_unknown", "network_offline", "coordinator_unavailable":
+            findings.append(ProviderDiagnosticFinding(
+                signatureID: .serveUnresponsive,
+                source: .status,
+                userMessage: "Provider is not confirmed available for customer work.",
+                evidence: snapshot.networkState.map { "network_state=\($0)" },
+                observedAt: snapshot.statusObservedAt ?? now
+            ))
+        default:
+            break
+        }
+        return findings
+    }
+
+    private static func diagnosticCredentialFindings(
+        _ snapshot: AgentSnapshot,
+        now: Date
+    ) -> [ProviderDiagnosticFinding] {
+        guard snapshot.credentialStatusFromDiagnostic,
+              snapshot.isCredentialStatusCurrent(at: now),
+              let credentialState = snapshot.credentialState,
+              credentialUnavailableStates.contains(credentialState) else {
+            return []
+        }
+        return [
+            ProviderDiagnosticFinding(
+                signatureID: .credentialStoreUnavailable,
+                source: .credentialsStatus,
+                userMessage: AgentSnapshotPresenter.credentialLine(snapshot),
+                evidence: "credential.state=\(credentialState)",
+                observedAt: snapshot.credentialStatusObservedAt ?? now
+            )
+        ]
+    }
+
+    private static func localUpdateRepairFindings(
+        _ snapshot: AgentSnapshot,
+        now: Date
+    ) -> [ProviderDiagnosticFinding] {
+        guard snapshot.cliUpdateInProgress || snapshot.providerSoftwareRepairInProgress else {
+            return []
+        }
+        return [
+            ProviderDiagnosticFinding(
+                signatureID: .autoupdateInProgress,
+                source: .status,
+                userMessage: "Provider software update is in progress.",
+                evidence: localUpdateRepairEvidence(snapshot),
+                observedAt: snapshot.statusObservedAt ?? now
+            )
+        ]
+    }
+
+    private static func localUpdateRepairEvidence(_ snapshot: AgentSnapshot) -> String? {
+        if snapshot.cliUpdateInProgress {
+            return "malibu.cli_update_in_progress=true"
+        }
+        if snapshot.providerSoftwareRepairInProgress {
+            return "malibu.provider_software_repair_in_progress=true"
+        }
+        return nil
+    }
+
+    private static func logFindings(
+        providerLogLines: [String],
+        watchdogLogLines: [String],
+        launchdNeedsRepair: Bool,
+        now: Date
+    ) -> [ProviderDiagnosticFinding] {
+        let findings = ProviderLogDiagnostics.diagnoseAll(
+            providerLines: providerLogLines,
+            watchdogLines: watchdogLogLines,
+            launchdNeedsRepair: launchdNeedsRepair
+        )
+        return findings.compactMap { finding in
+            guard let signatureID = ProviderDiagnosticSignatureID(rawValue: finding.id),
+                  ProviderLogDiagnostics.isActionable(finding, launchdNeedsRepair: launchdNeedsRepair) else {
+                return nil
+            }
+            return ProviderDiagnosticFinding(
+                signatureID: signatureID,
+                source: .providerLogDiagnostics,
+                userMessage: finding.userMessage,
+                evidence: finding.matchedLine,
+                observedAt: now
+            )
+        }
+    }
+
+    private static let credentialUnavailableStates: Set<String> = [
+        "locked", "not_logged_in", "permission_denied", "keychain_failure", "incompatible", "unavailable",
+    ]
+
+    private static let admissionIdentityBlockedStates: Set<String> = [
+        "missing", "recovery_pending", "degraded_previous_key", "recovery_required",
+    ]
+}

--- a/phase3-binary/app/Sources/Malibu/System/ProviderDiagnosticsBundle.swift
+++ b/phase3-binary/app/Sources/Malibu/System/ProviderDiagnosticsBundle.swift
@@ -5,7 +5,10 @@ import Foundation
 /// Malibu never copies config, Keychain values, environment variables, or raw
 /// coordinator frames into diagnostics.
 enum ProviderDiagnosticsBundle {
-    static let schema = "malibu.provider-diagnostics.v1"
+    static let schema = "malibu.provider-diagnostics.v2"
+    static let schemaVersion = 2
+    static let minimumReaderVersion = 1
+    static let supportedReaderVersion = 1
     private static let maximumLogBytes = 256 * 1024
     private static let maximumLogLines = 400
     private static let maximumLineCharacters = 8 * 1024
@@ -15,6 +18,7 @@ enum ProviderDiagnosticsBundle {
         providerLogLines: [String],
         watchdogLogURL: URL?,
         appVersion: String,
+        launchdNeedsRepair: Bool = false,
         now: Date = Date()
     ) throws -> Data {
         let formatter = ISO8601DateFormatter()
@@ -84,15 +88,30 @@ enum ProviderDiagnosticsBundle {
             "lifecycle_owner": json(snapshot.localStatusLifecycleOwner),
             "capabilities": snapshot.localStatusCapabilities.sorted(),
         ]
-        let watchdogLines = watchdogLogURL.map(readRedactedTail) ?? []
+        let watchdogRawLines = watchdogLogURL.map(readTail) ?? []
+        let watchdogLines = redactedLines(watchdogRawLines)
+        let findings = ProviderDiagnosticFindingAggregator.aggregate(
+            snapshot: snapshot,
+            providerLogLines: providerLogLines,
+            watchdogLogLines: watchdogRawLines,
+            launchdNeedsRepair: launchdNeedsRepair,
+            now: now
+        )
         let root: [String: Any] = [
             "schema": schema,
+            "schema_version": schemaVersion,
+            "minimum_reader_version": minimumReaderVersion,
             "created_at": formatter.string(from: now),
             "malibu_version": appVersion,
             "provider": [
                 "id": json(snapshot.localProviderID),
                 "ui_state": snapshot.state.rawValue,
-                "model_id": json(snapshot.currentModelID),
+                "model_id": json(redacted(snapshot.currentModelID)),
+                "model_loaded": json(snapshot.currentModelLoaded),
+                "model_hash": json(redacted(snapshot.modelHash)),
+                "model_hash_algorithm": json(redacted(snapshot.modelHashAlgorithm)),
+                "weights_manifest_sha256": json(redacted(snapshot.weightsManifestSHA256)),
+                "weights_manifest_algorithm": json(redacted(snapshot.weightsManifestAlgorithm)),
                 "cli_version": json(snapshot.cliVersion),
                 "network_state": json(snapshot.networkState),
                 "coordinator_connected": json(snapshot.coordinatorConnected),
@@ -110,6 +129,7 @@ enum ProviderDiagnosticsBundle {
             "credential": credential,
             "admission_identity": admissionIdentity,
             "catalog": catalog,
+            "diagnostic_findings": findings.map(\.jsonObject),
             "logs": [
                 "provider": redactedLines(providerLogLines),
                 "watchdog": watchdogLines,
@@ -122,6 +142,10 @@ enum ProviderDiagnosticsBundle {
     }
 
     static func readRedactedTail(_ url: URL) -> [String] {
+        redactedLines(readTail(url))
+    }
+
+    private static func readTail(_ url: URL) -> [String] {
         let descriptor = open(url.path, O_RDONLY | O_CLOEXEC | O_NOFOLLOW | O_NONBLOCK)
         guard descriptor >= 0 else { return [] }
         defer { close(descriptor) }
@@ -149,7 +173,7 @@ enum ProviderDiagnosticsBundle {
         if start > 0, let firstNewline = text.firstIndex(where: \.isNewline) {
             text = String(text[text.index(after: firstNewline)...])
         }
-        return redactedLines(text.components(separatedBy: .newlines).filter { !$0.isEmpty })
+        return text.components(separatedBy: .newlines).filter { !$0.isEmpty }
     }
 
     private static func hasNoExtendedACL(_ descriptor: Int32) -> Bool {

--- a/phase3-binary/app/Sources/Malibu/System/ProviderLogDiagnostics.swift
+++ b/phase3-binary/app/Sources/Malibu/System/ProviderLogDiagnostics.swift
@@ -156,15 +156,34 @@ enum ProviderLogDiagnostics {
     }
 
     static func diagnose(lines: [String]) -> Finding? {
+        diagnoseAll(lines: lines).first
+    }
+
+    static func diagnoseAll(lines: [String]) -> [Finding] {
+        var findings: [Finding] = []
         for line in lines.reversed() {
             let normalized = line.lowercased()
             for rule in rules {
                 if normalized.contains(rule.needle) {
-                    return Finding(id: rule.id, userMessage: rule.userMessage, matchedLine: line)
+                    findings.append(Finding(id: rule.id, userMessage: rule.userMessage, matchedLine: line))
+                    break
                 }
             }
+            if autoupdateDisabledEvidence(in: line) {
+                findings.append(Finding(
+                    id: "autoupdate_disabled",
+                    userMessage:
+                        "Provider automatic updates are disabled. Enable provider software updates before relying on automatic repair.",
+                    matchedLine: line
+                ))
+            }
         }
-        return nil
+        return findings
+    }
+
+    private static func autoupdateDisabledEvidence(in line: String) -> Bool {
+        let pattern = #"(?i)(^|[\s,{\[])[\"']?(?:auto_update_enabled|autoupdate\.enabled)[\"']?\s*[:=]\s*false($|[\s,}\]"'])"#
+        return line.range(of: pattern, options: .regularExpression) != nil
     }
 
     /// Provider stdout/stderr and watchdog logs have independent tails, so
@@ -175,15 +194,36 @@ enum ProviderLogDiagnostics {
         watchdogLines: [String],
         launchdNeedsRepair: Bool = false
     ) -> Finding? {
+        diagnoseAll(
+            providerLines: providerLines,
+            watchdogLines: watchdogLines,
+            launchdNeedsRepair: launchdNeedsRepair
+        ).first
+    }
+
+    static func diagnoseAll(
+        providerLines: [String],
+        watchdogLines: [String],
+        launchdNeedsRepair: Bool = false,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) -> [Finding] {
+        let allLines = providerLines + watchdogLines
+        let homeACLFinding = homeAutoupdateACLRejection(lines: allLines, homeDirectory: homeDirectory)
         if launchdNeedsRepair,
-           let staleFinding = diagnose(
-               lines: (providerLines + watchdogLines).filter {
+           let staleFinding = diagnoseAll(
+               lines: allLines.filter {
                    $0.lowercased().contains("provider process unhealthy: launchd service live.malibu.provider has no validated pid at")
                }
-           ) {
-            return staleFinding
+           ).first {
+            let supplementalFindings = diagnoseAll(lines: allLines)
+                .filter { $0.id != "stale_launch_agent" }
+            return [staleFinding] + optional(homeACLFinding) + supplementalFindings
         }
-        return diagnose(lines: providerLines) ?? diagnose(lines: watchdogLines)
+        return optional(homeACLFinding) + diagnoseAll(lines: providerLines) + diagnoseAll(lines: watchdogLines)
+    }
+
+    private static func optional(_ finding: Finding?) -> [Finding] {
+        finding.map { [$0] } ?? []
     }
 
     static func timeoutMessage(logHint: String) -> String {

--- a/phase3-binary/app/Tests/MalibuTests/AgentSnapshotPresenterTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/AgentSnapshotPresenterTests.swift
@@ -1584,7 +1584,10 @@ final class AgentSnapshotPresenterTests: XCTestCase {
             AgentSnapshotPresenter.publicErrorDetail(raw),
             "Details are available in Advanced diagnostics."
         )
-        XCTAssertEqual(LogTailBuffer.redacted(raw), raw)
+        XCTAssertEqual(
+            LogTailBuffer.redacted(raw),
+            "coordinator join requires model_artifact_sha256 in [path]"
+        )
     }
 
     func testStaleLaunchAgentRecoveryMessageRemainsUserVisible() {
@@ -1625,7 +1628,8 @@ final class AgentSnapshotPresenterTests: XCTestCase {
             providerLogLines: ["watchdog recovery started"]
         )
 
-        XCTAssertTrue(details.contains("coordinator join requires model_artifact_sha256 in /tmp/macprovider.err.log"))
+        XCTAssertTrue(details.contains("coordinator join requires model_artifact_sha256 in [path]"))
+        XCTAssertFalse(details.contains("/tmp/macprovider.err.log"))
         XCTAssertTrue(details.contains("[redacted]"))
         XCTAssertTrue(details.contains("watchdog recovery started"))
     }

--- a/phase3-binary/app/Tests/MalibuTests/ControlFrameCodecTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/ControlFrameCodecTests.swift
@@ -200,6 +200,44 @@ final class ControlFrameCodecTests: XCTestCase {
     }
 
     @MainActor
+    func testControlStatusResponseCannotOverrideFreshServeOwnedModelStatus() {
+        var initial = AgentSnapshot.empty
+        initial.currentModelID = "status-owned-model"
+        initial.currentModelIDFromStatus = true
+        initial.localStatusContractCompatible = true
+        initial.localStatusCapabilities = ["status_observation_v1", "model_status_v1"]
+        initial.statusObservationID = "observation-a"
+        initial.statusObservedAt = Date()
+        initial.statusObservationValidForMS = 5_000
+        initial.statusObservationFresh = true
+
+        let agent = MalibuAgent(initialSnapshot: initial)
+        agent.consume(.statusResponse(currentModelID: "control-fallback-model", runtimeState: "ready"))
+
+        XCTAssertEqual(agent.snapshot.currentModelID, "status-owned-model")
+        XCTAssertTrue(agent.snapshot.currentModelIDFromStatus)
+    }
+
+    @MainActor
+    func testControlStatusResponseFillsModelWhenStatusObservationIsStale() {
+        var initial = AgentSnapshot.empty
+        initial.currentModelID = "stale-status-model"
+        initial.currentModelIDFromStatus = true
+        initial.localStatusContractCompatible = true
+        initial.localStatusCapabilities = ["status_observation_v1", "model_status_v1"]
+        initial.statusObservationID = "observation-a"
+        initial.statusObservedAt = Date(timeIntervalSinceNow: -60)
+        initial.statusObservationValidForMS = 5_000
+        initial.statusObservationFresh = true
+
+        let agent = MalibuAgent(initialSnapshot: initial)
+        agent.consume(.statusResponse(currentModelID: "control-fallback-model", runtimeState: "ready"))
+
+        XCTAssertEqual(agent.snapshot.currentModelID, "control-fallback-model")
+        XCTAssertFalse(agent.snapshot.currentModelIDFromStatus)
+    }
+
+    @MainActor
     func testPartialProviderProjectionsKeepFreshnessSourceSpecific() {
         let earningsOnly = ProviderEarnings(
             walletBound: false,

--- a/phase3-binary/app/Tests/MalibuTests/InstalledProviderMonitorTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/InstalledProviderMonitorTests.swift
@@ -75,6 +75,7 @@ final class InstalledProviderMonitorTests: XCTestCase {
               "lifecycle_lease_v1",
               "lifecycle_significant_events_v1",
               "lifecycle_transition_v1",
+              "model_status_v1",
               "persisted_lifecycle_state_v1",
               "service_instance_v1",
               "status_observation_v1"
@@ -132,6 +133,12 @@ final class InstalledProviderMonitorTests: XCTestCase {
             "invalid_reason": null
           },
           "network_state": "buyer_serving",
+          "model": "status-owned-model",
+          "model_loaded": true,
+          "model_hash": "model-hash-a",
+          "model_hash_algorithm": "sha256",
+          "weights_manifest_sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+          "weights_manifest_algorithm": "safetensors-manifest-v1",
           "coordinator": {
             "connected": true,
             "tier": "trusted",
@@ -217,6 +224,13 @@ final class InstalledProviderMonitorTests: XCTestCase {
             "autoupdate:aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
         )
         XCTAssertEqual(snapshot.lifecycleLeaseExpiresWallMS, 1_784_012_400_000)
+        XCTAssertTrue(snapshot.modelStatusTrusted)
+        XCTAssertEqual(snapshot.modelID, "status-owned-model")
+        XCTAssertEqual(snapshot.modelLoaded, true)
+        XCTAssertEqual(snapshot.modelHash, "model-hash-a")
+        XCTAssertEqual(snapshot.modelHashAlgorithm, "sha256")
+        XCTAssertEqual(snapshot.weightsManifestSHA256, String(repeating: "d", count: 64))
+        XCTAssertEqual(snapshot.weightsManifestAlgorithm, "safetensors-manifest-v1")
         XCTAssertTrue(snapshot.coordinatorConnected)
         XCTAssertEqual(snapshot.coordinatorIdentityAdmissionMode, "signature")
         XCTAssertEqual(snapshot.catalogState, "live_verified")

--- a/phase3-binary/app/Tests/MalibuTests/LogTailReaderTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/LogTailReaderTests.swift
@@ -14,14 +14,17 @@ final class LogTailReaderTests: XCTestCase {
 
     func testSensitiveLinesAreRedacted() {
         var buffer = LogTailBuffer(capacity: 20)
+        let privateKeyMarker = "-----BEGIN " + "PRIVATE KEY-----"
         buffer.append(contentsOf: [
             "normal line",
             "provider_token: secret",
             "identity_signature abc",
             "Authorization: Bearer secret",
+            #"{"Authorization":"Basic secret"}"#,
+            "Authorization = Basic secret",
             "Bearer eyJhbGciOiJIUzI1NiJ9.secret.payload",
             "token_sha256=abc123",
-            "-----BEGIN PRIVATE KEY-----",
+            privateKeyMarker,
             "signed_payload={\"provider_id\":\"p\"}",
             "providerToken: secret",
             "identitySignature abc",
@@ -45,8 +48,86 @@ final class LogTailReaderTests: XCTestCase {
             "[redacted]",
             "[redacted]",
             "[redacted]",
+            "[redacted]",
+            "[redacted]",
             "[redacted]"
         ])
+    }
+
+    func testSecretDetectionUsesOriginalLineBeforeIdentifierScrubbing() {
+        XCTAssertEqual(
+            LogTailBuffer.redactedForTest(
+                "provider_token: secret-value",
+                usernameCandidates: ["provider"]
+            ),
+            "[redacted]"
+        )
+        XCTAssertEqual(
+            LogTailBuffer.redactedForTest(
+                "api_key=secret-value",
+                usernameCandidates: ["api"]
+            ),
+            "[redacted]"
+        )
+        XCTAssertEqual(
+            LogTailBuffer.redactedForTest(
+                "password=secret-value",
+                usernameCandidates: ["word"]
+            ),
+            "[redacted]"
+        )
+    }
+
+    func testV2RedactionScrubsFreeTextHostnameCandidates() {
+        let redacted = LogTailBuffer.redactedForTest(
+            "watchdog running on provider-host.example.net and provider-host",
+            usernameCandidates: [],
+            hostnameCandidates: ["provider-host.example.net", "provider-host"]
+        )
+
+        XCTAssertEqual(redacted, "watchdog running on [host] and [host]")
+    }
+
+    func testV2RedactionScrubsPrivateContextWithoutDroppingNonSecretLine() {
+        let username = NSUserName().isEmpty ? "provider" : NSUserName()
+        var buffer = LogTailBuffer(capacity: 20)
+        buffer.append(contentsOf: [
+            "path=/Users/\(username)/Library/Application Support/Malibu/provider.log username=\(username) hostname=provider-mac.local ip=10.1.2.3 text=\u{001B}[31mred\u{009B}",
+            "key:/Users/\(username)/Library/Application Support/Malibu/provider.log",
+            "acl_write_rejected:/Users/\(username)",
+            "file:///Users/\(username)/Library/Application Support/Malibu/provider.log",
+            #"json path=\/Users\/\#(username)\/Library\/Application Support\/Malibu\/provider.log"#,
+            #"json private=\/private\/var\/folders\/malibu\/provider.log"#,
+            #"json file=file:\/\/\/Users\/\#(username)\/Library\/Application Support\/Malibu\/provider.log"#,
+            "listen [fd00:1234::1]:11435",
+            "mesh fd00::1 2001:db8::1 ::1 fe80::1234%en0",
+            "punctuated fd00::1. [fd00:1234::1]. [2001:db8::1]:11435,"
+        ])
+
+        let joined = buffer.lines.joined(separator: "\n")
+        XCTAssertTrue(joined.contains("[path]"), joined)
+        XCTAssertTrue(joined.contains("username=[user]"), joined)
+        XCTAssertTrue(joined.contains("hostname=[host]"), joined)
+        XCTAssertTrue(joined.contains("[ip]"), joined)
+        XCTAssertFalse(joined.contains("/Users"), joined)
+        XCTAssertFalse(joined.contains(username), joined)
+        XCTAssertFalse(joined.contains("provider-mac.local"), joined)
+        XCTAssertFalse(joined.contains("10.1.2.3"), joined)
+        XCTAssertFalse(joined.contains("fd00:1234::1"), joined)
+        XCTAssertFalse(joined.contains("fd00::1"), joined)
+        XCTAssertFalse(joined.contains("2001:db8::1"), joined)
+        XCTAssertFalse(joined.contains("::1"), joined)
+        XCTAssertFalse(joined.contains("fe80::1234%en0"), joined)
+        XCTAssertFalse(joined.contains("fd00::1."), joined)
+        XCTAssertFalse(joined.contains("[fd00:1234::1]."), joined)
+        XCTAssertFalse(joined.contains("[2001:db8::1]:11435,"), joined)
+        XCTAssertFalse(joined.contains(#"\/Users"#), joined)
+        XCTAssertFalse(joined.contains(#"\/private"#), joined)
+        XCTAssertTrue(buffer.lines.allSatisfy { line in
+            !line.unicodeScalars.contains { scalar in
+                scalar.value <= 0x1F || (0x7F...0x9F).contains(scalar.value)
+            }
+        }, joined)
     }
 
     @MainActor

--- a/phase3-binary/app/Tests/MalibuTests/ProviderDiagnosticFindingTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/ProviderDiagnosticFindingTests.swift
@@ -1,0 +1,313 @@
+import Foundation
+import XCTest
+@testable import Malibu
+
+final class ProviderDiagnosticFindingTests: XCTestCase {
+    func testClosedTaxonomyCoversProviderLogDiagnosticIDs() {
+        let findings = ProviderLogDiagnostics.diagnoseAll(lines: [
+            "provider process unhealthy: launchd service live.malibu.provider has no validated PID at /Users/provider/macprovider-cli",
+            "model catalog provenance envelope is stale",
+            "model artifact is not admitted by the signed candidate catalog",
+            "model artifact is not admitted by the signed rate card",
+            "model must match model_catalog_key",
+            "model artifact hash mismatch",
+            "model artifact verification failed",
+            "model_artifact_sha256 requires model_catalog_* provenance",
+            "coordinator join requires model_artifact_sha256",
+            "model must be the catalog-pinned hugging face snapshot path",
+            "auto_update_enabled: false",
+        ])
+
+        XCTAssertFalse(findings.isEmpty)
+        for finding in findings {
+            XCTAssertNotNil(
+                ProviderDiagnosticSignatureID(rawValue: finding.id),
+                "log finding id \(finding.id) is not in the closed taxonomy"
+            )
+        }
+    }
+
+    func testClosedTaxonomyCoversExistingProviderLogAggregateIDs() {
+        let findings = ProviderLogDiagnostics.diagnoseAll(
+            providerLines: [
+                "provider process unhealthy: launchd service live.malibu.provider has no validated PID at /Users/provider/macprovider-cli"
+            ],
+            watchdogLines: [
+                "autoupdate recovery_error=acl_write_rejected:/Users/provider"
+            ],
+            launchdNeedsRepair: true,
+            homeDirectory: URL(fileURLWithPath: "/Users/provider")
+        )
+
+        XCTAssertEqual(
+            findings.map(\.id),
+            ["stale_launch_agent", "autoupdate_home_acl_rejected"]
+        )
+        for finding in findings {
+            XCTAssertNotNil(
+                ProviderDiagnosticSignatureID(rawValue: finding.id),
+                "aggregate log finding id \(finding.id) is not in the closed taxonomy"
+            )
+        }
+    }
+
+    func testFreshStatusFindingsPrecedeSupplementalLogFindings() {
+        let now = Date(timeIntervalSince1970: 1_788_249_600)
+        var snapshot = freshStatusSnapshot(now: now)
+        snapshot.credentialState = "locked"
+        snapshot.credentialRecoveryAction = "unlock_keychain"
+
+        let findings = ProviderDiagnosticFindingAggregator.aggregate(
+            snapshot: snapshot,
+            providerLogLines: [
+                "provider process unhealthy: launchd service live.malibu.provider has no validated PID at /Users/provider/macprovider-cli"
+            ],
+            watchdogLogLines: [],
+            launchdNeedsRepair: true,
+            now: now
+        )
+
+        XCTAssertEqual(findings.map(\.signatureID), [.credentialStoreUnavailable, .staleLaunchAgent])
+        XCTAssertEqual(findings.map(\.source), [.status, .providerLogDiagnostics])
+    }
+
+    func testCredentialStatusSubprocessCannotOverrideFreshServeCredentialState() {
+        let now = Date(timeIntervalSince1970: 1_788_249_600)
+        var snapshot = freshStatusSnapshot(now: now)
+        snapshot.credentialState = "ready"
+        snapshot.credentialRestartSafe = true
+
+        let subprocessFinding = ProviderDiagnosticFinding(
+            signatureID: .credentialStoreUnavailable,
+            source: .credentialsStatus,
+            userMessage: "stale subprocess says Keychain unavailable",
+            evidence: "condition=unavailable",
+            observedAt: now.addingTimeInterval(1)
+        )
+
+        let findings = ProviderDiagnosticFindingAggregator.aggregate(
+            snapshot: snapshot,
+            providerLogLines: [],
+            watchdogLogLines: [],
+            credentialsStatusFindings: [subprocessFinding],
+            now: now
+        )
+
+        XCTAssertFalse(findings.contains(subprocessFinding))
+    }
+
+    func testDiagnosticCredentialSnapshotIsNeverStatusOwned() {
+        let now = Date(timeIntervalSince1970: 1_788_249_600)
+        var snapshot = freshStatusSnapshot(now: now)
+        snapshot.credentialState = "unavailable"
+        snapshot.credentialStatusObservedAt = now
+        snapshot.credentialStatusFromDiagnostic = true
+
+        let findings = ProviderDiagnosticFindingAggregator.aggregate(
+            snapshot: snapshot,
+            providerLogLines: [],
+            watchdogLogLines: [],
+            now: now
+        )
+
+        XCTAssertFalse(snapshot.hasFreshServeOwnedCredentialState(at: now))
+        XCTAssertEqual(findings.map(\.source), [.credentialsStatus])
+        XCTAssertEqual(findings.map(\.signatureID), [.credentialStoreUnavailable])
+    }
+
+    func testStaleStatusAllowsDoctorServeDeadAndCredentialStatusFallbacks() {
+        let now = Date(timeIntervalSince1970: 1_788_249_600)
+        var snapshot = freshStatusSnapshot(now: now.addingTimeInterval(-120))
+        snapshot.statusObservationFresh = false
+        snapshot.credentialState = "ready"
+
+        let doctorServeDead = ProviderDiagnosticFinding(
+            signatureID: .serveUnresponsive,
+            source: .doctorReport,
+            userMessage: "doctor report found serve dead",
+            evidence: "serve_dead=true",
+            observedAt: now
+        )
+        let doctorWrongDomain = ProviderDiagnosticFinding(
+            signatureID: .catalogAdmission,
+            source: .doctorReport,
+            userMessage: "doctor report must not own catalog admission",
+            evidence: nil,
+            observedAt: now
+        )
+        let credentialFallback = ProviderDiagnosticFinding(
+            signatureID: .credentialStoreUnavailable,
+            source: .credentialsStatus,
+            userMessage: "credential status fallback",
+            evidence: "condition=unavailable",
+            observedAt: now
+        )
+
+        let findings = ProviderDiagnosticFindingAggregator.aggregate(
+            snapshot: snapshot,
+            providerLogLines: [],
+            watchdogLogLines: [],
+            doctorReportFindings: [doctorServeDead, doctorWrongDomain],
+            credentialsStatusFindings: [credentialFallback],
+            now: now
+        )
+
+        XCTAssertEqual(
+            findings.map { "\($0.source.rawValue):\($0.signatureID.rawValue)" },
+            [
+                "status:serve_unresponsive",
+                "doctor_report:serve_unresponsive",
+                "credentials_status:credential_store_unavailable",
+            ]
+        )
+    }
+
+    func testExpiredStatusLeaseAllowsFallbackEvenWhenUIWouldRetainObservation() {
+        let now = Date(timeIntervalSince1970: 1_788_249_600)
+        var snapshot = freshStatusSnapshot(now: now.addingTimeInterval(-6))
+        snapshot.statusObservationValidForMS = 5_000
+        snapshot.statusObservationFresh = true
+        snapshot.credentialState = "ready"
+        XCTAssertTrue(snapshot.isLocalStatusObservationCurrent(at: now))
+
+        let doctorServeDead = ProviderDiagnosticFinding(
+            signatureID: .serveUnresponsive,
+            source: .doctorReport,
+            userMessage: "doctor report found serve dead",
+            evidence: "serve_dead=true",
+            observedAt: now
+        )
+        let credentialFallback = ProviderDiagnosticFinding(
+            signatureID: .credentialStoreUnavailable,
+            source: .credentialsStatus,
+            userMessage: "credential status fallback",
+            evidence: "condition=unavailable",
+            observedAt: now
+        )
+
+        let findings = ProviderDiagnosticFindingAggregator.aggregate(
+            snapshot: snapshot,
+            providerLogLines: [],
+            watchdogLogLines: [],
+            doctorReportFindings: [doctorServeDead],
+            credentialsStatusFindings: [credentialFallback],
+            now: now
+        )
+
+        XCTAssertEqual(
+            findings.map { "\($0.source.rawValue):\($0.signatureID.rawValue)" },
+            [
+                "status:serve_unresponsive",
+                "doctor_report:serve_unresponsive",
+                "credentials_status:credential_store_unavailable",
+            ]
+        )
+    }
+
+    func testStaleStatusStillReportsLocalProviderSoftwareRepairInProgress() {
+        let now = Date(timeIntervalSince1970: 1_788_249_600)
+        var snapshot = freshStatusSnapshot(now: now.addingTimeInterval(-120))
+        snapshot.statusObservationFresh = false
+        snapshot.providerSoftwareRepairInProgress = true
+
+        let findings = ProviderDiagnosticFindingAggregator.aggregate(
+            snapshot: snapshot,
+            providerLogLines: [],
+            watchdogLogLines: [],
+            now: now
+        )
+
+        XCTAssertEqual(
+            findings.map(\.signatureID),
+            [.autoupdateInProgress, .serveUnresponsive]
+        )
+        XCTAssertEqual(
+            findings.first?.evidence,
+            "malibu.provider_software_repair_in_progress=true"
+        )
+    }
+
+    func testWithinSourceOrderingUsesSignatureRankBeforeTimestamp() {
+        let now = Date(timeIntervalSince1970: 1_788_249_600)
+        var snapshot = freshStatusSnapshot(now: now.addingTimeInterval(-120))
+        snapshot.statusObservationFresh = false
+
+        let findings = ProviderDiagnosticFindingAggregator.aggregate(
+            snapshot: snapshot,
+            providerLogLines: [],
+            watchdogLogLines: [],
+            appPollingHistoryFindings: [
+                ProviderDiagnosticFinding(
+                    signatureID: .serveUnresponsive,
+                    source: .appPollingHistory,
+                    userMessage: "newer serve finding",
+                    evidence: nil,
+                    observedAt: now
+                ),
+                ProviderDiagnosticFinding(
+                    signatureID: .credentialStoreUnavailable,
+                    source: .appPollingHistory,
+                    userMessage: "older credential finding",
+                    evidence: nil,
+                    observedAt: now.addingTimeInterval(-60)
+                ),
+            ],
+            now: now
+        )
+
+        XCTAssertEqual(
+            findings.filter { $0.source == .appPollingHistory }.map(\.signatureID),
+            [.credentialStoreUnavailable, .serveUnresponsive]
+        )
+    }
+
+    func testUnknownSignatureIDsAreSkippedWhenMinimumReaderVersionIsSupported() throws {
+        let data = Data("""
+        {
+          "minimum_reader_version": 1,
+          "diagnostic_findings": [
+            {"signature_id": "future_signature", "source": "status", "message": "future"},
+            {"signature_id": "serve_unresponsive", "source": "status", "message": "known"}
+          ]
+        }
+        """.utf8)
+
+        let findings = ProviderDiagnosticFindingAggregator.decodeBundleFindings(data)
+
+        XCTAssertEqual(findings.map(\.signatureID), [.serveUnresponsive])
+        XCTAssertEqual(findings.first?.userMessage, "known")
+    }
+
+    func testJSONSerializationRedactsCallerSuppliedMessageAndEvidence() throws {
+        let finding = ProviderDiagnosticFinding(
+            signatureID: .serveUnresponsive,
+            source: .doctorReport,
+            userMessage: #"serve dead at \/Users\/provider\/provider.log"#,
+            evidence: #"file:\/\/\/private\/var\/folders\/provider.log provider_token=must-not-export"#,
+            observedAt: Date(timeIntervalSince1970: 1_788_249_600)
+        )
+
+        let data = try JSONSerialization.data(withJSONObject: finding.jsonObject)
+        let text = try XCTUnwrap(String(data: data, encoding: .utf8))
+
+        XCTAssertTrue(text.contains("serve dead at [path]"), text)
+        XCTAssertTrue(text.contains("[redacted]"), text)
+        XCTAssertFalse(text.contains(#"\/Users\/provider"#), text)
+        XCTAssertFalse(text.contains(#"\/private"#), text)
+        XCTAssertFalse(text.contains("must-not-export"), text)
+    }
+
+    private func freshStatusSnapshot(now: Date) -> AgentSnapshot {
+        var snapshot = AgentSnapshot.empty
+        snapshot.state = .serving
+        snapshot.localStatusContractCompatible = true
+        snapshot.localStatusCapabilities = ["status_observation_v1"]
+        snapshot.statusObservationID = "11111111-1111-4111-8111-111111111111"
+        snapshot.statusObservedAt = now
+        snapshot.statusObservationValidForMS = 5_000
+        snapshot.statusObservationFresh = true
+        snapshot.networkState = "buyer_serving"
+        snapshot.admissionIdentityState = "ready"
+        return snapshot
+    }
+}

--- a/phase3-binary/app/Tests/MalibuTests/ProviderDiagnosticsBundleTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/ProviderDiagnosticsBundleTests.swift
@@ -38,6 +38,14 @@ final class ProviderDiagnosticsBundleTests: XCTestCase {
         snapshot.credentialState = "ready"
         snapshot.credentialRestartSafe = true
         snapshot.lastError = "provider_token=must-not-export"
+        snapshot.currentModelID = "/Users/provider/.cache/model"
+        snapshot.localStatusContractCompatible = true
+        snapshot.localStatusCapabilities = ["status_observation_v1"]
+        snapshot.statusObservationID = "11111111-1111-4111-8111-111111111111"
+        snapshot.statusObservedAt = Date(timeIntervalSince1970: 1_752_499_199)
+        snapshot.statusObservationValidForMS = 5_000
+        snapshot.statusObservationFresh = true
+        snapshot.networkState = "buyer_serving_unknown"
 
         let data = try ProviderDiagnosticsBundle.make(
             snapshot: snapshot,
@@ -45,6 +53,7 @@ final class ProviderDiagnosticsBundleTests: XCTestCase {
                 "provider healthy",
                 "api_key=must-not-export",
                 "GET https://example.test/status?access_token=must-not-export",
+                "model artifact hash mismatch at /Users/provider/.cache/model.safetensors host=provider-mac.local ip=192.168.1.44\u{001B}",
             ],
             watchdogLogURL: watchdog,
             appVersion: "1.8.33",
@@ -56,12 +65,30 @@ final class ProviderDiagnosticsBundleTests: XCTestCase {
         XCTAssertTrue(text.contains("Augustas11/macprovider:v1.8.33@abc123"), text)
         XCTAssertTrue(text.contains("\"compatibility_set_id\" : \"Augustas11/macprovider:v1.8.33@abc123\""), text)
         XCTAssertTrue(text.contains("\"admission_identity\""), text)
+        XCTAssertTrue(text.contains("\"schema\" : \"malibu.provider-diagnostics.v2\""), text)
+        XCTAssertTrue(text.contains("\"schema_version\" : 2"), text)
+        XCTAssertTrue(text.contains("\"minimum_reader_version\" : 1"), text)
+        XCTAssertTrue(text.contains("\"diagnostic_findings\""), text)
+        XCTAssertTrue(text.contains("\"signature_id\" : \"serve_unresponsive\""), text)
+        XCTAssertTrue(text.contains("\"signature_id\" : \"artifact_hash_mismatch\""), text)
         XCTAssertTrue(text.contains("restored_prior_release"), text)
         XCTAssertTrue(text.contains("readiness_timeout"), text)
         XCTAssertTrue(text.contains("watchdog_rollback_post_start_rejoin_timeout"), text)
         XCTAssertTrue(text.contains("[redacted]"), text)
+        XCTAssertTrue(text.contains("[path]"), text)
+        XCTAssertTrue(text.contains("\"model_id\" : \"[path]\""), text)
+        XCTAssertTrue(text.contains("[host]"), text)
+        XCTAssertTrue(text.contains("[ip]"), text)
         XCTAssertFalse(text.contains("must-not-export"), text)
+        XCTAssertFalse(text.contains("/Users/provider/.cache/model"), text)
         XCTAssertFalse(text.lowercased().contains("bearer watchdog-secret"), text)
+        XCTAssertFalse(text.contains("/Users/provider"), text)
+        XCTAssertFalse(text.contains("provider-mac.local"), text)
+        XCTAssertFalse(text.contains("192.168.1.44"), text)
+        XCTAssertFalse(text.contains("\u{001B}"), text)
+        XCTAssertFalse(text.contains("\u{009B}"), text)
+        XCTAssertFalse(text.contains("\\u001B"), text)
+        XCTAssertFalse(text.contains("\\u009B"), text)
     }
 
     func testWatchdogTailRejectsSymlink() throws {
@@ -75,5 +102,42 @@ final class ProviderDiagnosticsBundleTests: XCTestCase {
         try FileManager.default.createSymbolicLink(at: link, withDestinationURL: target)
 
         XCTAssertEqual(ProviderDiagnosticsBundle.readRedactedTail(link), [])
+    }
+
+    func testBundleClassifiesRawWatchdogAndLaunchdRepairBeforeExportRedaction() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("malibu-diagnostics-raw-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let watchdog = root.appendingPathComponent("watchdog.log")
+        let homePath = FileManager.default.homeDirectoryForCurrentUser.standardizedFileURL.path
+        try "autoupdate recovery_error=acl_write_rejected:\(homePath)\n"
+            .write(to: watchdog, atomically: true, encoding: .utf8)
+
+        var snapshot = AgentSnapshot.empty
+        snapshot.state = .reconnecting
+        snapshot.localStatusContractCompatible = true
+        snapshot.localStatusCapabilities = ["status_observation_v1"]
+        snapshot.statusObservedAt = Date(timeIntervalSince1970: 1_752_499_199)
+        snapshot.statusObservationValidForMS = 5_000
+        snapshot.statusObservationFresh = true
+        snapshot.networkState = "buyer_serving"
+
+        let data = try ProviderDiagnosticsBundle.make(
+            snapshot: snapshot,
+            providerLogLines: [
+                "provider process unhealthy: launchd service live.malibu.provider has no validated PID at \(homePath)/macprovider-cli"
+            ],
+            watchdogLogURL: watchdog,
+            appVersion: "1.8.33",
+            launchdNeedsRepair: true,
+            now: Date(timeIntervalSince1970: 1_752_499_200)
+        )
+        let text = try XCTUnwrap(String(data: data, encoding: .utf8))
+
+        XCTAssertTrue(text.contains("\"signature_id\" : \"stale_launch_agent\""), text)
+        XCTAssertTrue(text.contains("\"signature_id\" : \"autoupdate_home_acl_rejected\""), text)
+        XCTAssertTrue(text.contains("[path]"), text)
+        XCTAssertFalse(text.contains(homePath), text)
     }
 }

--- a/phase3-binary/app/Tests/MalibuTests/ProviderLogDiagnosticsTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/ProviderLogDiagnosticsTests.swift
@@ -165,6 +165,26 @@ final class ProviderLogDiagnosticsTests: XCTestCase {
         XCTAssertTrue(ProviderLogDiagnostics.isActionable(finding, launchdNeedsRepair: true))
     }
 
+    func testAutoupdateDisabledRequiresCanonicalFalseValuedKey() {
+        XCTAssertEqual(
+            ProviderLogDiagnostics.diagnose(lines: ["auto_update_enabled: false"])?.id,
+            "autoupdate_disabled"
+        )
+        XCTAssertEqual(
+            ProviderLogDiagnostics.diagnose(lines: ["status autoupdate.enabled=false"])?.id,
+            "autoupdate_disabled"
+        )
+        XCTAssertEqual(
+            ProviderLogDiagnostics.diagnose(lines: [#"{"auto_update_enabled":false}"#])?.id,
+            "autoupdate_disabled"
+        )
+        XCTAssertNil(ProviderLogDiagnostics.diagnose(lines: ["autoupdate_disabled=false"]))
+        XCTAssertNil(ProviderLogDiagnostics.diagnose(lines: ["cleared autoupdate_disabled"]))
+        XCTAssertNil(ProviderLogDiagnostics.diagnose(lines: ["autoupdate_enabled: false"]))
+        XCTAssertNil(ProviderLogDiagnostics.diagnose(lines: ["auto_update_enabled: true"]))
+        XCTAssertNil(ProviderLogDiagnostics.diagnose(lines: ["prefix_auto_update_enabled=false"]))
+    }
+
     func testDiagnoseReturnsNilForUnrecognizedLines() {
         XCTAssertNil(ProviderLogDiagnostics.diagnose(lines: ["serve starting", "connected to coordinator"]))
     }

--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -997,7 +997,7 @@
     {
       "spec_id": "SPEC-035",
       "title": "Provider connection diagnostics and failure history",
-      "version": "v0.4.1",
+      "version": "v0.4.2",
       "path": "specs/SPEC-035-provider-connection-diagnostics.md",
       "status": "draft",
       "owner": "@Augustas11",
@@ -2514,6 +2514,72 @@
         "owner": "@Augustas11",
         "issue": "https://github.com/Augustas11/macprovider/issues/535",
         "rationale": "Admission-ceiling drift diagnostics are implemented under coordinator unit tests; production Pearl deploy and operating-window alert evidence remain pending."
+      }
+    },
+    {
+      "requirement_id": "SPEC-035-R010",
+      "spec_id": "SPEC-035",
+      "state": "pending",
+      "implementation": [
+        "phase3-binary/app/Sources/Malibu/System/ProviderDiagnosticFinding.swift:enum ProviderDiagnosticSignatureID"
+      ],
+      "tests": [
+        "phase3-binary/app/Tests/MalibuTests/ProviderDiagnosticFindingTests.swift:testClosedTaxonomyCoversProviderLogDiagnosticIDs",
+        "phase3-binary/app/Tests/MalibuTests/ProviderDiagnosticFindingTests.swift:testClosedTaxonomyCoversExistingProviderLogAggregateIDs",
+        "phase3-binary/app/Tests/MalibuTests/ProviderDiagnosticFindingTests.swift:testUnknownSignatureIDsAreSkippedWhenMinimumReaderVersionIsSupported"
+      ],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "UNKNOWN",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/1314",
+        "rationale": "Local closed diagnostic signature schema is implemented under Malibu app unit tests; production support-bundle collection and follow-up diagnostic sources remain deferred."
+      }
+    },
+    {
+      "requirement_id": "SPEC-035-R011",
+      "spec_id": "SPEC-035",
+      "state": "pending",
+      "implementation": [
+        "phase3-binary/app/Sources/Malibu/System/ProviderDiagnosticFinding.swift:enum ProviderDiagnosticFindingAggregator"
+      ],
+      "tests": [
+        "phase3-binary/app/Tests/MalibuTests/ProviderDiagnosticFindingTests.swift:testFreshStatusFindingsPrecedeSupplementalLogFindings",
+        "phase3-binary/app/Tests/MalibuTests/ProviderDiagnosticFindingTests.swift:testCredentialStatusSubprocessCannotOverrideFreshServeCredentialState",
+        "phase3-binary/app/Tests/MalibuTests/ProviderDiagnosticFindingTests.swift:testStaleStatusAllowsDoctorServeDeadAndCredentialStatusFallbacks"
+      ],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "UNKNOWN",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/1314",
+        "rationale": "Local source precedence is implemented under aggregator unit tests; slice-2 doctor report ingestion remains deferred."
+      }
+    },
+    {
+      "requirement_id": "SPEC-035-R012",
+      "spec_id": "SPEC-035",
+      "state": "pending",
+      "implementation": [
+        "phase3-binary/app/Sources/Malibu/MalibuApp.swift:private func exportDiagnostics()",
+        "phase3-binary/app/Sources/Malibu/System/ProviderDiagnosticsBundle.swift:enum ProviderDiagnosticsBundle",
+        "phase3-binary/app/Sources/Malibu/System/LogTailReader.swift:struct LogTailBuffer"
+      ],
+      "tests": [
+        "phase3-binary/app/Tests/MalibuTests/LogTailReaderTests.swift:testV2RedactionScrubsPrivateContextWithoutDroppingNonSecretLine",
+        "phase3-binary/app/Tests/MalibuTests/ProviderDiagnosticsBundleTests.swift:testBundleIncludesLifecycleAndWatchdogEvidenceWithoutSecrets",
+        "phase3-binary/app/Tests/MalibuTests/ProviderDiagnosticsBundleTests.swift:testBundleClassifiesRawWatchdogAndLaunchdRepairBeforeExportRedaction",
+        "phase3-binary/app/Tests/MalibuTests/AgentSnapshotPresenterTests.swift:testOnboardingAdvancedFailureDiagnosticsKeepsRedactedDetails"
+      ],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "UNKNOWN",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/1314",
+        "rationale": "Diagnostics bundle v2 and LogTailBuffer v2 redaction are implemented under Malibu app unit tests; production bundle collection evidence remains deferred."
       }
     },
     {

--- a/specs/README.md
+++ b/specs/README.md
@@ -43,7 +43,7 @@ it can no longer drift. Do not hand-edit the table; edit each spec's
 | SPEC-032 | Autotune Hardware-Evidence Admission Gate, OPoI & Proof-of-Weights Boundary | v0.2.5 | draft | complete | pending: 3 | [SPEC-032-proof-of-weights-hello-gate.md](SPEC-032-proof-of-weights-hello-gate.md) |
 | SPEC-033 | Hardware-Evidence Verifier (`hardware-verifier.v2`) | v0.6.2 | draft | pending | conformant: 1 | [SPEC-033-hardware-verifier.md](SPEC-033-hardware-verifier.md) |
 | SPEC-034 | Referral admission, provider invites, and advocacy rewards | v0.4.7 | normative | pending | conformant: 1 | [SPEC-034-referral-gated-prebeta.md](SPEC-034-referral-gated-prebeta.md) |
-| SPEC-035 | Provider connection diagnostics and failure history | v0.4.1 | draft | complete | pending: 9 | [SPEC-035-provider-connection-diagnostics.md](SPEC-035-provider-connection-diagnostics.md) |
+| SPEC-035 | Provider connection diagnostics and failure history | v0.4.2 | draft | complete | pending: 12 | [SPEC-035-provider-connection-diagnostics.md](SPEC-035-provider-connection-diagnostics.md) |
 | SPEC-036 | Compute-Integrity Receipt Companion | v0.1.1 | draft | complete | pending: 17 | [SPEC-036-compute-integrity-receipt.md](SPEC-036-compute-integrity-receipt.md) |
 | SPEC-037 | KV survival across provider restarts (encrypted provider-local disk tier) | v0.1.1 | draft | complete | pending: 13 | [SPEC-037-kv-survival-restart.md](SPEC-037-kv-survival-restart.md) |
 | SPEC-038 | Continuous batching for concurrent provider inference | v0.2 | draft | complete | pending: 17 | [SPEC-038-continuous-batching.md](SPEC-038-continuous-batching.md) |

--- a/specs/SPEC-035-provider-connection-diagnostics.md
+++ b/specs/SPEC-035-provider-connection-diagnostics.md
@@ -1,7 +1,7 @@
 # SPEC-035 — Provider connection diagnostics and failure history
 
-Version: v0.4.1
-Status: draft (Partial #535 coordinator journal + provider diagnostic snapshot + monitor alerts + admission-ceiling drift diagnostics; #1267 operator onboarding funnel join)
+Version: v0.4.2
+Status: draft (Partial #535 coordinator journal + provider diagnostic snapshot + monitor alerts + admission-ceiling drift diagnostics; #1267 operator onboarding funnel join; #1314 local diagnostic signature schema)
 Owner: coordinator operator observability
 Issue: https://github.com/Augustas11/macprovider/issues/535
 
@@ -17,6 +17,9 @@ Changelog:
   `next_after` / `next_after_ts` cursor. After bootstrap-identity collection,
   a leftover redemption still projects as `failed_expired` with its redemption
   timestamp; expiry MAY be omitted.
+- v0.4.2 (2026-09-01): adds the closed local diagnostic `signature_id`
+  taxonomy, source precedence, and redacted diagnostics bundle v2 contract for
+  [#1314](https://github.com/Augustas11/macprovider/issues/1314).
 
 ## 1. Purpose and scope
 
@@ -170,11 +173,63 @@ MAY act on the same heartbeat; that predicate is not authority granted by this
 diagnostic event. They MUST NOT expose raw protocol payloads, tokens,
 Authorization values, local paths, or buyer-visible diagnostics.
 
+**SPEC-035-R010 — Closed local diagnostic signature taxonomy.** Malibu local
+diagnostic reports MUST use the closed `signature_id` set below. Unknown
+`signature_id` values MUST be ignored by readers whose supported reader version
+is at least the report `minimum_reader_version`; they MUST NOT make the whole
+report unreadable.
+
+| `signature_id` | Owned source/predicate |
+| --- | --- |
+| `stale_launch_agent` | `ProviderLogDiagnostics` log line `provider process unhealthy: launchd service live.malibu.provider has no validated pid at` plus current launchd repair state. |
+| `stale_model_catalog` | `ProviderLogDiagnostics` log line `model catalog provenance envelope is stale`. |
+| `catalog_admission` | `ProviderLogDiagnostics` log line `model artifact is not admitted by the signed candidate catalog`. |
+| `rate_card_admission` | `ProviderLogDiagnostics` log line `model artifact is not admitted by the signed rate card`. |
+| `catalog_key_mismatch` | `ProviderLogDiagnostics` log line `model must match model_catalog_key`. |
+| `artifact_hash_mismatch` | `ProviderLogDiagnostics` log line `model artifact hash mismatch`. |
+| `artifact_verification_failed` | `ProviderLogDiagnostics` log line `model artifact verification failed`. |
+| `missing_catalog_provenance` | `ProviderLogDiagnostics` log line `model_artifact_sha256 requires model_catalog_* provenance`. |
+| `missing_artifact_sha` | `ProviderLogDiagnostics` log line `coordinator join requires model_artifact_sha256`. |
+| `snapshot_path_mismatch` | `ProviderLogDiagnostics` log line `model must be the catalog-pinned hugging face snapshot path`. |
+| `autoupdate_home_acl_rejected` | `ProviderLogDiagnostics` watchdog line `autoupdate recovery_error=acl_write_rejected:<home>` without a later handled marker. |
+| `credential_store_unavailable` | Fresh, contract-compatible `/v1/status` `credential.state` in `locked`, `not_logged_in`, `permission_denied`, `keychain_failure`, `incompatible`, or `unavailable`. |
+| `serve_unresponsive` | Missing, stale, or contract-incompatible `/v1/status`; or fresh `/v1/status` `network_state` in `not_buyer_serving`, `buyer_serving_unknown`, `network_offline`, or `coordinator_unavailable`; or slice-2 `doctor report` serve-dead evidence when `/v1/status` is not fresh. |
+| `admission_identity_blocked` | Fresh, contract-compatible `/v1/status` `admission_identity.state` in `missing`, `recovery_pending`, `degraded_previous_key`, or `recovery_required`. |
+| `autoupdate_in_progress` | Fresh, contract-compatible `/v1/status` `lifecycle.state` in `update_in_progress` or `rollback_in_progress`, or the Malibu-local update/repair in-progress flags. |
+| `autoupdate_disabled` | Config/log evidence from the canonical key `auto_update_enabled` or dotted status key `autoupdate.enabled` showing `false`; legacy `autoupdate_enabled` MUST NOT be emitted as the canonical key. |
+
+Coordinator-only `waiting_trust_429` and `benchmark_quarantined` evidence is
+outside the local signature catalog unless a later SPEC names a local verified
+emitter.
+
+**SPEC-035-R011 — Diagnostic finding precedence.** Local diagnostic aggregators
+MUST return every closed finding, ordered by source precedence. A fresh,
+contract-compatible `/v1/status` observation wins the fields owned by serve
+status: credential, lifecycle, model, admission identity, and network. Log
+findings MAY supplement but MUST NOT override a fresh status-owned field. A
+doctor report MAY contribute only `serve_unresponsive`, and only when
+`/v1/status` is unavailable, stale according to `observation.valid_for_ms`, or
+contract-incompatible. A subprocess `credentials status` result MUST NOT
+override a fresh serve-owned `credential.state`; it MAY contribute only when
+fresh status is absent or lacks credential state.
+
+**SPEC-035-R012 — Diagnostics bundle v2 allowlist and redaction.** Malibu
+diagnostic bundles MUST be allowlist-only and MUST NOT copy config files,
+Keychain values, environment variables, raw coordinator frames, provider tokens,
+Authorization values, bootstrap-token material, private keys, or arbitrary local
+filesystem contents. Bundle v2 MUST include `schema_version: 2`,
+`minimum_reader_version`, redacted `diagnostic_findings`, and bounded redacted
+provider/watchdog log tails. `LogTailBuffer` v2 redaction MUST scrub secret
+lines, absolute paths, usernames, hostnames, IP addresses, and C0/C1 control
+characters. Redaction is a no-secrets/no-private-path guarantee; it is not an
+anonymity guarantee.
+
 ## 4. Rollout
 
 v0.4 ships coordinator-side journal/admin GETs, provider `status --json`,
 authenticated WSS `diagnostic_status` snapshots, Pearl monitor diagnostic
 alerts, and coordinator observe-only admission-ceiling drift events. v0.4.1
 adds the operator onboarding funnel join (`GET /admin/onboarding` and
-`coordinator-cli list-onboarding`). CLI inspect wrappers and any HTTPS beacon
-remain deferred under #535.
+`coordinator-cli list-onboarding`). v0.4.2 adds the local diagnostic signature
+schema and redacted bundle v2. CLI inspect wrappers and any HTTPS beacon remain
+deferred under #535.


### PR DESCRIPTION
## Summary

- define SPEC-035 diagnostic signature taxonomy, precedence, and diagnostics bundle v2 redaction requirements
- add Malibu diagnostic finding aggregation from status, provider logs, doctor/app/credential fallbacks
- make fresh `/v1/status` own model fields before health/control fallbacks
- export v2 diagnostics bundles with redacted findings and bounded provider/watchdog log tails

Closes #1314.

## Tests

- xcodebuild test -project Malibu.xcodeproj -scheme Malibu -destination 'platform=macOS'
- python3 scripts/check_spec_governance.py
- python3 scripts/gen_spec_index.py --check
- python3 scripts/gen_spec_index.py --lint
- git diff --check

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "issue": "https://github.com/Augustas11/macprovider/issues/1314",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": ["SPEC-035"],
  "requirements": ["SPEC-035-R010", "SPEC-035-R011", "SPEC-035-R012"],
  "authority_domains": ["provider-connection-diagnostics"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "xcodebuild test -project Malibu.xcodeproj -scheme Malibu -destination 'platform=macOS'",
    "python3 scripts/check_spec_governance.py",
    "python3 scripts/gen_spec_index.py --check",
    "python3 scripts/gen_spec_index.py --lint",
    "git diff --check"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END
