### PR TITLE
Add read-only doctor diagnostics report

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/DoctorCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/DoctorCommand.swift
@@ -1,4 +1,5 @@
 import ArgumentParser
+import Darwin
 import Foundation
 import MacProviderCore
 
@@ -22,6 +23,9 @@ struct DoctorCommand: AsyncParsableCommand {
         abstract: "Report this provider's binary version, coordinator endpoint, and version-floor standing."
     )
 
+    @Argument(help: "Optional report mode. Use `report --json` for the SPEC-035 diagnostics report.")
+    var mode: String?
+
     @Option(help: "YAML config path. Overrides MACPROVIDER_CONFIG. Defaults to ~/.config/macprovider/config.yaml.")
     var config: String?
 
@@ -31,10 +35,18 @@ struct DoctorCommand: AsyncParsableCommand {
     @Flag(help: "Skip the coordinator reachability + version-floor check entirely.")
     var offline = false
 
-    @Option(help: "Seconds to wait for the coordinator /healthz probe.")
+    @Option(help: "Seconds to wait for the coordinator /healthz probe, or report localhost /v1/status probe.")
     var timeoutSeconds: Double = 3
 
     func run() async throws {
+        if let mode {
+            guard mode == "report" else {
+                throw ValidationError("unknown doctor mode '\(mode)'")
+            }
+            try await runDiagnosticsReport()
+            return
+        }
+
         let resolved = try ConfigLoader.load(cli: CLIOverrides(configPath: config))
         let report = await DoctorRunner(
             binaryVersion: CoordinatorClient.binaryVersion,
@@ -54,6 +66,42 @@ struct DoctorCommand: AsyncParsableCommand {
         // offline-first tool must not fail because the network is down.
         if report.floorStanding == .belowFloor {
             throw ExitCode(1)
+        }
+    }
+
+    private func runDiagnosticsReport() async throws {
+        guard json else {
+            throw ValidationError("doctor report currently supports --json only")
+        }
+        let resolved: AppConfig
+        do {
+            resolved = try ConfigLoader.load(cli: CLIOverrides(configPath: config))
+        } catch {
+            let report = DoctorDiagnosticsReportRunner.configLoadFailureReport(
+                binaryVersion: CoordinatorClient.binaryVersion,
+                localEvidence: .empty
+            )
+            DoctorDiagnosticsReportPrinter.emitJSON(report)
+            throw ExitCode(Int32(report.exitCode))
+        }
+        let runner = DoctorDiagnosticsReportRunner(
+            binaryVersion: CoordinatorClient.binaryVersion,
+            config: resolved,
+            offline: offline,
+            timeoutSeconds: timeoutSeconds,
+            statusFetch: { port, timeout in
+                await DoctorDiagnosticsReportRunner.liveStatusFetch(port: port, timeout: timeout)
+            },
+            healthzFetch: DoctorRunner.liveFetch(timeout: timeoutSeconds),
+            localEvidence: {
+                DoctorLocalEvidenceCollector(homeDirectory: FileManager.default.homeDirectoryForCurrentUser)
+                    .collect(config: resolved)
+            }
+        )
+        let report = await runner.run()
+        DoctorDiagnosticsReportPrinter.emitJSON(report)
+        if report.exitCode != 0 {
+            throw ExitCode(Int32(report.exitCode))
         }
     }
 }
@@ -290,5 +338,976 @@ enum DoctorReportPrinter {
         }
         data.append(0x0A)
         FileHandle.standardOutput.write(data)
+    }
+}
+
+enum DoctorDiagnosticsReportExit: Int, Sendable {
+    /// JSON report emitted; fresh `/v1/status` says the provider is buyer-serving.
+    case healthy = 0
+    /// JSON report emitted; doctor contributed `serve_unresponsive` or version-floor evidence.
+    case providerAttention = 1
+    /// JSON report emitted, but fresh status owns the state or offline data is inconclusive.
+    case unknown = 2
+}
+
+struct DoctorDiagnosticsReport: Equatable, Sendable {
+    let createdAt: Date
+    let binaryVersion: String
+    let outcome: String
+    let exitCode: Int
+    let statusObservation: DoctorStatusObservation
+    let versionFloorStanding: DoctorFloorStanding
+    let localEvidence: DoctorLocalEvidence
+    let findings: [DoctorDiagnosticFinding]
+}
+
+struct DoctorDiagnosticFinding: Equatable, Sendable {
+    let signatureID: String
+    let source: String
+    let message: String
+    let evidence: String?
+    let observedAt: Date
+}
+
+struct DoctorStatusObservation: Equatable, Sendable {
+    enum State: String, Equatable, Sendable {
+        case unavailable
+        case stale
+        case contractIncompatible = "contract_incompatible"
+        case fresh
+    }
+
+    let state: State
+    let networkState: String?
+    let reason: String?
+    let observedAt: Date?
+    let validForMS: Int?
+}
+
+struct DoctorLocalEvidence: Equatable, Sendable {
+    let autoUpdateEnabled: Bool
+    let autoUpdateSource: String
+    let pendingUpdatePhase: String?
+    let pendingMarkerDeadline: String?
+    let launchd: DoctorLaunchdEvidence
+    let stat: [DoctorStatEvidence]
+    let logs: DoctorLogEvidence
+}
+
+struct DoctorLaunchdEvidence: Equatable, Sendable {
+    let providerPlist: DoctorPlistEvidence
+    let legacyProviderPlist: DoctorPlistEvidence
+    let providerLaunchctl: DoctorLaunchctlEvidence
+}
+
+struct DoctorPlistEvidence: Equatable, Sendable {
+    let present: Bool
+    let labelMatchesExpected: Bool?
+    let programConfigured: Bool
+}
+
+struct DoctorLaunchctlEvidence: Equatable, Sendable {
+    let available: Bool?
+    let pid: Int?
+    let reason: String?
+}
+
+struct DoctorStatEvidence: Equatable, Sendable {
+    let name: String
+    let present: Bool
+    let ownerCurrentUser: Bool?
+    let mode: String?
+    let aclExtended: Bool?
+}
+
+struct DoctorLogEvidence: Equatable, Sendable {
+    let provider: [String]
+    let watchdog: [String]
+}
+
+extension DoctorLocalEvidence {
+    static let empty = DoctorLocalEvidence(
+        autoUpdateEnabled: true,
+        autoUpdateSource: "unknown",
+        pendingUpdatePhase: nil,
+        pendingMarkerDeadline: nil,
+        launchd: DoctorLaunchdEvidence(
+            providerPlist: DoctorPlistEvidence(present: false, labelMatchesExpected: nil, programConfigured: false),
+            legacyProviderPlist: DoctorPlistEvidence(present: false, labelMatchesExpected: nil, programConfigured: false),
+            providerLaunchctl: DoctorLaunchctlEvidence(available: nil, pid: nil, reason: "config_load_failed")
+        ),
+        stat: [],
+        logs: DoctorLogEvidence(provider: [], watchdog: [])
+    )
+}
+
+struct DoctorDiagnosticsReportRunner: Sendable {
+    static let schema = "malibu.provider-diagnostics.v2"
+    static let schemaVersion = 2
+    static let minimumReaderVersion = 1
+    static let supportedLocalStatusReaderVersion = 1
+    static let localStatusObservationCapability = "status_observation_v1"
+    static let buyerServingAuthorityCapability = "buyer_serving_authority_v1"
+    static let networkStateAllowlist: Set<String> = [
+        "buyer_serving",
+        "not_buyer_serving",
+        "buyer_serving_unknown",
+        "network_offline",
+        "coordinator_unavailable",
+        "safe_offline_fallback",
+    ]
+
+    let binaryVersion: String
+    let config: AppConfig
+    let offline: Bool
+    let timeoutSeconds: TimeInterval
+    let statusFetch: @Sendable (Int, TimeInterval) async -> [String: Any]?
+    let healthzFetch: @Sendable (URL) async -> DoctorHealthz?
+    let localEvidence: @Sendable () -> DoctorLocalEvidence
+
+    func run(now: Date = Date()) async -> DoctorDiagnosticsReport {
+        let timeout = max(0.05, timeoutSeconds.isFinite ? timeoutSeconds : 1)
+        let status = Self.statusObservation(
+            await statusFetch(config.port, timeout),
+            now: now
+        )
+        let healthz = await healthz(now: now)
+        let standing = DoctorRunner.standing(
+            binaryVersion: binaryVersion,
+            requiredBinaryVersion: healthz?.requiredBinaryVersion
+        )
+        let evidence = localEvidence()
+        let findings = Self.findings(
+            status: status,
+            floorStanding: standing,
+            localEvidence: evidence,
+            now: now
+        )
+        let exit: DoctorDiagnosticsReportExit
+        let outcome: String
+        if !findings.isEmpty || standing == .belowFloor {
+            exit = .providerAttention
+            outcome = "provider_attention"
+        } else if status.state == .fresh, status.networkState == "buyer_serving" {
+            exit = .healthy
+            outcome = "healthy"
+        } else {
+            exit = .unknown
+            outcome = "unknown"
+        }
+        return DoctorDiagnosticsReport(
+            createdAt: now,
+            binaryVersion: binaryVersion,
+            outcome: outcome,
+            exitCode: exit.rawValue,
+            statusObservation: status,
+            versionFloorStanding: standing,
+            localEvidence: evidence,
+            findings: findings
+        )
+    }
+
+    private func healthz(now _: Date) async -> DoctorHealthz? {
+        guard !offline,
+              let url = DoctorRunner.healthzURL(coordinatorURL: config.coordinatorURL) else {
+            return nil
+        }
+        return await healthzFetch(url)
+    }
+
+    static func statusObservation(_ object: [String: Any]?, now: Date = Date()) -> DoctorStatusObservation {
+        guard let object else {
+            return DoctorStatusObservation(
+                state: .unavailable,
+                networkState: nil,
+                reason: "status_fetch_unavailable",
+                observedAt: nil,
+                validForMS: nil
+            )
+        }
+        let contract = object["local_status_contract"] as? [String: Any] ?? [:]
+        let observation = object["observation"] as? [String: Any] ?? [:]
+        let capabilities = Set((contract["capabilities"] as? [Any] ?? []).compactMap(Self.stringValue))
+        let networkState = capabilities.contains(buyerServingAuthorityCapability)
+            ? safeNetworkState(object["network_state"])
+            : nil
+        guard let version = intValue(contract["version"]),
+              let minimumReaderVersion = intValue(contract["minimum_reader_version"]),
+              version >= 1,
+              minimumReaderVersion <= supportedLocalStatusReaderVersion,
+              capabilities.contains(localStatusObservationCapability) else {
+            return DoctorStatusObservation(
+                state: .contractIncompatible,
+                networkState: networkState,
+                reason: "local_status_contract_incompatible",
+                observedAt: nil,
+                validForMS: nil
+            )
+        }
+        let observedAt = stringValue(observation["observed_at"]).flatMap(parseISO8601)
+        let validForMS = intValue(observation["valid_for_ms"])
+        guard let id = stringValue(observation["id"]),
+              !id.isEmpty,
+              let observedAt,
+              let validForMS,
+              (1...60_000).contains(validForMS) else {
+            return DoctorStatusObservation(
+                state: .stale,
+                networkState: networkState,
+                reason: "status_observation_invalid",
+                observedAt: observedAt,
+                validForMS: validForMS
+            )
+        }
+        let fresh = observedAt <= now.addingTimeInterval(1)
+            && observedAt.addingTimeInterval(Double(validForMS) / 1_000) >= now
+        return DoctorStatusObservation(
+            state: fresh ? .fresh : .stale,
+            networkState: networkState,
+            reason: fresh ? nil : "status_observation_stale",
+            observedAt: observedAt,
+            validForMS: validForMS
+        )
+    }
+
+    static func findings(
+        status: DoctorStatusObservation,
+        floorStanding: DoctorFloorStanding,
+        localEvidence: DoctorLocalEvidence,
+        now: Date
+    ) -> [DoctorDiagnosticFinding] {
+        guard status.state != .fresh else { return [] }
+        return [
+            DoctorDiagnosticFinding(
+                signatureID: "serve_unresponsive",
+                source: "doctor_report",
+                message: "Provider serve status is unavailable to the doctor report.",
+                evidence: evidenceString(status: status, floorStanding: floorStanding, localEvidence: localEvidence),
+                observedAt: now
+            )
+        ]
+    }
+
+    private static func evidenceString(
+        status: DoctorStatusObservation,
+        floorStanding: DoctorFloorStanding,
+        localEvidence: DoctorLocalEvidence
+    ) -> String {
+        var parts = [
+            "status_observation=\(status.state.rawValue)",
+            "version_floor_standing=\(floorStanding.rawValue)",
+            "auto_update_enabled=\(localEvidence.autoUpdateEnabled)",
+            "auto_update_source=\(localEvidence.autoUpdateSource)",
+            "launchd.provider_plist.present=\(localEvidence.launchd.providerPlist.present)",
+            "launchd.provider.loaded=\(localEvidence.launchd.providerLaunchctl.available.map(String.init) ?? "unknown")",
+        ]
+        if let reason = status.reason {
+            parts.append("status_reason=\(reason)")
+        }
+        if let networkState = status.networkState {
+            parts.append("network_state=\(networkState)")
+        }
+        if let phase = localEvidence.pendingUpdatePhase {
+            parts.append("pending_update.phase=\(phase)")
+        }
+        if let pid = localEvidence.launchd.providerLaunchctl.pid {
+            parts.append("launchd.provider.pid=\(pid)")
+        }
+        if let reason = localEvidence.launchd.providerLaunchctl.reason {
+            parts.append("launchd.provider.reason=\(reason)")
+        }
+        if localEvidence.logs.provider.contains(where: Self.containsStaleLaunchAgentNeedle) {
+            parts.append("provider_log.stale_launch_agent=true")
+        }
+        if localEvidence.logs.watchdog.contains(where: Self.containsAutoupdateACLNeedle) {
+            parts.append("watchdog_log.autoupdate_acl_rejected=true")
+        }
+        return parts.joined(separator: "; ")
+    }
+
+    private static func containsStaleLaunchAgentNeedle(_ line: String) -> Bool {
+        line.lowercased().contains(
+            "provider process unhealthy: launchd service live.malibu.provider has no validated pid at"
+        )
+    }
+
+    static func configLoadFailureReport(
+        binaryVersion: String,
+        localEvidence: DoctorLocalEvidence,
+        now: Date = Date()
+    ) -> DoctorDiagnosticsReport {
+        DoctorDiagnosticsReport(
+            createdAt: now,
+            binaryVersion: binaryVersion,
+            outcome: "unknown",
+            exitCode: DoctorDiagnosticsReportExit.unknown.rawValue,
+            statusObservation: DoctorStatusObservation(
+                state: .unavailable,
+                networkState: nil,
+                reason: "config_load_failed",
+                observedAt: nil,
+                validForMS: nil
+            ),
+            versionFloorStanding: .notChecked,
+            localEvidence: localEvidence,
+            findings: []
+        )
+    }
+
+    private static func containsAutoupdateACLNeedle(_ line: String) -> Bool {
+        line.lowercased().contains("autoupdate recovery_error=acl_write_rejected:")
+    }
+
+    static func liveStatusFetch(port: Int, timeout: TimeInterval) async -> [String: Any]? {
+        try? await LocalStatusClient.fetch(port: port, timeoutSeconds: timeout)
+    }
+
+    private static func stringValue(_ value: Any?) -> String? {
+        switch value {
+        case let value as String:
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        case let value as NSNumber:
+            return value.stringValue
+        default:
+            return nil
+        }
+    }
+
+    private static func intValue(_ value: Any?) -> Int? {
+        switch value {
+        case let value as Int:
+            return value
+        case let value as NSNumber:
+            return value.intValue
+        case let value as String:
+            return Int(value)
+        default:
+            return nil
+        }
+    }
+
+    private static func safeNetworkState(_ value: Any?) -> String? {
+        guard let state = stringValue(value),
+              networkStateAllowlist.contains(state) else {
+            return nil
+        }
+        return state
+    }
+
+    private static func parseISO8601(_ value: String) -> Date? {
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let parsed = fractional.date(from: value) {
+            return parsed
+        }
+        return ISO8601DateFormatter().date(from: value)
+    }
+}
+
+struct DoctorLocalEvidenceCollector: @unchecked Sendable {
+    let homeDirectory: URL
+    let launchctl: @Sendable (String) -> DoctorLaunchctlEvidence
+
+    init(
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        launchctl: @escaping @Sendable (String) -> DoctorLaunchctlEvidence = { label in
+            DoctorLocalEvidenceCollector.launchctlEvidence(label: label)
+        }
+    ) {
+        self.homeDirectory = homeDirectory
+        self.launchctl = launchctl
+    }
+
+    func collect(config: AppConfig) -> DoctorLocalEvidence {
+        collect(autoUpdateEnabled: config.autoUpdateEnabled, legacyAutoupdateEnabled: config.autoupdateEnabled)
+    }
+
+    func collect(
+        autoUpdateEnabled: Bool? = nil,
+        legacyAutoupdateEnabled: Bool? = nil
+    ) -> DoctorLocalEvidence {
+        let autoupdate = Self.effectiveAutoUpdateEnabled(
+            autoUpdateEnabled: autoUpdateEnabled,
+            legacyAutoupdateEnabled: legacyAutoupdateEnabled
+        )
+        let pending = readPendingMarker()
+        return DoctorLocalEvidence(
+            autoUpdateEnabled: autoupdate.enabled,
+            autoUpdateSource: autoupdate.source,
+            pendingUpdatePhase: pending?.transactionState?.rawValue,
+            pendingMarkerDeadline: pending?.markerDeadline,
+            launchd: DoctorLaunchdEvidence(
+                providerPlist: plistEvidence(providerPlistURL, expectedLabel: "live.malibu.provider"),
+                legacyProviderPlist: plistEvidence(legacyProviderPlistURL, expectedLabel: "live.streamvc.macprovider"),
+                providerLaunchctl: launchctl("live.malibu.provider")
+            ),
+            stat: [
+                statEvidence(name: "home", url: homeDirectory),
+                statEvidence(name: "autoupdate_root", url: autoupdateRoot),
+                statEvidence(name: "provider_plist", url: providerPlistURL),
+                statEvidence(name: "legacy_provider_plist", url: legacyProviderPlistURL),
+            ],
+            logs: DoctorLogEvidence(
+                provider: Self.readRedactedTail(providerStderrLogURL) + Self.readRedactedTail(providerStdoutLogURL),
+                watchdog: Self.readRedactedTail(watchdogLogURL)
+            )
+        )
+    }
+
+    private var autoupdateRoot: URL {
+        homeDirectory.appendingPathComponent(".local/share/macprovider/autoupdate", isDirectory: true)
+    }
+
+    private var pendingURL: URL {
+        autoupdateRoot.appendingPathComponent("pending.json")
+    }
+
+    private var providerPlistURL: URL {
+        homeDirectory.appendingPathComponent("Library/LaunchAgents/live.malibu.provider.plist")
+    }
+
+    private var legacyProviderPlistURL: URL {
+        homeDirectory.appendingPathComponent("Library/LaunchAgents/live.streamvc.macprovider.plist")
+    }
+
+    private var providerStdoutLogURL: URL {
+        homeDirectory.appendingPathComponent("Library/Logs/macprovider/macprovider.out.log")
+    }
+
+    private var providerStderrLogURL: URL {
+        homeDirectory.appendingPathComponent("Library/Logs/macprovider/macprovider.err.log")
+    }
+
+    private var watchdogLogURL: URL {
+        homeDirectory.appendingPathComponent("Library/Logs/macprovider/watchdog.log")
+    }
+
+    private func readPendingMarker() -> AutoUpdatePendingMarker? {
+        guard let data = try? Data(contentsOf: pendingURL) else { return nil }
+        return try? JSONDecoder().decode(AutoUpdatePendingMarker.self, from: data)
+    }
+
+    private func plistEvidence(_ url: URL, expectedLabel: String) -> DoctorPlistEvidence {
+        guard let data = try? Data(contentsOf: url),
+              let plist = try? PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any] else {
+            return DoctorPlistEvidence(present: false, labelMatchesExpected: nil, programConfigured: false)
+        }
+        let args = plist["ProgramArguments"] as? [String]
+        let labelMatchesExpected = plist["Label"] as? String == expectedLabel
+        return DoctorPlistEvidence(
+            present: true,
+            labelMatchesExpected: labelMatchesExpected,
+            programConfigured: labelMatchesExpected && args?.first?.isEmpty == false
+        )
+    }
+
+    private func statEvidence(name: String, url: URL) -> DoctorStatEvidence {
+        var info = stat()
+        guard lstat(url.path, &info) == 0 else {
+            return DoctorStatEvidence(name: name, present: false, ownerCurrentUser: nil, mode: nil, aclExtended: nil)
+        }
+        return DoctorStatEvidence(
+            name: name,
+            present: true,
+            ownerCurrentUser: info.st_uid == getuid(),
+            mode: String(format: "%04o", info.st_mode & mode_t(0o7777)),
+            aclExtended: Self.hasExtendedACL(url)
+        )
+    }
+
+    static func effectiveAutoUpdateEnabled(
+        autoUpdateEnabled: Bool?,
+        legacyAutoupdateEnabled: Bool?
+    ) -> (enabled: Bool, source: String) {
+        if let autoUpdateEnabled {
+            return (autoUpdateEnabled, "auto_update_enabled")
+        }
+        if let legacyAutoupdateEnabled {
+            return (legacyAutoupdateEnabled, "autoupdate.enabled")
+        }
+        return (true, "default_enabled")
+    }
+
+    static func launchctlEvidence(label: String) -> DoctorLaunchctlEvidence {
+        do {
+            let target = "gui/\(getuid())/\(label)"
+            let result = try SelfUpdate.runLaunchctlCommand(arguments: ["print", target], allowFailure: true, timeout: 1)
+            if result.terminationStatus == 113,
+               result.output.contains("Could not find service") {
+                return DoctorLaunchctlEvidence(available: false, pid: nil, reason: "service_not_found")
+            }
+            guard result.terminationStatus == 0 else {
+                return DoctorLaunchctlEvidence(available: nil, pid: nil, reason: "launchctl_exit_\(result.terminationStatus)")
+            }
+            return DoctorLaunchctlEvidence(
+                available: !result.output.lowercased().contains("disabled = true"),
+                pid: pid(fromLaunchctlPrint: result.output),
+                reason: nil
+            )
+        } catch {
+            return DoctorLaunchctlEvidence(available: nil, pid: nil, reason: "launchctl_unavailable")
+        }
+    }
+
+    static func readRedactedTail(_ url: URL, maximumBytes: Int = 256 * 1024, maximumLines: Int = 400) -> [String] {
+        let descriptor = open(url.path, O_RDONLY | O_CLOEXEC | O_NOFOLLOW | O_NONBLOCK)
+        guard descriptor >= 0 else { return [] }
+        defer { close(descriptor) }
+        var info = stat()
+        guard fstat(descriptor, &info) == 0,
+              (info.st_mode & S_IFMT) == S_IFREG,
+              info.st_uid == getuid(),
+              Int(info.st_nlink) == 1,
+              info.st_mode & (S_IWGRP | S_IWOTH) == 0,
+              hasNoExtendedACL(descriptor),
+              info.st_size >= 0 else {
+            return []
+        }
+        let start = max(off_t(0), info.st_size - off_t(maximumBytes))
+        guard lseek(descriptor, start, SEEK_SET) >= 0 else { return [] }
+        var bytes = Data()
+        var buffer = [UInt8](repeating: 0, count: 16 * 1024)
+        while bytes.count < maximumBytes {
+            let count = read(descriptor, &buffer, min(buffer.count, maximumBytes - bytes.count))
+            guard count >= 0 else { return [] }
+            if count == 0 { break }
+            bytes.append(contentsOf: buffer.prefix(count))
+        }
+        guard var text = String(data: bytes, encoding: .utf8) else { return [] }
+        if start > 0, let firstNewline = text.firstIndex(where: \.isNewline) {
+            text = String(text[text.index(after: firstNewline)...])
+        }
+        return text.components(separatedBy: .newlines)
+            .filter { !$0.isEmpty }
+            .suffix(maximumLines)
+            .map { String(DoctorReportRedactor.redacted($0).prefix(8 * 1024)) }
+    }
+
+    private static func hasExtendedACL(_ url: URL) -> Bool? {
+        errno = 0
+        guard let acl = acl_get_file(url.path, ACL_TYPE_EXTENDED) else {
+            if errno == ENOENT || errno == 0 {
+                return false
+            }
+            return nil
+        }
+        _ = acl_free(UnsafeMutableRawPointer(acl))
+        return true
+    }
+
+    private static func hasNoExtendedACL(_ descriptor: Int32) -> Bool {
+        errno = 0
+        guard let acl = acl_get_fd_np(descriptor, ACL_TYPE_EXTENDED) else {
+            return errno == 0 || errno == ENOENT || errno == ENOTSUP
+        }
+        defer { acl_free(UnsafeMutableRawPointer(acl)) }
+        return false
+    }
+
+    private static func pid(fromLaunchctlPrint output: String) -> Int? {
+        for line in output.components(separatedBy: .newlines) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard trimmed.lowercased().hasPrefix("pid =") else { continue }
+            return Int(trimmed.dropFirst("pid =".count).trimmingCharacters(in: .whitespaces))
+        }
+        return nil
+    }
+}
+
+enum DoctorDiagnosticsReportPrinter {
+    static func emitJSON(_ report: DoctorDiagnosticsReport) {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let payload: [String: Any] = [
+            "schema": DoctorDiagnosticsReportRunner.schema,
+            "schema_version": DoctorDiagnosticsReportRunner.schemaVersion,
+            "minimum_reader_version": DoctorDiagnosticsReportRunner.minimumReaderVersion,
+            "created_at": formatter.string(from: report.createdAt),
+            "binary_version": report.binaryVersion,
+            "doctor": [
+                "outcome": report.outcome,
+                "exit_code": report.exitCode,
+                "status_observation": statusObject(report.statusObservation, formatter: formatter),
+                "version_floor_standing": report.versionFloorStanding.rawValue,
+                "auto_update_enabled": report.localEvidence.autoUpdateEnabled,
+                "auto_update_source": report.localEvidence.autoUpdateSource,
+                "pending_update_phase": json(report.localEvidence.pendingUpdatePhase),
+                "launchd": launchdObject(report.localEvidence.launchd),
+                "stat": report.localEvidence.stat.map(statObject),
+            ],
+            "diagnostic_findings": report.findings.map { findingObject($0, formatter: formatter) },
+            "logs": [
+                "provider": report.localEvidence.logs.provider,
+                "watchdog": report.localEvidence.logs.watchdog,
+            ],
+        ]
+        guard JSONSerialization.isValidJSONObject(payload),
+              var data = try? JSONSerialization.data(
+                withJSONObject: payload,
+                options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+              ) else {
+            let fallback = "{\"minimum_reader_version\":\(DoctorDiagnosticsReportRunner.minimumReaderVersion),"
+                + "\"schema\":\"\(DoctorDiagnosticsReportRunner.schema)\","
+                + "\"schema_version\":\(DoctorDiagnosticsReportRunner.schemaVersion)}\n"
+            FileHandle.standardOutput.write(Data(fallback.utf8))
+            return
+        }
+        data.append(0x0A)
+        FileHandle.standardOutput.write(data)
+    }
+
+    private static func statusObject(_ status: DoctorStatusObservation, formatter: ISO8601DateFormatter) -> [String: Any] {
+        [
+            "state": status.state.rawValue,
+            "network_state": json(status.networkState),
+            "reason": json(status.reason),
+            "observed_at": json(status.observedAt.map(formatter.string(from:))),
+            "valid_for_ms": json(status.validForMS),
+        ]
+    }
+
+    private static func launchdObject(_ launchd: DoctorLaunchdEvidence) -> [String: Any] {
+        [
+            "provider_plist": plistObject(launchd.providerPlist),
+            "legacy_provider_plist": plistObject(launchd.legacyProviderPlist),
+            "provider": [
+                "available": json(launchd.providerLaunchctl.available),
+                "pid": json(launchd.providerLaunchctl.pid),
+                "reason": json(launchd.providerLaunchctl.reason),
+            ],
+        ]
+    }
+
+    private static func plistObject(_ plist: DoctorPlistEvidence) -> [String: Any] {
+        [
+            "present": plist.present,
+            "label_matches_expected": json(plist.labelMatchesExpected),
+            "program_configured": plist.programConfigured,
+        ]
+    }
+
+    private static func statObject(_ stat: DoctorStatEvidence) -> [String: Any] {
+        [
+            "name": stat.name,
+            "present": stat.present,
+            "owner_current_user": json(stat.ownerCurrentUser),
+            "mode": json(stat.mode),
+            "acl_extended": json(stat.aclExtended),
+        ]
+    }
+
+    private static func findingObject(_ finding: DoctorDiagnosticFinding, formatter: ISO8601DateFormatter) -> [String: Any] {
+        [
+            "signature_id": finding.signatureID,
+            "source": finding.source,
+            "message": DoctorReportRedactor.redacted(finding.message),
+            "evidence": finding.evidence.map(DoctorReportRedactor.redacted) ?? NSNull(),
+            "observed_at": formatter.string(from: finding.observedAt),
+        ]
+    }
+
+    private static func json<T>(_ value: T?) -> Any {
+        guard let value else { return NSNull() }
+        return value
+    }
+}
+
+enum DoctorReportRedactor {
+    static func redacted(_ line: String) -> String {
+        let sanitized = scrubNonSecretIdentifiers(line)
+        if containsSecret(line) || containsSecret(sanitized) {
+            return "[redacted]"
+        }
+        return sanitized
+    }
+
+    static func redactedForTest(
+        _ line: String,
+        usernameCandidates: [String],
+        hostnameCandidates: [String?] = []
+    ) -> String {
+        let sanitized = scrubNonSecretIdentifiers(
+            line,
+            usernameCandidates: usernameCandidates,
+            hostnameCandidates: hostnameCandidates
+        )
+        if containsSecret(line) || containsSecret(sanitized) {
+            return "[redacted]"
+        }
+        return sanitized
+    }
+
+    private static func containsSecret(_ line: String) -> Bool {
+        let lower = line.lowercased()
+        let normalizedIdentifierText = lower.filter { $0.isLetter || $0.isNumber }
+        return lower.contains("provider_token")
+            || lower.contains("provider_id")
+            || lower.contains("identity_signature")
+            || lower.contains("authorization:")
+            || lower.contains("token_sha256")
+            || lower.contains("token_hash")
+            || lower.contains("private_key")
+            || lower.contains("api_key")
+            || lower.contains("client_secret")
+            || lower.contains("secret")
+            || lower.contains("credential")
+            || lower.contains("password")
+            || lower.contains("set-cookie")
+            || lower.contains("signed_payload")
+            || lower.contains("payload_to_sign")
+            || normalizedIdentifierText.contains("providertoken")
+            || normalizedIdentifierText.contains("providerid")
+            || normalizedIdentifierText.contains("identitysignature")
+            || normalizedIdentifierText.contains("privatekey")
+            || normalizedIdentifierText.contains("apikey")
+            || normalizedIdentifierText.contains("clientsecret")
+            || normalizedIdentifierText.contains("secretkey")
+            || normalizedIdentifierText.contains("credential")
+            || normalizedIdentifierText.contains("password")
+            || normalizedIdentifierText.contains("setcookie")
+            || normalizedIdentifierText.contains("signedpayload")
+            || normalizedIdentifierText.contains("payloadtosign")
+            || normalizedIdentifierText.contains("tokensha256")
+            || normalizedIdentifierText.contains("tokenhash")
+            || (lower.contains("-----begin") && lower.contains("private key-----"))
+            || matchesSecretPattern(line)
+    }
+
+    private static func matchesSecretPattern(_ line: String) -> Bool {
+        let patterns = [
+            #"(?i)\bbearer\s+[A-Za-z0-9._~+/\-=]{12,}"#,
+            #"(?i)(^|[^A-Za-z0-9_-])["']?authorization["']?\s*[:=]\s*["']?\S+"#,
+            #"(?i)\b(provider|identity|auth|access|refresh|session)[_-]?token\b\s*[:=]\s*\S+"#,
+            #"(?i)\b(api[_-]?key|client[_-]?secret|secret|secret[_-]?key|x[_-]?secret[_-]?key|credential|password|cookie)\b\s*[:=]\s*\S+"#,
+            #"(?i)https?://\S+\?\S+"#,
+        ]
+        return patterns.contains { pattern in
+            line.range(of: pattern, options: .regularExpression) != nil
+        }
+    }
+
+    private static func scrubNonSecretIdentifiers(_ line: String) -> String {
+        scrubNonSecretIdentifiers(
+            line,
+            usernameCandidates: [
+                NSUserName(),
+                FileManager.default.homeDirectoryForCurrentUser.lastPathComponent,
+            ],
+            hostnameCandidates: currentHostnameCandidates()
+        )
+    }
+
+    private static func currentHostnameCandidates() -> [String?] {
+        var candidates: [String?] = [
+            ProcessInfo.processInfo.hostName,
+            ProcessInfo.processInfo.hostName.components(separatedBy: ".").first,
+        ]
+        var buffer = [CChar](repeating: 0, count: Int(MAXHOSTNAMELEN) + 1)
+        if gethostname(&buffer, buffer.count) == 0 {
+            let hostname = String(cString: buffer)
+            candidates.append(hostname)
+            candidates.append(hostname.components(separatedBy: ".").first)
+        }
+        return candidates
+    }
+
+    private static func scrubNonSecretIdentifiers(
+        _ line: String,
+        usernameCandidates rawUsernameCandidates: [String],
+        hostnameCandidates rawHostnameCandidates: [String?]
+    ) -> String {
+        var output = String(line.unicodeScalars.filter { scalar in
+            let value = scalar.value
+            return !(value <= 0x1F || (0x7F...0x9F).contains(value))
+        })
+        for username in orderedIdentifierCandidates(rawUsernameCandidates) {
+            output = output.replacingOccurrences(of: username, with: "[user]")
+        }
+        for hostname in orderedIdentifierCandidates(rawHostnameCandidates.compactMap { $0 }) {
+            output = output.replacingOccurrences(of: hostname, with: "[host]")
+        }
+        let replacements: [(String, String)] = [
+            (#"(?i)\b(user(?:name)?|login|account)=([^\s,;]+)"#, "$1=[user]"),
+            (#"(?i)\b(host(?:name)?|computer[_-]?name|machine|nodename)=([^\s,;]+)"#, "$1=[host]"),
+            (#"\b[A-Za-z0-9][A-Za-z0-9-]*(?:\.[A-Za-z0-9][A-Za-z0-9-]*)*\.local\b"#, "[host]"),
+            (#"\b(?:(?:25[0-5]|2[0-4]\d|1?\d?\d)\.){3}(?:25[0-5]|2[0-4]\d|1?\d?\d)(?::\d{1,5})?\b"#, "[ip]"),
+        ]
+        for (pattern, template) in replacements {
+            output = output.replacingOccurrences(of: pattern, with: template, options: .regularExpression)
+        }
+        return scrubAbsolutePaths(scrubIPAddresses(output))
+    }
+
+    private static func orderedIdentifierCandidates(_ candidates: [String]) -> [String] {
+        Array(Set(candidates.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }.filter { $0.count >= 2 }))
+            .sorted { lhs, rhs in
+                if lhs.count != rhs.count { return lhs.count > rhs.count }
+                return lhs < rhs
+            }
+    }
+
+    private static func scrubAbsolutePaths(_ line: String) -> String {
+        let line = line.replacingOccurrences(of: #"\/"#, with: "/")
+        var output = ""
+        var index = line.startIndex
+        while index < line.endIndex {
+            if line.lowercasedRange(from: index, hasPrefix: "file:///") {
+                let pathStart = line.index(index, offsetBy: "file://".count)
+                output += "file://[path]"
+                index = line.indexAfterAbsolutePath(startingAt: pathStart)
+                continue
+            }
+            let character = line[index]
+            if character == "/", isPathBoundary(before: index, in: line) {
+                output += "[path]"
+                index = line.indexAfterAbsolutePath(startingAt: index)
+            } else {
+                output.append(character)
+                index = line.index(after: index)
+            }
+        }
+        return output
+    }
+
+    private static func scrubIPAddresses(_ line: String) -> String {
+        var output = ""
+        var token = ""
+
+        func flushToken() {
+            guard !token.isEmpty else { return }
+            output += redactedIPToken(token) ?? token
+            token = ""
+        }
+
+        for character in line {
+            if isIPTokenCharacter(character) {
+                token.append(character)
+            } else {
+                flushToken()
+                output.append(character)
+            }
+        }
+        flushToken()
+        return output
+    }
+
+    private static func isIPTokenCharacter(_ character: Character) -> Bool {
+        character.isLetter
+            || character.isNumber
+            || character == "."
+            || character == ":"
+            || character == "%"
+            || character == "["
+            || character == "]"
+    }
+
+    private static func redactedIPToken(_ token: String) -> String? {
+        guard token.contains(".") || token.contains(":") else { return nil }
+        let split = splitTrailingPunctuation(from: token)
+        let candidate = split.candidate
+        if candidate.hasPrefix("["),
+           let closeBracket = candidate.firstIndex(of: "]") {
+            let addressStart = candidate.index(after: candidate.startIndex)
+            let address = String(candidate[addressStart..<closeBracket])
+            let suffix = candidate[candidate.index(after: closeBracket)...]
+            guard suffix.isEmpty || isPortSuffix(suffix), isIPAddress(address) else { return nil }
+            return "[ip]" + split.trailing
+        }
+        if isIPAddress(candidate) {
+            return "[ip]" + split.trailing
+        }
+        if let colon = candidate.lastIndex(of: ":") {
+            let suffix = candidate[colon...]
+            let prefix = String(candidate[..<colon])
+            if isPortSuffix(suffix), isIPAddress(prefix) {
+                return "[ip]" + split.trailing
+            }
+        }
+        return nil
+    }
+
+    private static func splitTrailingPunctuation(from token: String) -> (candidate: String, trailing: String) {
+        var candidate = token
+        var trailing = ""
+        while let last = candidate.last, last == "." || last == "," || last == ";" {
+            trailing.insert(last, at: trailing.startIndex)
+            candidate.removeLast()
+        }
+        return (candidate, trailing)
+    }
+
+    private static func isPortSuffix(_ suffix: Substring) -> Bool {
+        guard suffix.first == ":" else { return false }
+        let digits = suffix.dropFirst()
+        return (1...5).contains(digits.count) && digits.allSatisfy(\.isNumber)
+    }
+
+    private static func isIPAddress(_ rawAddress: String) -> Bool {
+        let address = rawAddress.split(separator: "%", maxSplits: 1, omittingEmptySubsequences: false).first
+            .map(String.init) ?? rawAddress
+        guard !address.isEmpty else { return false }
+        var ipv4 = in_addr()
+        if address.withCString({ inet_pton(AF_INET, $0, &ipv4) }) == 1 {
+            return true
+        }
+        var ipv6 = in6_addr()
+        return address.withCString { inet_pton(AF_INET6, $0, &ipv6) } == 1
+    }
+
+    private static func isPathBoundary(before index: String.Index, in line: String) -> Bool {
+        guard index > line.startIndex else { return true }
+        let previous = line[line.index(before: index)]
+        if previous == ":" {
+            let next = line.index(after: index)
+            return next == line.endIndex || line[next] != "/"
+        }
+        return previous.isWhitespace || #""'(<[{="#.contains(previous)
+    }
+}
+
+private extension String {
+    func lowercasedRange(from index: String.Index, hasPrefix prefix: String) -> Bool {
+        let end = self.index(index, offsetBy: prefix.count, limitedBy: endIndex) ?? endIndex
+        guard distance(from: index, to: end) == prefix.count else { return false }
+        return self[index..<end].lowercased() == prefix
+    }
+
+    func indexAfterAbsolutePath(startingAt start: String.Index) -> String.Index {
+        var index = self.index(after: start)
+        while index < endIndex {
+            let character = self[index]
+            if #""'`<>|;,"#.contains(character) {
+                break
+            }
+            if character.isWhitespace {
+                let next = self.index(after: index)
+                if next == endIndex || tokenAfterWhitespaceStartsKeyValue(at: next) {
+                    break
+                }
+            }
+            index = self.index(after: index)
+        }
+        return index
+    }
+
+    private func tokenAfterWhitespaceStartsKeyValue(at start: String.Index) -> Bool {
+        var index = start
+        guard index < endIndex, self[index].isLetter || self[index] == "_" else {
+            return false
+        }
+        index = self.index(after: index)
+        while index < endIndex {
+            let character = self[index]
+            if character == "=" || character == ":" {
+                return true
+            }
+            if character.isLetter || character.isNumber || character == "_" || character == "-" || character == "." {
+                index = self.index(after: index)
+            } else {
+                return false
+            }
+        }
+        return false
     }
 }

--- a/phase3-binary/Tests/macprovider-cliTests/DoctorCommandTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/DoctorCommandTests.swift
@@ -1,5 +1,8 @@
 import Foundation
+import Darwin
+import ArgumentParser
 import XCTest
+import MacProviderCore
 @testable import macprovider_cli
 
 /// Issue #767 item 3 — `macprovider-cli doctor`. Offline-first: everything but
@@ -22,6 +25,8 @@ final class DoctorCommandTests: XCTestCase {
     }
 
     private static let unreachable: @Sendable (URL) async -> DoctorHealthz? = { _ in nil }
+
+    private static let reportNow = Date(timeIntervalSince1970: 1_786_000_000)
 
     // MARK: - endpoint derivation
 
@@ -132,5 +137,440 @@ final class DoctorCommandTests: XCTestCase {
         XCTAssertNil(noFloor.requiredBinaryVersion)
 
         XCTAssertNil(DoctorRunner.parseHealthz(Data("not json".utf8)))
+    }
+
+    // MARK: - SPEC-035 doctor report
+
+    func testDoctorReportJSONCommandRemainsParseable() throws {
+        let command = try XCTUnwrap(MacProviderCLI.parseAsRoot([
+            "doctor", "report", "--json", "--offline", "--timeout-seconds", "0.25",
+        ]) as? DoctorCommand)
+        XCTAssertEqual(command.mode, "report")
+        XCTAssertTrue(command.json)
+        XCTAssertTrue(command.offline)
+        XCTAssertEqual(command.timeoutSeconds, 0.25, accuracy: 0.001)
+    }
+
+    func testDoctorReportEmitsOnlyServeUnresponsiveWhenStatusUnavailable() async {
+        let report = await diagnosticsRunner(status: nil).run(now: Self.reportNow)
+        XCTAssertEqual(report.exitCode, DoctorDiagnosticsReportExit.providerAttention.rawValue)
+        XCTAssertEqual(report.outcome, "provider_attention")
+        XCTAssertEqual(report.statusObservation.state, .unavailable)
+        XCTAssertEqual(report.findings.map(\.signatureID), ["serve_unresponsive"])
+        XCTAssertEqual(report.findings.map(\.source), ["doctor_report"])
+    }
+
+    func testDoctorReportSuppressesFindingsWhenStatusIsFresh() async {
+        let report = await diagnosticsRunner(status: freshStatus(networkState: "buyer_serving")).run(now: Self.reportNow)
+        XCTAssertEqual(report.exitCode, DoctorDiagnosticsReportExit.healthy.rawValue)
+        XCTAssertEqual(report.outcome, "healthy")
+        XCTAssertEqual(report.statusObservation.state, .fresh)
+        XCTAssertTrue(report.findings.isEmpty)
+    }
+
+    func testDoctorReportDoesNotTrustNetworkStateWithoutAuthorityCapability() async {
+        let report = await diagnosticsRunner(
+            status: freshStatus(networkState: "buyer_serving", capabilities: ["status_observation_v1"])
+        ).run(now: Self.reportNow)
+        XCTAssertEqual(report.exitCode, DoctorDiagnosticsReportExit.unknown.rawValue)
+        XCTAssertEqual(report.outcome, "unknown")
+        XCTAssertEqual(report.statusObservation.state, .fresh)
+        XCTAssertNil(report.statusObservation.networkState)
+        XCTAssertTrue(report.findings.isEmpty)
+    }
+
+    func testDoctorReportAllowlistsNetworkStateBeforeEmission() async throws {
+        let report = await diagnosticsRunner(status: freshStatus(
+            networkState: "buyer_serving /Users/alice provider_id=mp-secret 192.168.1.20\u{0007}"
+        )).run(now: Self.reportNow)
+        XCTAssertEqual(report.statusObservation.state, .fresh)
+        XCTAssertNil(report.statusObservation.networkState)
+        XCTAssertEqual(report.exitCode, DoctorDiagnosticsReportExit.unknown.rawValue)
+        let stdout = captureStdout {
+            DoctorDiagnosticsReportPrinter.emitJSON(report)
+        }
+        XCTAssertFalse(stdout.contains("/Users/alice"))
+        XCTAssertFalse(stdout.contains("provider_id"))
+        XCTAssertFalse(stdout.contains("192.168.1.20"))
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(stdout.utf8)) as? [String: Any])
+        let doctor = try XCTUnwrap(object["doctor"] as? [String: Any])
+        let status = try XCTUnwrap(doctor["status_observation"] as? [String: Any])
+        XCTAssertTrue(status["network_state"] is NSNull)
+    }
+
+    func testDoctorReportDoesNotOverrideFreshStatusOwnedNetworkState() async {
+        let report = await diagnosticsRunner(status: freshStatus(networkState: "not_buyer_serving")).run(now: Self.reportNow)
+        XCTAssertEqual(report.exitCode, DoctorDiagnosticsReportExit.unknown.rawValue)
+        XCTAssertEqual(report.outcome, "unknown")
+        XCTAssertEqual(report.statusObservation.state, .fresh)
+        XCTAssertEqual(report.statusObservation.networkState, "not_buyer_serving")
+        XCTAssertTrue(report.findings.isEmpty)
+    }
+
+    func testDoctorReportContributesServeUnresponsiveForStaleOrIncompatibleStatus() async {
+        let stale = await diagnosticsRunner(status: freshStatus(
+            networkState: "buyer_serving",
+            observedAt: Self.reportNow.addingTimeInterval(-6),
+            validForMS: 5_000
+        )).run(now: Self.reportNow)
+        XCTAssertEqual(stale.statusObservation.state, .stale)
+        XCTAssertEqual(stale.findings.map(\.signatureID), ["serve_unresponsive"])
+
+        let incompatible = await diagnosticsRunner(status: [
+            "local_status_contract": [
+                "version": 1,
+                "minimum_reader_version": 99,
+                "capabilities": ["status_observation_v1"],
+            ],
+            "network_state": "buyer_serving",
+        ]).run(now: Self.reportNow)
+        XCTAssertEqual(incompatible.statusObservation.state, .contractIncompatible)
+        XCTAssertEqual(incompatible.findings.map(\.signatureID), ["serve_unresponsive"])
+    }
+
+    func testDoctorReportAttachesBelowFloorAsServeUnresponsiveEvidenceOnly() async {
+        let report = await diagnosticsRunner(
+            binaryVersion: "1.8.32",
+            status: nil,
+            healthz: DoctorHealthz(version: "v1.4.0", requiredBinaryVersion: "1.8.33", recommendedBinaryVersion: "1.8.65")
+        ).run(now: Self.reportNow)
+        XCTAssertEqual(report.versionFloorStanding, .belowFloor)
+        XCTAssertEqual(report.exitCode, DoctorDiagnosticsReportExit.providerAttention.rawValue)
+        XCTAssertEqual(report.findings.map(\.signatureID), ["serve_unresponsive"])
+        XCTAssertTrue(try! XCTUnwrap(report.findings.first?.evidence).contains("version_floor_standing=below_floor"))
+    }
+
+    func testDoctorReportJSONIsBackCompatAndDoesNotExposeConfigPathOrProviderID() async throws {
+        var config = AppConfig.defaults(configPath: "/Users/alice/.config/macprovider/config.yaml")
+        config.providerID = "provider-full-id-must-not-leak"
+        let report = await diagnosticsRunner(config: config, status: nil).run(now: Self.reportNow)
+        let stdout = captureStdout {
+            DoctorDiagnosticsReportPrinter.emitJSON(report)
+        }
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(stdout.utf8)) as? [String: Any])
+        XCTAssertEqual(object["schema"] as? String, DoctorDiagnosticsReportRunner.schema)
+        XCTAssertEqual(object["schema_version"] as? Int, 2)
+        XCTAssertEqual(object["minimum_reader_version"] as? Int, 1)
+        let findings = try XCTUnwrap(object["diagnostic_findings"] as? [[String: Any]])
+        XCTAssertEqual(findings.count, 1)
+        XCTAssertEqual(findings.first?["signature_id"] as? String, "serve_unresponsive")
+        XCTAssertFalse(stdout.contains("config_path"))
+        XCTAssertFalse(stdout.contains(config.configPath))
+        XCTAssertFalse(stdout.contains("provider-full-id-must-not-leak"))
+        XCTAssertFalse(stdout.contains("provider_id"))
+    }
+
+    func testDoctorReportConfigLoadFailureEmitsRedactedJSON() async throws {
+        let badPath = "/Users/alice/.config/macprovider/missing-config.yaml"
+        let command = try XCTUnwrap(DoctorCommand.parse([
+            "report", "--json", "--config", badPath,
+        ]))
+        let capture = await captureStdoutAsync {
+            try await command.run()
+        }
+        XCTAssertEqual(capture.error as? ExitCode, ExitCode(Int32(DoctorDiagnosticsReportExit.unknown.rawValue)))
+        XCTAssertFalse(capture.stdout.contains(badPath))
+        XCTAssertFalse(capture.stdout.contains("config_path"))
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(capture.stdout.utf8)) as? [String: Any])
+        XCTAssertEqual(object["schema"] as? String, DoctorDiagnosticsReportRunner.schema)
+        XCTAssertEqual(object["minimum_reader_version"] as? Int, 1)
+        let doctor = try XCTUnwrap(object["doctor"] as? [String: Any])
+        XCTAssertEqual(doctor["outcome"] as? String, "unknown")
+        let status = try XCTUnwrap(doctor["status_observation"] as? [String: Any])
+        XCTAssertEqual(status["reason"] as? String, "config_load_failed")
+        let findings = try XCTUnwrap(object["diagnostic_findings"] as? [[String: Any]])
+        XCTAssertTrue(findings.isEmpty)
+    }
+
+    func testDoctorReportRedactsLogsByConstruction() {
+        let nonSecret = DoctorReportRedactor.redactedForTest(
+            "provider process unhealthy at /Users/alice/macprovider-cli host=myhost.local ip=192.168.1.20\u{0007}",
+            usernameCandidates: ["alice"],
+            hostnameCandidates: ["myhost.local", "myhost"]
+        )
+        XCTAssertFalse(nonSecret.contains("/Users/alice"))
+        XCTAssertFalse(nonSecret.contains("alice"))
+        XCTAssertFalse(nonSecret.contains("myhost"))
+        XCTAssertFalse(nonSecret.contains("192.168.1.20"))
+        XCTAssertFalse(nonSecret.unicodeScalars.contains { $0.value <= 0x1F || (0x7F...0x9F).contains($0.value) })
+        XCTAssertTrue(nonSecret.contains("[path]"))
+        XCTAssertTrue(nonSecret.contains("[host]"))
+        XCTAssertTrue(nonSecret.contains("[ip]"))
+
+        XCTAssertEqual(
+            DoctorReportRedactor.redactedForTest(
+                "Authorization: Bearer abcdefghijklmnop provider_token=secret",
+                usernameCandidates: []
+            ),
+            "[redacted]"
+        )
+        XCTAssertEqual(
+            DoctorReportRedactor.redactedForTest(
+                "secret=abc credential=def x-secret-key=ghi",
+                usernameCandidates: []
+            ),
+            "[redacted]"
+        )
+        XCTAssertEqual(
+            DoctorReportRedactor.redactedForTest(
+                "status provider_id=mp-full-provider-id",
+                usernameCandidates: []
+            ),
+            "[redacted]"
+        )
+    }
+
+    func testDoctorReportAutoupdateConfigPrecedence() {
+        XCTAssertEqual(
+            DoctorLocalEvidenceCollector.effectiveAutoUpdateEnabled(
+                autoUpdateEnabled: false,
+                legacyAutoupdateEnabled: true
+            ).enabled,
+            false
+        )
+        XCTAssertEqual(
+            DoctorLocalEvidenceCollector.effectiveAutoUpdateEnabled(
+                autoUpdateEnabled: nil,
+                legacyAutoupdateEnabled: false
+            ).source,
+            "autoupdate.enabled"
+        )
+        XCTAssertTrue(DoctorLocalEvidenceCollector.effectiveAutoUpdateEnabled(
+            autoUpdateEnabled: nil,
+            legacyAutoupdateEnabled: nil
+        ).enabled)
+    }
+
+    func testDoctorReportTimeoutIsPassedToServeStatusProbe() async {
+        let seen = LockedBox<TimeInterval?>(nil)
+        _ = await diagnosticsRunner(
+            timeoutSeconds: 0.25,
+            statusFetch: { _, timeout in
+                seen.set(timeout)
+                return nil
+            }
+        ).run(now: Self.reportNow)
+        XCTAssertEqual(try XCTUnwrap(seen.get()), 0.25, accuracy: 0.001)
+    }
+
+    func testDoctorReportDoesNotEmitRawPlistLabels() async throws {
+        let report = await diagnosticsRunner(
+            status: nil,
+            localEvidence: {
+                DoctorLocalEvidence(
+                    autoUpdateEnabled: true,
+                    autoUpdateSource: "default_enabled",
+                    pendingUpdatePhase: nil,
+                    pendingMarkerDeadline: nil,
+                    launchd: DoctorLaunchdEvidence(
+                        providerPlist: DoctorPlistEvidence(
+                            present: true,
+                            labelMatchesExpected: false,
+                            programConfigured: false
+                        ),
+                        legacyProviderPlist: DoctorPlistEvidence(
+                            present: false,
+                            labelMatchesExpected: nil,
+                            programConfigured: false
+                        ),
+                        providerLaunchctl: DoctorLaunchctlEvidence(available: false, pid: nil, reason: "service_not_found")
+                    ),
+                    stat: [],
+                    logs: DoctorLogEvidence(provider: [], watchdog: [])
+                )
+            }
+        ).run(now: Self.reportNow)
+        let stdout = captureStdout {
+            DoctorDiagnosticsReportPrinter.emitJSON(report)
+        }
+        XCTAssertFalse(stdout.contains("label\""))
+        XCTAssertFalse(stdout.contains("/Users/alice"))
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(stdout.utf8)) as? [String: Any])
+        let doctor = try XCTUnwrap(object["doctor"] as? [String: Any])
+        let launchd = try XCTUnwrap(doctor["launchd"] as? [String: Any])
+        let plist = try XCTUnwrap(launchd["provider_plist"] as? [String: Any])
+        XCTAssertEqual(plist["label_matches_expected"] as? Bool, false)
+    }
+
+    func testDoctorReportReadOnlyCollectorCreatesNoFilesOrLocks() async throws {
+        let home = try temporaryDirectory(name: "doctor-report-readonly")
+        defer { try? FileManager.default.removeItem(at: home) }
+        let autoupdateRoot = home.appendingPathComponent(".local/share/macprovider/autoupdate", isDirectory: true)
+        let launchAgents = home.appendingPathComponent("Library/LaunchAgents", isDirectory: true)
+        let logs = home.appendingPathComponent("Library/Logs/macprovider", isDirectory: true)
+        try FileManager.default.createDirectory(at: autoupdateRoot, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: launchAgents, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: logs, withIntermediateDirectories: true)
+        try makePendingMarker().write(to: autoupdateRoot.appendingPathComponent("pending.json"))
+        try Data("""
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0"><dict>
+        <key>Label</key><string>live.malibu.provider</string>
+        <key>ProgramArguments</key><array><string>/Users/alice/macprovider-cli</string><string>serve</string></array>
+        </dict></plist>
+        """.utf8).write(to: launchAgents.appendingPathComponent("live.malibu.provider.plist"))
+        try Data("provider process unhealthy: launchd service live.malibu.provider has no validated PID at /Users/alice/macprovider-cli\n".utf8)
+            .write(to: logs.appendingPathComponent("macprovider.err.log"))
+        var config = AppConfig.defaults(configPath: home.appendingPathComponent(".config/macprovider/config.yaml").path)
+        config.autoUpdateEnabled = false
+        let collector = DoctorLocalEvidenceCollector(
+            homeDirectory: home,
+            launchctl: { _ in DoctorLaunchctlEvidence(available: false, pid: nil, reason: "service_not_found") }
+        )
+        let collectorConfig = config
+        let before = try treeSnapshot(home)
+        let report = await diagnosticsRunner(
+            config: config,
+            status: nil,
+            localEvidence: { collector.collect(config: collectorConfig) }
+        ).run(now: Self.reportNow)
+        let after = try treeSnapshot(home)
+        XCTAssertEqual(report.localEvidence.pendingUpdatePhase, CompatibilitySetTransactionState.activatingTarget.rawValue)
+        XCTAssertEqual(report.localEvidence.autoUpdateEnabled, false)
+        XCTAssertTrue(report.localEvidence.logs.provider.contains { $0.contains("[path]") })
+        XCTAssertFalse(report.localEvidence.logs.provider.joined(separator: "\n").contains("/Users/alice"))
+        XCTAssertEqual(before, after)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: autoupdateRoot.appendingPathComponent("update.lock").path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: home.appendingPathComponent(".config/macprovider/install.lock").path))
+    }
+
+    private func diagnosticsRunner(
+        binaryVersion: String = "1.8.65",
+        config: AppConfig = AppConfig.defaults(),
+        timeoutSeconds: TimeInterval = 1,
+        status: [String: Any]? = nil,
+        healthz: DoctorHealthz? = nil,
+        localEvidence: @escaping @Sendable () -> DoctorLocalEvidence = { DoctorCommandTests.emptyEvidence },
+        statusFetch: (@Sendable (Int, TimeInterval) async -> [String: Any]?)? = nil
+    ) -> DoctorDiagnosticsReportRunner {
+        var runnerConfig = config
+        if runnerConfig.coordinatorURL == nil {
+            runnerConfig.coordinatorURL = "wss://coordinator.malibu.tech/ws/provider"
+        }
+        let statusBox = LockedBox(status)
+        let healthzBox = LockedBox(healthz)
+        return DoctorDiagnosticsReportRunner(
+            binaryVersion: binaryVersion,
+            config: runnerConfig,
+            offline: false,
+            timeoutSeconds: timeoutSeconds,
+            statusFetch: statusFetch ?? { _, _ in statusBox.get() },
+            healthzFetch: { _ in healthzBox.get() },
+            localEvidence: localEvidence
+        )
+    }
+
+    private static var emptyEvidence: DoctorLocalEvidence {
+        DoctorLocalEvidence(
+            autoUpdateEnabled: true,
+            autoUpdateSource: "default_enabled",
+            pendingUpdatePhase: nil,
+            pendingMarkerDeadline: nil,
+            launchd: DoctorLaunchdEvidence(
+                providerPlist: DoctorPlistEvidence(present: false, labelMatchesExpected: nil, programConfigured: false),
+                legacyProviderPlist: DoctorPlistEvidence(present: false, labelMatchesExpected: nil, programConfigured: false),
+                providerLaunchctl: DoctorLaunchctlEvidence(available: false, pid: nil, reason: "service_not_found")
+            ),
+            stat: [],
+            logs: DoctorLogEvidence(provider: [], watchdog: [])
+        )
+    }
+
+    private func freshStatus(
+        networkState: String,
+        observedAt: Date = reportNow,
+        validForMS: Int = 5_000,
+        capabilities: [String] = ["buyer_serving_authority_v1", "status_observation_v1"]
+    ) -> [String: Any] {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return [
+            "local_status_contract": [
+                "version": 1,
+                "minimum_reader_version": 1,
+                "capabilities": capabilities,
+            ],
+            "observation": [
+                "id": "obs-1",
+                "observed_at": formatter.string(from: observedAt),
+                "valid_for_ms": validForMS,
+            ],
+            "network_state": networkState,
+        ]
+    }
+
+    private func temporaryDirectory(name: String) throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(name)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    private func makePendingMarker() throws -> Data {
+        let marker = AutoUpdatePendingMarker(
+            updateID: "00000000-0000-4000-8000-000000000000",
+            targetVersion: "1.8.66",
+            targetPath: "/tmp/macprovider-cli",
+            backupPath: "/tmp/macprovider-cli.backup",
+            size: 1,
+            mode: 0o755,
+            sha256: String(repeating: "a", count: 64),
+            markerDeadline: "2026-09-01T00:00:00Z",
+            transactionState: .activatingTarget
+        )
+        return try JSONEncoder().encode(marker)
+    }
+
+    private func treeSnapshot(_ root: URL) throws -> [String: String] {
+        guard let enumerator = FileManager.default.enumerator(
+            at: root,
+            includingPropertiesForKeys: [.isRegularFileKey, .isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return [:]
+        }
+        var snapshot: [String: String] = [:]
+        for case let url as URL in enumerator {
+            let relative = String(url.path.dropFirst(root.path.count + 1))
+            let values = try url.resourceValues(forKeys: [.isRegularFileKey, .isDirectoryKey])
+            if values.isDirectory == true {
+                snapshot[relative] = "dir"
+            } else if values.isRegularFile == true {
+                snapshot[relative] = String(decoding: try Data(contentsOf: url), as: UTF8.self)
+            }
+        }
+        return snapshot
+    }
+
+    private func captureStdout(_ body: () -> Void) -> String {
+        let pipe = Pipe()
+        let saved = dup(STDOUT_FILENO)
+        dup2(pipe.fileHandleForWriting.fileDescriptor, STDOUT_FILENO)
+        body()
+        fflush(stdout)
+        dup2(saved, STDOUT_FILENO)
+        close(saved)
+        pipe.fileHandleForWriting.closeFile()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    private func captureStdoutAsync(_ body: () async throws -> Void) async -> (stdout: String, error: Error?) {
+        let pipe = Pipe()
+        let saved = dup(STDOUT_FILENO)
+        dup2(pipe.fileHandleForWriting.fileDescriptor, STDOUT_FILENO)
+        var caught: Error?
+        do {
+            try await body()
+        } catch {
+            caught = error
+        }
+        fflush(stdout)
+        dup2(saved, STDOUT_FILENO)
+        close(saved)
+        pipe.fileHandleForWriting.closeFile()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        return (String(decoding: data, as: UTF8.self), caught)
     }
 }

--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -2521,20 +2521,23 @@
       "spec_id": "SPEC-035",
       "state": "pending",
       "implementation": [
-        "phase3-binary/app/Sources/Malibu/System/ProviderDiagnosticFinding.swift:enum ProviderDiagnosticSignatureID"
+        "phase3-binary/app/Sources/Malibu/System/ProviderDiagnosticFinding.swift:enum ProviderDiagnosticSignatureID",
+        "phase3-binary/Sources/macprovider-cli/DoctorCommand.swift:struct DoctorDiagnosticsReportRunner"
       ],
       "tests": [
         "phase3-binary/app/Tests/MalibuTests/ProviderDiagnosticFindingTests.swift:testClosedTaxonomyCoversProviderLogDiagnosticIDs",
         "phase3-binary/app/Tests/MalibuTests/ProviderDiagnosticFindingTests.swift:testClosedTaxonomyCoversExistingProviderLogAggregateIDs",
-        "phase3-binary/app/Tests/MalibuTests/ProviderDiagnosticFindingTests.swift:testUnknownSignatureIDsAreSkippedWhenMinimumReaderVersionIsSupported"
+        "phase3-binary/app/Tests/MalibuTests/ProviderDiagnosticFindingTests.swift:testUnknownSignatureIDsAreSkippedWhenMinimumReaderVersionIsSupported",
+        "phase3-binary/Tests/macprovider-cliTests/DoctorCommandTests.swift:testDoctorReportEmitsOnlyServeUnresponsiveWhenStatusUnavailable",
+        "phase3-binary/Tests/macprovider-cliTests/DoctorCommandTests.swift:testDoctorReportJSONIsBackCompatAndDoesNotExposeConfigPathOrProviderID"
       ],
       "journeys": [],
       "evidence": [],
       "gap": {
         "verdict": "UNKNOWN",
         "owner": "@Augustas11",
-        "issue": "https://github.com/Augustas11/macprovider/issues/1314",
-        "rationale": "Local closed diagnostic signature schema is implemented under Malibu app unit tests; production support-bundle collection and follow-up diagnostic sources remain deferred."
+        "issue": "https://github.com/Augustas11/macprovider/issues/1315",
+        "rationale": "Local closed diagnostic signature schema is implemented under Malibu app unit tests, and the CLI doctor report emits only the slice-2 serve_unresponsive source under Doctor tests; production support-bundle collection evidence remains deferred."
       }
     },
     {
@@ -2542,20 +2545,28 @@
       "spec_id": "SPEC-035",
       "state": "pending",
       "implementation": [
-        "phase3-binary/app/Sources/Malibu/System/ProviderDiagnosticFinding.swift:enum ProviderDiagnosticFindingAggregator"
+        "phase3-binary/app/Sources/Malibu/System/ProviderDiagnosticFinding.swift:enum ProviderDiagnosticFindingAggregator",
+        "phase3-binary/Sources/macprovider-cli/DoctorCommand.swift:static func findings",
+        "phase3-binary/Sources/macprovider-cli/DoctorCommand.swift:static func statusObservation"
       ],
       "tests": [
         "phase3-binary/app/Tests/MalibuTests/ProviderDiagnosticFindingTests.swift:testFreshStatusFindingsPrecedeSupplementalLogFindings",
         "phase3-binary/app/Tests/MalibuTests/ProviderDiagnosticFindingTests.swift:testCredentialStatusSubprocessCannotOverrideFreshServeCredentialState",
-        "phase3-binary/app/Tests/MalibuTests/ProviderDiagnosticFindingTests.swift:testStaleStatusAllowsDoctorServeDeadAndCredentialStatusFallbacks"
+        "phase3-binary/app/Tests/MalibuTests/ProviderDiagnosticFindingTests.swift:testStaleStatusAllowsDoctorServeDeadAndCredentialStatusFallbacks",
+        "phase3-binary/Tests/macprovider-cliTests/DoctorCommandTests.swift:testDoctorReportSuppressesFindingsWhenStatusIsFresh",
+        "phase3-binary/Tests/macprovider-cliTests/DoctorCommandTests.swift:testDoctorReportDoesNotTrustNetworkStateWithoutAuthorityCapability",
+        "phase3-binary/Tests/macprovider-cliTests/DoctorCommandTests.swift:testDoctorReportAllowlistsNetworkStateBeforeEmission",
+        "phase3-binary/Tests/macprovider-cliTests/DoctorCommandTests.swift:testDoctorReportDoesNotOverrideFreshStatusOwnedNetworkState",
+        "phase3-binary/Tests/macprovider-cliTests/DoctorCommandTests.swift:testDoctorReportContributesServeUnresponsiveForStaleOrIncompatibleStatus",
+        "phase3-binary/Tests/macprovider-cliTests/DoctorCommandTests.swift:testDoctorReportAttachesBelowFloorAsServeUnresponsiveEvidenceOnly"
       ],
       "journeys": [],
       "evidence": [],
       "gap": {
         "verdict": "UNKNOWN",
         "owner": "@Augustas11",
-        "issue": "https://github.com/Augustas11/macprovider/issues/1314",
-        "rationale": "Local source precedence is implemented under aggregator unit tests; slice-2 doctor report ingestion remains deferred."
+        "issue": "https://github.com/Augustas11/macprovider/issues/1315",
+        "rationale": "Local source precedence is implemented under aggregator unit tests; the CLI doctor report now suppresses doctor findings for fresh compatible /v1/status and contributes only serve_unresponsive when local status is unavailable, stale, or incompatible. Production support-bundle ingestion evidence remains deferred."
       }
     },
     {
@@ -2565,21 +2576,31 @@
       "implementation": [
         "phase3-binary/app/Sources/Malibu/MalibuApp.swift:private func exportDiagnostics()",
         "phase3-binary/app/Sources/Malibu/System/ProviderDiagnosticsBundle.swift:enum ProviderDiagnosticsBundle",
-        "phase3-binary/app/Sources/Malibu/System/LogTailReader.swift:struct LogTailBuffer"
+        "phase3-binary/app/Sources/Malibu/System/LogTailReader.swift:struct LogTailBuffer",
+        "phase3-binary/Sources/macprovider-cli/DoctorCommand.swift:enum DoctorDiagnosticsReportPrinter",
+        "phase3-binary/Sources/macprovider-cli/DoctorCommand.swift:enum DoctorReportRedactor",
+        "phase3-binary/Sources/macprovider-cli/DoctorCommand.swift:struct DoctorLocalEvidenceCollector"
       ],
       "tests": [
         "phase3-binary/app/Tests/MalibuTests/LogTailReaderTests.swift:testV2RedactionScrubsPrivateContextWithoutDroppingNonSecretLine",
         "phase3-binary/app/Tests/MalibuTests/ProviderDiagnosticsBundleTests.swift:testBundleIncludesLifecycleAndWatchdogEvidenceWithoutSecrets",
         "phase3-binary/app/Tests/MalibuTests/ProviderDiagnosticsBundleTests.swift:testBundleClassifiesRawWatchdogAndLaunchdRepairBeforeExportRedaction",
-        "phase3-binary/app/Tests/MalibuTests/AgentSnapshotPresenterTests.swift:testOnboardingAdvancedFailureDiagnosticsKeepsRedactedDetails"
+        "phase3-binary/app/Tests/MalibuTests/AgentSnapshotPresenterTests.swift:testOnboardingAdvancedFailureDiagnosticsKeepsRedactedDetails",
+        "phase3-binary/Tests/macprovider-cliTests/DoctorCommandTests.swift:testDoctorReportJSONCommandRemainsParseable",
+        "phase3-binary/Tests/macprovider-cliTests/DoctorCommandTests.swift:testDoctorReportJSONIsBackCompatAndDoesNotExposeConfigPathOrProviderID",
+        "phase3-binary/Tests/macprovider-cliTests/DoctorCommandTests.swift:testDoctorReportConfigLoadFailureEmitsRedactedJSON",
+        "phase3-binary/Tests/macprovider-cliTests/DoctorCommandTests.swift:testDoctorReportDoesNotEmitRawPlistLabels",
+        "phase3-binary/Tests/macprovider-cliTests/DoctorCommandTests.swift:testDoctorReportRedactsLogsByConstruction",
+        "phase3-binary/Tests/macprovider-cliTests/DoctorCommandTests.swift:testDoctorReportReadOnlyCollectorCreatesNoFilesOrLocks",
+        "phase3-binary/Tests/macprovider-cliTests/DoctorCommandTests.swift:testDoctorReportTimeoutIsPassedToServeStatusProbe"
       ],
       "journeys": [],
       "evidence": [],
       "gap": {
         "verdict": "UNKNOWN",
         "owner": "@Augustas11",
-        "issue": "https://github.com/Augustas11/macprovider/issues/1314",
-        "rationale": "Diagnostics bundle v2 and LogTailBuffer v2 redaction are implemented under Malibu app unit tests; production bundle collection evidence remains deferred."
+        "issue": "https://github.com/Augustas11/macprovider/issues/1315",
+        "rationale": "Diagnostics bundle v2 and LogTailBuffer v2 redaction are implemented under Malibu app unit tests; the CLI doctor report emits schema_version/minimum_reader_version, redacts report tails by construction, omits config_path/provider_id, and verifies read-only collection under Doctor tests. Production bundle collection evidence remains deferred."
       }
     },
     {


### PR DESCRIPTION
## Summary
- Add `macprovider-cli doctor report --json` as the read-only SPEC-035 fallback report for serve-dead / never-started cases.
- Emit schema v2 with `minimum_reader_version`, only `serve_unresponsive` from `doctor_report` when local `/v1/status` is unavailable/stale/incompatible, and redacted log/local evidence.
- Map the new CLI report implementation and Doctor tests into SPEC-035 conformance evidence.

## Tests
- `cd phase3-binary && swift build && swift test --filter Doctor`
- `python3 -m json.tool specs/CONFORMANCE.json`
- `git diff --check`
- isolated serve-down smoke: `doctor report --json --offline --timeout-seconds 0.05 --config <tmp>` emitted schema v2, `serve_unresponsive`, exit 1, no config/provider-id leakage

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "issue": "https://github.com/Augustas11/macprovider/issues/1315",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": ["SPEC-035"],
  "requirements": ["SPEC-035-R010", "SPEC-035-R011", "SPEC-035-R012"],
  "authority_domains": ["provider-connection-diagnostics"],
  "arbitration": ["UNKNOWN"],
  "tests": [
    "phase3-binary/Tests/macprovider-cliTests/DoctorCommandTests.swift::testDoctorReportJSONCommandRemainsParseable",
    "phase3-binary/Tests/macprovider-cliTests/DoctorCommandTests.swift::testDoctorReportEmitsOnlyServeUnresponsiveWhenStatusUnavailable",
    "phase3-binary/Tests/macprovider-cliTests/DoctorCommandTests.swift::testDoctorReportSuppressesFindingsWhenStatusIsFresh",
    "phase3-binary/Tests/macprovider-cliTests/DoctorCommandTests.swift::testDoctorReportDoesNotTrustNetworkStateWithoutAuthorityCapability",
    "phase3-binary/Tests/macprovider-cliTests/DoctorCommandTests.swift::testDoctorReportDoesNotEmitRawPlistLabels",
    "phase3-binary/Tests/macprovider-cliTests/DoctorCommandTests.swift::testDoctorReportConfigLoadFailureEmitsRedactedJSON",
    "phase3-binary/Tests/macprovider-cliTests/DoctorCommandTests.swift::testDoctorReportAllowlistsNetworkStateBeforeEmission",
    "phase3-binary/Tests/macprovider-cliTests/DoctorCommandTests.swift::testDoctorReportContributesServeUnresponsiveForStaleOrIncompatibleStatus",
    "phase3-binary/Tests/macprovider-cliTests/DoctorCommandTests.swift::testDoctorReportJSONIsBackCompatAndDoesNotExposeConfigPathOrProviderID",
    "phase3-binary/Tests/macprovider-cliTests/DoctorCommandTests.swift::testDoctorReportReadOnlyCollectorCreatesNoFilesOrLocks"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END
