### PR TITLE
Centralize reward verdict authority

### DIFF
--- a/phase3-binary/app/Sources/Malibu/Agent/AgentSnapshot.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/AgentSnapshot.swift
@@ -38,7 +38,7 @@ struct AgentSnapshot: Equatable {
     var unpaidLedgerBacklogUSDC: Double?
     var unpaidLedgerBacklogMALIBU: Double?
     var walletBound: Bool
-    var trustTier: TrustTier
+    fileprivate var rewardInputs: RewardInputs
     var uptimeSec: Int?
     var requestsServedToday: Int?
     var requestsServedAllTime: Int?
@@ -51,21 +51,10 @@ struct AgentSnapshot: Equatable {
     var earningsUsdcPending: Double?
     var earningsUsdcLifetime: Double?
     var malibuAccruedAllTime: Double?
-    var malibuWithdrawable: Double?
-    var malibuHeld: Double?
-    var malibuHoldReasons: [String]
-    var malibuDailyCap: Double?
-    var malibuWalletDailyCap: Double?
-    var malibuRewardEligibility: MalibuRewardEligibility?
     /// Last-hour idle-prewarm event/skip counts from the provider earnings
     /// endpoint. Gated by `providerEarningsFresh`, same as the other fields
     /// sourced from that projection.
     var idlePrewarmSummary: ProviderIdlePrewarmSummary = .empty
-    /// Freshness for the provider earnings endpoint.
-    var providerEarningsFresh: Bool
-    /// Reward-specific freshness. It is separate so a partial earnings frame
-    /// cannot authorize held/withdrawable/trust copy.
-    var malibuProjectionFresh: Bool
     var gpuUtilizationPct: Double?
     var gpuTemperatureC: Double?
     var latencyP50Ms: Int?
@@ -75,8 +64,6 @@ struct AgentSnapshot: Equatable {
     var declinedRequests: Int?
     var restartCount: Int?
     var weightsPath: String?
-    var trustCriteriaMet: Int?
-    var trustCriteriaRequired: Int?
     var thermalState: MalibuThermalState?
     var lastError: String?
 
@@ -413,6 +400,160 @@ struct AgentSnapshot: Equatable {
         payoutLastStatus = nil
     }
 
+    fileprivate struct RewardInputs: Equatable {
+        var trustTier: TrustTier = .provisional
+        var providerEarningsFresh: Bool = false
+        var malibuProjectionFresh: Bool = false
+        var rewardTelemetryUnavailable: Bool = false
+        var malibuWithdrawable: Double?
+        var malibuHeld: Double?
+        var malibuHoldReasons: [String] = []
+        var malibuDailyCap: Double?
+        var malibuWalletDailyCap: Double?
+        var malibuRewardEligibility: MalibuRewardEligibility?
+        var trustCriteriaMet: Int?
+        var trustCriteriaRequired: Int?
+        var economicCriteria: [String] = []
+        var additionalCriteria: [String] = []
+        var hasGranularTrustCriteria: Bool = false
+    }
+
+    fileprivate var malibuDailyCap: Double? {
+        get { rewardInputs.malibuDailyCap }
+        set { rewardInputs.malibuDailyCap = newValue }
+    }
+
+    fileprivate var malibuWalletDailyCap: Double? {
+        get { rewardInputs.malibuWalletDailyCap }
+        set { rewardInputs.malibuWalletDailyCap = newValue }
+    }
+
+    mutating func updateRewardInputs(
+        walletBound: Bool? = nil,
+        trustTier: TrustTier? = nil,
+        providerEarningsFresh: Bool? = nil,
+        malibuProjectionFresh: Bool? = nil,
+        rewardTelemetryUnavailable: Bool? = nil,
+        malibuWithdrawable: Double?? = nil,
+        malibuHeld: Double?? = nil,
+        malibuHoldReasons: [String]? = nil,
+        malibuDailyCap: Double?? = nil,
+        malibuWalletDailyCap: Double?? = nil,
+        malibuRewardEligibility: MalibuRewardEligibility?? = nil,
+        trustCriteriaMet: Int?? = nil,
+        trustCriteriaRequired: Int?? = nil,
+        economicCriteria: [String]? = nil,
+        additionalCriteria: [String]? = nil,
+        hasGranularTrustCriteria: Bool? = nil
+    ) {
+        if let walletBound { self.walletBound = walletBound }
+        if let trustTier { rewardInputs.trustTier = trustTier }
+        if let providerEarningsFresh { rewardInputs.providerEarningsFresh = providerEarningsFresh }
+        if let malibuProjectionFresh { rewardInputs.malibuProjectionFresh = malibuProjectionFresh }
+        if let rewardTelemetryUnavailable { rewardInputs.rewardTelemetryUnavailable = rewardTelemetryUnavailable }
+        if let malibuWithdrawable { rewardInputs.malibuWithdrawable = malibuWithdrawable }
+        if let malibuHeld { rewardInputs.malibuHeld = malibuHeld }
+        if let malibuHoldReasons { rewardInputs.malibuHoldReasons = malibuHoldReasons }
+        if let malibuDailyCap { rewardInputs.malibuDailyCap = malibuDailyCap }
+        if let malibuWalletDailyCap { rewardInputs.malibuWalletDailyCap = malibuWalletDailyCap }
+        if let malibuRewardEligibility { rewardInputs.malibuRewardEligibility = malibuRewardEligibility }
+        if let trustCriteriaMet { rewardInputs.trustCriteriaMet = trustCriteriaMet }
+        if let trustCriteriaRequired { rewardInputs.trustCriteriaRequired = trustCriteriaRequired }
+        if let economicCriteria { rewardInputs.economicCriteria = economicCriteria }
+        if let additionalCriteria { rewardInputs.additionalCriteria = additionalCriteria }
+        if let hasGranularTrustCriteria { rewardInputs.hasGranularTrustCriteria = hasGranularTrustCriteria }
+    }
+
+    mutating func demoteRewardInputsAfterLegacyStub() {
+        rewardInputs.providerEarningsFresh = false
+        rewardInputs.malibuProjectionFresh = false
+        rewardInputs.rewardTelemetryUnavailable = false
+    }
+
+    mutating func clearRuntimeRewardInputs() {
+        walletBound = true
+        rewardInputs = RewardInputs()
+    }
+
+    mutating func applyDashboardObservation(_ record: DashboardObservationStore.Record) {
+        hasObservedProviderEarnings = record.hasObservedProviderEarnings
+        earningsUsdcToday = record.earningsUsdcToday
+        earningsUsdcWeek = record.earningsUsdcWeek
+        earningsUsdcPending = record.earningsUsdcPending
+        earningsUsdcLifetime = record.earningsUsdcLifetime
+        malibuAccruedToday = record.malibuAccruedToday
+        malibuAccruedAllTime = record.malibuAccruedAllTime
+        rewardInputs.malibuWithdrawable = record.malibuWithdrawable
+        rewardInputs.malibuHeld = record.malibuHeld
+        if let walletBound = record.walletBound {
+            self.walletBound = walletBound
+        }
+    }
+
+    func dashboardObservationRecord(providerID: String, recordedAt: Date = Date()) -> DashboardObservationStore.Record {
+        DashboardObservationStore.Record(
+            providerID: providerID,
+            lastBuyerServingAt: shouldClearBuyerServingHold ? nil : lastBuyerServingAt,
+            hasObservedProviderEarnings: hasObservedProviderEarnings,
+            earningsUsdcToday: earningsUsdcToday,
+            earningsUsdcWeek: earningsUsdcWeek,
+            earningsUsdcPending: earningsUsdcPending,
+            earningsUsdcLifetime: earningsUsdcLifetime,
+            malibuAccruedToday: malibuAccruedToday,
+            malibuAccruedAllTime: malibuAccruedAllTime,
+            malibuWithdrawable: rewardInputs.malibuWithdrawable,
+            malibuHeld: rewardInputs.malibuHeld,
+            walletBound: walletBound,
+            recordedAt: recordedAt
+        )
+    }
+
+    mutating func updateRewardFreshness(
+        providerProjectionEligible: Bool,
+        providerEarnings: ProviderEarnings?
+    ) {
+        rewardInputs.malibuProjectionFresh = providerProjectionEligible
+            && providerEarnings?.malibuProjectionFresh == true
+        rewardInputs.providerEarningsFresh = providerProjectionEligible
+            && providerEarnings?.earningsProjectionFresh == true
+        rewardInputs.rewardTelemetryUnavailable = providerEarnings?.rewardTelemetryUnavailable == true
+    }
+
+    mutating func applyProviderEarnings(
+        _ providerEarnings: ProviderEarnings,
+        providerProjectionEligible: Bool
+    ) {
+        updateRewardFreshness(
+            providerProjectionEligible: providerProjectionEligible,
+            providerEarnings: providerEarnings
+        )
+        walletBound = providerEarnings.walletBound
+        rewardInputs.trustTier = providerEarnings.trustTier
+        unpaidLedgerBacklogUSDC = providerEarnings.unpaidLedgerBacklogUSDC
+        unpaidLedgerBacklogMALIBU = providerEarnings.unpaidLedgerBacklogMALIBU
+        earningsUsdcToday = providerEarnings.usdcToday
+        earningsUsdcWeek = providerEarnings.usdcWeek
+        earningsUsdcPending = providerEarnings.usdcPending
+        earningsUsdcLifetime = providerEarnings.usdcLifetime
+        malibuAccruedToday = providerEarnings.malibuToday
+        malibuAccruedAllTime = providerEarnings.malibuAllTime
+        rewardInputs.malibuWithdrawable = providerEarnings.malibuWithdrawable
+        rewardInputs.malibuHeld = providerEarnings.malibuHeld
+        rewardInputs.malibuHoldReasons = providerEarnings.malibuHoldReasons
+        rewardInputs.malibuDailyCap = providerEarnings.malibuDailyCap
+        rewardInputs.malibuWalletDailyCap = providerEarnings.malibuWalletDailyCap
+        rewardInputs.malibuRewardEligibility = providerEarnings.malibuRewardEligibility
+        rewardInputs.trustCriteriaMet = providerEarnings.trustCriteriaMet
+        rewardInputs.trustCriteriaRequired = providerEarnings.trustCriteriaRequired
+        rewardInputs.economicCriteria = providerEarnings.economicCriteria
+        rewardInputs.additionalCriteria = providerEarnings.additionalCriteria
+        rewardInputs.hasGranularTrustCriteria = providerEarnings.hasGranularTrustCriteria
+        idlePrewarmSummary = providerEarnings.idlePrewarm
+        if providerProjectionEligible && providerEarnings.earningsProjectionFresh {
+            hasObservedProviderEarnings = true
+        }
+    }
+
     static let empty = AgentSnapshot(
         state: .idle,
         currentModelID: nil,
@@ -421,7 +562,7 @@ struct AgentSnapshot: Equatable {
         unpaidLedgerBacklogUSDC: nil,
         unpaidLedgerBacklogMALIBU: nil,
         walletBound: false,
-        trustTier: .provisional,
+        rewardInputs: RewardInputs(),
         uptimeSec: nil,
         requestsServedToday: nil,
         requestsServedAllTime: nil,
@@ -434,14 +575,6 @@ struct AgentSnapshot: Equatable {
         earningsUsdcPending: nil,
         earningsUsdcLifetime: nil,
         malibuAccruedAllTime: nil,
-        malibuWithdrawable: nil,
-        malibuHeld: nil,
-        malibuHoldReasons: [],
-        malibuDailyCap: nil,
-        malibuWalletDailyCap: nil,
-        malibuRewardEligibility: nil,
-        providerEarningsFresh: false,
-        malibuProjectionFresh: false,
         gpuUtilizationPct: nil,
         gpuTemperatureC: nil,
         latencyP50Ms: nil,
@@ -451,8 +584,6 @@ struct AgentSnapshot: Equatable {
         declinedRequests: nil,
         restartCount: nil,
         weightsPath: nil,
-        trustCriteriaMet: nil,
-        trustCriteriaRequired: nil,
         thermalState: nil,
         lastError: nil,
         cliVersion: nil,
@@ -574,7 +705,418 @@ enum AgentSnapshotPresenter {
         let trustSummary: String
     }
 
+    struct RewardVerdict: Equatable {
+        enum ReasonCode: Equatable {
+            case earningVerifiedWork
+            case eligibleIdleNoWork
+            case heldProviderDailyCap
+            case heldWalletDailyCap
+            case heldProvisionalTrustTier
+            case heldDemotionCooldown
+            case heldEpochDisposition
+            case excludedEpochDisposition
+            case burnedOrRetiredEpochDisposition
+            case withdrawableBalanceAvailable
+            case withdrawableNoBalance
+            case insufficientVerifiedReceipts
+            case appAttestationMissing
+            case computeIntegrityBlocked
+            case providerTokenUntrusted
+            case hardwareEvidenceUnavailable
+            case hardwareEvidenceMissingOrExpired
+            case computeIntegrityUnavailable
+            case computeIntegrityPending
+            case localOnBattery
+            case localThermalPressure
+            case modelNotReady
+            case telemetryUnavailable
+            case walletMissing
+            case trustedWithdrawable
+            case rewardsHeld
+            case trustTierProvisional
+            case rewardProjectionUnavailable
+            case rewardProjectionWarmingUp
+            case earning
+            case idleNoWork
+            case waitingSettlement
+            case none
+            case unknown(String)
+
+            var rawValue: String {
+                switch self {
+                case .earningVerifiedWork: return "earning_verified_work"
+                case .eligibleIdleNoWork: return "eligible_idle_no_work"
+                case .heldProviderDailyCap: return "held_provider_daily_cap"
+                case .heldWalletDailyCap: return "held_wallet_daily_cap"
+                case .heldProvisionalTrustTier: return "held_provisional_trust_tier"
+                case .heldDemotionCooldown: return "held_demotion_cooldown"
+                case .heldEpochDisposition: return "held_epoch_disposition"
+                case .excludedEpochDisposition: return "excluded_epoch_disposition"
+                case .burnedOrRetiredEpochDisposition: return "burned_or_retired_epoch_disposition"
+                case .withdrawableBalanceAvailable: return "withdrawable_balance_available"
+                case .withdrawableNoBalance: return "withdrawable_no_balance"
+                case .insufficientVerifiedReceipts: return "insufficient_verified_receipts"
+                case .appAttestationMissing: return "app_attestation_missing"
+                case .computeIntegrityBlocked: return "compute_integrity_blocked"
+                case .providerTokenUntrusted: return "provider_token_untrusted"
+                case .hardwareEvidenceUnavailable: return "hardware_evidence_unavailable"
+                case .hardwareEvidenceMissingOrExpired: return "hardware_evidence_missing_or_expired"
+                case .computeIntegrityUnavailable: return "compute_integrity_unavailable"
+                case .computeIntegrityPending: return "compute_integrity_pending"
+                case .localOnBattery: return "local_on_battery"
+                case .localThermalPressure: return "local_thermal_pressure"
+                case .modelNotReady: return "model_not_ready"
+                case .telemetryUnavailable: return "reward_telemetry_outage"
+                case .walletMissing: return "wallet_missing"
+                case .trustedWithdrawable: return "trusted_withdrawable"
+                case .rewardsHeld: return "rewards_held"
+                case .trustTierProvisional: return "trust_tier_provisional"
+                case .rewardProjectionUnavailable: return "reward_projection_unavailable"
+                case .rewardProjectionWarmingUp: return "reward_projection_warming_up"
+                case .earning: return "earning"
+                case .idleNoWork: return "idle_no_work"
+                case .waitingSettlement: return "eligible_waiting_settlement"
+                case .none: return "none"
+                case .unknown(let raw): return "unknown:\(raw)"
+                }
+            }
+
+            static func coordinator(_ raw: String?) -> ReasonCode {
+                guard let raw, !raw.isEmpty else { return .none }
+                switch raw {
+                case "earning_verified_work": return .earningVerifiedWork
+                case "eligible_idle_no_work": return .eligibleIdleNoWork
+                case "held_provider_daily_cap": return .heldProviderDailyCap
+                case "held_wallet_daily_cap": return .heldWalletDailyCap
+                case "held_provisional_trust_tier": return .heldProvisionalTrustTier
+                case "held_demotion_cooldown": return .heldDemotionCooldown
+                case "held_epoch_disposition": return .heldEpochDisposition
+                case "excluded_epoch_disposition": return .excludedEpochDisposition
+                case "burned_or_retired_epoch_disposition": return .burnedOrRetiredEpochDisposition
+                case "withdrawable_balance_available": return .withdrawableBalanceAvailable
+                case "withdrawable_no_balance": return .withdrawableNoBalance
+                case "missing_wallet_binding": return .walletMissing
+                case "insufficient_verified_receipts": return .insufficientVerifiedReceipts
+                case "app_attestation_missing": return .appAttestationMissing
+                case "compute_integrity_blocked": return .computeIntegrityBlocked
+                case "provider_token_untrusted": return .providerTokenUntrusted
+                case "hardware_evidence_unavailable": return .hardwareEvidenceUnavailable
+                case "hardware_evidence_missing_or_expired": return .hardwareEvidenceMissingOrExpired
+                case "compute_integrity_unavailable": return .computeIntegrityUnavailable
+                case "compute_integrity_pending": return .computeIntegrityPending
+                case "local_on_battery": return .localOnBattery
+                case "local_thermal_pressure": return .localThermalPressure
+                case "model_not_ready": return .modelNotReady
+                case "telemetry_unavailable": return .telemetryUnavailable
+                default: return .unknown(raw)
+                }
+            }
+        }
+
+        enum MalibuWithdrawal: Equatable {
+            case unlocked
+            case held(ReasonCode)
+            case capped(ReasonCode)
+            case lockedProvisional
+            case epochDisposition(ReasonCode)
+            case unavailable
+            case unknown
+            case none
+        }
+
+        enum UsdcActivity: Equatable {
+            case earning
+            case idle
+            case unavailable
+            case none
+        }
+
+        enum TrustDisplay: Equatable {
+            case trustedAuthoritative
+            case trustedStaleNeutral
+            case provisional
+            case unknown
+        }
+
+        struct TrustProgress: Equatable {
+            let met: Int
+            let required: Int
+        }
+
+        let reasonCode: ReasonCode
+        let malibuWithdrawal: MalibuWithdrawal
+        let usdcActivity: UsdcActivity
+        let trustDisplay: TrustDisplay
+        let trustProgress: TrustProgress?
+        let canClaimWithdrawable: Bool
+        let providerEarningsFresh: Bool
+        let malibuProjectionFresh: Bool
+        let hasObservedProviderEarnings: Bool
+        let walletBound: Bool
+        let malibuWithdrawable: Double?
+        let malibuHeld: Double?
+        let unpaidLedgerBacklogUSDC: Double?
+        let unpaidLedgerBacklogMALIBU: Double?
+    }
+
+    static func rewardVerdict(_ s: AgentSnapshot) -> RewardVerdict {
+        let inputs = s.rewardInputs
+        let authoritativeEligibility = authoritativeRewardEligibility(inputs)
+        let displayEligibility = displayRewardEligibility(inputs, authoritativeEligibility)
+        let ignoreLeftoverProvisionalLock = shouldIgnoreLeftoverProvisionalLock(
+            inputs,
+            authoritativeEligibility
+        )
+        let rewardTelemetryUnavailable = isRewardTelemetryUnavailable(inputs, authoritativeEligibility)
+        let trustDisplay: RewardVerdict.TrustDisplay
+        if inputs.malibuProjectionFresh, !rewardTelemetryUnavailable, inputs.trustTier == .trusted {
+            trustDisplay = .trustedAuthoritative
+        } else if !inputs.malibuProjectionFresh, inputs.trustTier == .trusted {
+            trustDisplay = .trustedStaleNeutral
+        } else if inputs.malibuProjectionFresh, !rewardTelemetryUnavailable, inputs.trustTier == .provisional {
+            trustDisplay = .provisional
+        } else {
+            trustDisplay = .unknown
+        }
+
+        let usdcActivity: RewardVerdict.UsdcActivity
+        if inputs.providerEarningsFresh {
+            usdcActivity = hasFreshUsdcActivity(s) ? .earning : .idle
+        } else if !s.hasObservedProviderEarnings && !inputs.malibuProjectionFresh {
+            usdcActivity = .unavailable
+        } else {
+            usdcActivity = .none
+        }
+
+        let progress = sanitizedTrustProgress(inputs)
+        let withdrawal: RewardVerdict.MalibuWithdrawal
+        let reason: RewardVerdict.ReasonCode
+        if rewardTelemetryUnavailable {
+            withdrawal = .unavailable
+            reason = .telemetryUnavailable
+        } else if !inputs.malibuProjectionFresh {
+            withdrawal = .unknown
+            reason = .rewardProjectionUnavailable
+        } else if let eligibility = displayEligibility,
+                  let eligibilityVerdict = withdrawalVerdictFromEligibility(
+                    eligibility,
+                    inputs: inputs,
+                    walletBound: s.walletBound
+                  ) {
+            withdrawal = eligibilityVerdict.withdrawal
+            reason = eligibilityVerdict.reason
+        } else if s.walletBound == false {
+            withdrawal = .none
+            reason = .walletMissing
+        } else if inputs.trustTier == .provisional,
+                  inputs.malibuHoldReasons.contains("demotion_cooldown") {
+            withdrawal = .lockedProvisional
+            reason = .heldDemotionCooldown
+        } else if inputs.trustTier == .provisional {
+            withdrawal = .lockedProvisional
+            reason = .trustTierProvisional
+        } else if displayMalibuHoldReasons(inputs).contains("per_wallet_daily_cap") {
+            withdrawal = .capped(.heldWalletDailyCap)
+            reason = .heldWalletDailyCap
+        } else if !ignoreLeftoverProvisionalLock,
+                  !displayMalibuHoldReasons(inputs).isEmpty || (inputs.malibuHeld ?? 0) > 0 {
+            withdrawal = .held(.rewardsHeld)
+            reason = .rewardsHeld
+        } else if inputs.trustTier == .trusted,
+                  (inputs.malibuWithdrawable ?? 0) > 0,
+                  displayMalibuHoldReasons(inputs).isEmpty,
+                  displayEligibility == nil {
+            withdrawal = .unlocked
+            reason = .trustedWithdrawable
+        } else {
+            withdrawal = .none
+            reason = usdcActivity == .earning ? .earning : .idleNoWork
+        }
+        return RewardVerdict(
+            reasonCode: reason,
+            malibuWithdrawal: withdrawal,
+            usdcActivity: usdcActivity,
+            trustDisplay: trustDisplay,
+            trustProgress: progress,
+            canClaimWithdrawable: withdrawal == .unlocked,
+            providerEarningsFresh: inputs.providerEarningsFresh,
+            malibuProjectionFresh: inputs.malibuProjectionFresh,
+            hasObservedProviderEarnings: s.hasObservedProviderEarnings,
+            walletBound: s.walletBound,
+            malibuWithdrawable: inputs.malibuWithdrawable,
+            malibuHeld: inputs.malibuHeld,
+            unpaidLedgerBacklogUSDC: s.unpaidLedgerBacklogUSDC,
+            unpaidLedgerBacklogMALIBU: s.unpaidLedgerBacklogMALIBU
+        )
+    }
+
+    static func malibuRewardTextColorIsLocked(_ verdict: RewardVerdict) -> Bool {
+        verdict.malibuWithdrawal == .lockedProvisional
+    }
+
+    private static func hasFreshUsdcActivity(_ s: AgentSnapshot) -> Bool {
+        (s.requestsPerMinute ?? 0) > 0
+            || (s.earningsUsdcToday ?? 0) > 0
+    }
+
+    private static func authoritativeRewardEligibility(
+        _ inputs: AgentSnapshot.RewardInputs
+    ) -> MalibuRewardEligibility? {
+        guard inputs.malibuProjectionFresh else { return nil }
+        return inputs.malibuRewardEligibility ?? MalibuRewardEligibility.unavailableForMissingObject()
+    }
+
+    private static func displayRewardEligibility(
+        _ inputs: AgentSnapshot.RewardInputs,
+        _ authoritative: MalibuRewardEligibility? = nil
+    ) -> MalibuRewardEligibility? {
+        guard let eligibility = authoritative ?? authoritativeRewardEligibility(inputs) else { return nil }
+        guard inputs.trustTier == .trusted,
+              leftoverProvisionalEligibilityReasons.contains(eligibility.primaryReason) else {
+            return eligibility
+        }
+        return nil
+    }
+
+    private static func isRewardTelemetryUnavailable(
+        _ inputs: AgentSnapshot.RewardInputs,
+        _ authoritative: MalibuRewardEligibility? = nil
+    ) -> Bool {
+        if inputs.rewardTelemetryUnavailable { return true }
+        guard let eligibility = authoritative ?? authoritativeRewardEligibility(inputs) else { return false }
+        return eligibility.primaryReason == "telemetry_unavailable"
+    }
+
+    private static func eligibilityReasonCode(_ eligibility: MalibuRewardEligibility) -> RewardVerdict.ReasonCode {
+        let raw = eligibility.primaryReason.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !raw.isEmpty else { return .unknown("missing_primary_reason") }
+        return RewardVerdict.ReasonCode.coordinator(raw)
+    }
+
+    private static func withdrawalVerdictFromEligibility(
+        _ eligibility: MalibuRewardEligibility,
+        inputs: AgentSnapshot.RewardInputs,
+        walletBound: Bool
+    ) -> (withdrawal: RewardVerdict.MalibuWithdrawal, reason: RewardVerdict.ReasonCode)? {
+        let code = eligibilityReasonCode(eligibility)
+        if eligibility.withdrawalState == "withdrawable" {
+            switch code {
+            case .withdrawableBalanceAvailable:
+                guard hasCoherentKnownReasonSet(eligibility) else {
+                    return (.unknown, .unknown("malformed_withdrawable_reason_set"))
+                }
+                if inputs.trustTier == .trusted,
+                   walletBound != false,
+                   (inputs.malibuWithdrawable ?? 0) > 0,
+                   displayMalibuHoldReasons(inputs).isEmpty {
+                    return (.unlocked, code)
+                }
+                return (.none, code)
+            case .withdrawableNoBalance, .earningVerifiedWork, .eligibleIdleNoWork:
+                return nil
+            case .unknown:
+                return (.unknown, code)
+            default:
+                return (withdrawalFromNonWithdrawableEligibility(code), code)
+            }
+        }
+        return (withdrawalFromNonWithdrawableEligibility(code), code)
+    }
+
+    private static func hasCoherentKnownReasonSet(_ eligibility: MalibuRewardEligibility) -> Bool {
+        let primary = eligibility.primaryReason.trimmingCharacters(in: .whitespacesAndNewlines)
+        let reasons = eligibility.reasons.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        guard !primary.isEmpty, !reasons.isEmpty else { return false }
+        guard reasons.allSatisfy({ MalibuRewardEligibility.knownReasons.contains($0) }) else {
+            return false
+        }
+        return reasons.contains(primary)
+    }
+
+    private static func withdrawalFromNonWithdrawableEligibility(
+        _ code: RewardVerdict.ReasonCode
+    ) -> RewardVerdict.MalibuWithdrawal {
+        switch code {
+        case .walletMissing:
+            return .none
+        case .heldProviderDailyCap, .heldWalletDailyCap:
+            return .capped(code)
+        case .heldEpochDisposition, .excludedEpochDisposition, .burnedOrRetiredEpochDisposition:
+            return .epochDisposition(code)
+        case .hardwareEvidenceUnavailable,
+             .hardwareEvidenceMissingOrExpired,
+             .computeIntegrityUnavailable,
+             .computeIntegrityPending,
+             .appAttestationMissing:
+            return .unavailable
+        case .unknown:
+            return .unknown
+        default:
+            return .held(code)
+        }
+    }
+
+    private static func displayMalibuHoldReasons(_ inputs: AgentSnapshot.RewardInputs) -> [String] {
+        guard inputs.trustTier == .trusted else { return inputs.malibuHoldReasons }
+        return inputs.malibuHoldReasons.filter { !leftoverProvisionalHoldReasons.contains($0) }
+    }
+
+    private static func shouldIgnoreLeftoverProvisionalLock(
+        _ inputs: AgentSnapshot.RewardInputs,
+        _ authoritative: MalibuRewardEligibility? = nil
+    ) -> Bool {
+        guard inputs.trustTier == .trusted, displayMalibuHoldReasons(inputs).isEmpty else {
+            return false
+        }
+        if inputs.malibuHoldReasons.contains(where: leftoverProvisionalHoldReasons.contains) {
+            return true
+        }
+        if let eligibility = authoritative ?? authoritativeRewardEligibility(inputs),
+           leftoverProvisionalEligibilityReasons.contains(eligibility.primaryReason) {
+            return true
+        }
+        return false
+    }
+
+    private static func sanitizedTrustProgress(
+        _ inputs: AgentSnapshot.RewardInputs
+    ) -> RewardVerdict.TrustProgress? {
+        if inputs.hasGranularTrustCriteria {
+            let met = (inputs.economicCriteria.isEmpty ? 0 : 1)
+                + (additionalSlotDone(inputs) ? 1 : 0)
+            return RewardVerdict.TrustProgress(met: met, required: 2)
+        }
+        guard let required = inputs.trustCriteriaRequired else { return nil }
+        let boundedRequired = max(required, 0)
+        let met = min(max(inputs.trustCriteriaMet ?? 0, 0), boundedRequired)
+        return RewardVerdict.TrustProgress(met: met, required: boundedRequired)
+    }
+
+    private static func criteriaOverlap(_ economic: String, _ additional: String) -> Bool {
+        economic == additional
+            || (economic == "E2" && additional == "A3")
+            || (economic == "A3" && additional == "E2")
+    }
+
+    private static func hasDistinctUnlockPair(_ economic: [String], _ additional: [String]) -> Bool {
+        for e in economic {
+            for a in additional where !criteriaOverlap(e, a) {
+                return true
+            }
+        }
+        return false
+    }
+
+    private static func additionalSlotDone(_ inputs: AgentSnapshot.RewardInputs) -> Bool {
+        if inputs.economicCriteria.isEmpty { return !inputs.additionalCriteria.isEmpty }
+        return hasDistinctUnlockPair(inputs.economicCriteria, inputs.additionalCriteria)
+    }
+
     static func miningHealth(_ s: AgentSnapshot) -> MiningHealth {
+        miningHealth(s, verdict: rewardVerdict(s))
+    }
+
+    static func miningHealth(_ s: AgentSnapshot, verdict: RewardVerdict) -> MiningHealth {
         func result(
             status: String,
             code: String,
@@ -586,8 +1128,8 @@ enum AgentSnapshotPresenter {
                 reasonCode: code,
                 reason: reason,
                 nextAction: action,
-                rewardSummary: miningRewardSummary(s),
-                trustSummary: miningTrustSummary(s)
+                rewardSummary: miningRewardSummary(s, verdict: verdict),
+                trustSummary: miningTrustSummary(verdict)
             )
         }
 
@@ -615,7 +1157,7 @@ enum AgentSnapshotPresenter {
                 action: publicStatus(s).safeNextAction ?? "Export diagnostics for support."
             )
         }
-        if miningSkipCount(s, "on_battery") > 0 {
+        if miningSkipCount(s, verdict: verdict, "on_battery") > 0 {
             return result(
                 status: "Blocked locally",
                 code: "local_on_battery",
@@ -623,7 +1165,7 @@ enum AgentSnapshotPresenter {
                 action: "Plug in power to earn."
             )
         }
-        if miningSkipCount(s, "thermal_pressure") > 0 {
+        if miningSkipCount(s, verdict: verdict, "thermal_pressure") > 0 {
             return result(
                 status: "Blocked locally",
                 code: "local_thermal_pressure",
@@ -631,7 +1173,7 @@ enum AgentSnapshotPresenter {
                 action: "Let this Mac cool before earning resumes."
             )
         }
-        if miningSkipCount(s, "model_not_loaded") > 0 || isModelPreparing(s) {
+        if miningSkipCount(s, verdict: verdict, "model_not_loaded") > 0 || isModelPreparing(s) {
             return result(
                 status: "Preparing",
                 code: "local_model_preparing",
@@ -639,7 +1181,15 @@ enum AgentSnapshotPresenter {
                 action: "Keep Malibu open while setup continues."
             )
         }
-        if !s.providerEarningsFresh && !s.hasObservedProviderEarnings {
+        if verdict.reasonCode == .telemetryUnavailable {
+            return result(
+                status: "Reward status unavailable",
+                code: verdict.reasonCode.rawValue,
+                reason: "MALIBU reward status can't be reached right now. Your USDC earnings are unaffected.",
+                action: "Nothing to do — this refreshes on its own."
+            )
+        }
+        if !verdict.providerEarningsFresh && !verdict.hasObservedProviderEarnings && verdict.malibuWithdrawal == .unknown {
             // Reframe only when the provider is genuinely buyer-serving-admitted
             // (isNetworkReady) AND has no fresh MALIBU projection that a later
             // branch would report as held/withdrawable/locked. This keeps the
@@ -647,19 +1197,19 @@ enum AgentSnapshotPresenter {
             // reconnecting, or reward-bearing states — those keep the
             // conservative wording below. For such a clean fresh-provider state
             // this is normal, not a fault: frame it forward and name the one real
-            // next step (bind a payout wallet, or the trust-unlock path).
-            if isNetworkReady(s) && !s.malibuProjectionFresh {
+            // next step (bind a payout wallet, or complete trust criteria).
+            if isNetworkReady(s) && !verdict.malibuProjectionFresh {
                 let action: String
                 if s.walletBound == false {
                     action = "Add a payout wallet so your earnings can be paid out."
-                } else if let criteria = trustCriteriaAction(s) {
+                } else if let criteria = trustCriteriaAction(verdict) {
                     action = criteria
                 } else {
                     action = "Stay online — you'll start earning as customer jobs arrive."
                 }
                 return result(
                     status: "No earnings yet",
-                    code: "reward_projection_unavailable",
+                    code: RewardVerdict.ReasonCode.rewardProjectionUnavailable.rawValue,
                     reason: "You're live and building trust. Earnings appear after your first paid job.",
                     action: action
                 )
@@ -671,66 +1221,90 @@ enum AgentSnapshotPresenter {
                 action: isActive(s) ? "Keep Malibu open while reward status refreshes." : "Start the provider to refresh reward status."
             )
         }
-        if s.walletBound == false {
+        if verdict.reasonCode == .walletMissing {
             return result(
-                status: "Missing wallet",
-                code: "wallet_missing",
-                reason: "Rewards are visible, but no payout wallet is bound.",
-                action: "Add a payout wallet."
+                status: "No payout wallet yet",
+                code: verdict.reasonCode.rawValue,
+                reason: "You're set up to earn — you just need somewhere to be paid.",
+                action: "Add a payout wallet to receive earnings."
             )
         }
-        if s.malibuProjectionFresh {
-            if let eligibility = authoritativeRewardEligibility(s), eligibility.primaryReason == "held_provider_daily_cap" {
+        switch verdict.malibuWithdrawal {
+        case .capped(.heldProviderDailyCap):
+            return result(
+                status: "Provider cap held",
+                code: "provider_daily_cap_held",
+                reason: "MALIBU above the provider daily cap is held.",
+                action: "Wait for the next UTC day."
+            )
+        case .capped(.heldWalletDailyCap):
+            return result(
+                status: "Wallet cap held",
+                code: "wallet_daily_cap_held",
+                reason: "MALIBU above the wallet daily cap is held.",
+                action: "Wait for the next UTC day or use a wallet below the cap."
+            )
+        case .lockedProvisional:
+            return result(
+                status: "Trust verification incomplete",
+                code: RewardVerdict.ReasonCode.trustTierProvisional.rawValue,
+                reason: "MALIBU is accruing, but withdrawal eligibility requires Trusted status.",
+                action: trustCriteriaAction(verdict) ?? "Complete trust criteria for withdrawal eligibility."
+            )
+        case .held(let reason):
+            switch reason {
+            case .computeIntegrityBlocked, .providerTokenUntrusted:
                 return result(
-                    status: "Provider cap held",
-                    code: "provider_daily_cap_held",
-                    reason: "MALIBU above the provider daily cap is held.",
-                    action: "Wait for the next UTC day."
+                    status: "Reward eligibility needs review",
+                    code: "reward_eligibility_review",
+                    reason: sentence(rewardReasonCopy(reason)),
+                    action: rewardReasonNextAction(reason)
                 )
-            }
-            if let eligibility = authoritativeRewardEligibility(s), eligibility.primaryReason == "held_wallet_daily_cap" {
-                return result(
-                    status: "Wallet cap held",
-                    code: "wallet_daily_cap_held",
-                    reason: "MALIBU above the wallet daily cap is held.",
-                    action: "Wait for the next UTC day or use a wallet below the cap."
-                )
-            }
-            if s.malibuHoldReasons.contains("per_wallet_daily_cap") {
-                return result(
-                    status: "Wallet cap held",
-                    code: "wallet_daily_cap_held",
-                    reason: "MALIBU above the wallet daily cap is held.",
-                    action: "Wait for the next UTC day or use a wallet below the cap."
-                )
-            }
-            if s.trustTier == .provisional {
-                return result(
-                    status: "Locked until Trusted",
-                    code: "trust_tier_provisional",
-                    reason: "MALIBU is accruing, but withdrawals are locked until Trusted.",
-                    action: trustCriteriaAction(s) ?? "Complete trust criteria to unlock withdrawals."
-                )
-            }
-            if !shouldIgnoreLeftoverProvisionalLock(s),
-               !displayMalibuHoldReasons(s).isEmpty || (s.malibuHeld ?? 0) > 0 {
+            default:
                 return result(
                     status: "Rewards held",
-                    code: "rewards_held",
-                    reason: "Some MALIBU is held while payout eligibility is being verified.",
-                    action: "Review the hold reason before withdrawing."
+                    code: RewardVerdict.ReasonCode.rewardsHeld.rawValue,
+                    reason: sentence(rewardReasonCopy(reason)),
+                    action: rewardReasonNextAction(reason)
                 )
             }
-            if s.trustTier == .trusted, let withdrawable = s.malibuWithdrawable, withdrawable > 0 {
-                return result(
-                    status: "Withdrawable",
-                    code: "trusted_withdrawable",
-                    reason: "Trusted reward projection reports withdrawable MALIBU.",
-                    action: "No local action needed."
-                )
-            }
+        case .epochDisposition(let reason):
+            let status = reason == .heldEpochDisposition ? "Rewards held" : "Reward epoch update"
+            return result(
+                status: status,
+                code: reason == .heldEpochDisposition
+                    ? RewardVerdict.ReasonCode.rewardsHeld.rawValue
+                    : "reward_epoch_disposition",
+                reason: sentence(rewardReasonCopy(reason)),
+                action: rewardReasonNextAction(reason)
+            )
+        case .unavailable:
+            return result(
+                status: "Reward status unavailable",
+                code: RewardVerdict.ReasonCode.telemetryUnavailable.rawValue,
+                reason: "MALIBU reward status could not be determined right now.",
+                action: "Nothing to do — this refreshes on its own."
+            )
+        case .unlocked:
+            return result(
+                status: "Withdrawable",
+                code: RewardVerdict.ReasonCode.trustedWithdrawable.rawValue,
+                reason: "Trusted reward projection reports withdrawable MALIBU.",
+                action: "No local action needed."
+            )
+        case .unknown:
+            break
+        case .none:
+            break
+        case .capped(let reason):
+            return result(
+                status: "Rewards held",
+                code: reason.rawValue,
+                reason: sentence(rewardReasonCopy(reason)),
+                action: rewardReasonNextAction(reason)
+            )
         }
-        if hasMiningEarningsActivity(s) {
+        if verdict.usdcActivity == .earning {
             return result(
                 status: "Earning",
                 code: "earning",
@@ -762,59 +1336,82 @@ enum AgentSnapshotPresenter {
         )
     }
 
-    private static func miningSkipCount(_ s: AgentSnapshot, _ reason: String) -> Int64 {
-        guard s.providerEarningsFresh else { return 0 }
+    private static func miningSkipCount(_ s: AgentSnapshot, verdict: RewardVerdict, _ reason: String) -> Int64 {
+        guard verdict.providerEarningsFresh else { return 0 }
         return s.idlePrewarmSummary.skipsByReasonLast1h[reason] ?? 0
     }
 
-    private static func hasMiningEarningsActivity(_ s: AgentSnapshot) -> Bool {
-        (s.requestsPerMinute ?? 0) > 0
-            || (s.earningsUsdcToday ?? 0) > 0
-            || (s.malibuAccruedToday ?? 0) > 0
+    private static func miningRewardSummary(_ s: AgentSnapshot) -> String {
+        miningRewardSummary(s, verdict: rewardVerdict(s))
     }
 
-    private static func miningRewardSummary(_ s: AgentSnapshot) -> String {
-        let usdc = canShowLastKnownUSDC(s)
-            ? s.earningsUsdcToday.map { "\(formatUSDC($0)) USDC today" } ?? "n/a USDC today"
+    private static func miningRewardSummary(_ s: AgentSnapshot, verdict: RewardVerdict) -> String {
+        let usdc = canShowLastKnownUSDC(s, verdict: verdict)
+            ? s.earningsUsdcToday.map { "\(formatUSDC($0)) \(usdcSummarySuffix(verdict))" } ?? "n/a USDC today"
             : "USDC unavailable"
         let malibu: String
-        if s.malibuProjectionFresh {
-            let withdrawable = s.malibuWithdrawable.map { String(format: "%.2f withdrawable", $0) }
-                ?? "n/a withdrawable"
-            let held = s.malibuHeld.map { String(format: "%.2f held", $0) }
-                ?? "n/a held"
-            malibu = "MALIBU \(withdrawable) / \(held)"
-        } else {
+        switch verdict.malibuWithdrawal {
+        case .unavailable:
+            malibu = "MALIBU reward status unavailable"
+        case .unknown:
             malibu = "MALIBU unavailable"
+        default:
+            malibu = miningMalibuSummary(verdict)
         }
         return "\(usdc) · \(malibu)"
     }
 
-    private static func miningTrustSummary(_ s: AgentSnapshot) -> String {
-        guard s.malibuProjectionFresh else {
-            return "MALIBU trust telemetry not published yet"
+    private static func miningMalibuSummary(_ verdict: RewardVerdict) -> String {
+        let withdrawableAmount = verdict.malibuWithdrawable.map { String(format: "%.2f", $0) } ?? "n/a"
+        let held = verdict.malibuHeld.map { String(format: "%.2f held", $0) } ?? "n/a held"
+        switch verdict.malibuWithdrawal {
+        case .unlocked:
+            return "MALIBU \(withdrawableAmount) withdrawable / \(held)"
+        case .held, .lockedProvisional, .epochDisposition:
+            return "MALIBU not withdrawable / \(held)"
+        case .capped:
+            return "MALIBU withdrawal capped / \(held)"
+        case .none where verdict.reasonCode == .walletMissing:
+            return "MALIBU wallet required / \(held)"
+        case .none:
+            return "MALIBU not withdrawable / \(held)"
+        case .unavailable:
+            return "MALIBU reward status unavailable"
+        case .unknown:
+            return "MALIBU unavailable"
         }
-        let tier = s.trustTier.rawValue.capitalized
-        if hasDemotionCooldown(s) {
-            return "Trust: \(tier) · Trust review in progress"
-        }
-        if s.trustTier == .trusted {
-            return "Trust: Trusted"
-        }
-        if let met = s.trustCriteriaMet, let required = s.trustCriteriaRequired {
-            return "Trust: \(tier) · \(met) of \(required) criteria met"
-        }
-        return "Trust: \(tier)"
     }
 
-    private static func trustCriteriaAction(_ s: AgentSnapshot) -> String? {
-        if hasDemotionCooldown(s) {
-            return "Keep Malibu online; withdrawals unlock automatically when Trusted."
+    private static func miningTrustSummary(_ s: AgentSnapshot) -> String {
+        miningTrustSummary(rewardVerdict(s))
+    }
+
+    private static func miningTrustSummary(_ verdict: RewardVerdict) -> String {
+        switch verdict.trustDisplay {
+        case .trustedAuthoritative:
+            return "Trust: Trusted"
+        case .trustedStaleNeutral:
+            return "MALIBU trust telemetry not published yet"
+        case .provisional:
+            if verdict.reasonCode == .heldDemotionCooldown {
+                return "Trust: Provisional · Trust review in progress"
+            }
+            if let progress = verdict.trustProgress {
+                return "Trust: Provisional · \(progress.met) of \(progress.required) criteria met"
+            }
+            return "Trust: Provisional"
+        case .unknown:
+            return "MALIBU trust telemetry not published yet"
         }
-        guard let met = s.trustCriteriaMet,
-              let required = s.trustCriteriaRequired,
-              required > met else { return nil }
-        return "Complete \(required - met) more trust criteria to unlock withdrawals."
+    }
+
+    private static func trustCriteriaAction(_ verdict: RewardVerdict) -> String? {
+        if verdict.reasonCode == .heldDemotionCooldown {
+            return "Keep Malibu online while trust review completes."
+        }
+        guard let progress = verdict.trustProgress,
+              progress.required > progress.met else { return nil }
+        return "Complete \(progress.required - progress.met) more trust criteria for withdrawal eligibility."
     }
 
     private static func isActive(_ s: AgentSnapshot) -> Bool {
@@ -1146,10 +1743,11 @@ enum AgentSnapshotPresenter {
 
     static func dashboardSubtitle(_ s: AgentSnapshot) -> String? {
         let status = publicStatus(s)
+        let verdict = rewardVerdict(s)
         switch s.state {
         case .serving where !isNetworkReady(s):
             return status.detail
-        case .serving where !s.providerEarningsFresh && !s.hasObservedProviderEarnings:
+        case .serving where !verdict.providerEarningsFresh && !verdict.hasObservedProviderEarnings:
             return "Ready for customer work · earnings unavailable"
         case .serving where idleEarningsAreZero(s):
             return idleHonestySubtitle(s)
@@ -1215,27 +1813,39 @@ enum AgentSnapshotPresenter {
     }
 
     static func earningsLine(_ s: AgentSnapshot) -> String {
-        if !s.providerEarningsFresh || !s.malibuProjectionFresh {
-            if !canShowLastKnownUSDC(s), s.malibuAccruedToday == nil {
+        earningsLine(s, verdict: rewardVerdict(s))
+    }
+
+    static func earningsLine(_ s: AgentSnapshot, verdict: RewardVerdict) -> String {
+        if !verdict.providerEarningsFresh || !verdict.malibuProjectionFresh {
+            if !canShowLastKnownUSDC(s, verdict: verdict), s.malibuAccruedToday == nil {
                 return isActive(s) ? "Today: reward status unavailable" : "Today: not running"
             }
-            let usdc = canShowLastKnownUSDC(s)
+            if verdict.malibuWithdrawal == .unavailable, s.earningsUsdcToday == nil {
+                return isActive(s) ? "Today: reward status unavailable" : "Today: not running"
+            }
+            let usdc = canShowLastKnownUSDC(s, verdict: verdict)
                 ? s.earningsUsdcToday.map { formatUSDC($0) } ?? "n/a"
                 : "n/a"
-            let malibu = s.malibuProjectionFresh
-                ? malibuTodayLine(s, compact: false)
-                : "MALIBU reward status unavailable"
-            return "Today: \(usdc) USDC · \(malibu)"
+            let malibu: String
+            switch verdict.malibuWithdrawal {
+            case .unknown, .unavailable:
+                malibu = "MALIBU reward status unavailable"
+            default:
+                malibu = malibuTodayLine(s, verdict: verdict, compact: false)
+            }
+            let prefix = isShowingLastKnownUSDC(s, verdict: verdict) ? "Last known" : "Today"
+            return "\(prefix): \(usdc) USDC · \(malibu)"
         }
         switch (s.earningsUsdcToday, s.malibuAccruedToday) {
         case (nil, nil):
             return isActive(s) ? "Today: reward status unavailable" : "Today: not running"
         case let (usdc?, malibu?):
-            return "Today: \(formatUSDC(usdc)) USDC · \(malibuDisplay(malibu, snapshot: s))"
+            return "Today: \(formatUSDC(usdc)) USDC · \(malibuDisplay(malibu, verdict: verdict))"
         case let (usdc?, nil):
-            return "Today: \(formatUSDC(usdc)) USDC · \(malibuTodayLine(s, compact: false))"
+            return "Today: \(formatUSDC(usdc)) USDC · \(malibuTodayLine(s, verdict: verdict, compact: false))"
         case let (nil, malibu?):
-            return "Today: n/a USDC · \(malibuDisplay(malibu, snapshot: s))"
+            return "Today: n/a USDC · \(malibuDisplay(malibu, verdict: verdict))"
         }
     }
 
@@ -1244,10 +1854,23 @@ enum AgentSnapshotPresenter {
     /// counts. Gated by `providerEarningsFresh` since idle-prewarm data
     /// arrives on the same projection as the other earnings fields.
     static func eligibilityLine(_ s: AgentSnapshot) -> String? {
-        if let eligibility = displayRewardEligibility(s) {
-            return rewardEligibilityLine(eligibility)
+        eligibilityLine(s, verdict: rewardVerdict(s))
+    }
+
+    static func eligibilityLine(_ s: AgentSnapshot, verdict: RewardVerdict) -> String? {
+        switch verdict.malibuWithdrawal {
+        case .unavailable:
+            return "Reward status unavailable"
+        case .held(let reason), .capped(let reason), .epochDisposition(let reason):
+            return rewardReasonCopy(reason)
+        case .lockedProvisional:
+            return "MALIBU withdrawals require Trusted status"
+        case .unlocked:
+            return "MALIBU withdrawals are available"
+        default:
+            break
         }
-        guard s.providerEarningsFresh else { return nil }
+        guard verdict.providerEarningsFresh else { return nil }
         let skips = s.idlePrewarmSummary.skipsByReasonLast1h
         if (skips["on_battery"] ?? 0) > 0 {
             return "On battery — plug in to earn"
@@ -1271,15 +1894,19 @@ enum AgentSnapshotPresenter {
     }
 
     static func backlogLine(_ s: AgentSnapshot) -> String? {
-        guard s.providerEarningsFresh,
-              s.malibuProjectionFresh,
-              s.walletBound == false,
-              let usdc = s.unpaidLedgerBacklogUSDC,
-              let malibu = s.unpaidLedgerBacklogMALIBU,
+        backlogLine(s, verdict: rewardVerdict(s))
+    }
+
+    static func backlogLine(_ s: AgentSnapshot, verdict: RewardVerdict) -> String? {
+        guard verdict.providerEarningsFresh,
+              verdict.malibuWithdrawal != .unknown,
+              verdict.walletBound == false,
+              let usdc = verdict.unpaidLedgerBacklogUSDC,
+              let malibu = verdict.unpaidLedgerBacklogMALIBU,
               usdc + malibu > 0 else {
             return nil
         }
-        return String(format: "Unclaimed: $%.2f USDC · %@", usdc, malibuDisplay(malibu, snapshot: s))
+        return String(format: "Unclaimed: $%.2f USDC · %@", usdc, malibuDisplay(malibu, verdict: verdict))
     }
 
     static func modelLine(_ s: AgentSnapshot) -> String {
@@ -1601,12 +2228,17 @@ enum AgentSnapshotPresenter {
     }
 
     static func usdcFullLine(_ s: AgentSnapshot) -> String {
-        if !canShowLastKnownUSDC(s) {
+        usdcFullLine(s, verdict: rewardVerdict(s))
+    }
+
+    static func usdcFullLine(_ s: AgentSnapshot, verdict: RewardVerdict) -> String {
+        if !canShowLastKnownUSDC(s, verdict: verdict) {
             let today = "n/a today"
             return "\(today) · n/a wk · n/a accrued · n/a life"
         }
+        let todaySuffix = isShowingLastKnownUSDC(s, verdict: verdict) ? "last known" : "today"
         return [
-            s.earningsUsdcToday.map { "\(formatUSDC($0)) today" } ?? "n/a today",
+            s.earningsUsdcToday.map { "\(formatUSDC($0)) \(todaySuffix)" } ?? "n/a today",
             s.earningsUsdcWeek.map { "\(formatUSDC($0)) wk" } ?? "n/a wk",
             s.earningsUsdcPending.map { "\(formatUSDC($0)) accrued" } ?? "n/a accrued",
             s.earningsUsdcLifetime.map { "\(formatUSDC($0)) life" } ?? "n/a life"
@@ -1616,118 +2248,138 @@ enum AgentSnapshotPresenter {
     /// Caption for the accrued amount in `usdcFullLine`, kept on its own line
     /// so the full line stays scannable.
     static func usdcAccrualCaption(_ s: AgentSnapshot) -> String? {
-        guard s.providerEarningsFresh, s.earningsUsdcPending != nil else { return nil }
+        usdcAccrualCaption(s, verdict: rewardVerdict(s))
+    }
+
+    static func usdcAccrualCaption(_ s: AgentSnapshot, verdict: RewardVerdict) -> String? {
+        guard verdict.usdcActivity != .unavailable,
+              verdict.usdcActivity != .none,
+              s.earningsUsdcPending != nil else { return nil }
         return "Accrued — payouts open in beta"
     }
 
     static func usdcTodayDisplay(_ s: AgentSnapshot) -> String {
-        guard canShowLastKnownUSDC(s) else {
+        usdcTodayDisplay(s, verdict: rewardVerdict(s))
+    }
+
+    static func usdcTodayDisplay(_ s: AgentSnapshot, verdict: RewardVerdict) -> String {
+        guard canShowLastKnownUSDC(s, verdict: verdict) else {
             return "n/a"
         }
         return s.earningsUsdcToday.map { formatUSDC($0) } ?? "n/a"
     }
 
+    static func usdcPeriodLabel(_ s: AgentSnapshot, verdict: RewardVerdict) -> String {
+        isShowingLastKnownUSDC(s, verdict: verdict) ? "Last known" : "Today"
+    }
+
     static func malibuFullLine(_ s: AgentSnapshot) -> String {
-        if !s.malibuProjectionFresh {
+        malibuFullLine(s, verdict: rewardVerdict(s))
+    }
+
+    static func malibuFullLine(_ s: AgentSnapshot, verdict: RewardVerdict) -> String {
+        if verdict.malibuWithdrawal == .unknown {
             let today = "n/a MALIBU today"
             return "\(today) · n/a all-time"
         }
-        let today = malibuTodayLine(s, compact: true)
+        if verdict.malibuWithdrawal == .unavailable {
+            let allTime = s.malibuAccruedAllTime.map { String(format: "%.2f all-time", $0) }
+                ?? "n/a all-time"
+            return "MALIBU today unavailable · \(allTime) · reward status unavailable"
+        }
+        let today = malibuTodayLine(s, verdict: verdict, compact: true)
         let allTime = s.malibuAccruedAllTime.map { String(format: "%.2f all-time", $0) }
             ?? "n/a all-time"
-        if let eligibility = displayRewardEligibility(s) {
-            switch eligibility.withdrawalState {
-            case "withdrawable":
-                return "\(today) · \(allTime)"
-            default:
-                return "\(today) · \(allTime) · \(rewardEligibilityShortCopy(eligibility))"
-            }
-        }
-        switch s.trustTier {
-        case .trusted:
+        switch verdict.malibuWithdrawal {
+        case .unlocked:
             return "\(today) · \(allTime)"
-        case .provisional:
-            return "\(today) · \(allTime) · [locked] unlocks at Trusted"
+        case .none:
+            return "\(today) · \(allTime)"
+        case .lockedProvisional:
+            return "\(today) · \(allTime) · [locked] Trusted status required"
+        case .held(let reason), .capped(let reason), .epochDisposition(let reason):
+            return "\(today) · \(allTime) · \(rewardReasonShortCopy(reason))"
+        case .unavailable, .unknown:
+            return "\(today) · \(allTime)"
         }
     }
 
-    private static func malibuTodayLine(_ s: AgentSnapshot, compact: Bool) -> String {
+    private static func malibuTodayLine(_ s: AgentSnapshot, verdict: RewardVerdict, compact: Bool) -> String {
         if let malibu = s.malibuAccruedToday {
-            return malibuDisplay(malibu, snapshot: s, compact: compact)
+            return malibuDisplay(malibu, verdict: verdict, compact: compact)
         }
-        if s.malibuAccruedAllTime != nil || s.malibuWithdrawable != nil || s.malibuHeld != nil {
+        if s.malibuAccruedAllTime != nil || verdict.malibuWithdrawable != nil || verdict.malibuHeld != nil {
             return "MALIBU daily not reported yet"
         }
         return compact ? "n/a MALIBU today" : "n/a MALIBU"
     }
 
     static func malibuAvailabilityLine(_ s: AgentSnapshot) -> String? {
-        guard s.malibuProjectionFresh,
-              s.malibuWithdrawable != nil || s.malibuHeld != nil else { return nil }
+        malibuAvailabilityLine(s, verdict: rewardVerdict(s))
+    }
+
+    static func malibuAvailabilityLine(_ s: AgentSnapshot, verdict: RewardVerdict) -> String? {
+        guard verdict.malibuWithdrawal != .unknown,
+              verdict.malibuWithdrawable != nil || verdict.malibuHeld != nil else { return nil }
         let withdrawable: String
-        if let eligibility = displayRewardEligibility(s) {
-            withdrawable = malibuWithdrawableDisplay(s.malibuWithdrawable, eligibility: eligibility)
-        } else {
-            withdrawable = s.malibuWithdrawable.map { String(format: "%.2f available", $0) } ?? "n/a available"
+        switch verdict.malibuWithdrawal {
+        case .unlocked:
+            withdrawable = verdict.malibuWithdrawable.map { String(format: "%.2f available", $0) } ?? "n/a available"
+        case .none where verdict.reasonCode == .walletMissing:
+            withdrawable = "wallet required"
+        case .none:
+            withdrawable = "not withdrawable"
+        case .held, .lockedProvisional, .epochDisposition:
+            withdrawable = "not withdrawable"
+        case .capped:
+            withdrawable = "withdrawal capped"
+        case .unavailable:
+            withdrawable = "status unavailable"
+        case .unknown:
+            return nil
         }
-        let held = s.malibuHeld.map { String(format: "%.2f held", $0) } ?? "n/a held"
+        let held = verdict.malibuHeld.map { String(format: "%.2f held", $0) } ?? "n/a held"
         return "MALIBU: \(withdrawable) · \(held)"
     }
 
-    private static func malibuWithdrawableDisplay(_ amount: Double?, eligibility: MalibuRewardEligibility) -> String {
-        switch eligibility.withdrawalState {
-        case "withdrawable":
-            return amount.map { String(format: "%.2f available", $0) } ?? "n/a available"
-        case "held":
-            return "not withdrawable"
-        case "capped":
-            return "withdrawal capped"
-        case "ineligible":
-            return "not eligible"
-        case "unavailable":
-            return "status unavailable"
-        default:
-            return "status unavailable"
-        }
+    static func malibuHoldLine(_ s: AgentSnapshot) -> String? {
+        malibuHoldLine(s, verdict: rewardVerdict(s))
     }
 
-    static func malibuHoldLine(_ s: AgentSnapshot) -> String? {
-        if let eligibility = displayRewardEligibility(s),
-           eligibility.withdrawalState != "withdrawable" {
-            return "MALIBU status: \(rewardReasonCopy(eligibility.primaryReason)) Next: \(rewardReasonNextAction(eligibility.primaryReason))"
+    static func malibuHoldLine(_ s: AgentSnapshot, verdict: RewardVerdict) -> String? {
+        switch verdict.malibuWithdrawal {
+        case .held(let reason), .capped(let reason), .epochDisposition(let reason):
+            return "MALIBU status: \(rewardReasonCopy(reason)) Next: \(rewardReasonNextAction(reason))"
+        case .unavailable:
+            return "MALIBU status: \(rewardReasonCopy(.telemetryUnavailable)) Next: \(rewardReasonNextAction(.telemetryUnavailable))"
+        default:
+            break
         }
-        let holdReasons = displayMalibuHoldReasons(s)
-        guard s.malibuProjectionFresh, !holdReasons.isEmpty else { return nil }
-        let reasons = holdReasons.map { malibuHoldReasonCopy($0) }
-        let nextAction: String
-        if holdReasons.contains("trust_tier_provisional"),
-           let met = s.trustCriteriaMet,
-           let required = s.trustCriteriaRequired,
-           required > met {
-            nextAction = "Complete \(required - met) more trust criteria to unlock withdrawals."
-        } else if holdReasons.contains("per_wallet_daily_cap") {
-            nextAction = "The wallet cap resets at the next UTC day."
-        } else if holdReasons.contains("demotion_cooldown") {
-            nextAction = "Keep Malibu online; withdrawals unlock automatically when Trusted."
-        } else {
-            nextAction = "Review the hold reason above before withdrawing."
-        }
-        return "Held because: \(reasons.joined(separator: "; ")) Next: \(nextAction)"
+        return nil
     }
 
     static func trustLine(_ s: AgentSnapshot) -> String {
-        guard s.malibuProjectionFresh else { return "MALIBU trust telemetry not published yet" }
-        let tier = s.trustTier.rawValue.capitalized
-        if hasDemotionCooldown(s) {
-            return "\(tier) — Trust review in progress"
-        }
-        if s.trustTier == .trusted {
+        trustLine(rewardVerdict(s))
+    }
+
+    static func trustLine(_ verdict: RewardVerdict) -> String {
+        switch verdict.trustDisplay {
+        case .trustedAuthoritative:
             return "Trusted"
+        case .trustedStaleNeutral:
+            return "Live"
+        case .provisional:
+            if verdict.reasonCode == .heldDemotionCooldown {
+                return "Provisional — Trust review in progress"
+            }
+            if let progress = verdict.trustProgress {
+                let base = "Provisional — \(progress.met) of \(progress.required) criteria met"
+                return progress.required > progress.met ? "\(base) · Trust criteria →" : base
+            }
+            return "Provisional"
+        case .unknown:
+            return "MALIBU trust telemetry not published yet"
         }
-        if let met = s.trustCriteriaMet, let required = s.trustCriteriaRequired {
-            return "\(tier) — \(met) of \(required) criteria met · Unlock Trusted →"
-        }
-        return tier
     }
 
     static func uptimeLine(_ s: AgentSnapshot) -> String {
@@ -1780,7 +2432,15 @@ enum AgentSnapshotPresenter {
     }
 
     static func unclaimedBadge(_ s: AgentSnapshot, dismissedThreshold: Double?) -> String? {
-        guard let total = unclaimedBacklogTotal(s),
+        unclaimedBadge(s, verdict: rewardVerdict(s), dismissedThreshold: dismissedThreshold)
+    }
+
+    static func unclaimedBadge(
+        _ s: AgentSnapshot,
+        verdict: RewardVerdict,
+        dismissedThreshold: Double?
+    ) -> String? {
+        guard let total = unclaimedBacklogTotal(s, verdict: verdict),
               let threshold = UnclaimedBadgePolicy.visibleThreshold(
                 totalBacklog: total,
                 dismissedThreshold: dismissedThreshold
@@ -1791,8 +2451,14 @@ enum AgentSnapshotPresenter {
     }
 
     static func unclaimedBacklogTotal(_ s: AgentSnapshot) -> Double? {
-        guard s.providerEarningsFresh, s.malibuProjectionFresh, s.walletBound == false else { return nil }
-        let total = (s.unpaidLedgerBacklogUSDC ?? 0) + (s.unpaidLedgerBacklogMALIBU ?? 0)
+        unclaimedBacklogTotal(s, verdict: rewardVerdict(s))
+    }
+
+    static func unclaimedBacklogTotal(_ s: AgentSnapshot, verdict: RewardVerdict) -> Double? {
+        guard verdict.providerEarningsFresh,
+              verdict.malibuWithdrawal != .unknown,
+              verdict.walletBound == false else { return nil }
+        let total = (verdict.unpaidLedgerBacklogUSDC ?? 0) + (verdict.unpaidLedgerBacklogMALIBU ?? 0)
         return total > 0 ? total : nil
     }
 
@@ -2182,72 +2848,34 @@ enum AgentSnapshotPresenter {
         return String(format: "$%.2f", amount)
     }
 
-    private static func malibuDisplay(_ amount: Double, snapshot: AgentSnapshot, compact: Bool = false) -> String {
-        if let eligibility = displayRewardEligibility(snapshot) {
-            switch eligibility.withdrawalState {
-            case "withdrawable":
-                return String(format: "%.2f MALIBU", amount)
-            case "capped":
-                if compact {
-                    return String(format: "%.2f MALIBU today (capped)", amount)
-                }
-                return String(format: "[capped] %.2f MALIBU", amount)
-            case "unavailable":
-                if compact {
-                    return "MALIBU today unavailable"
-                }
-                return "MALIBU reward status unavailable"
-            default:
-                if compact {
-                    return String(format: "%.2f MALIBU today (locked)", amount)
-                }
-                return String(format: "[locked] %.2f MALIBU", amount)
-            }
-        }
-        return malibuDisplay(amount, tier: snapshot.trustTier, compact: compact)
+    private static func sentence(_ clause: String) -> String {
+        guard let first = clause.first else { return clause }
+        let capitalized = first.uppercased() + clause.dropFirst()
+        return capitalized.hasSuffix(".") ? capitalized : capitalized + "."
     }
 
-    private static func malibuDisplay(_ amount: Double, tier: AgentSnapshot.TrustTier, compact: Bool = false) -> String {
-        switch tier {
-        case .trusted:
+    private static func malibuDisplay(_ amount: Double, verdict: RewardVerdict, compact: Bool = false) -> String {
+        switch verdict.malibuWithdrawal {
+        case .unlocked:
             return String(format: "%.2f MALIBU", amount)
-        case .provisional:
+        case .none where verdict.reasonCode != .walletMissing:
+            return String(format: "%.2f MALIBU", amount)
+        case .capped:
+            if compact {
+                return String(format: "%.2f MALIBU today (capped)", amount)
+            }
+            return String(format: "[capped] %.2f MALIBU", amount)
+        case .unavailable:
+            if compact {
+                return "MALIBU today unavailable"
+            }
+            return "MALIBU reward status unavailable"
+        case .held, .lockedProvisional, .epochDisposition, .none, .unknown:
             if compact {
                 return String(format: "%.2f MALIBU today (locked)", amount)
             }
-            return String(format: "[locked] %.2f MALIBU (unlocks at Trusted)", amount)
+            return String(format: "[locked] %.2f MALIBU", amount)
         }
-    }
-
-    private static func malibuHoldReasonCopy(_ reason: String) -> String {
-        switch reason {
-        case "trust_tier_provisional":
-            return "Trust verification is incomplete"
-        case "per_wallet_daily_cap":
-            return "the wallet's daily limit has been reached"
-        case "demotion_cooldown":
-            return "Trust verification is in progress"
-        default:
-            return "payout eligibility is still being verified"
-        }
-    }
-
-    private static func authoritativeRewardEligibility(_ s: AgentSnapshot) -> MalibuRewardEligibility? {
-        guard s.malibuProjectionFresh else { return nil }
-        return s.malibuRewardEligibility ?? MalibuRewardEligibility.unavailableForMissingObject()
-    }
-
-    /// Current demotion cooldown only. A historical `demotion_cooldown` hold
-    /// row on an already-Trusted snapshot must not hide Trusted or show
-    /// requalification copy.
-    private static func hasDemotionCooldown(_ s: AgentSnapshot) -> Bool {
-        guard s.trustTier == .provisional else {
-            return false
-        }
-        if s.malibuHoldReasons.contains("demotion_cooldown") {
-            return true
-        }
-        return authoritativeRewardEligibility(s)?.primaryReason == "held_demotion_cooldown"
     }
 
     private static let leftoverProvisionalHoldReasons: Set<String> = [
@@ -2259,92 +2887,38 @@ enum AgentSnapshotPresenter {
         "held_demotion_cooldown",
     ]
 
-    /// Trusted snapshots can still carry leftover provisional hold rows from
-    /// 1.8.102. Those must not tell a Trusted earner they are locked.
-    private static func displayMalibuHoldReasons(_ s: AgentSnapshot) -> [String] {
-        guard s.trustTier == .trusted else { return s.malibuHoldReasons }
-        return s.malibuHoldReasons.filter { !leftoverProvisionalHoldReasons.contains($0) }
-    }
-
-    private static func displayRewardEligibility(_ s: AgentSnapshot) -> MalibuRewardEligibility? {
-        guard let eligibility = authoritativeRewardEligibility(s) else { return nil }
-        guard s.trustTier == .trusted,
-              leftoverProvisionalEligibilityReasons.contains(eligibility.primaryReason) else {
-            return eligibility
-        }
-        return nil
-    }
-
-    private static func shouldIgnoreLeftoverProvisionalLock(_ s: AgentSnapshot) -> Bool {
-        guard s.trustTier == .trusted, displayMalibuHoldReasons(s).isEmpty else {
-            return false
-        }
-        if s.malibuHoldReasons.contains(where: leftoverProvisionalHoldReasons.contains) {
-            return true
-        }
-        if let eligibility = authoritativeRewardEligibility(s),
-           leftoverProvisionalEligibilityReasons.contains(eligibility.primaryReason) {
-            return true
-        }
-        return false
-    }
 
     private static func canShowLastKnownUSDC(_ s: AgentSnapshot) -> Bool {
-        s.providerEarningsFresh || (s.hasObservedProviderEarnings && s.earningsUsdcToday != nil)
+        canShowLastKnownUSDC(s, verdict: rewardVerdict(s))
     }
 
-    private static func rewardEligibilityLine(_ eligibility: MalibuRewardEligibility) -> String {
-        switch eligibility.primaryReason {
-        case "earning_verified_work":
-            return "Earning MALIBU from verified work"
-        case "eligible_idle_no_work":
-            return "Eligible · network is quiet"
-        case "held_provider_daily_cap":
-            return "MALIBU provider daily cap reached"
-        case "held_wallet_daily_cap":
-            return "MALIBU wallet daily cap reached"
-        case "held_provisional_trust_tier":
-            return "MALIBU is locked until Trusted"
-        case "held_demotion_cooldown":
-            return "MALIBU is locked until Trusted"
-        case "withdrawable_balance_available":
-            return "MALIBU is available to withdraw"
-        case "withdrawable_no_balance":
-            return "No MALIBU is available yet"
-        case "missing_wallet_binding":
-            return "Add a wallet to unlock MALIBU withdrawals"
-        case "local_on_battery":
-            return "On battery — plug in to earn"
-        case "local_thermal_pressure":
-            return "Thermal throttle — waiting to cool before earning"
-        case "model_not_ready":
-            return "Model is preparing — earning starts when ready"
-        case "compute_integrity_pending", "insufficient_verified_receipts", "app_attestation_missing":
-            return "Reward status is being verified"
-        case "compute_integrity_blocked", "provider_token_untrusted":
-            return "Reward eligibility needs review"
-        case "hardware_evidence_unavailable",
-             "hardware_evidence_missing_or_expired",
-             "compute_integrity_unavailable",
-             "telemetry_unavailable":
-            return "Reward status unavailable"
-        default:
-            return "Reward status unavailable"
+    private static func canShowLastKnownUSDC(_ s: AgentSnapshot, verdict: RewardVerdict) -> Bool {
+        if verdict.providerEarningsFresh {
+            return verdict.usdcActivity != .unavailable
         }
+        return s.hasObservedProviderEarnings && s.earningsUsdcToday != nil
     }
 
-    private static func rewardEligibilityShortCopy(_ eligibility: MalibuRewardEligibility) -> String {
-        switch eligibility.withdrawalState {
-        case "capped":
+    private static func isShowingLastKnownUSDC(_ s: AgentSnapshot, verdict: RewardVerdict) -> Bool {
+        !verdict.providerEarningsFresh && s.hasObservedProviderEarnings && s.earningsUsdcToday != nil
+    }
+
+    private static func usdcSummarySuffix(_ verdict: RewardVerdict) -> String {
+        verdict.providerEarningsFresh ? "USDC today" : "USDC last known"
+    }
+
+    private static func rewardReasonShortCopy(_ reason: RewardVerdict.ReasonCode) -> String {
+        switch reason {
+        case .heldProviderDailyCap, .heldWalletDailyCap:
             return "limited by daily cap"
-        case "held":
-            return "locked until eligible"
-        case "ineligible":
-            return "not eligible for withdrawal"
-        case "unavailable":
+        case .telemetryUnavailable:
             return "reward status unavailable"
+        case .unknown:
+            return "reward status needs review"
+        case .excludedEpochDisposition, .burnedOrRetiredEpochDisposition:
+            return "epoch reward update"
         default:
-            return rewardEligibilityLine(eligibility)
+            return "locked until eligible"
         }
     }
 
@@ -2378,6 +2952,37 @@ enum AgentSnapshotPresenter {
         }
     }
 
+    private static func rewardReasonCopy(_ reason: RewardVerdict.ReasonCode) -> String {
+        switch reason {
+        case .telemetryUnavailable:
+            return "MALIBU reward status is temporarily unavailable"
+        case .walletMissing:
+            return "No payout wallet is bound"
+        case .trustedWithdrawable:
+            return "withdrawals are available"
+        case .rewardsHeld:
+            return "payout eligibility is still being verified"
+        case .trustTierProvisional:
+            return "Trust verification is incomplete"
+        case .rewardProjectionUnavailable:
+            return "MALIBU reward telemetry is not published yet"
+        case .rewardProjectionWarmingUp:
+            return "earnings appear after your first paid job"
+        case .earning:
+            return "paid work or rewards have settled"
+        case .idleNoWork:
+            return "the network is quiet right now"
+        case .waitingSettlement:
+            return "paid credits appear when jobs settle"
+        case .none:
+            return "no reward action is available"
+        case .unknown:
+            return "reward status needs review"
+        default:
+            return rewardReasonCopy(reason.rawValue)
+        }
+    }
+
     private static func rewardReasonNextAction(_ reason: String) -> String {
         switch reason {
         case "held_provider_daily_cap":
@@ -2385,9 +2990,9 @@ enum AgentSnapshotPresenter {
         case "held_wallet_daily_cap":
             return "The wallet cap resets at the next UTC day."
         case "held_provisional_trust_tier":
-            return "Complete the remaining trust criteria to unlock withdrawals."
+            return "Complete the remaining trust criteria for withdrawal eligibility."
         case "held_demotion_cooldown":
-            return "Keep Malibu online; withdrawals unlock automatically when Trusted."
+            return "Keep Malibu online while trust review completes."
         case "missing_wallet_binding":
             return "Add a payout wallet."
         case "insufficient_verified_receipts":
@@ -2398,6 +3003,25 @@ enum AgentSnapshotPresenter {
             return "Review Advanced diagnostics."
         default:
             return "Try again when reward status refreshes."
+        }
+    }
+
+    private static func rewardReasonNextAction(_ reason: RewardVerdict.ReasonCode) -> String {
+        switch reason {
+        case .unknown:
+            return "Keep Malibu open while reward status refreshes."
+        case .telemetryUnavailable:
+            return "Nothing to do — this refreshes on its own."
+        case .rewardProjectionUnavailable:
+            return "Keep Malibu open while reward status refreshes."
+        case .rewardProjectionWarmingUp:
+            return "Stay online — you'll start earning as customer jobs arrive."
+        case .walletMissing:
+            return "Add a payout wallet to receive earnings."
+        case .trustedWithdrawable, .earning, .idleNoWork, .waitingSettlement, .none:
+            return "No local action needed."
+        default:
+            return rewardReasonNextAction(reason.rawValue)
         }
     }
 

--- a/phase3-binary/app/Sources/Malibu/Agent/EarningsClient.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/EarningsClient.swift
@@ -30,6 +30,7 @@ struct ProviderIdlePrewarmSummary: Codable, Equatable {
 /// Coordinator-owned MALIBU reward eligibility reason model.
 struct MalibuRewardEligibility: Codable, Equatable {
     static let schemaV1 = "malibu_reward_eligibility.v1"
+    static let schemaDriftNotification = Notification.Name("MalibuRewardEligibilitySchemaDrift")
 
     let schemaVersion: String
     let earningState: String
@@ -78,14 +79,7 @@ struct MalibuRewardEligibility: Codable, Equatable {
             self = .unavailable(schemaVersion: rawSchema, driftField: "withdrawal_state")
             return
         }
-        if !Self.allowedReasons.contains(rawPrimaryReason) {
-            self = .unavailable(schemaVersion: rawSchema, driftField: "primary_reason")
-            return
-        }
-        if rawReasons.contains(where: { !Self.allowedReasons.contains($0) }) {
-            self = .unavailable(schemaVersion: rawSchema, driftField: "reasons")
-            return
-        }
+        Self.logReasonDriftIfNeeded(primaryReason: rawPrimaryReason, reasons: rawReasons)
         self.init(
             schemaVersion: rawSchema,
             earningState: rawEarningState,
@@ -113,6 +107,27 @@ struct MalibuRewardEligibility: Codable, Equatable {
     private static func logSchemaDrift(schemaVersion: String, field: String) {
         let schema = schemaVersion.isEmpty ? "missing" : schemaVersion
         NSLog("[malibu] malibu_reward_eligibility_schema_drift schema_version=%@ field=%@", schema, field)
+        NotificationCenter.default.post(
+            name: schemaDriftNotification,
+            object: nil,
+            userInfo: [
+                "schema_version": schema,
+                "field": field,
+            ]
+        )
+    }
+
+    private static func logReasonDriftIfNeeded(primaryReason: String, reasons: [String]) {
+        if primaryReason.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
+            !knownReasons.contains(primaryReason) {
+            logSchemaDrift(schemaVersion: schemaV1, field: "primary_reason")
+        }
+        if reasons.contains(where: { reason in
+            let trimmed = reason.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty || !knownReasons.contains(trimmed)
+        }) {
+            logSchemaDrift(schemaVersion: schemaV1, field: "reasons")
+        }
     }
 
     private static let allowedEarningStates: Set<String> = [
@@ -121,13 +136,16 @@ struct MalibuRewardEligibility: Codable, Equatable {
     private static let allowedWithdrawalStates: Set<String> = [
         "withdrawable", "held", "capped", "ineligible", "unavailable"
     ]
-    private static let allowedReasons: Set<String> = [
+    static let knownReasons: Set<String> = [
         "earning_verified_work",
         "eligible_idle_no_work",
         "held_provisional_trust_tier",
         "held_provider_daily_cap",
         "held_wallet_daily_cap",
         "held_demotion_cooldown",
+        "held_epoch_disposition",
+        "excluded_epoch_disposition",
+        "burned_or_retired_epoch_disposition",
         "withdrawable_balance_available",
         "withdrawable_no_balance",
         "missing_wallet_binding",
@@ -167,6 +185,10 @@ struct ProviderEarnings: Codable, Equatable {
     let malibuDailyCap: Double?
     let malibuWalletDailyCap: Double?
     let malibuRewardEligibility: MalibuRewardEligibility?
+    let economicCriteria: [String]
+    let additionalCriteria: [String]
+    let hasGranularTrustCriteria: Bool
+    let rewardTelemetryUnavailable: Bool
     /// Last-hour idle-prewarm event/skip counts, used to explain why a
     /// serving provider is not currently earning. Display-only.
     let idlePrewarm: ProviderIdlePrewarmSummary
@@ -195,6 +217,9 @@ struct ProviderEarnings: Codable, Equatable {
         case malibuDailyCap = "malibu_daily_cap"
         case malibuWalletDailyCap = "malibu_wallet_daily_cap"
         case malibuRewardEligibility = "malibu_reward_eligibility"
+        case economicCriteria = "economic_criteria"
+        case additionalCriteria = "additional_criteria"
+        case rewardTelemetryUnavailable = "reward_telemetry_unavailable"
         case idlePrewarm = "idle_prewarm"
         case malibuProjectionFresh = "malibu_projection_fresh"
         case earningsProjectionFresh = "earnings_projection_fresh"
@@ -219,6 +244,13 @@ struct ProviderEarnings: Codable, Equatable {
         malibuHoldReasons = try c.decodeIfPresent([String].self, forKey: .malibuHoldReasons) ?? []
         malibuDailyCap = try c.decodeIfPresent(Double.self, forKey: .malibuDailyCap)
         malibuWalletDailyCap = try c.decodeIfPresent(Double.self, forKey: .malibuWalletDailyCap)
+        economicCriteria = try c.decodeIfPresent([String].self, forKey: .economicCriteria) ?? []
+        additionalCriteria = try c.decodeIfPresent([String].self, forKey: .additionalCriteria) ?? []
+        hasGranularTrustCriteria = c.contains(.economicCriteria) || c.contains(.additionalCriteria)
+        rewardTelemetryUnavailable = try c.decodeIfPresent(
+            Bool.self,
+            forKey: .rewardTelemetryUnavailable
+        ) ?? false
         idlePrewarm = try c.decodeIfPresent(ProviderIdlePrewarmSummary.self, forKey: .idlePrewarm) ?? .empty
         let decodedMalibuProjectionFresh = try c.decodeIfPresent(Bool.self, forKey: .malibuProjectionFresh) ?? false
         malibuProjectionFresh = decodedMalibuProjectionFresh
@@ -233,6 +265,44 @@ struct ProviderEarnings: Codable, Equatable {
             malibuRewardEligibility = nil
         }
         earningsProjectionFresh = try c.decodeIfPresent(Bool.self, forKey: .earningsProjectionFresh) ?? false
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(walletBound, forKey: .walletBound)
+        try c.encode(trustTier, forKey: .trustTier)
+        try c.encode(unpaidLedgerBacklogUSDC, forKey: .unpaidLedgerBacklogUSDC)
+        try c.encode(unpaidLedgerBacklogMALIBU, forKey: .unpaidLedgerBacklogMALIBU)
+        try c.encodeIfPresent(usdcToday, forKey: .usdcToday)
+        try c.encodeIfPresent(usdcWeek, forKey: .usdcWeek)
+        try c.encodeIfPresent(usdcPending, forKey: .usdcPending)
+        try c.encodeIfPresent(usdcLifetime, forKey: .usdcLifetime)
+        try c.encodeIfPresent(malibuToday, forKey: .malibuToday)
+        try c.encodeIfPresent(malibuAllTime, forKey: .malibuAllTime)
+        try c.encodeIfPresent(trustCriteriaMet, forKey: .trustCriteriaMet)
+        try c.encodeIfPresent(trustCriteriaRequired, forKey: .trustCriteriaRequired)
+        try c.encodeIfPresent(malibuWithdrawable, forKey: .malibuWithdrawable)
+        try c.encodeIfPresent(malibuHeld, forKey: .malibuHeld)
+        if !malibuHoldReasons.isEmpty {
+            try c.encode(malibuHoldReasons, forKey: .malibuHoldReasons)
+        }
+        try c.encodeIfPresent(malibuDailyCap, forKey: .malibuDailyCap)
+        try c.encodeIfPresent(malibuWalletDailyCap, forKey: .malibuWalletDailyCap)
+        try c.encodeIfPresent(malibuRewardEligibility, forKey: .malibuRewardEligibility)
+        if hasGranularTrustCriteria || !economicCriteria.isEmpty {
+            try c.encode(economicCriteria, forKey: .economicCriteria)
+        }
+        if hasGranularTrustCriteria || !additionalCriteria.isEmpty {
+            try c.encode(additionalCriteria, forKey: .additionalCriteria)
+        }
+        if rewardTelemetryUnavailable {
+            try c.encode(rewardTelemetryUnavailable, forKey: .rewardTelemetryUnavailable)
+        }
+        if idlePrewarm != .empty {
+            try c.encode(idlePrewarm, forKey: .idlePrewarm)
+        }
+        try c.encode(malibuProjectionFresh, forKey: .malibuProjectionFresh)
+        try c.encode(earningsProjectionFresh, forKey: .earningsProjectionFresh)
     }
 
     init(
@@ -254,6 +324,10 @@ struct ProviderEarnings: Codable, Equatable {
         malibuDailyCap: Double? = nil,
         malibuWalletDailyCap: Double? = nil,
         malibuRewardEligibility: MalibuRewardEligibility? = nil,
+        economicCriteria: [String] = [],
+        additionalCriteria: [String] = [],
+        hasGranularTrustCriteria: Bool = false,
+        rewardTelemetryUnavailable: Bool = false,
         idlePrewarm: ProviderIdlePrewarmSummary = .empty,
         malibuProjectionFresh: Bool = false,
         earningsProjectionFresh: Bool = false
@@ -276,6 +350,10 @@ struct ProviderEarnings: Codable, Equatable {
         self.malibuDailyCap = malibuDailyCap
         self.malibuWalletDailyCap = malibuWalletDailyCap
         self.malibuRewardEligibility = malibuRewardEligibility
+        self.economicCriteria = economicCriteria
+        self.additionalCriteria = additionalCriteria
+        self.hasGranularTrustCriteria = hasGranularTrustCriteria
+        self.rewardTelemetryUnavailable = rewardTelemetryUnavailable
         self.idlePrewarm = idlePrewarm
         self.malibuProjectionFresh = malibuProjectionFresh
         self.earningsProjectionFresh = earningsProjectionFresh

--- a/phase3-binary/app/Sources/Malibu/Agent/INVARIANTS.md
+++ b/phase3-binary/app/Sources/Malibu/Agent/INVARIANTS.md
@@ -1,0 +1,35 @@
+# Reward Verdict Invariants
+
+Slice A owns the app-side typed reward-verdict contract for existing money-path
+surfaces. It does not implement the consolidated-status card from Slice C
+(#1323), and it does not repair CLI wallet/bridge frame integrity from Slice B
+(#1322). Frame-ingestion honesty remains conditional on `MalibuAgent.swift`
+preserving the existing legacy-stub demotion rules.
+
+`AgentSnapshotPresenter.rewardVerdict(_:)` is the only place MALIBU
+withdrawal/trust truth and USDC activity truth are decided. Dashboard and menu
+bar surfaces must project from `RewardVerdict`; raw reward inputs stay behind
+the `AgentSnapshot` fileprivate access wall.
+
+1. Trusted legacy snapshots can carry leftover provisional locks from 1.8.102.
+   When a fresh Trusted snapshot has withdrawable MALIBU and only leftover
+   provisional hold evidence (`trust_tier_provisional`,
+   `demotion_cooldown`, `held_provisional_trust_tier`, or
+   `held_demotion_cooldown`), the verdict must ignore that stale lock and
+   allow withdrawable MALIBU.
+2. Stale Trusted trust telemetry is neutral `Live`. It must not render Trusted,
+   earning, withdrawable, or unlocked MALIBU.
+3. USDC earning is separate from MALIBU withdrawal. Earning requires fresh
+   provider earnings evidence and must not imply MALIBU unlock.
+4. Provider-earnings freshness and MALIBU-projection freshness are independent.
+   Fresh MALIBU verdicts can render while USDC projection is stale, and fresh
+   USDC can render while MALIBU projection is unknown.
+5. Explicit coordinator non-withdrawable reasons outrank raw amounts. Held,
+   capped, and epoch-disposition reasons must prevent withdrawable/unlocked
+   copy even if an amount field is positive.
+6. Explicit reward telemetry outage outranks calm warming-up/no-earnings copy.
+7. Coordinator reason handling is closed over known semantic cases and retains
+   `.unknown(String)` for future non-rendered semantics.
+8. Trust progress is sanitized before rendering. Granular economic/additional
+   criteria count distinct unlock slots, while legacy counters are clamped.
+   Slice C owns phase-card rendering; Slice A must not add it.

--- a/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
@@ -1335,8 +1335,10 @@ final class MalibuAgent: ObservableObject {
     }
 
     private func invalidateProviderProjectionFreshness() {
-        snapshot.providerEarningsFresh = false
-        snapshot.malibuProjectionFresh = false
+        snapshot.updateRewardInputs(
+            providerEarningsFresh: false,
+            malibuProjectionFresh: false
+        )
         providerProjectionEligible = false
     }
 
@@ -1355,18 +1357,7 @@ final class MalibuAgent: ObservableObject {
         guard record.hasObservedProviderEarnings, !snapshot.hasObservedProviderEarnings else {
             return
         }
-        snapshot.hasObservedProviderEarnings = true
-        snapshot.earningsUsdcToday = record.earningsUsdcToday
-        snapshot.earningsUsdcWeek = record.earningsUsdcWeek
-        snapshot.earningsUsdcPending = record.earningsUsdcPending
-        snapshot.earningsUsdcLifetime = record.earningsUsdcLifetime
-        snapshot.malibuAccruedToday = record.malibuAccruedToday
-        snapshot.malibuAccruedAllTime = record.malibuAccruedAllTime
-        snapshot.malibuWithdrawable = record.malibuWithdrawable
-        snapshot.malibuHeld = record.malibuHeld
-        if let walletBound = record.walletBound {
-            snapshot.walletBound = walletBound
-        }
+        snapshot.applyDashboardObservation(record)
     }
 
     private func persistDashboardObservation() {
@@ -1375,33 +1366,27 @@ final class MalibuAgent: ObservableObject {
             return
         }
         let fileURL = DashboardObservationStore.fileURL()
-        var holdDate = snapshot.lastBuyerServingAt
-        if snapshot.shouldClearBuyerServingHold {
-            holdDate = nil
-        } else if holdDate == nil {
-            holdDate = DashboardObservationStore.load(
-                providerID: providerID,
-                fileURL: fileURL
-            )?.lastBuyerServingAt
+        var record = snapshot.dashboardObservationRecord(providerID: providerID)
+        if record.lastBuyerServingAt == nil,
+           !snapshot.shouldClearBuyerServingHold,
+           let held = DashboardObservationStore.load(providerID: providerID, fileURL: fileURL)?.lastBuyerServingAt {
+            record = DashboardObservationStore.Record(
+                providerID: record.providerID,
+                lastBuyerServingAt: held,
+                hasObservedProviderEarnings: record.hasObservedProviderEarnings,
+                earningsUsdcToday: record.earningsUsdcToday,
+                earningsUsdcWeek: record.earningsUsdcWeek,
+                earningsUsdcPending: record.earningsUsdcPending,
+                earningsUsdcLifetime: record.earningsUsdcLifetime,
+                malibuAccruedToday: record.malibuAccruedToday,
+                malibuAccruedAllTime: record.malibuAccruedAllTime,
+                malibuWithdrawable: record.malibuWithdrawable,
+                malibuHeld: record.malibuHeld,
+                walletBound: record.walletBound,
+                recordedAt: record.recordedAt
+            )
         }
-        DashboardObservationStore.save(
-            DashboardObservationStore.Record(
-                providerID: providerID,
-                lastBuyerServingAt: holdDate,
-                hasObservedProviderEarnings: snapshot.hasObservedProviderEarnings,
-                earningsUsdcToday: snapshot.earningsUsdcToday,
-                earningsUsdcWeek: snapshot.earningsUsdcWeek,
-                earningsUsdcPending: snapshot.earningsUsdcPending,
-                earningsUsdcLifetime: snapshot.earningsUsdcLifetime,
-                malibuAccruedToday: snapshot.malibuAccruedToday,
-                malibuAccruedAllTime: snapshot.malibuAccruedAllTime,
-                malibuWithdrawable: snapshot.malibuWithdrawable,
-                malibuHeld: snapshot.malibuHeld,
-                walletBound: snapshot.walletBound,
-                recordedAt: Date()
-            ),
-            fileURL: fileURL
-        )
+        DashboardObservationStore.save(record, fileURL: fileURL)
     }
 
     func consume(_ frame: ControlFrame) {
@@ -1458,6 +1443,7 @@ final class MalibuAgent: ObservableObject {
                                  && inputTokensAllTime == nil && outputTokensAllTime == nil
             if looksLikeStub {
                 if snapshot.hasObservedProviderEarnings {
+                    snapshot.demoteRewardInputsAfterLegacyStub()
                     persistDashboardObservation()
                     return
                 }
@@ -1480,33 +1466,15 @@ final class MalibuAgent: ObservableObject {
                 snapshot.inputTokensAllTime = inputTokensAllTime
                 snapshot.outputTokensAllTime = outputTokensAllTime
             }
-            snapshot.malibuProjectionFresh = providerProjectionEligible
-                && providerEarnings?.malibuProjectionFresh == true
-            snapshot.providerEarningsFresh = providerProjectionEligible
-                && providerEarnings?.earningsProjectionFresh == true
+            snapshot.updateRewardFreshness(
+                providerProjectionEligible: providerProjectionEligible,
+                providerEarnings: providerEarnings
+            )
             if let providerEarnings {
-                snapshot.walletBound = providerEarnings.walletBound
-                snapshot.trustTier = providerEarnings.trustTier
-                snapshot.unpaidLedgerBacklogUSDC = providerEarnings.unpaidLedgerBacklogUSDC
-                snapshot.unpaidLedgerBacklogMALIBU = providerEarnings.unpaidLedgerBacklogMALIBU
-                snapshot.earningsUsdcToday = providerEarnings.usdcToday
-                snapshot.earningsUsdcWeek = providerEarnings.usdcWeek
-                snapshot.earningsUsdcPending = providerEarnings.usdcPending
-                snapshot.earningsUsdcLifetime = providerEarnings.usdcLifetime
-                snapshot.malibuAccruedToday = providerEarnings.malibuToday
-                snapshot.malibuAccruedAllTime = providerEarnings.malibuAllTime
-                snapshot.malibuWithdrawable = providerEarnings.malibuWithdrawable
-                snapshot.malibuHeld = providerEarnings.malibuHeld
-                snapshot.malibuHoldReasons = providerEarnings.malibuHoldReasons
-                snapshot.malibuDailyCap = providerEarnings.malibuDailyCap
-                snapshot.malibuWalletDailyCap = providerEarnings.malibuWalletDailyCap
-                snapshot.malibuRewardEligibility = providerEarnings.malibuRewardEligibility
-                snapshot.trustCriteriaMet = providerEarnings.trustCriteriaMet
-                snapshot.trustCriteriaRequired = providerEarnings.trustCriteriaRequired
-                snapshot.idlePrewarmSummary = providerEarnings.idlePrewarm
-                if providerProjectionEligible && providerEarnings.earningsProjectionFresh {
-                    snapshot.hasObservedProviderEarnings = true
-                }
+                snapshot.applyProviderEarnings(
+                    providerEarnings,
+                    providerProjectionEligible: providerProjectionEligible
+                )
             }
             persistDashboardObservation()
         case let .pauseAck(accepted, reason):
@@ -1687,6 +1655,7 @@ final class MalibuAgent: ObservableObject {
     private func clearRuntimeMetrics() {
         snapshot.earningsUsdcToday = nil
         snapshot.malibuAccruedToday = nil
+        snapshot.clearRuntimeRewardInputs()
         snapshot.uptimeSec = nil
         snapshot.gpuTemperatureC = nil
         snapshot.gpuUtilizationPct = nil

--- a/phase3-binary/app/Sources/Malibu/Dashboard/DashboardWindow.swift
+++ b/phase3-binary/app/Sources/Malibu/Dashboard/DashboardWindow.swift
@@ -239,40 +239,43 @@ private struct DashboardView: View {
 
             HStack(alignment: .top, spacing: 16) {
                 panel {
-                    Text("Today").font(.caption).foregroundStyle(.secondary)
-                    Text(AgentSnapshotPresenter.usdcTodayDisplay(agent.snapshot))
+                    let rewardVerdict = AgentSnapshotPresenter.rewardVerdict(agent.snapshot)
+                    Text(AgentSnapshotPresenter.usdcPeriodLabel(agent.snapshot, verdict: rewardVerdict))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text(AgentSnapshotPresenter.usdcTodayDisplay(agent.snapshot, verdict: rewardVerdict))
                         .font(.system(size: 28, weight: .semibold, design: .rounded))
-                    Text(AgentSnapshotPresenter.usdcFullLine(agent.snapshot))
+                    Text(AgentSnapshotPresenter.usdcFullLine(agent.snapshot, verdict: rewardVerdict))
                         .foregroundStyle(.secondary)
                         .font(.callout)
-                    if let caption = AgentSnapshotPresenter.usdcAccrualCaption(agent.snapshot) {
+                    if let caption = AgentSnapshotPresenter.usdcAccrualCaption(agent.snapshot, verdict: rewardVerdict) {
                         Text(caption)
                             .font(.caption2)
                             .foregroundStyle(.secondary)
                     }
-                    Text(AgentSnapshotPresenter.malibuFullLine(agent.snapshot))
+                    Text(AgentSnapshotPresenter.malibuFullLine(agent.snapshot, verdict: rewardVerdict))
                         .foregroundStyle(
-                            agent.snapshot.malibuProjectionFresh && agent.snapshot.trustTier == .provisional
+                            AgentSnapshotPresenter.malibuRewardTextColorIsLocked(rewardVerdict)
                                 ? MalibuBrand.coral
                                 : .secondary
                         )
                         .font(.callout)
-                    if let availability = AgentSnapshotPresenter.malibuAvailabilityLine(agent.snapshot) {
+                    if let availability = AgentSnapshotPresenter.malibuAvailabilityLine(agent.snapshot, verdict: rewardVerdict) {
                         Text(availability)
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
-                    if let hold = AgentSnapshotPresenter.malibuHoldLine(agent.snapshot) {
+                    if let hold = AgentSnapshotPresenter.malibuHoldLine(agent.snapshot, verdict: rewardVerdict) {
                         Text(hold)
                             .font(.caption)
                             .foregroundStyle(MalibuBrand.coral)
                     }
-                    if let backlog = AgentSnapshotPresenter.backlogLine(agent.snapshot) {
+                    if let backlog = AgentSnapshotPresenter.backlogLine(agent.snapshot, verdict: rewardVerdict) {
                         Text(backlog)
                             .font(.caption)
                             .foregroundStyle(MalibuBrand.coral)
                     }
-                    if let eligibility = AgentSnapshotPresenter.eligibilityLine(agent.snapshot) {
+                    if let eligibility = AgentSnapshotPresenter.eligibilityLine(agent.snapshot, verdict: rewardVerdict) {
                         Text(eligibility)
                             .font(.caption)
                             .foregroundStyle(.secondary)
@@ -470,7 +473,8 @@ private struct DashboardView: View {
     }
 
     private var miningHealthPanel: some View {
-        let mining = AgentSnapshotPresenter.miningHealth(agent.snapshot)
+        let rewardVerdict = AgentSnapshotPresenter.rewardVerdict(agent.snapshot)
+        let mining = AgentSnapshotPresenter.miningHealth(agent.snapshot, verdict: rewardVerdict)
         return VStack(alignment: .leading, spacing: 10) {
             HStack(alignment: .firstTextBaseline) {
                 Text(DashboardCopy.miningHealthTitle)

--- a/phase3-binary/app/Sources/Malibu/MenuBar/MenuBarController.swift
+++ b/phase3-binary/app/Sources/Malibu/MenuBar/MenuBarController.swift
@@ -167,9 +167,14 @@ final class MenuBarController {
     }
 
     private func updateMenu(_ menu: NSMenu, snapshot: AgentSnapshot) {
-        let badge = AgentSnapshotPresenter.unclaimedBadge(snapshot, dismissedThreshold: dismissedUnclaimedThreshold)
+        let rewardVerdict = AgentSnapshotPresenter.rewardVerdict(snapshot)
+        let badge = AgentSnapshotPresenter.unclaimedBadge(
+            snapshot,
+            verdict: rewardVerdict,
+            dismissedThreshold: dismissedUnclaimedThreshold
+        )
         menu.item(withIdentifier: .statusRow)?.title = AgentSnapshotPresenter.stateLine(snapshot)
-        menu.item(withIdentifier: .earningsRow)?.title = AgentSnapshotPresenter.earningsLine(snapshot)
+        menu.item(withIdentifier: .earningsRow)?.title = AgentSnapshotPresenter.earningsLine(snapshot, verdict: rewardVerdict)
         if let cliLine = AgentSnapshotPresenter.cliVersionMenuLine(snapshot),
            let item = menu.item(withIdentifier: .cliVersionRow) {
             item.title = cliLine
@@ -195,7 +200,7 @@ final class MenuBarController {
                 updateItem.isEnabled = false
             }
         }
-        if let backlog = AgentSnapshotPresenter.backlogLine(snapshot),
+        if let backlog = AgentSnapshotPresenter.backlogLine(snapshot, verdict: rewardVerdict),
            let item = menu.item(withIdentifier: .backlogRow) {
             item.title = backlog
             item.isHidden = false
@@ -216,9 +221,10 @@ final class MenuBarController {
     }
 
     private func menuTooltip(_ snapshot: AgentSnapshot) -> String {
+        let rewardVerdict = AgentSnapshotPresenter.rewardVerdict(snapshot)
         var lines = [
             AgentSnapshotPresenter.stateLine(snapshot),
-            AgentSnapshotPresenter.earningsLine(snapshot),
+            AgentSnapshotPresenter.earningsLine(snapshot, verdict: rewardVerdict),
         ]
         if let cliLine = AgentSnapshotPresenter.cliVersionMenuLine(snapshot) {
             lines.append(cliLine)

--- a/phase3-binary/app/Tests/MalibuTests/AgentSnapshotPresenterTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/AgentSnapshotPresenterTests.swift
@@ -32,18 +32,20 @@ final class AgentSnapshotPresenterTests: XCTestCase {
     func testMalibuDailyMissingExplainsProjectionInsteadOfShowingNA() {
         var s = AgentSnapshot.empty
         s.state = .serving
-        s.providerEarningsFresh = true
-        s.malibuProjectionFresh = true
         s.earningsUsdcToday = 0.04
         s.malibuAccruedToday = nil
         s.malibuAccruedAllTime = 12.5
-        s.malibuHeld = 12.5
-        s.trustTier = .provisional
-        s.malibuRewardEligibility = MalibuRewardEligibility(
-            earningState: "held",
-            withdrawalState: "held",
-            primaryReason: "held_provisional_trust_tier",
-            reasons: ["held_provisional_trust_tier"]
+        s.updateRewardInputs(
+            trustTier: .provisional,
+            providerEarningsFresh: true,
+            malibuProjectionFresh: true,
+            malibuHeld: 12.5,
+            malibuRewardEligibility: MalibuRewardEligibility(
+                earningState: "held",
+                withdrawalState: "held",
+                primaryReason: "held_provisional_trust_tier",
+                reasons: ["held_provisional_trust_tier"]
+            )
         )
 
         XCTAssertEqual(
@@ -488,14 +490,16 @@ final class AgentSnapshotPresenterTests: XCTestCase {
         s.state = .serving
         s.earningsUsdcToday = 1
         s.malibuAccruedToday = 2
-        s.trustTier = .provisional
-        s.providerEarningsFresh = true
-        s.malibuProjectionFresh = true
-        s.malibuRewardEligibility = MalibuRewardEligibility(
-            earningState: "held",
-            withdrawalState: "held",
-            primaryReason: "held_provisional_trust_tier",
-            reasons: ["held_provisional_trust_tier"]
+        s.updateRewardInputs(
+            trustTier: .provisional,
+            providerEarningsFresh: true,
+            malibuProjectionFresh: true,
+            malibuRewardEligibility: MalibuRewardEligibility(
+                earningState: "held",
+                withdrawalState: "held",
+                primaryReason: "held_provisional_trust_tier",
+                reasons: ["held_provisional_trust_tier"]
+            )
         )
         XCTAssertTrue(AgentSnapshotPresenter.earningsLine(s).contains("[locked] 2.00 MALIBU"))
         XCTAssertFalse(AgentSnapshotPresenter.earningsLine(s).contains("unlocks at Trusted"))
@@ -506,8 +510,7 @@ final class AgentSnapshotPresenterTests: XCTestCase {
         s.unpaidLedgerBacklogUSDC = 10
         s.unpaidLedgerBacklogMALIBU = 5
         s.walletBound = false
-        s.providerEarningsFresh = true
-        s.malibuProjectionFresh = true
+        s.updateRewardInputs(providerEarningsFresh: true, malibuProjectionFresh: true)
         XCTAssertNotNil(AgentSnapshotPresenter.backlogLine(s))
         s.walletBound = true
         XCTAssertNil(AgentSnapshotPresenter.backlogLine(s))
@@ -1032,8 +1035,7 @@ final class AgentSnapshotPresenterTests: XCTestCase {
         s.walletBound = false
         s.unpaidLedgerBacklogUSDC = 9
         s.unpaidLedgerBacklogMALIBU = 0
-        s.providerEarningsFresh = true
-        s.malibuProjectionFresh = true
+        s.updateRewardInputs(providerEarningsFresh: true, malibuProjectionFresh: true)
         XCTAssertEqual(AgentSnapshotPresenter.unclaimedBadge(s, dismissedThreshold: nil), "$1+")
         XCTAssertNil(AgentSnapshotPresenter.unclaimedBadge(s, dismissedThreshold: 10))
 
@@ -1110,82 +1112,93 @@ final class AgentSnapshotPresenterTests: XCTestCase {
 
     func testMalibuAvailabilityAndHoldCopyExplainWithdrawalState() {
         var snapshot = AgentSnapshot.empty
-        snapshot.trustTier = .provisional
-        snapshot.providerEarningsFresh = true
-        snapshot.malibuProjectionFresh = true
-        snapshot.malibuWithdrawable = 0
-        snapshot.malibuHeld = 12.5
-        snapshot.malibuHoldReasons = ["trust_tier_provisional"]
-        snapshot.trustCriteriaMet = 2
-        snapshot.trustCriteriaRequired = 4
-        snapshot.malibuRewardEligibility = MalibuRewardEligibility(
-            earningState: "held",
-            withdrawalState: "held",
-            primaryReason: "held_provisional_trust_tier",
-            reasons: ["held_provisional_trust_tier"]
+        snapshot.updateRewardInputs(
+            trustTier: .provisional,
+            providerEarningsFresh: true,
+            malibuProjectionFresh: true,
+            malibuWithdrawable: 0,
+            malibuHeld: 12.5,
+            malibuHoldReasons: ["trust_tier_provisional"],
+            malibuRewardEligibility: MalibuRewardEligibility(
+                earningState: "held",
+                withdrawalState: "held",
+                primaryReason: "held_provisional_trust_tier",
+                reasons: ["held_provisional_trust_tier"]
+            ),
+            trustCriteriaMet: 2,
+            trustCriteriaRequired: 4
         )
 
         XCTAssertEqual(AgentSnapshotPresenter.malibuAvailabilityLine(snapshot), "MALIBU: not withdrawable · 12.50 held")
         XCTAssertEqual(
             AgentSnapshotPresenter.malibuHoldLine(snapshot),
-            "MALIBU status: Trust verification is incomplete Next: Complete the remaining trust criteria to unlock withdrawals."
+            "MALIBU status: Trust verification is incomplete Next: Complete the remaining trust criteria for withdrawal eligibility."
         )
 
-        snapshot.malibuHoldReasons = ["per_wallet_daily_cap"]
-        snapshot.malibuRewardEligibility = MalibuRewardEligibility(
-            earningState: "capped",
-            withdrawalState: "capped",
-            primaryReason: "held_wallet_daily_cap",
-            reasons: ["held_wallet_daily_cap"]
+        snapshot.updateRewardInputs(
+            malibuHoldReasons: ["per_wallet_daily_cap"],
+            malibuRewardEligibility: MalibuRewardEligibility(
+                earningState: "capped",
+                withdrawalState: "capped",
+                primaryReason: "held_wallet_daily_cap",
+                reasons: ["held_wallet_daily_cap"]
+            )
         )
         XCTAssertEqual(
             AgentSnapshotPresenter.malibuHoldLine(snapshot),
             "MALIBU status: wallet daily limit reached Next: The wallet cap resets at the next UTC day."
         )
 
-        snapshot.malibuHoldReasons = []
-        snapshot.malibuRewardEligibility = MalibuRewardEligibility(
-            earningState: "capped",
-            withdrawalState: "capped",
-            primaryReason: "held_provider_daily_cap",
-            reasons: ["held_provider_daily_cap"]
+        snapshot.updateRewardInputs(
+            malibuHoldReasons: [],
+            malibuRewardEligibility: MalibuRewardEligibility(
+                earningState: "capped",
+                withdrawalState: "capped",
+                primaryReason: "held_provider_daily_cap",
+                reasons: ["held_provider_daily_cap"]
+            )
         )
         XCTAssertEqual(
             AgentSnapshotPresenter.malibuHoldLine(snapshot),
             "MALIBU status: provider daily limit reached Next: The provider cap resets at the next UTC day."
         )
 
-        snapshot.trustTier = .provisional
-        snapshot.malibuRewardEligibility = MalibuRewardEligibility(
-            earningState: "held",
-            withdrawalState: "held",
-            primaryReason: "held_demotion_cooldown",
-            reasons: ["held_demotion_cooldown"]
+        snapshot.updateRewardInputs(
+            trustTier: .provisional,
+            malibuRewardEligibility: MalibuRewardEligibility(
+                earningState: "held",
+                withdrawalState: "held",
+                primaryReason: "held_demotion_cooldown",
+                reasons: ["held_demotion_cooldown"]
+            )
         )
         XCTAssertEqual(
             AgentSnapshotPresenter.malibuHoldLine(snapshot),
-            "MALIBU status: Trust verification is in progress Next: Keep Malibu online; withdrawals unlock automatically when Trusted."
+            "MALIBU status: Trust verification is in progress Next: Keep Malibu online while trust review completes."
         )
     }
 
     func testRewardEligibilityV1OverridesLegacyMalibuPresentation() {
         var snapshot = AgentSnapshot.empty
-        snapshot.trustTier = .trusted
-        snapshot.providerEarningsFresh = true
-        snapshot.malibuProjectionFresh = true
+        snapshot.walletBound = true
         snapshot.malibuAccruedToday = 2
         snapshot.malibuAccruedAllTime = 2
-        snapshot.malibuWithdrawable = 2
-        snapshot.malibuHeld = 0
-        snapshot.malibuHoldReasons = []
-        snapshot.malibuRewardEligibility = MalibuRewardEligibility(
-            earningState: "held",
-            withdrawalState: "held",
-            primaryReason: "held_provisional_trust_tier",
-            reasons: ["held_provisional_trust_tier"]
+        snapshot.updateRewardInputs(
+            trustTier: .trusted,
+            providerEarningsFresh: true,
+            malibuProjectionFresh: true,
+            malibuWithdrawable: 2,
+            malibuHeld: 0,
+            malibuHoldReasons: [],
+            malibuRewardEligibility: MalibuRewardEligibility(
+                earningState: "held",
+                withdrawalState: "held",
+                primaryReason: "held_provisional_trust_tier",
+                reasons: ["held_provisional_trust_tier"]
+            )
         )
 
-        XCTAssertNil(AgentSnapshotPresenter.eligibilityLine(snapshot))
+        XCTAssertEqual(AgentSnapshotPresenter.eligibilityLine(snapshot), "MALIBU withdrawals are available")
         XCTAssertEqual(
             AgentSnapshotPresenter.malibuAvailabilityLine(snapshot),
             "MALIBU: 2.00 available · 0.00 held"
@@ -1201,20 +1214,22 @@ final class AgentSnapshotPresenterTests: XCTestCase {
         var snapshot = AgentSnapshot.empty
         snapshot.state = .serving
         snapshot.networkState = "buyer_serving"
-        snapshot.trustTier = .trusted
-        snapshot.providerEarningsFresh = true
-        snapshot.malibuProjectionFresh = true
         snapshot.walletBound = true
         snapshot.malibuAccruedToday = 2
         snapshot.malibuAccruedAllTime = 2
-        snapshot.malibuWithdrawable = 2
-        snapshot.malibuHeld = 12.5
-        snapshot.malibuHoldReasons = ["trust_tier_provisional", "demotion_cooldown"]
-        snapshot.malibuRewardEligibility = MalibuRewardEligibility(
-            earningState: "held",
-            withdrawalState: "held",
-            primaryReason: "held_provisional_trust_tier",
-            reasons: ["held_provisional_trust_tier"]
+        snapshot.updateRewardInputs(
+            trustTier: .trusted,
+            providerEarningsFresh: true,
+            malibuProjectionFresh: true,
+            malibuWithdrawable: 2,
+            malibuHeld: 12.5,
+            malibuHoldReasons: ["trust_tier_provisional", "demotion_cooldown"],
+            malibuRewardEligibility: MalibuRewardEligibility(
+                earningState: "held",
+                withdrawalState: "held",
+                primaryReason: "held_provisional_trust_tier",
+                reasons: ["held_provisional_trust_tier"]
+            )
         )
 
         let health = AgentSnapshotPresenter.miningHealth(snapshot)
@@ -1237,16 +1252,19 @@ final class AgentSnapshotPresenterTests: XCTestCase {
 
     func testRewardEligibilityUsesFreshMalibuProjectionWithoutFreshUSDCProjection() {
         var snapshot = AgentSnapshot.empty
-        snapshot.trustTier = .trusted
-        snapshot.providerEarningsFresh = false
-        snapshot.malibuProjectionFresh = true
+        snapshot.walletBound = true
         snapshot.malibuAccruedToday = 2
         snapshot.malibuAccruedAllTime = 2
-        snapshot.malibuRewardEligibility = MalibuRewardEligibility(
-            earningState: "held",
-            withdrawalState: "held",
-            primaryReason: "held_provisional_trust_tier",
-            reasons: ["held_provisional_trust_tier"]
+        snapshot.updateRewardInputs(
+            trustTier: .trusted,
+            providerEarningsFresh: false,
+            malibuProjectionFresh: true,
+            malibuRewardEligibility: MalibuRewardEligibility(
+                earningState: "held",
+                withdrawalState: "held",
+                primaryReason: "held_provisional_trust_tier",
+                reasons: ["held_provisional_trust_tier"]
+            )
         )
 
         XCTAssertNil(AgentSnapshotPresenter.eligibilityLine(snapshot))
@@ -1256,7 +1274,7 @@ final class AgentSnapshotPresenterTests: XCTestCase {
         )
     }
 
-    func testProviderEarningsUnknownRewardEligibilityNormalizesUnavailable() throws {
+    func testProviderEarningsUnknownRewardEligibilityPreservesUnknownReason() throws {
         let data = Data("""
         {
           "wallet_bound": true,
@@ -1275,10 +1293,10 @@ final class AgentSnapshotPresenterTests: XCTestCase {
 
         let decoded = try JSONDecoder().decode(ProviderEarnings.self, from: data)
         XCTAssertEqual(decoded.malibuRewardEligibility?.schemaVersion, "malibu_reward_eligibility.v1")
-        XCTAssertEqual(decoded.malibuRewardEligibility?.earningState, "unavailable")
-        XCTAssertEqual(decoded.malibuRewardEligibility?.withdrawalState, "unavailable")
-        XCTAssertEqual(decoded.malibuRewardEligibility?.primaryReason, "telemetry_unavailable")
-        XCTAssertEqual(decoded.malibuRewardEligibility?.reasons, ["telemetry_unavailable"])
+        XCTAssertEqual(decoded.malibuRewardEligibility?.earningState, "earning")
+        XCTAssertEqual(decoded.malibuRewardEligibility?.withdrawalState, "withdrawable")
+        XCTAssertEqual(decoded.malibuRewardEligibility?.primaryReason, "future_reason")
+        XCTAssertEqual(decoded.malibuRewardEligibility?.reasons, ["future_reason"])
     }
 
     func testFreshProviderEarningsWithoutRewardEligibilityFailsClosed() throws {
@@ -1300,13 +1318,15 @@ final class AgentSnapshotPresenterTests: XCTestCase {
         XCTAssertEqual(decoded.malibuRewardEligibility?.withdrawalState, "unavailable")
 
         var snapshot = AgentSnapshot.empty
-        snapshot.walletBound = decoded.walletBound
-        snapshot.trustTier = decoded.trustTier
-        snapshot.providerEarningsFresh = decoded.earningsProjectionFresh
-        snapshot.malibuProjectionFresh = decoded.malibuProjectionFresh
-        snapshot.malibuWithdrawable = decoded.malibuWithdrawable
-        snapshot.malibuHeld = decoded.malibuHeld
-        snapshot.malibuRewardEligibility = decoded.malibuRewardEligibility
+        snapshot.updateRewardInputs(
+            walletBound: decoded.walletBound,
+            trustTier: decoded.trustTier,
+            providerEarningsFresh: decoded.earningsProjectionFresh,
+            malibuProjectionFresh: decoded.malibuProjectionFresh,
+            malibuWithdrawable: decoded.malibuWithdrawable,
+            malibuHeld: decoded.malibuHeld,
+            malibuRewardEligibility: decoded.malibuRewardEligibility
+        )
 
         XCTAssertEqual(AgentSnapshotPresenter.malibuAvailabilityLine(snapshot), "MALIBU: status unavailable · 0.00 held")
         XCTAssertEqual(AgentSnapshotPresenter.eligibilityLine(snapshot), "Reward status unavailable")
@@ -1315,12 +1335,14 @@ final class AgentSnapshotPresenterTests: XCTestCase {
     func testUnavailableRewardEligibilityDoesNotRenderLockedAmount() {
         var snapshot = AgentSnapshot.empty
         snapshot.state = .serving
-        snapshot.providerEarningsFresh = true
-        snapshot.malibuProjectionFresh = true
         snapshot.earningsUsdcToday = 0.04
         snapshot.malibuAccruedToday = 8
         snapshot.malibuAccruedAllTime = 8
-        snapshot.malibuRewardEligibility = MalibuRewardEligibility.unavailableForMissingObject()
+        snapshot.updateRewardInputs(
+            providerEarningsFresh: true,
+            malibuProjectionFresh: true,
+            malibuRewardEligibility: MalibuRewardEligibility.unavailableForMissingObject()
+        )
 
         let earningsLine = AgentSnapshotPresenter.earningsLine(snapshot)
         let fullLine = AgentSnapshotPresenter.malibuFullLine(snapshot)

--- a/phase3-binary/app/Tests/MalibuTests/ControlFrameCodecTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/ControlFrameCodecTests.swift
@@ -150,8 +150,6 @@ final class ControlFrameCodecTests: XCTestCase {
     @MainActor
     func testMetricsFrameWithoutProviderEarningsHidesPriorRewardProjection() {
         var initial = AgentSnapshot.empty
-        initial.providerEarningsFresh = true
-        initial.malibuProjectionFresh = true
         initial.earningsUsdcToday = 4.12
         initial.earningsUsdcWeek = 18.4
         initial.earningsUsdcPending = 6.9
@@ -160,12 +158,16 @@ final class ControlFrameCodecTests: XCTestCase {
         initial.malibuAccruedAllTime = 50
         initial.unpaidLedgerBacklogUSDC = 1
         initial.unpaidLedgerBacklogMALIBU = 2
-        initial.trustTier = .provisional
-        initial.trustCriteriaMet = 4
-        initial.trustCriteriaRequired = 4
-        initial.malibuWithdrawable = 3
-        initial.malibuHeld = 0.5
-        initial.malibuHoldReasons = ["per_wallet_daily_cap"]
+        initial.updateRewardInputs(
+            trustTier: .provisional,
+            providerEarningsFresh: true,
+            malibuProjectionFresh: true,
+            malibuWithdrawable: 3,
+            malibuHeld: 0.5,
+            malibuHoldReasons: ["per_wallet_daily_cap"],
+            trustCriteriaMet: 4,
+            trustCriteriaRequired: 4
+        )
 
         let agent = MalibuAgent(initialSnapshot: initial)
         agent.consume(.metricsResponse(
@@ -187,8 +189,7 @@ final class ControlFrameCodecTests: XCTestCase {
             uptimeSec: nil
         ))
 
-        XCTAssertFalse(agent.snapshot.providerEarningsFresh)
-        XCTAssertFalse(agent.snapshot.malibuProjectionFresh)
+        XCTAssertEqual(AgentSnapshotPresenter.rewardVerdict(agent.snapshot).malibuWithdrawal, .unknown)
         XCTAssertNil(AgentSnapshotPresenter.malibuAvailabilityLine(agent.snapshot))
         XCTAssertNil(AgentSnapshotPresenter.malibuHoldLine(agent.snapshot))
         XCTAssertFalse(AgentSnapshotPresenter.usdcFullLine(agent.snapshot).contains("$18.40"))
@@ -282,8 +283,9 @@ final class ControlFrameCodecTests: XCTestCase {
             uptimeSec: 1
         ))
 
-        XCTAssertTrue(agent.snapshot.providerEarningsFresh)
-        XCTAssertFalse(agent.snapshot.malibuProjectionFresh)
+        let earningsOnlyVerdict = AgentSnapshotPresenter.rewardVerdict(agent.snapshot)
+        XCTAssertEqual(earningsOnlyVerdict.usdcActivity, .earning)
+        XCTAssertEqual(earningsOnlyVerdict.malibuWithdrawal, .unknown)
         XCTAssertEqual(AgentSnapshotPresenter.usdcTodayDisplay(agent.snapshot), "$4.00")
         XCTAssertNil(AgentSnapshotPresenter.malibuAvailabilityLine(agent.snapshot))
         XCTAssertTrue(AgentSnapshotPresenter.earningsLine(agent.snapshot).contains("$4.00 USDC"))
@@ -326,14 +328,18 @@ final class ControlFrameCodecTests: XCTestCase {
             uptimeSec: 1
         ))
 
-        XCTAssertFalse(agent.snapshot.providerEarningsFresh)
-        XCTAssertTrue(agent.snapshot.malibuProjectionFresh)
+        let accrualOnlyVerdict = AgentSnapshotPresenter.rewardVerdict(agent.snapshot)
+        XCTAssertEqual(accrualOnlyVerdict.usdcActivity, .none)
+        XCTAssertEqual(accrualOnlyVerdict.malibuWithdrawal, .unavailable)
         XCTAssertEqual(AgentSnapshotPresenter.usdcTodayDisplay(agent.snapshot), "n/a")
         XCTAssertEqual(
             AgentSnapshotPresenter.malibuAvailabilityLine(agent.snapshot),
             "MALIBU: status unavailable · 8.00 held"
         )
-        XCTAssertTrue(AgentSnapshotPresenter.malibuFullLine(agent.snapshot).contains("MALIBU daily not reported yet"))
+        XCTAssertEqual(
+            AgentSnapshotPresenter.malibuFullLine(agent.snapshot),
+            "MALIBU today unavailable · 30.00 all-time · reward status unavailable"
+        )
         XCTAssertEqual(AgentSnapshotPresenter.earningsLine(agent.snapshot), "Today: reward status unavailable")
     }
 
@@ -381,7 +387,7 @@ final class ControlFrameCodecTests: XCTestCase {
             uptimeSec: 1
         ))
 
-        XCTAssertTrue(agent.snapshot.providerEarningsFresh)
+        XCTAssertEqual(AgentSnapshotPresenter.rewardVerdict(agent.snapshot).usdcActivity, .earning)
         XCTAssertEqual(agent.snapshot.idlePrewarmSummary.skipsByReasonLast1h["on_battery"], 1)
         XCTAssertEqual(AgentSnapshotPresenter.eligibilityLine(agent.snapshot), "On battery — plug in to earn")
     }

--- a/phase3-binary/app/Tests/MalibuTests/DashboardViewTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/DashboardViewTests.swift
@@ -58,7 +58,7 @@ final class DashboardViewTests: XCTestCase {
         snapshot.state = .serving
         snapshot.coordinatorConnected = true
         snapshot.networkState = "buyer_serving"
-        snapshot.providerEarningsFresh = true
+        snapshot.updateRewardInputs(providerEarningsFresh: true)
 
         XCTAssertEqual(
             AgentSnapshotPresenter.dashboardSubtitle(snapshot),
@@ -71,7 +71,7 @@ final class DashboardViewTests: XCTestCase {
         snapshot.state = .serving
         snapshot.coordinatorConnected = true
         snapshot.networkState = "buyer_serving"
-        snapshot.providerEarningsFresh = true
+        snapshot.updateRewardInputs(providerEarningsFresh: true)
         snapshot.earningsUsdcToday = 0
         snapshot.currentModelID = "Qwen3-8B"
 
@@ -86,7 +86,7 @@ final class DashboardViewTests: XCTestCase {
         snapshot.state = .serving
         snapshot.coordinatorConnected = true
         snapshot.networkState = "buyer_serving"
-        snapshot.providerEarningsFresh = true
+        snapshot.updateRewardInputs(providerEarningsFresh: true)
         snapshot.earningsUsdcToday = 0
         snapshot.queueDepth = 2
 
@@ -105,7 +105,7 @@ final class DashboardViewTests: XCTestCase {
         snapshot.state = .serving
         snapshot.coordinatorConnected = true
         snapshot.networkState = "buyer_serving"
-        snapshot.providerEarningsFresh = true
+        snapshot.updateRewardInputs(providerEarningsFresh: true)
         snapshot.earningsUsdcToday = 0
         snapshot.requestsServedToday = 4
 
@@ -153,15 +153,17 @@ final class DashboardViewTests: XCTestCase {
         snapshot.earningsUsdcLifetime = 211
         snapshot.malibuAccruedToday = 12
         snapshot.malibuAccruedAllTime = 50
-        snapshot.trustTier = .provisional
-        snapshot.malibuRewardEligibility = MalibuRewardEligibility(
-            earningState: "held",
-            withdrawalState: "held",
-            primaryReason: "held_provisional_trust_tier",
-            reasons: ["held_provisional_trust_tier"]
+        snapshot.updateRewardInputs(
+            trustTier: .provisional,
+            providerEarningsFresh: true,
+            malibuProjectionFresh: true,
+            malibuRewardEligibility: MalibuRewardEligibility(
+                earningState: "held",
+                withdrawalState: "held",
+                primaryReason: "held_provisional_trust_tier",
+                reasons: ["held_provisional_trust_tier"]
+            )
         )
-        snapshot.providerEarningsFresh = true
-        snapshot.malibuProjectionFresh = true
         snapshot.gpuUtilizationPct = 62
         snapshot.latencyP50Ms = 42
         snapshot.latencyP99Ms = 180
@@ -183,7 +185,7 @@ final class DashboardViewTests: XCTestCase {
     func testUsdcAdaptivePrecisionShowsFourDecimalsUnderACentAndTwoOtherwise() {
         var snapshot = AgentSnapshot.empty
         snapshot.state = .serving
-        snapshot.providerEarningsFresh = true
+        snapshot.updateRewardInputs(providerEarningsFresh: true)
 
         snapshot.earningsUsdcToday = 0.0047
         XCTAssertEqual(AgentSnapshotPresenter.usdcTodayDisplay(snapshot), "$0.0047")
@@ -215,7 +217,7 @@ final class DashboardViewTests: XCTestCase {
         snapshot.state = .serving
         snapshot.coordinatorConnected = true
         snapshot.networkState = "buyer_serving"
-        snapshot.providerEarningsFresh = true
+        snapshot.updateRewardInputs(providerEarningsFresh: true)
 
         XCTAssertNil(AgentSnapshotPresenter.eligibilityLine(AgentSnapshot.empty))
 
@@ -243,7 +245,7 @@ final class DashboardViewTests: XCTestCase {
         snapshot.idlePrewarmSummary = .empty
         XCTAssertEqual(AgentSnapshotPresenter.eligibilityLine(snapshot), "Eligible · network is quiet")
 
-        snapshot.providerEarningsFresh = false
+        snapshot.updateRewardInputs(providerEarningsFresh: false)
         XCTAssertNil(AgentSnapshotPresenter.eligibilityLine(snapshot))
     }
 
@@ -285,7 +287,7 @@ final class DashboardViewTests: XCTestCase {
         unavailable.state = .serving
         unavailable.networkState = "buyer_serving"
         unavailable.earningsUsdcToday = 0
-        unavailable.malibuWithdrawable = 0
+        unavailable.updateRewardInputs(malibuWithdrawable: 0)
         let unavailableHealth = AgentSnapshotPresenter.miningHealth(unavailable)
         XCTAssertEqual(unavailableHealth.reasonCode, "reward_projection_unavailable")
         XCTAssertEqual(unavailableHealth.rewardSummary, "USDC unavailable · MALIBU unavailable")
@@ -322,37 +324,40 @@ final class DashboardViewTests: XCTestCase {
         var malibuFresh = AgentSnapshot.empty
         malibuFresh.state = .serving
         malibuFresh.networkState = "buyer_serving"
-        malibuFresh.malibuProjectionFresh = true
-        malibuFresh.trustTier = .provisional
+        malibuFresh.updateRewardInputs(trustTier: .provisional, malibuProjectionFresh: true)
         XCTAssertNotEqual(
             AgentSnapshotPresenter.miningHealth(malibuFresh).status, "No earnings yet")
 
         var provisional = miningBase()
-        provisional.trustTier = .provisional
-        provisional.malibuHoldReasons = ["trust_tier_provisional"]
-        provisional.trustCriteriaMet = 1
-        provisional.trustCriteriaRequired = 3
+        provisional.updateRewardInputs(
+            trustTier: .provisional,
+            malibuHoldReasons: ["trust_tier_provisional"],
+            trustCriteriaMet: 1,
+            trustCriteriaRequired: 3
+        )
         let provisionalHealth = AgentSnapshotPresenter.miningHealth(provisional)
         XCTAssertEqual(provisionalHealth.reasonCode, "trust_tier_provisional")
-        XCTAssertEqual(provisionalHealth.nextAction, "Complete 2 more trust criteria to unlock withdrawals.")
+        XCTAssertEqual(provisionalHealth.nextAction, "Complete 2 more trust criteria for withdrawal eligibility.")
 
-        provisional.malibuHoldReasons = []
+        provisional.updateRewardInputs(malibuHoldReasons: [])
         XCTAssertEqual(AgentSnapshotPresenter.miningHealth(provisional).reasonCode, "trust_tier_provisional")
         XCTAssertEqual(
             AgentSnapshotPresenter.miningHealth(provisional).nextAction,
-            "Complete 2 more trust criteria to unlock withdrawals."
+            "Complete 2 more trust criteria for withdrawal eligibility."
         )
 
-        provisional.malibuHoldReasons = ["demotion_cooldown"]
-        provisional.trustCriteriaMet = 2
-        provisional.trustCriteriaRequired = 2
+        provisional.updateRewardInputs(
+            malibuHoldReasons: ["demotion_cooldown"],
+            trustCriteriaMet: 2,
+            trustCriteriaRequired: 2
+        )
         let cooldownHealth = AgentSnapshotPresenter.miningHealth(provisional)
         XCTAssertEqual(cooldownHealth.trustSummary, "Trust: Provisional · Trust review in progress")
-        XCTAssertEqual(cooldownHealth.nextAction, "Keep Malibu online; withdrawals unlock automatically when Trusted.")
+        XCTAssertEqual(cooldownHealth.nextAction, "Keep Malibu online while trust review completes.")
         XCTAssertEqual(AgentSnapshotPresenter.trustLine(provisional), "Provisional — Trust review in progress")
 
         var trustedWithHistoricalHold = provisional
-        trustedWithHistoricalHold.trustTier = .trusted
+        trustedWithHistoricalHold.updateRewardInputs(trustTier: .trusted)
         XCTAssertEqual(AgentSnapshotPresenter.trustLine(trustedWithHistoricalHold), "Trusted")
         XCTAssertNotEqual(
             AgentSnapshotPresenter.miningHealth(trustedWithHistoricalHold).reasonCode,
@@ -371,52 +376,61 @@ final class DashboardViewTests: XCTestCase {
         )
 
         var unlockTrusted = miningBase()
-        unlockTrusted.trustTier = .provisional
-        unlockTrusted.trustCriteriaMet = 1
-        unlockTrusted.trustCriteriaRequired = 3
+        unlockTrusted.updateRewardInputs(
+            trustTier: .provisional,
+            trustCriteriaMet: 1,
+            trustCriteriaRequired: 3
+        )
         XCTAssertEqual(
             AgentSnapshotPresenter.trustLine(unlockTrusted),
-            "Provisional — 1 of 3 criteria met · Unlock Trusted →"
+            "Provisional — 1 of 3 criteria met · Trust criteria →"
         )
 
         var walletCap = miningBase()
-        walletCap.malibuHeld = 2
-        walletCap.malibuHoldReasons = ["per_wallet_daily_cap"]
+        walletCap.updateRewardInputs(malibuHeld: 2, malibuHoldReasons: ["per_wallet_daily_cap"])
         XCTAssertEqual(AgentSnapshotPresenter.miningHealth(walletCap).reasonCode, "wallet_daily_cap_held")
 
         var providerCap = miningBase()
-        providerCap.malibuHeld = 2
-        providerCap.malibuRewardEligibility = MalibuRewardEligibility(
-            earningState: "capped",
-            withdrawalState: "capped",
-            primaryReason: "held_provider_daily_cap",
-            reasons: ["held_provider_daily_cap"]
+        providerCap.updateRewardInputs(
+            malibuHeld: 2,
+            malibuRewardEligibility: MalibuRewardEligibility(
+                earningState: "capped",
+                withdrawalState: "capped",
+                primaryReason: "held_provider_daily_cap",
+                reasons: ["held_provider_daily_cap"]
+            )
         )
         let providerCapHealth = AgentSnapshotPresenter.miningHealth(providerCap)
         XCTAssertEqual(providerCapHealth.reasonCode, "provider_daily_cap_held")
         XCTAssertEqual(providerCapHealth.nextAction, "Wait for the next UTC day.")
 
         var genericHold = miningBase()
-        genericHold.malibuHeld = 2
-        genericHold.malibuHoldReasons = ["manual_review"]
+        genericHold.updateRewardInputs(malibuHeld: 2, malibuHoldReasons: ["manual_review"])
         XCTAssertEqual(AgentSnapshotPresenter.miningHealth(genericHold).reasonCode, "rewards_held")
 
         var withdrawable = miningBase()
-        withdrawable.malibuWithdrawable = 2
+        withdrawable.updateRewardInputs(
+            malibuWithdrawable: 2,
+            malibuRewardEligibility: MalibuRewardEligibility(
+                earningState: "earning",
+                withdrawalState: "withdrawable",
+                primaryReason: "withdrawable_balance_available",
+                reasons: ["withdrawable_balance_available"]
+            )
+        )
         XCTAssertEqual(AgentSnapshotPresenter.miningHealth(withdrawable).reasonCode, "trusted_withdrawable")
     }
 
     func testMiningHealthDistinguishesFreshPartialAndUnavailableRewards() {
         var fresh = miningBase()
         fresh.earningsUsdcToday = nil
-        fresh.malibuWithdrawable = 0
-        fresh.malibuHeld = 0
+        fresh.updateRewardInputs(malibuWithdrawable: 0, malibuHeld: 0)
         let freshHealth = AgentSnapshotPresenter.miningHealth(fresh)
         XCTAssertEqual(freshHealth.reasonCode, "idle_no_work")
-        XCTAssertEqual(freshHealth.rewardSummary, "n/a USDC today · MALIBU 0.00 withdrawable / 0.00 held")
+        XCTAssertEqual(freshHealth.rewardSummary, "n/a USDC today · MALIBU not withdrawable / 0.00 held")
 
         var partial = miningBase()
-        partial.malibuProjectionFresh = false
+        partial.updateRewardInputs(malibuProjectionFresh: false)
         partial.earningsUsdcToday = 0.04
         let partialHealth = AgentSnapshotPresenter.miningHealth(partial)
         XCTAssertEqual(partialHealth.reasonCode, "earning")
@@ -424,7 +438,7 @@ final class DashboardViewTests: XCTestCase {
         XCTAssertEqual(partialHealth.trustSummary, "MALIBU trust telemetry not published yet")
 
         var partialIdle = miningBase()
-        partialIdle.malibuProjectionFresh = false
+        partialIdle.updateRewardInputs(malibuProjectionFresh: false)
         partialIdle.earningsUsdcToday = 0
         let partialIdleHealth = AgentSnapshotPresenter.miningHealth(partialIdle)
         XCTAssertEqual(partialIdleHealth.reasonCode, "idle_no_work")
@@ -432,25 +446,22 @@ final class DashboardViewTests: XCTestCase {
         XCTAssertEqual(partialIdleHealth.trustSummary, "MALIBU trust telemetry not published yet")
 
         var stale = miningBase()
-        stale.providerEarningsFresh = false
-        stale.malibuProjectionFresh = false
+        stale.updateRewardInputs(providerEarningsFresh: false, malibuProjectionFresh: false)
         stale.earningsUsdcToday = 0
-        stale.malibuWithdrawable = 0
+        stale.updateRewardInputs(malibuWithdrawable: 0)
         let staleHealth = AgentSnapshotPresenter.miningHealth(stale)
         XCTAssertEqual(staleHealth.reasonCode, "reward_projection_unavailable")
         XCTAssertFalse(staleHealth.rewardSummary.contains("$0.00"))
         XCTAssertFalse(staleHealth.rewardSummary.contains("0.00 MALIBU"))
 
         var lastKnown = miningBase()
-        lastKnown.providerEarningsFresh = false
-        lastKnown.malibuProjectionFresh = false
+        lastKnown.updateRewardInputs(providerEarningsFresh: false, malibuProjectionFresh: false)
         lastKnown.hasObservedProviderEarnings = true
         lastKnown.earningsUsdcToday = 0.04
-        lastKnown.malibuWithdrawable = 2
-        lastKnown.malibuHeld = 0
+        lastKnown.updateRewardInputs(malibuWithdrawable: 2, malibuHeld: 0)
         let lastKnownHealth = AgentSnapshotPresenter.miningHealth(lastKnown)
         XCTAssertNotEqual(lastKnownHealth.reasonCode, "reward_projection_unavailable")
-        XCTAssertTrue(lastKnownHealth.rewardSummary.contains("$0.04 USDC today"))
+        XCTAssertTrue(lastKnownHealth.rewardSummary.contains("$0.04 USDC last known"))
         XCTAssertEqual(AgentSnapshotPresenter.usdcTodayDisplay(lastKnown), "$0.04")
         XCTAssertNotEqual(
             AgentSnapshotPresenter.dashboardSubtitle(lastKnown),
@@ -463,12 +474,20 @@ final class DashboardViewTests: XCTestCase {
         snapshot.state = .serving
         snapshot.coordinatorConnected = true
         snapshot.networkState = "buyer_serving"
-        snapshot.providerEarningsFresh = true
-        snapshot.malibuProjectionFresh = true
+        snapshot.updateRewardInputs(
+            trustTier: .trusted,
+            providerEarningsFresh: true,
+            malibuProjectionFresh: true,
+            malibuWithdrawable: 0,
+            malibuHeld: 0,
+            malibuRewardEligibility: MalibuRewardEligibility(
+                earningState: "eligible_idle",
+                withdrawalState: "withdrawable",
+                primaryReason: "eligible_idle_no_work",
+                reasons: ["eligible_idle_no_work"]
+            )
+        )
         snapshot.walletBound = true
-        snapshot.trustTier = .trusted
-        snapshot.malibuWithdrawable = 0
-        snapshot.malibuHeld = 0
         return snapshot
     }
 

--- a/phase3-binary/app/Tests/MalibuTests/DashboardWindowE2ETests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/DashboardWindowE2ETests.swift
@@ -306,8 +306,7 @@ final class DashboardWindowE2ETests: XCTestCase {
         snapshot.coordinatorConnected = true
         snapshot.networkState = "buyer_serving"
         snapshot.currentModelID = "qwen3-8b"
-        snapshot.providerEarningsFresh = true
-        snapshot.malibuProjectionFresh = false
+        snapshot.updateRewardInputs(providerEarningsFresh: true, malibuProjectionFresh: false)
         snapshot.walletBound = true
         snapshot.earningsUsdcToday = 0
         snapshot.earningsUsdcPending = 0.07

--- a/phase3-binary/app/Tests/MalibuTests/DashboardWindowSmokeTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/DashboardWindowSmokeTests.swift
@@ -35,8 +35,7 @@ final class DashboardWindowSmokeTests: XCTestCase {
         snapshot.coordinatorConnected = true
         snapshot.networkState = "buyer_serving"
         snapshot.currentModelID = "qwen3-8b"
-        snapshot.providerEarningsFresh = true
-        snapshot.malibuProjectionFresh = false
+        snapshot.updateRewardInputs(providerEarningsFresh: true, malibuProjectionFresh: false)
         snapshot.walletBound = true
         snapshot.earningsUsdcToday = 0
         snapshot.earningsUsdcPending = 0.07

--- a/phase3-binary/app/Tests/MalibuTests/MenuBarBadgeThresholdTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/MenuBarBadgeThresholdTests.swift
@@ -28,8 +28,7 @@ final class MenuBarBadgeThresholdTests: XCTestCase {
         snapshot.walletBound = false
         snapshot.unpaidLedgerBacklogUSDC = 0.50
         snapshot.unpaidLedgerBacklogMALIBU = 0.50
-        snapshot.providerEarningsFresh = true
-        snapshot.malibuProjectionFresh = true
+        snapshot.updateRewardInputs(providerEarningsFresh: true, malibuProjectionFresh: true)
 
         XCTAssertEqual(AgentSnapshotPresenter.unclaimedBacklogTotal(snapshot), 1.0)
         XCTAssertEqual(AgentSnapshotPresenter.unclaimedBadge(snapshot, dismissedThreshold: nil), "$1+")

--- a/phase3-binary/app/Tests/MalibuTests/RewardVerdictContractTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/RewardVerdictContractTests.swift
@@ -1,0 +1,475 @@
+import XCTest
+@testable import Malibu
+
+final class RewardVerdictContractTests: XCTestCase {
+    func testTrustedLegacyLeftoverProvisionalLockStillUnlocksWithdrawableMalibu() {
+        var snapshot = trustedServing()
+        snapshot.malibuAccruedToday = 2
+        snapshot.malibuAccruedAllTime = 14.5
+        snapshot.updateRewardInputs(
+            malibuWithdrawable: 2,
+            malibuHeld: 12.5,
+            malibuHoldReasons: ["trust_tier_provisional", "demotion_cooldown"],
+            malibuRewardEligibility: MalibuRewardEligibility(
+                earningState: "held",
+                withdrawalState: "held",
+                primaryReason: "held_provisional_trust_tier",
+                reasons: ["held_provisional_trust_tier"]
+            )
+        )
+
+        let verdict = AgentSnapshotPresenter.rewardVerdict(snapshot)
+        XCTAssertEqual(verdict.trustDisplay, .trustedAuthoritative)
+        XCTAssertEqual(verdict.malibuWithdrawal, .unlocked)
+        XCTAssertTrue(verdict.canClaimWithdrawable)
+        XCTAssertEqual(AgentSnapshotPresenter.miningHealth(snapshot).reasonCode, "trusted_withdrawable")
+        XCTAssertNil(AgentSnapshotPresenter.malibuHoldLine(snapshot))
+        XCTAssertFalse(AgentSnapshotPresenter.malibuFullLine(snapshot).lowercased().contains("locked"))
+    }
+
+    func testStaleTrustedTrustIsNeutralLiveAndCannotUnlockMalibu() {
+        var snapshot = trustedServing()
+        snapshot.updateRewardInputs(
+            providerEarningsFresh: false,
+            malibuProjectionFresh: false,
+            malibuWithdrawable: 8,
+            malibuHeld: 0
+        )
+
+        let verdict = AgentSnapshotPresenter.rewardVerdict(snapshot)
+        XCTAssertEqual(verdict.trustDisplay, .trustedStaleNeutral)
+        XCTAssertEqual(verdict.malibuWithdrawal, .unknown)
+        XCTAssertFalse(verdict.canClaimWithdrawable)
+        XCTAssertEqual(AgentSnapshotPresenter.trustLine(snapshot), "Live")
+    }
+
+    func testFreshUsdcEarningDoesNotAssertMalibuUnlockWhenMalibuProjectionIsAbsent() {
+        var snapshot = trustedServing()
+        snapshot.earningsUsdcToday = 0.04
+        snapshot.updateRewardInputs(malibuProjectionFresh: false)
+
+        let verdict = AgentSnapshotPresenter.rewardVerdict(snapshot)
+        XCTAssertEqual(verdict.usdcActivity, .earning)
+        XCTAssertEqual(verdict.malibuWithdrawal, .unknown)
+        XCTAssertFalse(verdict.canClaimWithdrawable)
+
+        let health = AgentSnapshotPresenter.miningHealth(snapshot)
+        XCTAssertEqual(health.reasonCode, "earning")
+        XCTAssertTrue(health.rewardSummary.contains("MALIBU unavailable"))
+    }
+
+    func testFreshMalibuVerdictIsIndependentFromStaleUsdcProjection() {
+        var snapshot = trustedServing()
+        snapshot.updateRewardInputs(
+            providerEarningsFresh: false,
+            malibuHeld: 4,
+            malibuRewardEligibility: MalibuRewardEligibility(
+                earningState: "capped",
+                withdrawalState: "capped",
+                primaryReason: "held_provider_daily_cap",
+                reasons: ["held_provider_daily_cap"]
+            )
+        )
+
+        let verdict = AgentSnapshotPresenter.rewardVerdict(snapshot)
+        XCTAssertEqual(verdict.usdcActivity, .none)
+        XCTAssertEqual(verdict.malibuWithdrawal, .capped(.heldProviderDailyCap))
+        XCTAssertFalse(verdict.canClaimWithdrawable)
+        XCTAssertEqual(AgentSnapshotPresenter.miningHealth(snapshot).reasonCode, "provider_daily_cap_held")
+    }
+
+    func testEpochDispositionOutranksWithdrawableAmount() {
+        var snapshot = trustedServing()
+        snapshot.updateRewardInputs(
+            malibuWithdrawable: 3,
+            malibuHeld: 0,
+            malibuRewardEligibility: MalibuRewardEligibility(
+                earningState: "held",
+                withdrawalState: "held",
+                primaryReason: "held_epoch_disposition",
+                reasons: ["held_epoch_disposition"]
+            )
+        )
+
+        let verdict = AgentSnapshotPresenter.rewardVerdict(snapshot)
+        XCTAssertEqual(verdict.reasonCode, .heldEpochDisposition)
+        XCTAssertEqual(verdict.malibuWithdrawal, .epochDisposition(.heldEpochDisposition))
+        XCTAssertFalse(verdict.canClaimWithdrawable)
+        XCTAssertEqual(AgentSnapshotPresenter.miningHealth(snapshot).reasonCode, "rewards_held")
+    }
+
+    func testExplicitRewardTelemetryOutageOutranksWarmingUpAndEarningCopy() {
+        var snapshot = AgentSnapshot.empty
+        snapshot.state = .serving
+        snapshot.networkState = "buyer_serving"
+        snapshot.earningsUsdcToday = 0.04
+        snapshot.updateRewardInputs(
+            walletBound: true,
+            trustTier: .trusted,
+            providerEarningsFresh: true,
+            malibuProjectionFresh: false,
+            rewardTelemetryUnavailable: true
+        )
+
+        let verdict = AgentSnapshotPresenter.rewardVerdict(snapshot)
+        XCTAssertEqual(verdict.usdcActivity, .earning)
+        XCTAssertEqual(verdict.malibuWithdrawal, .unavailable)
+        XCTAssertEqual(verdict.reasonCode, .telemetryUnavailable)
+
+        let health = AgentSnapshotPresenter.miningHealth(snapshot)
+        XCTAssertEqual(health.status, "Reward status unavailable")
+        XCTAssertFalse(health.status.contains("No earnings yet"))
+        XCTAssertFalse(health.reason.contains("warming"))
+    }
+
+    func testReasonCodeHasClosedSemanticKnownSetAndUnknownEscapeHatch() {
+        XCTAssertEqual(
+            AgentSnapshotPresenter.RewardVerdict.ReasonCode.coordinator("held_epoch_disposition"),
+            .heldEpochDisposition
+        )
+        XCTAssertEqual(
+            AgentSnapshotPresenter.RewardVerdict.ReasonCode.coordinator("future_reason"),
+            .unknown("future_reason")
+        )
+        XCTAssertEqual(
+            AgentSnapshotPresenter.RewardVerdict.ReasonCode.coordinator("future_reason").rawValue,
+            "unknown:future_reason"
+        )
+    }
+
+    func testEveryKnownCoordinatorReasonMapsToTypedReasonCode() {
+        for reason in MalibuRewardEligibility.knownReasons {
+            if case .unknown = AgentSnapshotPresenter.RewardVerdict.ReasonCode.coordinator(reason) {
+                XCTFail("\(reason) must be a typed RewardVerdict reason")
+            }
+        }
+    }
+
+    func testDecodedUnknownCoordinatorReasonReachesVerdictEscapeHatch() throws {
+        let data = Data("""
+        {
+          "wallet_bound": true,
+          "trust_tier": "trusted",
+          "unpaid_ledger_backlog_usdc": 0,
+          "unpaid_ledger_backlog_malibu": 0,
+          "malibu_withdrawable": 0,
+          "malibu_held": 0,
+          "malibu_projection_fresh": true,
+          "malibu_reward_eligibility": {
+            "schema_version": "malibu_reward_eligibility.v1",
+            "earning_state": "held",
+            "withdrawal_state": "held",
+            "primary_reason": "future_reason",
+            "reasons": ["future_reason"]
+          }
+        }
+        """.utf8)
+
+        let decoded = try JSONDecoder().decode(ProviderEarnings.self, from: data)
+        var snapshot = trustedServing()
+        snapshot.applyProviderEarnings(decoded, providerProjectionEligible: true)
+
+        let verdict = AgentSnapshotPresenter.rewardVerdict(snapshot)
+        XCTAssertEqual(verdict.reasonCode, .unknown("future_reason"))
+        XCTAssertEqual(verdict.malibuWithdrawal, .unknown)
+    }
+
+    func testDecodedUnknownCoordinatorReasonLogsSchemaDriftFields() throws {
+        var logged: [(String, String)] = []
+        let observer = NotificationCenter.default.addObserver(
+            forName: MalibuRewardEligibility.schemaDriftNotification,
+            object: nil,
+            queue: nil
+        ) { note in
+            guard let schema = note.userInfo?["schema_version"] as? String,
+                  let field = note.userInfo?["field"] as? String else { return }
+            logged.append((schema, field))
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        let data = Data("""
+        {
+          "wallet_bound": true,
+          "trust_tier": "trusted",
+          "unpaid_ledger_backlog_usdc": 0,
+          "unpaid_ledger_backlog_malibu": 0,
+          "malibu_projection_fresh": true,
+          "malibu_reward_eligibility": {
+            "schema_version": "malibu_reward_eligibility.v1",
+            "earning_state": "held",
+            "withdrawal_state": "held",
+            "primary_reason": "future_reason",
+            "reasons": ["future_reason", "held_provider_daily_cap"]
+          }
+        }
+        """.utf8)
+
+        let decoded = try JSONDecoder().decode(ProviderEarnings.self, from: data)
+
+        XCTAssertEqual(decoded.malibuRewardEligibility?.primaryReason, "future_reason")
+        XCTAssertEqual(decoded.malibuRewardEligibility?.reasons.first, "future_reason")
+        XCTAssertEqual(logged.map { "\($0.0):\($0.1)" }, [
+            "malibu_reward_eligibility.v1:primary_reason",
+            "malibu_reward_eligibility.v1:reasons",
+        ])
+    }
+
+    func testUnknownWithdrawableReasonCannotUnlockPositiveMalibuAmount() {
+        var snapshot = trustedServing()
+        snapshot.updateRewardInputs(
+            malibuWithdrawable: 4,
+            malibuHeld: 0,
+            malibuRewardEligibility: MalibuRewardEligibility(
+                earningState: "earning",
+                withdrawalState: "withdrawable",
+                primaryReason: "future_reason",
+                reasons: ["future_reason"]
+            )
+        )
+
+        let verdict = AgentSnapshotPresenter.rewardVerdict(snapshot)
+        XCTAssertEqual(verdict.reasonCode, .unknown("future_reason"))
+        XCTAssertEqual(verdict.malibuWithdrawal, .unknown)
+        XCTAssertFalse(verdict.canClaimWithdrawable)
+        XCTAssertFalse(AgentSnapshotPresenter.malibuFullLine(snapshot).contains("4.00 MALIBU ·"))
+    }
+
+    func testMissingPrimaryReasonCannotBecomeNoActionHeldVerdict() {
+        var snapshot = trustedServing()
+        snapshot.updateRewardInputs(
+            malibuRewardEligibility: MalibuRewardEligibility(
+                earningState: "held",
+                withdrawalState: "held",
+                primaryReason: "",
+                reasons: []
+            )
+        )
+
+        let verdict = AgentSnapshotPresenter.rewardVerdict(snapshot)
+        XCTAssertEqual(verdict.reasonCode, .unknown("missing_primary_reason"))
+        XCTAssertEqual(verdict.malibuWithdrawal, .unknown)
+    }
+
+    func testStaleUsdcWithoutPriorFreshObservationDoesNotRenderAsTodayMoney() {
+        var snapshot = trustedServing()
+        snapshot.hasObservedProviderEarnings = false
+        snapshot.earningsUsdcToday = 9.25
+        snapshot.updateRewardInputs(
+            providerEarningsFresh: false,
+            malibuProjectionFresh: true,
+            malibuRewardEligibility: MalibuRewardEligibility(
+                earningState: "eligible_idle",
+                withdrawalState: "withdrawable",
+                primaryReason: "withdrawable_no_balance",
+                reasons: ["withdrawable_no_balance"]
+            )
+        )
+
+        let verdict = AgentSnapshotPresenter.rewardVerdict(snapshot)
+        XCTAssertEqual(verdict.usdcActivity, .none)
+        XCTAssertEqual(AgentSnapshotPresenter.usdcPeriodLabel(snapshot, verdict: verdict), "Today")
+        XCTAssertEqual(AgentSnapshotPresenter.usdcTodayDisplay(snapshot, verdict: verdict), "n/a")
+        XCTAssertFalse(AgentSnapshotPresenter.usdcFullLine(snapshot, verdict: verdict).contains("$9.25 today"))
+        XCTAssertFalse(AgentSnapshotPresenter.usdcFullLine(snapshot, verdict: verdict).contains("Today: $9.25"))
+    }
+
+    func testUnavailableStatePreservesNonTelemetryPrimaryReason() {
+        var snapshot = trustedServing()
+        snapshot.updateRewardInputs(
+            malibuRewardEligibility: MalibuRewardEligibility(
+                earningState: "unavailable",
+                withdrawalState: "unavailable",
+                primaryReason: "compute_integrity_pending",
+                reasons: ["compute_integrity_pending"]
+            )
+        )
+
+        let verdict = AgentSnapshotPresenter.rewardVerdict(snapshot)
+        XCTAssertEqual(verdict.reasonCode, .computeIntegrityPending)
+        XCTAssertEqual(verdict.malibuWithdrawal, .unavailable)
+    }
+
+    func testMissingWalletReasonCannotRenderPositiveWithdrawableAsAvailable() {
+        var snapshot = trustedServing()
+        snapshot.walletBound = false
+        snapshot.malibuAccruedToday = 3
+        snapshot.updateRewardInputs(
+            malibuWithdrawable: 3,
+            malibuHeld: 1,
+            malibuRewardEligibility: MalibuRewardEligibility(
+                earningState: "ineligible",
+                withdrawalState: "ineligible",
+                primaryReason: "missing_wallet_binding",
+                reasons: ["missing_wallet_binding"]
+            )
+        )
+
+        let verdict = AgentSnapshotPresenter.rewardVerdict(snapshot)
+        XCTAssertEqual(verdict.reasonCode, .walletMissing)
+        XCTAssertEqual(verdict.malibuWithdrawal, .none)
+        XCTAssertFalse(verdict.canClaimWithdrawable)
+        XCTAssertEqual(
+            AgentSnapshotPresenter.malibuAvailabilityLine(snapshot),
+            "MALIBU: wallet required · 1.00 held"
+        )
+        let rewardSummary = AgentSnapshotPresenter.miningHealth(snapshot).rewardSummary
+        XCTAssertFalse(rewardSummary.contains("3.00 withdrawable"))
+        XCTAssertFalse(rewardSummary.contains("3.00 available"))
+    }
+
+    func testCoordinatorNoBalanceReasonCannotUnlockPositiveMalibuAmount() {
+        var snapshot = trustedServing()
+        snapshot.updateRewardInputs(
+            malibuWithdrawable: 3,
+            malibuHeld: 0,
+            malibuRewardEligibility: MalibuRewardEligibility(
+                earningState: "eligible_idle",
+                withdrawalState: "withdrawable",
+                primaryReason: "withdrawable_no_balance",
+                reasons: ["withdrawable_no_balance"]
+            )
+        )
+
+        let verdict = AgentSnapshotPresenter.rewardVerdict(snapshot)
+        XCTAssertEqual(verdict.reasonCode, .idleNoWork)
+        XCTAssertEqual(verdict.malibuWithdrawal, .none)
+        XCTAssertFalse(verdict.canClaimWithdrawable)
+        let rewardSummary = AgentSnapshotPresenter.miningHealth(snapshot).rewardSummary
+        XCTAssertTrue(rewardSummary.contains("not withdrawable"))
+        XCTAssertFalse(rewardSummary.contains("3.00 withdrawable"))
+        XCTAssertFalse(rewardSummary.contains("3.00 available"))
+    }
+
+    func testPositiveWithdrawableReasonRequiresNonEmptyKnownReasonsSet() {
+        var emptyReasons = trustedServing()
+        emptyReasons.updateRewardInputs(
+            malibuWithdrawable: 3,
+            malibuHeld: 0,
+            malibuRewardEligibility: MalibuRewardEligibility(
+                earningState: "earning",
+                withdrawalState: "withdrawable",
+                primaryReason: "withdrawable_balance_available",
+                reasons: []
+            )
+        )
+        let emptyVerdict = AgentSnapshotPresenter.rewardVerdict(emptyReasons)
+        XCTAssertEqual(emptyVerdict.reasonCode, .unknown("malformed_withdrawable_reason_set"))
+        XCTAssertEqual(emptyVerdict.malibuWithdrawal, .unknown)
+        XCTAssertFalse(emptyVerdict.canClaimWithdrawable)
+
+        var unknownExtraReason = trustedServing()
+        unknownExtraReason.updateRewardInputs(
+            malibuWithdrawable: 3,
+            malibuHeld: 0,
+            malibuRewardEligibility: MalibuRewardEligibility(
+                earningState: "earning",
+                withdrawalState: "withdrawable",
+                primaryReason: "withdrawable_balance_available",
+                reasons: ["withdrawable_balance_available", "future_positive_reason"]
+            )
+        )
+        let unknownExtraVerdict = AgentSnapshotPresenter.rewardVerdict(unknownExtraReason)
+        XCTAssertEqual(unknownExtraVerdict.reasonCode, .unknown("malformed_withdrawable_reason_set"))
+        XCTAssertEqual(unknownExtraVerdict.malibuWithdrawal, .unknown)
+        XCTAssertFalse(unknownExtraVerdict.canClaimWithdrawable)
+    }
+
+    func testTrustProgressIsSanitizedFromGranularAndLegacyInputs() {
+        var overlapping = AgentSnapshot.empty
+        overlapping.updateRewardInputs(
+            trustTier: .provisional,
+            economicCriteria: ["E2"],
+            additionalCriteria: ["A3"],
+            hasGranularTrustCriteria: true
+        )
+        XCTAssertEqual(
+            AgentSnapshotPresenter.rewardVerdict(overlapping).trustProgress,
+            AgentSnapshotPresenter.RewardVerdict.TrustProgress(met: 1, required: 2)
+        )
+
+        var distinct = overlapping
+        distinct.updateRewardInputs(additionalCriteria: ["A4"])
+        XCTAssertEqual(
+            AgentSnapshotPresenter.rewardVerdict(distinct).trustProgress,
+            AgentSnapshotPresenter.RewardVerdict.TrustProgress(met: 2, required: 2)
+        )
+
+        var clamped = AgentSnapshot.empty
+        clamped.updateRewardInputs(
+            trustTier: .provisional,
+            trustCriteriaMet: 4,
+            trustCriteriaRequired: 2
+        )
+        XCTAssertEqual(
+            AgentSnapshotPresenter.rewardVerdict(clamped).trustProgress,
+            AgentSnapshotPresenter.RewardVerdict.TrustProgress(met: 2, required: 2)
+        )
+    }
+
+    func testSliceADoesNotExposeRawRewardInputsToMoneyPathViewsAndLegacyHelpers() throws {
+        let testsFile = URL(fileURLWithPath: #filePath)
+        let appRoot = testsFile
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let files = [
+            appRoot.appendingPathComponent("Sources/Malibu/Dashboard/DashboardWindow.swift"),
+            appRoot.appendingPathComponent("Sources/Malibu/MenuBar/MenuBarController.swift"),
+        ]
+        let prohibited = [
+            ".trustTier",
+            ".malibuProjectionFresh",
+            ".providerEarningsFresh",
+            ".malibuWithdrawable",
+            ".malibuHeld",
+            ".malibuHoldReasons",
+            ".malibuRewardEligibility",
+            ".trustCriteriaMet",
+            ".trustCriteriaRequired",
+            ".rewardTelemetryUnavailable",
+            ".economicCriteria",
+            ".additionalCriteria",
+        ]
+
+        for file in files {
+            let contents = try String(contentsOf: file, encoding: .utf8)
+            for token in prohibited {
+                XCTAssertFalse(
+                    contents.contains(token),
+                    "\(file.lastPathComponent) must consume RewardVerdict instead of \(token)"
+                )
+            }
+        }
+
+        let presenter = try String(
+            contentsOf: appRoot.appendingPathComponent("Sources/Malibu/Agent/AgentSnapshot.swift"),
+            encoding: .utf8
+        )
+        for legacyHelper in [
+            "displayRewardEligibility(_ s: AgentSnapshot)",
+            "displayMalibuHoldReasons(_ s: AgentSnapshot)",
+            "shouldIgnoreLeftoverProvisionalLock(_ s: AgentSnapshot)",
+            "malibuDisplay(_ amount: Double, snapshot: AgentSnapshot",
+        ] {
+            XCTAssertFalse(
+                presenter.contains(legacyHelper),
+                "AgentSnapshotPresenter must consume RewardVerdict instead of legacy raw helper \(legacyHelper)"
+            )
+        }
+    }
+
+    private func trustedServing() -> AgentSnapshot {
+        var snapshot = AgentSnapshot.empty
+        snapshot.state = .serving
+        snapshot.networkState = "buyer_serving"
+        snapshot.walletBound = true
+        snapshot.updateRewardInputs(
+            trustTier: .trusted,
+            providerEarningsFresh: true,
+            malibuProjectionFresh: true,
+            malibuWithdrawable: 0,
+            malibuHeld: 0
+        )
+        return snapshot
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a typed `RewardVerdict` contract as the single app-side authority for MALIBU withdrawal/trust and USDC activity.
- Routes mining health, dashboard reward/trust rows, provisional-lock color, and menu bar money-path copy through the verdict.
- Adds Slice A invariants and crafted-frame regression coverage, including the Trusted leftover-provisional exemption.

## Scope
Slice A only. This does not include #1322 CLI wallet/bridge fixes or #1323 consolidated status card work.

## Validation
- `xcodegen generate`
- `xcodebuild -project phase3-binary/app/Malibu.xcodeproj -scheme Malibu -destination 'platform=macOS' test` — 526 tests, 0 failures
- `git diff --check --cached`
- Dashboard/Menu raw reward input scan — no matches
- Obsolete raw presenter helper scan — no matches
- Three-lane Codex audit — code review, security/money-path, architecture: 0 C/H/M

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "issue": "https://github.com/Augustas11/macprovider/issues/1321",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": [
    "SPEC-005",
    "SPEC-021"
  ],
  "requirements": [
    "SPEC-005-R007",
    "SPEC-021-R007",
    "SPEC-021-R009",
    "SPEC-021-R010"
  ],
  "authority_domains": [
    "billing-settlement-formula",
    "malibu-emission-ledger",
    "malibu-epoch-disposition-state"
  ],
  "arbitration": [
    "CODE_BUG"
  ],
  "tests": [
    "xcodegen generate",
    "xcodebuild -project phase3-binary/app/Malibu.xcodeproj -scheme Malibu -destination 'platform=macOS' test",
    "RewardVerdictContractTests invariant and crafted-frame corpus",
    "three-lane Codex audit 0 C/H/M"
  ],
  "journeys": [
    "not-required"
  ]
}
SPEC-GOVERNANCE-DECLARATION-END

Fixes #1321
Part of #1312
