### PR TITLE
Fence Malibu provider repair behind diagnostics capability

### DIFF
--- a/phase3-binary/app/Sources/Malibu/Agent/AgentSnapshot.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/AgentSnapshot.swift
@@ -168,6 +168,7 @@ struct AgentSnapshot: Equatable {
     var providerSoftwareRepairRecommended: Bool
     var providerSoftwareRepairInProgress: Bool
     var providerSoftwareRepairLastError: String?
+    var diagnosticFindings: [ProviderDiagnosticFinding] = []
     /// Dashboard-triggered online recommend/apply/submit for #582 hello-gate recovery.
     var hardwareVerificationRetryInProgress: Bool = false
     var hardwareVerificationRetryLastError: String? = nil
@@ -518,8 +519,18 @@ struct AgentSnapshot: Equatable {
         providerSoftwareRepairRecommended: false,
         providerSoftwareRepairInProgress: false,
         providerSoftwareRepairLastError: nil,
+        diagnosticFindings: [],
         pauseAcknowledged: false
     )
+}
+
+enum ProviderSoftwareRepairCapabilityGate {
+    static let repairFromProtectedSource = "provider_software_repair_from_protected_source_v1"
+
+    static func allowsProtectedSourceRepair(_ s: AgentSnapshot, at now: Date = Date()) -> Bool {
+        s.hasFreshContractValidatedStatusObservation(at: now)
+            && s.localStatusCapabilities.contains(repairFromProtectedSource)
+    }
 }
 
 enum AgentSnapshotPresenter {
@@ -851,6 +862,9 @@ enum AgentSnapshotPresenter {
                 detail: "Malibu is reinstalling the bundled provider software and watchdog. Keep Malibu open. Your identity, models, and payout stay on this Mac.",
                 safeNextAction: "Keep Malibu open. You do not need a new invite."
             )
+        }
+        if let diagnostic = publicStatusForTopDiagnosticFinding(s) {
+            return diagnostic
         }
         // A still-serving (or paused) CLI must keep earnings/traffic/USDC and
         // the ready/paused truth. HOME-ACL repair is a software update, not a
@@ -1796,8 +1810,186 @@ enum AgentSnapshotPresenter {
 
     static func canRepairProviderSoftware(_ s: AgentSnapshot) -> Bool {
         s.providerSoftwareRepairRecommended
+            && ProviderSoftwareRepairCapabilityGate.allowsProtectedSourceRepair(s)
             && !s.providerSoftwareRepairInProgress
             && !s.cliUpdateInProgress
+    }
+
+    static func diagnosticFindingLines(_ s: AgentSnapshot) -> [String] {
+        s.diagnosticFindings.map { finding in
+            let title = diagnosticTitle(finding)
+            let cause = diagnosticCause(finding)
+            let context = diagnosticContext(finding, snapshot: s)
+            return ([title, LogTailBuffer.redacted(finding.userMessage), "Cause: \(cause)"] + context)
+                .joined(separator: " · ")
+        }
+    }
+
+    private static func publicStatusForTopDiagnosticFinding(_ s: AgentSnapshot) -> PublicStatus? {
+        guard let finding = s.diagnosticFindings.first(where: { canUseAsPrimaryDiagnosticStatus($0, snapshot: s) }) else {
+            return nil
+        }
+        switch finding.signatureID {
+        case .credentialStoreUnavailable:
+            return PublicStatus(
+                title: "Provider access needs attention",
+                detail: LogTailBuffer.redacted(finding.userMessage),
+                safeNextAction: canRepairCredential(s)
+                    ? "Repair saved access."
+                    : "Unlock or authorize saved access, then retry. Your provider identity stays on this Mac.",
+                executableAction: canRepairCredential(s) ? .repairCredential : nil
+            )
+        case .admissionIdentityBlocked:
+            return PublicStatus(
+                title: "Network verification needs attention",
+                detail: LogTailBuffer.redacted(finding.userMessage),
+                safeNextAction: canRepairAdmissionIdentity(s)
+                    ? "\(admissionIdentityRepairButtonTitle(s))."
+                    : "Keep the current provider identity and export diagnostics for support.",
+                executableAction: canRepairAdmissionIdentity(s) ? .repairAdmissionIdentity : .exportDiagnostics
+            )
+        case .autoupdateInProgress:
+            return PublicStatus(
+                title: "Provider software update in progress",
+                detail: LogTailBuffer.redacted(finding.userMessage),
+                safeNextAction: "Keep Malibu open. You do not need a new invite."
+            )
+        case .serveUnresponsive:
+            return PublicStatus(
+                title: serveUnresponsiveTitle(finding),
+                detail: serveUnresponsiveDetail(finding),
+                safeNextAction: "Keep Malibu open while status updates. Export diagnostics if this persists.",
+                executableAction: .exportDiagnostics
+            )
+        case .autoupdateHomeACLRejected:
+            if canRepairProviderSoftware(s) {
+                return PublicStatus(
+                    title: "Provider software repair available",
+                    detail: "A permission on your home folder blocked automatic update recovery.",
+                    safeNextAction: "Repair provider software. Malibu will reinstall the bundled provider software and watchdog. Your provider identity and downloaded models will be kept.",
+                    executableAction: .repairProviderSoftware
+                )
+            }
+            return PublicStatus(
+                title: "Provider software repair pending",
+                detail: "A macOS folder permission blocked automatic update recovery.",
+                safeNextAction: "Repair is pending protected delivery. Export diagnostics for support; your provider identity and downloaded models stay on this Mac.",
+                executableAction: .exportDiagnostics
+            )
+        case .staleLaunchAgent:
+            return PublicStatus(
+                title: "Provider setup needs attention",
+                detail: LogTailBuffer.redacted(finding.userMessage),
+                safeNextAction: "Use Launch Provider or export diagnostics. Your provider identity and downloaded models stay on this Mac.",
+                executableAction: .exportDiagnostics
+            )
+        case .staleModelCatalog, .catalogAdmission, .rateCardAdmission, .catalogKeyMismatch,
+             .missingCatalogProvenance, .missingArtifactSHA, .snapshotPathMismatch:
+            return PublicStatus(
+                title: "Provider software update needed",
+                detail: LogTailBuffer.redacted(finding.userMessage),
+                safeNextAction: updateAvailable(s)
+                    ? "Install latest provider software. Your provider identity and downloaded models stay on this Mac."
+                    : "Export diagnostics for support. Your provider identity and downloaded models stay on this Mac.",
+                executableAction: updateAvailable(s) ? .updateProviderSoftware : .exportDiagnostics
+            )
+        case .artifactHashMismatch, .artifactVerificationFailed:
+            return PublicStatus(
+                title: "Model verification needs attention",
+                detail: LogTailBuffer.redacted(finding.userMessage),
+                safeNextAction: "Pick the recommended model again or export diagnostics. Your provider identity stays on this Mac.",
+                executableAction: .exportDiagnostics
+            )
+        case .autoupdateDisabled:
+            return PublicStatus(
+                title: "Provider automatic updates are disabled",
+                detail: LogTailBuffer.redacted(finding.userMessage),
+                safeNextAction: "Enable provider software updates, then retry. Your provider identity stays on this Mac.",
+                executableAction: .exportDiagnostics
+            )
+        }
+    }
+
+    private static func canUseAsPrimaryDiagnosticStatus(
+        _ finding: ProviderDiagnosticFinding,
+        snapshot s: AgentSnapshot
+    ) -> Bool {
+        switch finding.source {
+        case .status:
+            return true
+        case .credentialsStatus:
+            return !s.hasFreshServeOwnedCredentialState()
+        case .doctorReport, .appPollingHistory, .providerLogDiagnostics:
+            return !s.hasFreshContractValidatedStatusObservation()
+        }
+    }
+
+    private static func diagnosticTitle(_ finding: ProviderDiagnosticFinding) -> String {
+        switch finding.signatureID {
+        case .credentialStoreUnavailable: return "Provider access"
+        case .admissionIdentityBlocked: return "Network verification"
+        case .serveUnresponsive: return "Customer availability"
+        case .autoupdateInProgress: return "Provider software update"
+        case .autoupdateHomeACLRejected: return "Provider software repair pending"
+        case .staleLaunchAgent: return "Background service"
+        case .staleModelCatalog, .catalogAdmission, .rateCardAdmission, .catalogKeyMismatch,
+             .missingCatalogProvenance, .missingArtifactSHA, .snapshotPathMismatch:
+            return "Provider software"
+        case .artifactHashMismatch, .artifactVerificationFailed:
+            return "Model verification"
+        case .autoupdateDisabled:
+            return "Automatic updates"
+        }
+    }
+
+    private static func diagnosticCause(_ finding: ProviderDiagnosticFinding) -> String {
+        switch finding.signatureID {
+        case .serveUnresponsive:
+            return hasNetworkStateEvidence(finding) ? "status_context" : "unknown_cause"
+        case .autoupdateHomeACLRejected:
+            return "repair_delivery_pending"
+        default:
+            return finding.signatureID.rawValue
+        }
+    }
+
+    private static func diagnosticContext(
+        _ finding: ProviderDiagnosticFinding,
+        snapshot s: AgentSnapshot
+    ) -> [String] {
+        guard finding.signatureID == .serveUnresponsive,
+              hasNetworkStateEvidence(finding) else { return [] }
+        if let networkState = s.networkState {
+            return ["Network context: \(networkStateLabel(networkState))"]
+        }
+        return []
+    }
+
+    private static func serveUnresponsiveTitle(_ finding: ProviderDiagnosticFinding) -> String {
+        hasNetworkStateEvidence(finding)
+            ? "Customer availability is interrupted"
+            : "Provider status is unavailable"
+    }
+
+    private static func serveUnresponsiveDetail(_ finding: ProviderDiagnosticFinding) -> String {
+        if hasNetworkStateEvidence(finding) {
+            return "Provider local status is current, but customer availability is not confirmed. This is context, not a diagnosed root cause."
+        }
+        return "Malibu cannot confirm current provider status. Cause unknown."
+    }
+
+    private static func hasNetworkStateEvidence(_ finding: ProviderDiagnosticFinding) -> Bool {
+        finding.evidence?.hasPrefix("network_state=") == true
+    }
+
+    private static func networkStateLabel(_ state: String) -> String {
+        switch state {
+        case "not_buyer_serving": return "not receiving customer work"
+        case "buyer_serving_unknown": return "customer availability unknown"
+        case "network_offline": return "network offline"
+        case "coordinator_unavailable": return "network unavailable"
+        default: return state.replacingOccurrences(of: "_", with: " ")
+        }
     }
 
     private static func isLiveProviderVisibleDuringSoftwareRepair(_ s: AgentSnapshot) -> Bool {
@@ -1808,13 +2000,23 @@ enum AgentSnapshotPresenter {
         _ status: PublicStatus,
         _ s: AgentSnapshot
     ) -> PublicStatus {
-        guard canRepairProviderSoftware(s) else { return status }
+        if canRepairProviderSoftware(s) {
+            return PublicStatus(
+                title: status.title,
+                detail: status.detail,
+                safeNextAction:
+                    "Repair provider software. Malibu will reinstall the bundled provider software and watchdog. Your provider identity and downloaded models will be kept.",
+                executableAction: .repairProviderSoftware
+            )
+        }
+        guard s.diagnosticFindings.contains(where: { $0.signatureID == .autoupdateHomeACLRejected }) else {
+            return status
+        }
         return PublicStatus(
             title: status.title,
             detail: status.detail,
-            safeNextAction:
-                "Repair provider software. Malibu will reinstall the bundled provider software and watchdog. Your provider identity and downloaded models will be kept.",
-            executableAction: .repairProviderSoftware
+            safeNextAction: "Provider software repair pending. Export diagnostics for support; your provider identity and downloaded models stay on this Mac.",
+            executableAction: .exportDiagnostics
         )
     }
 

--- a/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
@@ -49,6 +49,7 @@ final class MalibuAgent: ObservableObject {
     private var latestReleaseFetchedAt: Date?
     private var cliUpdateTask: Task<Void, Never>?
     private var providerSoftwareRepairTask: Task<Void, Never>?
+    private var suppressedProviderSoftwareRepairEvidenceLine: String?
     /// HOME-ACL stranded installs get one automatic repair attempt per session
     /// so a sideloaded Malibu.app actually lands the bundled watchdog/CLI.
     private var homeACLAutoRepairAttempted = false
@@ -67,6 +68,16 @@ final class MalibuAgent: ObservableObject {
         _ compatibilitySetID: String?,
         _ onLogLine: @escaping @Sendable @MainActor (String) -> Void
     ) async throws -> Void
+    private let providerSoftwareRepairRunner: @Sendable (
+        _ onLogLine: @escaping @Sendable @MainActor (String) -> Void
+    ) async throws -> Void
+    private let recoveryDiagnosticsBundleWriter: @Sendable @MainActor (
+        _ snapshot: AgentSnapshot,
+        _ providerLogLines: [String],
+        _ watchdogLogURL: URL?,
+        _ launchdNeedsRepair: Bool,
+        _ appVersion: String
+    ) throws -> URL
     private var lastReferralRefreshRequestedAt: Date?
     private let latestReleaseTTL: TimeInterval = 3600
 
@@ -83,11 +94,38 @@ final class MalibuAgent: ObservableObject {
                 compatibilitySetID: compatibilitySetID,
                 onLogLine: onLogLine
             )
+        },
+        providerSoftwareRepairRunner: @escaping @Sendable (
+            _ onLogLine: @escaping @Sendable @MainActor (String) -> Void
+        ) async throws -> Void = { onLogLine in
+            try await CLIInstallRunner.run(
+                referralCode: nil,
+                replacingIncumbentProvider: false,
+                repairExistingInstall: true,
+                onLogLine: onLogLine
+            )
+        },
+        recoveryDiagnosticsBundleWriter: @escaping @Sendable @MainActor (
+            _ snapshot: AgentSnapshot,
+            _ providerLogLines: [String],
+            _ watchdogLogURL: URL?,
+            _ launchdNeedsRepair: Bool,
+            _ appVersion: String
+        ) throws -> URL = { snapshot, providerLogLines, watchdogLogURL, launchdNeedsRepair, appVersion in
+            try ProviderRecoveryDiagnosticsBundle.write(
+                snapshot: snapshot,
+                providerLogLines: providerLogLines,
+                watchdogLogURL: watchdogLogURL,
+                launchdNeedsRepair: launchdNeedsRepair,
+                appVersion: appVersion
+            )
         }
     ) {
         snapshot = initialSnapshot
         providerProjectionEligible = projectionEligibleForMetrics
         self.cliUpdateRunner = cliUpdateRunner
+        self.providerSoftwareRepairRunner = providerSoftwareRepairRunner
+        self.recoveryDiagnosticsBundleWriter = recoveryDiagnosticsBundleWriter
         thermalMonitor.$state
             .sink { [weak self] state in
                 self?.snapshot.thermalState = state
@@ -322,6 +360,7 @@ final class MalibuAgent: ObservableObject {
                 self.snapshot.hardwareVerificationRetryLastError =
                     AgentSnapshotPresenter.publicErrorDetail(error.localizedDescription)
                     ?? "Provider setup could not be completed. Export diagnostics for support."
+                self.assembleRecoveryDiagnosticsBundle()
             }
         }
         await hardwareVerificationRetryTask?.value
@@ -376,6 +415,10 @@ final class MalibuAgent: ObservableObject {
             await previous.value
         }
         guard !isShuttingDown, !Task.isCancelled else { return }
+        let attemptedRepairEvidenceLine = providerSoftwareRepairEvidenceLine(
+            watchdogLogLines: watchdogLogLines,
+            watchdogLogURL: ProviderPaths.current.watchdogLog
+        )
         snapshot.providerSoftwareRepairInProgress = true
         snapshot.providerSoftwareRepairLastError = nil
         providerSoftwareRepairTask = Task { [weak self] in
@@ -383,23 +426,22 @@ final class MalibuAgent: ObservableObject {
             defer {
                 if !self.isShuttingDown {
                     self.snapshot.providerSoftwareRepairInProgress = false
+                    self.refreshDiagnosticFindings()
                 }
             }
             do {
-                try await CLIInstallRunner.run(
-                    referralCode: nil,
-                    replacingIncumbentProvider: false,
-                    repairExistingInstall: true
-                ) { line in
+                try await self.providerSoftwareRepairRunner { line in
                     self.logLines.append(LogTailBuffer.redacted(line))
                     if self.logLines.count > 400 {
                         self.logLines.removeFirst(self.logLines.count - 400)
                     }
+                    self.refreshDiagnosticFindings()
                 }
                 guard !Task.isCancelled, !self.isShuttingDown else { return }
                 self.snapshot.providerSoftwareRepairLastError = nil
                 self.snapshot.providerSoftwareRepairRecommended = false
                 self.recordProviderSoftwareInstallHandledAutoupdateACL()
+                self.watchdogLogLines.append(ProviderLogDiagnostics.providerSoftwareInstallHandledAutoupdateACLMarker)
                 do {
                     try await ProviderConfig.importExistingCLIConfig()
                 } catch {
@@ -415,6 +457,12 @@ final class MalibuAgent: ObservableObject {
             } catch {
                 guard !Task.isCancelled, !self.isShuttingDown else { return }
                 self.snapshot.providerSoftwareRepairLastError = error.localizedDescription
+                self.suppressedProviderSoftwareRepairEvidenceLine = attemptedRepairEvidenceLine
+                self.snapshot.providerSoftwareRepairRecommended = false
+                self.snapshot.providerSoftwareRepairInProgress = false
+                self.assembleRecoveryDiagnosticsBundle()
+                self.recordProviderSoftwareInstallFailedAutoupdateACL()
+                self.watchdogLogLines.append(ProviderLogDiagnostics.providerSoftwareInstallFailedAutoupdateACLMarker)
             }
         }
         await providerSoftwareRepairTask?.value
@@ -431,13 +479,30 @@ final class MalibuAgent: ObservableObject {
     }
 
     private func recordProviderSoftwareInstallHandledAutoupdateACL(paths: ProviderPaths = .current) {
+        recordProviderSoftwareInstallAutoupdateACLMarker(
+            ProviderLogDiagnostics.providerSoftwareInstallHandledAutoupdateACLMarker,
+            paths: paths
+        )
+    }
+
+    private func recordProviderSoftwareInstallFailedAutoupdateACL(paths: ProviderPaths = .current) {
+        recordProviderSoftwareInstallAutoupdateACLMarker(
+            ProviderLogDiagnostics.providerSoftwareInstallFailedAutoupdateACLMarker,
+            paths: paths
+        )
+    }
+
+    private func recordProviderSoftwareInstallAutoupdateACLMarker(
+        _ marker: String,
+        paths: ProviderPaths = .current
+    ) {
         do {
             try FileManager.default.createDirectory(
                 at: paths.watchdogLog.deletingLastPathComponent(),
                 withIntermediateDirectories: true
             )
             let timestamp = ISO8601DateFormatter().string(from: Date())
-            let line = "[\(timestamp)] \(ProviderLogDiagnostics.providerSoftwareInstallHandledAutoupdateACLMarker)\n"
+            let line = "[\(timestamp)] \(marker)\n"
             let data = Data(line.utf8)
             if FileManager.default.fileExists(atPath: paths.watchdogLog.path) {
                 let handle = try FileHandle(forWritingTo: paths.watchdogLog)
@@ -483,6 +548,7 @@ final class MalibuAgent: ObservableObject {
                 guard !Task.isCancelled, !self.isShuttingDown else { return }
                 self.snapshot.credentialRepairLastError = error.localizedDescription
                 await self.refreshCredentialDiagnosis()
+                self.assembleRecoveryDiagnosticsBundle()
             }
             if !self.isShuttingDown {
                 self.snapshot.credentialRepairInProgress = false
@@ -548,6 +614,7 @@ final class MalibuAgent: ObservableObject {
             } catch {
                 guard !Task.isCancelled, !self.isShuttingDown else { return }
                 self.snapshot.admissionIdentityRecoveryLastError = error.localizedDescription
+                self.assembleRecoveryDiagnosticsBundle()
             }
             if !self.isShuttingDown {
                 self.snapshot.admissionIdentityRecoveryInProgress = false
@@ -785,6 +852,7 @@ final class MalibuAgent: ObservableObject {
         }
         reconcileNetworkState(localReady: localReady)
         await refreshLatestReleaseIfNeeded()
+        refreshDiagnosticFindings()
     }
 
     private func refreshCredentialDiagnosis() async {
@@ -834,6 +902,7 @@ final class MalibuAgent: ObservableObject {
         snapshot.credentialRecoveryAction = credential.action
         snapshot.credentialStatusObservedAt = Date()
         snapshot.credentialStatusFromDiagnostic = true
+        refreshDiagnosticFindings()
     }
 
     /// Local /v1/health readiness only — coordinator session is reconciled separately.
@@ -1640,23 +1709,40 @@ final class MalibuAgent: ObservableObject {
         let tail = ProviderLogTail()
         providerLogTailCancellable = tail.$lines
             .sink { [weak self] lines in
-                self?.logLines = lines
+                self?.applyProviderLogLines(lines)
             }
         watchdogLogTailCancellable = tail.$watchdogLines
             .sink { [weak self] lines in
                 guard let self else { return }
-                self.watchdogLogLines = lines
-                self.snapshot.providerSoftwareRepairRecommended =
-                    ProviderLogDiagnostics.homeAutoupdateACLRejection(lines: lines) != nil
-                    || ProviderLogDiagnostics.homeAutoupdateACLRejection(logFile: paths.watchdogLog) != nil
+                self.applyWatchdogLogLines(lines, paths: paths)
                 self.scheduleHomeACLAutoRepairIfNeeded()
             }
         providerLogTail = tail
         tail.start(paths: paths)
         if ProviderLogDiagnostics.homeAutoupdateACLRejection(logFile: paths.watchdogLog) != nil {
             snapshot.providerSoftwareRepairRecommended = true
+            refreshDiagnosticFindings(watchdogLogURL: paths.watchdogLog)
             scheduleHomeACLAutoRepairIfNeeded()
         }
+    }
+
+    func applyProviderLogTailsForTest(
+        providerLogLines: [String],
+        watchdogLogLines: [String],
+        launchdNeedsRepair: Bool = false,
+        now: Date = Date()
+    ) {
+        applyProviderLogLines(providerLogLines, launchdNeedsRepair: launchdNeedsRepair, now: now)
+        applyWatchdogLogLines(watchdogLogLines, paths: nil, launchdNeedsRepair: launchdNeedsRepair, now: now)
+        scheduleHomeACLAutoRepairIfNeeded()
+    }
+
+    func allowHomeACLAutoRepairForTest() {
+        homeACLAutoRepairAllowed = true
+    }
+
+    var providerSoftwareRepairTaskScheduledForTest: Bool {
+        providerSoftwareRepairTask != nil
     }
 
     private func stopProviderLogTail() {
@@ -1667,6 +1753,87 @@ final class MalibuAgent: ObservableObject {
         providerLogTail?.stop()
         providerLogTail = nil
         watchdogLogLines = []
+        snapshot.diagnosticFindings = []
+    }
+
+    private func applyProviderLogLines(
+        _ lines: [String],
+        launchdNeedsRepair: Bool? = nil,
+        now: Date = Date()
+    ) {
+        logLines = lines
+        refreshDiagnosticFindings(launchdNeedsRepair: launchdNeedsRepair, now: now)
+    }
+
+    private func applyWatchdogLogLines(
+        _ lines: [String],
+        paths: ProviderPaths?,
+        launchdNeedsRepair: Bool? = nil,
+        now: Date = Date()
+    ) {
+        watchdogLogLines = lines
+        let evidenceLine = providerSoftwareRepairEvidenceLine(
+            watchdogLogLines: lines,
+            watchdogLogURL: paths?.watchdogLog
+        )
+        if evidenceLine != nil && evidenceLine != suppressedProviderSoftwareRepairEvidenceLine {
+            suppressedProviderSoftwareRepairEvidenceLine = nil
+        }
+        snapshot.providerSoftwareRepairRecommended = evidenceLine != nil
+            && evidenceLine != suppressedProviderSoftwareRepairEvidenceLine
+        refreshDiagnosticFindings(watchdogLogURL: paths?.watchdogLog, launchdNeedsRepair: launchdNeedsRepair, now: now)
+    }
+
+    private func refreshDiagnosticFindings(
+        watchdogLogURL: URL? = nil,
+        launchdNeedsRepair: Bool? = nil,
+        now: Date = Date()
+    ) {
+        var diagnosticWatchdogLines = watchdogLogLines
+        if let watchdogLogURL,
+           let fileFinding = ProviderLogDiagnostics.homeAutoupdateACLRejection(logFile: watchdogLogURL) {
+            diagnosticWatchdogLines.append(fileFinding.matchedLine)
+        }
+        snapshot.diagnosticFindings = ProviderDiagnosticFindingAggregator.aggregate(
+            snapshot: snapshot,
+            providerLogLines: logLines,
+            watchdogLogLines: diagnosticWatchdogLines,
+            launchdNeedsRepair: launchdNeedsRepair ?? currentLaunchdNeedsRepair(),
+            now: now
+        )
+    }
+
+    private func providerSoftwareRepairEvidenceLine(
+        watchdogLogLines: [String],
+        watchdogLogURL: URL?
+    ) -> String? {
+        ProviderLogDiagnostics.homeAutoupdateACLRejection(lines: watchdogLogLines)?.matchedLine
+            ?? watchdogLogURL.flatMap { ProviderLogDiagnostics.homeAutoupdateACLRejection(logFile: $0)?.matchedLine }
+    }
+
+    private func currentLaunchdNeedsRepair() -> Bool {
+        StartupState.launchdInstallEvidenceExists()
+            && InstalledProviderMonitor.launchdServiceRepairState().needsRepair
+    }
+
+    @discardableResult
+    private func assembleRecoveryDiagnosticsBundle() -> URL? {
+        refreshDiagnosticFindings(watchdogLogURL: ProviderPaths.current.watchdogLog)
+        do {
+            return try recoveryDiagnosticsBundleWriter(
+                snapshot,
+                logLines,
+                ProviderPaths.current.watchdogLog,
+                currentLaunchdNeedsRepair(),
+                ProviderRecoveryDiagnosticsBundle.appVersion()
+            )
+        } catch {
+            logLines.append("Recovery diagnostics bundle could not be assembled.")
+            if logLines.count > 400 {
+                logLines.removeFirst(logLines.count - 400)
+            }
+            return nil
+        }
     }
 
     private func diagnosedProviderFailure(includingLaunchdState: Bool = false) -> String? {

--- a/phase3-binary/app/Sources/Malibu/Dashboard/DashboardWindow.swift
+++ b/phase3-binary/app/Sources/Malibu/Dashboard/DashboardWindow.swift
@@ -91,6 +91,7 @@ enum DashboardCopy {
 
     static func advancedDiagnosticsStrings(_ snapshot: AgentSnapshot, logLines: [String]) -> [String] {
         var strings = ["Advanced diagnostics"]
+        strings.append(contentsOf: AgentSnapshotPresenter.diagnosticFindingLines(snapshot))
         strings.append(contentsOf: logLines.map(LogTailBuffer.redacted))
         strings.append(AgentSnapshotPresenter.modelLine(snapshot))
         strings.append(AgentSnapshotPresenter.compatibilitySetLine(snapshot))
@@ -409,6 +410,16 @@ private struct DashboardView: View {
                                             ? Color.secondary
                                             : Color.red
                                     )
+                            }
+                            ForEach(
+                                Array(AgentSnapshotPresenter.diagnosticFindingLines(agent.snapshot).enumerated()),
+                                id: \.offset
+                            ) { _, line in
+                                Text(line)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                    .fixedSize(horizontal: false, vertical: true)
+                                    .textSelection(.enabled)
                             }
                             if !agent.logLines.isEmpty {
                                 LogTailView(lines: agent.logLines)

--- a/phase3-binary/app/Sources/Malibu/System/ProviderLogDiagnostics.swift
+++ b/phase3-binary/app/Sources/Malibu/System/ProviderLogDiagnostics.swift
@@ -4,6 +4,8 @@ import Foundation
 enum ProviderLogDiagnostics {
     static let providerSoftwareInstallHandledAutoupdateACLMarker =
         "autoupdate acl_home_repair_handled=malibu_provider_software_install_success"
+    static let providerSoftwareInstallFailedAutoupdateACLMarker =
+        "autoupdate acl_home_repair_handled=malibu_provider_software_install_failed"
 
     static let staleLaunchAgentMessage =
         "Provider setup is blocked by a previous installation. "
@@ -106,6 +108,7 @@ enum ProviderLogDiagnostics {
         for line in lines.reversed() {
             let lower = line.lowercased()
             if lower.contains(providerSoftwareInstallHandledAutoupdateACLMarker)
+                || lower.contains(providerSoftwareInstallFailedAutoupdateACLMarker)
                 || lower.contains("autoupdate lifecycle_transition=watchdog_recovery ") {
                 return nil
             }
@@ -116,7 +119,7 @@ enum ProviderLogDiagnostics {
                 return Finding(
                     id: "autoupdate_home_acl_rejected",
                     userMessage:
-                        "Provider software repair is needed. A macOS folder permission is blocking automatic update recovery; Malibu can repair the provider software while keeping your provider identity and downloaded model files.",
+                        "Provider software repair is pending. A macOS folder permission is blocking automatic update recovery; protected repair delivery is not available yet. Your provider identity and downloaded model files stay on this Mac.",
                     matchedLine: line
                 )
             }
@@ -126,7 +129,7 @@ enum ProviderLogDiagnostics {
             return Finding(
                 id: "autoupdate_home_acl_rejected",
                 userMessage:
-                    "Provider software repair is needed. A macOS folder permission is blocking automatic update recovery; Malibu can repair the provider software while keeping your provider identity and downloaded model files.",
+                    "Provider software repair is pending. A macOS folder permission is blocking automatic update recovery; protected repair delivery is not available yet. Your provider identity and downloaded model files stay on this Mac.",
                 matchedLine: line
             )
         }

--- a/phase3-binary/app/Sources/Malibu/System/ProviderRecoveryDiagnosticsBundle.swift
+++ b/phase3-binary/app/Sources/Malibu/System/ProviderRecoveryDiagnosticsBundle.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+enum ProviderRecoveryDiagnosticsBundle {
+    static func write(
+        snapshot: AgentSnapshot,
+        providerLogLines: [String],
+        watchdogLogURL: URL?,
+        launchdNeedsRepair: Bool,
+        appVersion: String,
+        paths: ProviderPaths = .current,
+        now: Date = Date()
+    ) throws -> URL {
+        let directory = paths.appSupport.appendingPathComponent("Diagnostics", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: directory.path)
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyyMMdd-HHmmss"
+        let destination = directory
+            .appendingPathComponent("malibu-recovery-failure-\(formatter.string(from: now)).json")
+        let data = try ProviderDiagnosticsBundle.make(
+            snapshot: snapshot,
+            providerLogLines: providerLogLines,
+            watchdogLogURL: watchdogLogURL,
+            appVersion: appVersion,
+            launchdNeedsRepair: launchdNeedsRepair,
+            now: now
+        )
+        try data.write(to: destination, options: [.atomic])
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: destination.path)
+        return destination
+    }
+
+    static func appVersion(bundle: Bundle = .main) -> String {
+        (bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String) ?? "unknown"
+    }
+}

--- a/phase3-binary/app/Tests/MalibuTests/AgentSnapshotPresenterTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/AgentSnapshotPresenterTests.swift
@@ -1365,13 +1365,30 @@ final class AgentSnapshotPresenterTests: XCTestCase {
         }
     }
 
-    func testProviderSoftwareRepairRecommendedTakesSoftwareUpdateAction() {
+    func testProviderSoftwareRepairRequiresFreshProtectedSourceCapability() {
         var snapshot = AgentSnapshot.empty
         snapshot.state = .serving
         snapshot.networkState = "catalog_update_required"
         snapshot.cliVersion = "1.8.93"
         snapshot.coordinatorRecommendedVersion = "1.8.101"
         snapshot.providerSoftwareRepairRecommended = true
+
+        let status = AgentSnapshotPresenter.publicStatus(snapshot)
+
+        XCTAssertEqual(status.title, "This Mac is not currently eligible")
+        XCTAssertEqual(status.safeNextAction, "Install latest provider software.")
+        XCTAssertEqual(status.executableAction, .updateProviderSoftware)
+        XCTAssertFalse(AgentSnapshotPresenter.canRepairProviderSoftware(snapshot))
+    }
+
+    func testProviderSoftwareRepairCapabilityTakesSoftwareUpdateAction() {
+        var snapshot = AgentSnapshot.empty
+        snapshot.state = .serving
+        snapshot.networkState = "catalog_update_required"
+        snapshot.cliVersion = "1.8.93"
+        snapshot.coordinatorRecommendedVersion = "1.8.101"
+        snapshot.providerSoftwareRepairRecommended = true
+        enableProtectedProviderSoftwareRepair(&snapshot)
 
         let status = AgentSnapshotPresenter.publicStatus(snapshot)
 
@@ -1395,6 +1412,7 @@ final class AgentSnapshotPresenterTests: XCTestCase {
         snapshot.statusObservedAt = Date()
         snapshot.statusObservationValidForMS = 5_000
         snapshot.providerSoftwareRepairRecommended = true
+        enableProtectedProviderSoftwareRepair(&snapshot)
 
         let status = AgentSnapshotPresenter.publicStatus(snapshot)
 
@@ -1407,6 +1425,7 @@ final class AgentSnapshotPresenterTests: XCTestCase {
         var snapshot = AgentSnapshot.empty
         snapshot.state = .paused
         snapshot.providerSoftwareRepairRecommended = true
+        enableProtectedProviderSoftwareRepair(&snapshot)
 
         let status = AgentSnapshotPresenter.publicStatus(snapshot)
 
@@ -1414,7 +1433,7 @@ final class AgentSnapshotPresenterTests: XCTestCase {
         XCTAssertEqual(status.executableAction, .repairProviderSoftware)
     }
 
-    func testProviderSoftwareRepairRecommendationSurvivesStatusInvalidation() {
+    func testProviderSoftwareRepairCapabilityDoesNotSurviveStatusInvalidation() {
         var snapshot = AgentSnapshot.empty
         snapshot.state = .serving
         snapshot.networkState = "buyer_serving"
@@ -1423,13 +1442,13 @@ final class AgentSnapshotPresenterTests: XCTestCase {
         snapshot.statusObservedAt = Date()
         snapshot.statusObservationValidForMS = 5_000
         snapshot.providerSoftwareRepairRecommended = true
+        enableProtectedProviderSoftwareRepair(&snapshot)
 
         snapshot.invalidateLocalStatusObservation()
         let status = AgentSnapshotPresenter.publicStatus(snapshot)
 
-        XCTAssertEqual(status.title, "Provider software repair available")
-        XCTAssertEqual(status.executableAction, .repairProviderSoftware)
-        XCTAssertTrue(AgentSnapshotPresenter.canRepairProviderSoftware(snapshot))
+        XCTAssertNotEqual(status.executableAction, .repairProviderSoftware)
+        XCTAssertFalse(AgentSnapshotPresenter.canRepairProviderSoftware(snapshot))
     }
 
     func testProviderSoftwareUpdateInProgressSurvivesStatusInvalidation() {
@@ -1458,6 +1477,7 @@ final class AgentSnapshotPresenterTests: XCTestCase {
         snapshot.cliVersion = "1.8.93"
         snapshot.coordinatorRecommendedVersion = "1.8.101"
         snapshot.providerSoftwareRepairRecommended = true
+        enableProtectedProviderSoftwareRepair(&snapshot)
         snapshot.providerSoftwareRepairInProgress = true
 
         let status = AgentSnapshotPresenter.publicStatus(snapshot)
@@ -1481,6 +1501,7 @@ final class AgentSnapshotPresenterTests: XCTestCase {
         snapshot.statusObservedAt = Date()
         snapshot.statusObservationValidForMS = 5_000
         snapshot.providerSoftwareRepairRecommended = true
+        enableProtectedProviderSoftwareRepair(&snapshot)
         snapshot.providerSoftwareRepairInProgress = true
 
         let status = AgentSnapshotPresenter.publicStatus(snapshot)
@@ -1634,6 +1655,127 @@ final class AgentSnapshotPresenterTests: XCTestCase {
         XCTAssertTrue(details.contains("watchdog recovery started"))
     }
 
+    func testHomeACLDiagnosticFindingShowsRepairPendingWithoutRepairCTA() {
+        var snapshot = AgentSnapshot.empty
+        snapshot.state = .serving
+        snapshot.networkState = "buyer_serving"
+        snapshot.providerSoftwareRepairRecommended = true
+        snapshot.diagnosticFindings = [
+            ProviderDiagnosticFinding(
+                signatureID: .autoupdateHomeACLRejected,
+                source: .providerLogDiagnostics,
+                userMessage: "Provider software repair is pending.",
+                evidence: "autoupdate recovery_error=acl_write_rejected:/Users/provider",
+                observedAt: Date()
+            )
+        ]
+
+        let status = AgentSnapshotPresenter.publicStatus(snapshot)
+
+        XCTAssertEqual(status.title, "Provider software repair pending")
+        XCTAssertEqual(status.executableAction, .exportDiagnostics)
+        XCTAssertFalse(AgentSnapshotPresenter.canRepairProviderSoftware(snapshot))
+        XCTAssertFalse(status.safeNextAction?.contains("Repair provider software.") == true)
+    }
+
+    func testFreshReadyStatusKeepsPrimaryStateWhenLogFindingSupplementsDiagnostics() {
+        var snapshot = AgentSnapshot.empty
+        snapshot.state = .serving
+        snapshot.networkState = "buyer_serving"
+        snapshot.localStatusContractCompatible = true
+        snapshot.localStatusCapabilities = ["status_observation_v1"]
+        snapshot.statusObservationID = "ready-observation"
+        snapshot.statusObservedAt = Date()
+        snapshot.statusObservationValidForMS = 5_000
+        snapshot.statusObservationFresh = true
+        snapshot.diagnosticFindings = [
+            ProviderDiagnosticFinding(
+                signatureID: .staleModelCatalog,
+                source: .providerLogDiagnostics,
+                userMessage: "Model options changed since this Mac last picked a model.",
+                evidence: "model catalog provenance envelope is stale",
+                observedAt: Date()
+            )
+        ]
+
+        let status = AgentSnapshotPresenter.publicStatus(snapshot)
+        let diagnosticLines = AgentSnapshotPresenter.diagnosticFindingLines(snapshot)
+
+        XCTAssertEqual(status.title, "Provider is ready")
+        XCTAssertNil(status.executableAction)
+        XCTAssertTrue(diagnosticLines.joined(separator: "\n").contains("Provider software"))
+    }
+
+    func testServeUnresponsiveUnknownCauseIsRenderedHonestly() {
+        var snapshot = AgentSnapshot.empty
+        snapshot.state = .error
+        snapshot.diagnosticFindings = [
+            ProviderDiagnosticFinding(
+                signatureID: .serveUnresponsive,
+                source: .status,
+                userMessage: "Provider local status is unavailable or stale.",
+                evidence: nil,
+                observedAt: Date()
+            )
+        ]
+
+        let status = AgentSnapshotPresenter.publicStatus(snapshot)
+        let diagnosticLines = AgentSnapshotPresenter.diagnosticFindingLines(snapshot)
+
+        XCTAssertEqual(status.title, "Provider status is unavailable")
+        XCTAssertEqual(status.detail, "Malibu cannot confirm current provider status. Cause unknown.")
+        XCTAssertTrue(diagnosticLines.joined(separator: "\n").contains("Cause: unknown_cause"))
+    }
+
+    func testStaleObservationIDDoesNotFabricateNetworkContext() {
+        var snapshot = AgentSnapshot.empty
+        snapshot.state = .reconnecting
+        snapshot.networkState = "coordinator_unavailable"
+        snapshot.diagnosticFindings = [
+            ProviderDiagnosticFinding(
+                signatureID: .serveUnresponsive,
+                source: .status,
+                userMessage: "Provider local status is unavailable or stale.",
+                evidence: "observation.id=stale-observation",
+                observedAt: Date()
+            )
+        ]
+
+        let status = AgentSnapshotPresenter.publicStatus(snapshot)
+        let diagnosticLines = AgentSnapshotPresenter.diagnosticFindingLines(snapshot).joined(separator: "\n")
+
+        XCTAssertEqual(status.title, "Provider status is unavailable")
+        XCTAssertEqual(status.detail, "Malibu cannot confirm current provider status. Cause unknown.")
+        XCTAssertTrue(diagnosticLines.contains("Cause: unknown_cause"))
+        XCTAssertFalse(diagnosticLines.contains("Network context:"))
+    }
+
+    func testCoordinatorUnavailableIsContextNotRootCause() {
+        var snapshot = AgentSnapshot.empty
+        snapshot.state = .reconnecting
+        snapshot.networkState = "coordinator_unavailable"
+        snapshot.diagnosticFindings = [
+            ProviderDiagnosticFinding(
+                signatureID: .serveUnresponsive,
+                source: .status,
+                userMessage: "Provider is not confirmed available for customer work.",
+                evidence: "network_state=coordinator_unavailable",
+                observedAt: Date()
+            )
+        ]
+
+        let status = AgentSnapshotPresenter.publicStatus(snapshot)
+        let diagnosticLines = AgentSnapshotPresenter.diagnosticFindingLines(snapshot)
+
+        XCTAssertEqual(status.title, "Customer availability is interrupted")
+        XCTAssertEqual(
+            status.detail,
+            "Provider local status is current, but customer availability is not confirmed. This is context, not a diagnosed root cause."
+        )
+        XCTAssertTrue(diagnosticLines.joined(separator: "\n").contains("Network context: network unavailable"))
+        XCTAssertFalse(status.detail?.lowercased().contains("coordinator") == true)
+    }
+
     private func buyerServingObservationSnapshot(observedAt: Date) -> AgentSnapshot {
         var snapshot = AgentSnapshot.empty
         snapshot.state = .serving
@@ -1646,5 +1788,17 @@ final class AgentSnapshotPresenterTests: XCTestCase {
         snapshot.coordinatorConnected = true
         snapshot.serviceInstanceID = "instance-a"
         return snapshot
+    }
+
+    private func enableProtectedProviderSoftwareRepair(_ snapshot: inout AgentSnapshot) {
+        snapshot.localStatusContractCompatible = true
+        snapshot.localStatusCapabilities = [
+            "status_observation_v1",
+            ProviderSoftwareRepairCapabilityGate.repairFromProtectedSource,
+        ]
+        snapshot.statusObservationID = snapshot.statusObservationID ?? "repair-observation"
+        snapshot.statusObservedAt = snapshot.statusObservedAt ?? Date()
+        snapshot.statusObservationValidForMS = snapshot.statusObservationValidForMS ?? 5_000
+        snapshot.statusObservationFresh = true
     }
 }

--- a/phase3-binary/app/Tests/MalibuTests/MalibuAgentDiagnosticsTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/MalibuAgentDiagnosticsTests.swift
@@ -1,0 +1,176 @@
+import Foundation
+import XCTest
+@testable import Malibu
+
+final class MalibuAgentDiagnosticsTests: XCTestCase {
+    @MainActor
+    func testWatchdogHomeACLFindingDoesNotScheduleAutoRepairBeforeProtectedCapability() async throws {
+        let now = Date()
+        let snapshot = Self.freshReadySnapshot(now: now)
+        let repairRecorder = RepairRunnerRecorder()
+        let agent = MalibuAgent(
+            initialSnapshot: snapshot,
+            providerSoftwareRepairRunner: { onLogLine in
+                await repairRecorder.record()
+                await onLogLine("unexpected provider software repair")
+            }
+        )
+        agent.allowHomeACLAutoRepairForTest()
+
+        let homePath = FileManager.default.homeDirectoryForCurrentUser.standardizedFileURL.path
+        agent.applyProviderLogTailsForTest(
+            providerLogLines: [],
+            watchdogLogLines: ["autoupdate recovery_error=acl_write_rejected:\(homePath)"],
+            now: now
+        )
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        let status = AgentSnapshotPresenter.publicStatus(agent.snapshot)
+        let repairInvocationCount = await repairRecorder.snapshot()
+        XCTAssertEqual(repairInvocationCount, 0)
+        XCTAssertFalse(agent.providerSoftwareRepairTaskScheduledForTest)
+        XCTAssertTrue(agent.snapshot.providerSoftwareRepairRecommended)
+        XCTAssertEqual(agent.snapshot.diagnosticFindings.map(\.signatureID), [.autoupdateHomeACLRejected])
+        XCTAssertEqual(status.title, "Provider is ready")
+        XCTAssertEqual(status.executableAction, .exportDiagnostics)
+        XCTAssertFalse(AgentSnapshotPresenter.canRepairProviderSoftware(agent.snapshot))
+        XCTAssertTrue(status.safeNextAction?.contains("repair pending") == true)
+        XCTAssertFalse(status.safeNextAction?.contains("Repair provider software.") == true)
+    }
+
+    @MainActor
+    func testProviderSoftwareRepairFailureAutoAssemblesV2RedactedBundle() async throws {
+        let bundleNow = Date(timeIntervalSince1970: 1_788_249_600)
+        var snapshot = Self.freshReadySnapshot(now: Date())
+        snapshot.providerSoftwareRepairRecommended = true
+        snapshot.localStatusCapabilities.insert(ProviderSoftwareRepairCapabilityGate.repairFromProtectedSource)
+        let bundleRecorder = DiagnosticsBundleRecorder()
+        let agent = MalibuAgent(
+            initialSnapshot: snapshot,
+            providerSoftwareRepairRunner: { onLogLine in
+                await onLogLine("provider_token=must-not-export")
+                throw CLIInstallRunner.Error.nonZeroExit(7)
+            },
+            recoveryDiagnosticsBundleWriter: { snapshot, providerLogLines, _, launchdNeedsRepair, appVersion in
+                let data = try ProviderDiagnosticsBundle.make(
+                    snapshot: snapshot,
+                    providerLogLines: providerLogLines,
+                    watchdogLogURL: nil,
+                    appVersion: appVersion,
+                    launchdNeedsRepair: launchdNeedsRepair,
+                    now: bundleNow
+                )
+                bundleRecorder.record(data)
+                return URL(fileURLWithPath: "/tmp/malibu-recovery-failure.json")
+            }
+        )
+
+        await agent.repairProviderSoftware()
+
+        let data = try XCTUnwrap(bundleRecorder.snapshot())
+        let text = try XCTUnwrap(String(data: data, encoding: .utf8))
+        XCTAssertEqual(
+            agent.snapshot.providerSoftwareRepairLastError,
+            "Provider software install failed (exit 7). Your provider identity was not changed."
+        )
+        XCTAssertTrue(text.contains("\"schema\" : \"malibu.provider-diagnostics.v2\""), text)
+        XCTAssertTrue(text.contains("\"schema_version\" : 2"), text)
+        XCTAssertTrue(text.contains("\"diagnostic_findings\""), text)
+        XCTAssertTrue(text.contains("[redacted]"), text)
+        XCTAssertFalse(text.contains("must-not-export"), text)
+    }
+
+    @MainActor
+    func testFailedProviderSoftwareRepairDoesNotResuggestRepairUntilFreshACLEvidence() async throws {
+        let observedAt = Date()
+        var snapshot = Self.freshReadySnapshot(now: observedAt)
+        snapshot.localStatusCapabilities.insert(ProviderSoftwareRepairCapabilityGate.repairFromProtectedSource)
+        let repairRecorder = RepairRunnerRecorder()
+        let agent = MalibuAgent(
+            initialSnapshot: snapshot,
+            providerSoftwareRepairRunner: { _ in
+                await repairRecorder.record()
+                throw CLIInstallRunner.Error.nonZeroExit(17)
+            },
+            recoveryDiagnosticsBundleWriter: { _, _, _, _, _ in
+                URL(fileURLWithPath: "/tmp/malibu-recovery-failure.json")
+            }
+        )
+        let homePath = FileManager.default.homeDirectoryForCurrentUser.standardizedFileURL.path
+        let firstEvidence = "autoupdate recovery_error=acl_write_rejected:\(homePath)"
+
+        agent.applyProviderLogTailsForTest(
+            providerLogLines: [],
+            watchdogLogLines: [firstEvidence],
+            now: observedAt
+        )
+        XCTAssertTrue(AgentSnapshotPresenter.canRepairProviderSoftware(agent.snapshot))
+
+        await agent.repairProviderSoftware()
+
+        let repairInvocationCount = await repairRecorder.snapshot()
+        XCTAssertEqual(repairInvocationCount, 1)
+        XCTAssertFalse(AgentSnapshotPresenter.canRepairProviderSoftware(agent.snapshot))
+        XCTAssertNotEqual(AgentSnapshotPresenter.publicStatus(agent.snapshot).executableAction, .repairProviderSoftware)
+
+        agent.applyProviderLogTailsForTest(
+            providerLogLines: [],
+            watchdogLogLines: [firstEvidence],
+            now: Date()
+        )
+        XCTAssertFalse(AgentSnapshotPresenter.canRepairProviderSoftware(agent.snapshot))
+        XCTAssertNotEqual(AgentSnapshotPresenter.publicStatus(agent.snapshot).executableAction, .repairProviderSoftware)
+
+        let freshEvidence = "\(firstEvidence) attempt=2"
+        agent.applyProviderLogTailsForTest(
+            providerLogLines: [],
+            watchdogLogLines: [freshEvidence],
+            now: Date()
+        )
+        XCTAssertTrue(AgentSnapshotPresenter.canRepairProviderSoftware(agent.snapshot))
+        XCTAssertEqual(AgentSnapshotPresenter.publicStatus(agent.snapshot).executableAction, .repairProviderSoftware)
+    }
+
+    private static func freshReadySnapshot(now: Date) -> AgentSnapshot {
+        var snapshot = AgentSnapshot.empty
+        snapshot.state = .serving
+        snapshot.networkState = "buyer_serving"
+        snapshot.localStatusContractCompatible = true
+        snapshot.localStatusCapabilities = ["status_observation_v1"]
+        snapshot.statusObservationID = "11111111-1111-4111-8111-111111111111"
+        snapshot.statusObservedAt = now
+        snapshot.statusObservationValidForMS = 5_000
+        snapshot.statusObservationFresh = true
+        return snapshot
+    }
+
+}
+
+private actor RepairRunnerRecorder {
+    private var count = 0
+
+    func record() {
+        count += 1
+    }
+
+    func snapshot() -> Int {
+        count
+    }
+}
+
+private final class DiagnosticsBundleRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var data: Data?
+
+    func record(_ data: Data) {
+        lock.lock()
+        self.data = data
+        lock.unlock()
+    }
+
+    func snapshot() -> Data? {
+        lock.lock()
+        defer { lock.unlock() }
+        return data
+    }
+}

--- a/phase3-binary/app/Tests/MalibuTests/ProviderLogDiagnosticsTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/ProviderLogDiagnosticsTests.swift
@@ -85,6 +85,30 @@ final class ProviderLogDiagnosticsTests: XCTestCase {
         XCTAssertEqual(finding?.id, "autoupdate_home_acl_rejected")
     }
 
+    func testIgnoresHomeAutoupdateACLRejectionBeforeFailedBundledRepairMarker() {
+        let finding = ProviderLogDiagnostics.homeAutoupdateACLRejection(
+            lines: [
+                "[2026-08-19T01:05:42Z] autoupdate recovery_error=acl_write_rejected:/Users/provider",
+                "[2026-08-19T01:08:20Z] \(ProviderLogDiagnostics.providerSoftwareInstallFailedAutoupdateACLMarker)",
+            ],
+            homeDirectory: URL(fileURLWithPath: "/Users/provider")
+        )
+
+        XCTAssertNil(finding)
+    }
+
+    func testDetectsHomeAutoupdateACLRejectionAfterFailedBundledRepairMarker() {
+        let finding = ProviderLogDiagnostics.homeAutoupdateACLRejection(
+            lines: [
+                "[2026-08-19T01:08:20Z] \(ProviderLogDiagnostics.providerSoftwareInstallFailedAutoupdateACLMarker)",
+                "[2026-08-19T01:09:42Z] autoupdate recovery_error=acl_write_rejected:/Users/provider",
+            ],
+            homeDirectory: URL(fileURLWithPath: "/Users/provider")
+        )
+
+        XCTAssertEqual(finding?.id, "autoupdate_home_acl_rejected")
+    }
+
     func testIgnoresHomeAutoupdateACLRejectionBeforeWatchdogRecoverySuccess() {
         let finding = ProviderLogDiagnostics.homeAutoupdateACLRejection(
             lines: [

--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -2545,11 +2545,21 @@
       "spec_id": "SPEC-035",
       "state": "pending",
       "implementation": [
+        "phase3-binary/app/Sources/Malibu/Agent/AgentSnapshot.swift:private static func publicStatusForTopDiagnosticFinding",
+        "phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift:private func refreshDiagnosticFindings",
+        "phase3-binary/app/Sources/Malibu/Dashboard/DashboardWindow.swift:static func advancedDiagnosticsStrings",
         "phase3-binary/app/Sources/Malibu/System/ProviderDiagnosticFinding.swift:enum ProviderDiagnosticFindingAggregator",
         "phase3-binary/Sources/macprovider-cli/DoctorCommand.swift:static func findings",
         "phase3-binary/Sources/macprovider-cli/DoctorCommand.swift:static func statusObservation"
       ],
       "tests": [
+        "phase3-binary/app/Tests/MalibuTests/AgentSnapshotPresenterTests.swift:testCoordinatorUnavailableIsContextNotRootCause",
+        "phase3-binary/app/Tests/MalibuTests/AgentSnapshotPresenterTests.swift:testFreshReadyStatusKeepsPrimaryStateWhenLogFindingSupplementsDiagnostics",
+        "phase3-binary/app/Tests/MalibuTests/AgentSnapshotPresenterTests.swift:testHomeACLDiagnosticFindingShowsRepairPendingWithoutRepairCTA",
+        "phase3-binary/app/Tests/MalibuTests/AgentSnapshotPresenterTests.swift:testServeUnresponsiveUnknownCauseIsRenderedHonestly",
+        "phase3-binary/app/Tests/MalibuTests/AgentSnapshotPresenterTests.swift:testStaleObservationIDDoesNotFabricateNetworkContext",
+        "phase3-binary/app/Tests/MalibuTests/MalibuAgentDiagnosticsTests.swift:testFailedProviderSoftwareRepairDoesNotResuggestRepairUntilFreshACLEvidence",
+        "phase3-binary/app/Tests/MalibuTests/MalibuAgentDiagnosticsTests.swift:testWatchdogHomeACLFindingDoesNotScheduleAutoRepairBeforeProtectedCapability",
         "phase3-binary/app/Tests/MalibuTests/ProviderDiagnosticFindingTests.swift:testFreshStatusFindingsPrecedeSupplementalLogFindings",
         "phase3-binary/app/Tests/MalibuTests/ProviderDiagnosticFindingTests.swift:testCredentialStatusSubprocessCannotOverrideFreshServeCredentialState",
         "phase3-binary/app/Tests/MalibuTests/ProviderDiagnosticFindingTests.swift:testStaleStatusAllowsDoctorServeDeadAndCredentialStatusFallbacks",
@@ -2565,8 +2575,8 @@
       "gap": {
         "verdict": "UNKNOWN",
         "owner": "@Augustas11",
-        "issue": "https://github.com/Augustas11/macprovider/issues/1315",
-        "rationale": "Local source precedence is implemented under aggregator unit tests; the CLI doctor report now suppresses doctor findings for fresh compatible /v1/status and contributes only serve_unresponsive when local status is unavailable, stale, or incompatible. Production support-bundle ingestion evidence remains deferred."
+        "issue": "https://github.com/Augustas11/macprovider/issues/1316",
+        "rationale": "Local source precedence is implemented under aggregator unit tests; the CLI doctor report suppresses doctor findings for fresh compatible /v1/status and contributes only serve_unresponsive when local status is unavailable, stale, or incompatible. Malibu now wires aggregated findings into AgentSnapshot presentation and dashboard diagnostics while keeping coordinator state as context, rendering unknown_cause honestly, and fencing HOME-ACL repair evidence from auto-repair or executable Repair CTAs until protected repair delivery is explicitly capable. Production support-bundle ingestion evidence remains deferred."
       }
     },
     {
@@ -2576,6 +2586,7 @@
       "implementation": [
         "phase3-binary/app/Sources/Malibu/MalibuApp.swift:private func exportDiagnostics()",
         "phase3-binary/app/Sources/Malibu/System/ProviderDiagnosticsBundle.swift:enum ProviderDiagnosticsBundle",
+        "phase3-binary/app/Sources/Malibu/System/ProviderRecoveryDiagnosticsBundle.swift:enum ProviderRecoveryDiagnosticsBundle",
         "phase3-binary/app/Sources/Malibu/System/LogTailReader.swift:struct LogTailBuffer",
         "phase3-binary/Sources/macprovider-cli/DoctorCommand.swift:enum DoctorDiagnosticsReportPrinter",
         "phase3-binary/Sources/macprovider-cli/DoctorCommand.swift:enum DoctorReportRedactor",
@@ -2583,6 +2594,7 @@
       ],
       "tests": [
         "phase3-binary/app/Tests/MalibuTests/LogTailReaderTests.swift:testV2RedactionScrubsPrivateContextWithoutDroppingNonSecretLine",
+        "phase3-binary/app/Tests/MalibuTests/MalibuAgentDiagnosticsTests.swift:testProviderSoftwareRepairFailureAutoAssemblesV2RedactedBundle",
         "phase3-binary/app/Tests/MalibuTests/ProviderDiagnosticsBundleTests.swift:testBundleIncludesLifecycleAndWatchdogEvidenceWithoutSecrets",
         "phase3-binary/app/Tests/MalibuTests/ProviderDiagnosticsBundleTests.swift:testBundleClassifiesRawWatchdogAndLaunchdRepairBeforeExportRedaction",
         "phase3-binary/app/Tests/MalibuTests/AgentSnapshotPresenterTests.swift:testOnboardingAdvancedFailureDiagnosticsKeepsRedactedDetails",
@@ -2599,8 +2611,8 @@
       "gap": {
         "verdict": "UNKNOWN",
         "owner": "@Augustas11",
-        "issue": "https://github.com/Augustas11/macprovider/issues/1315",
-        "rationale": "Diagnostics bundle v2 and LogTailBuffer v2 redaction are implemented under Malibu app unit tests; the CLI doctor report emits schema_version/minimum_reader_version, redacts report tails by construction, omits config_path/provider_id, and verifies read-only collection under Doctor tests. Production bundle collection evidence remains deferred."
+        "issue": "https://github.com/Augustas11/macprovider/issues/1316",
+        "rationale": "Diagnostics bundle v2 and LogTailBuffer v2 redaction are implemented under Malibu app unit tests; Malibu now auto-assembles the existing v2 redacted bundle on recovery failures without introducing a new diagnostics schema. The CLI doctor report emits schema_version/minimum_reader_version, redacts report tails by construction, omits config_path/provider_id, and verifies read-only collection under Doctor tests. Production bundle collection evidence remains deferred."
       }
     },
     {


### PR DESCRIPTION
## Summary
- Wire SPEC-035 diagnostic findings into Malibu AgentSnapshot presentation and dashboard diagnostics.
- Fence provider-software Repair behind a fresh protected-source capability; HOME-ACL evidence stays identity-preserving and non-executable before delivery is proven.
- Auto-assemble the existing v2 redacted diagnostics bundle on recovery failure.

## Tests
- xcodegen generate
- xcodebuild test -quiet -project Malibu.xcodeproj -scheme Malibu -configuration Debug -destination 'platform=macOS'
- python3 -m json.tool specs/CONFORMANCE.json
- git diff --check
- Three native audit lanes: code, security, architecture, all 0 C/H/M

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "issue": "https://github.com/Augustas11/macprovider/issues/1316",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": ["SPEC-025", "SPEC-035"],
  "requirements": ["SPEC-035-R011", "SPEC-035-R012"],
  "authority_domains": ["native-app-lifecycle", "provider-connection-diagnostics"],
  "arbitration": ["UNKNOWN"],
  "tests": [
    "xcodebuild test -quiet -project Malibu.xcodeproj -scheme Malibu -configuration Debug -destination 'platform=macOS'",
    "python3 -m json.tool specs/CONFORMANCE.json",
    "git diff --check"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END

