### PR TITLE
fix: add safe headless update handoff

### DIFF
--- a/docs/runbooks/headless-provider-updates.md
+++ b/docs/runbooks/headless-provider-updates.md
@@ -1,0 +1,78 @@
+# Headless provider updates
+
+`headless_fleet` providers run as system-domain LaunchDaemons and keep their
+credentials in protected files owned by the fleet user. They do not use the
+consumer LaunchAgent autoupdater.
+
+When a newer release is recommended, the provider remains available and emits:
+
+```text
+phase: eligibility
+outcome: skipped
+reason: headless_operator_update_required
+```
+
+This is an operator handoff, not an update failure. It must not produce a
+cooldown, drain the provider, download release bytes, or invoke a user-domain
+reload helper.
+
+## Supported update path
+
+Use only a protected signed acceptance bundle produced by the repository's
+`Sign private acceptance candidate` workflow. Run the bundled installer as the
+existing non-root fleet user over SSH with:
+
+- `MACPROVIDER_HEADLESS=1`;
+- `MACPROVIDER_NO_PROMPT=1`;
+- `MACPROVIDER_HEADLESS_USER` set to that fleet user;
+- all six acceptance identity fields set to the exact bundle version,
+  candidate commit, control commit, run ID, and run attempt;
+- `MACPROVIDER_CREDENTIAL_STORE=protected_file` and the incumbent protected
+  credential root.
+
+The candidate must be strictly newer than the installed compatibility set. Do
+not use a public mutable `latest` download as a headless substitute, fabricate
+an install manifest, copy bearer/key files into a new profile, or point the
+consumer updater at `/Library/LaunchDaemons`.
+
+Before cutover, capture only redacted evidence:
+
+1. installed and running CLI versions;
+2. provider ID digest or approved short prefix, never the full identity in a
+   public artifact;
+3. `credentials verify` status (`ready` and `restart_safe`, without paths or
+   credential bytes);
+4. system LaunchDaemon state and absence/presence of pending recovery state;
+5. acceptance-bundle SHA-256 and exact provenance pins.
+
+After cutover, prove that the installed and running versions match the signed
+target, the provider ID did not change, protected credentials still verify,
+the service returned to buyer-serving, and restart/reboot persistence works
+without a GUI login.
+
+## Noncanonical incumbents
+
+A provider created by an older smoke or manually staged headless flow may run
+from a noncanonical support directory and may lack the installer manifest or
+managed LaunchDaemon copy. The consumer autoupdater correctly refuses that
+shape. Preserve the node and use the signed headless installer migration path.
+
+For the historical SSH-smoke topology only, set both:
+
+- `MACPROVIDER_ADOPT_HEADLESS_INCUMBENT=1`;
+- `MACPROVIDER_INSTALL_DIR` to the incumbent support directory reported by the
+  root LaunchDaemon.
+
+The bridge is available only with the protected signed acceptance bundle and
+all its provenance pins. It requires a loaded system provider service, an
+absent managed provider plist, an absent install manifest, and no unmanaged
+root watchdog. It descriptor-validates the root-owned `0644` plist against the
+exact historical program, arguments, user, config, credential root, environment,
+working directory, logging paths, and keepalive shapes. Before any live cutover,
+it writes a byte-identical, user-owned managed plist for transactional rollback.
+It does not change the running service and does not create an install manifest.
+
+Any mismatch fails before mutation. Do not repair it by inventing metadata,
+loosening the accepted plist shape, copying credentials, or silently trusting
+the running path. A later successful signed installer transaction creates the
+normal manifest and canonical provider/watchdog LaunchDaemons.

--- a/phase3-binary/Sources/macprovider-cli/AutoUpdater.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutoUpdater.swift
@@ -122,9 +122,10 @@ struct AutoUpdater: Sendable {
     /// Lightweight outcome of a single coordinator-recommendation cycle, used by
     /// the caller (CoordinatorClient) to drive SPEC-020-R005 accepted-session
     /// recovery. The mapping to exit points is:
-    /// - `.notAttempted`: trust-skip, autoupdate-disabled, an invalid/unparseable
-    ///   recommended version, or `target_not_newer`. Not counted, not reset — the
-    ///   recommendation never engaged a real target and recorded no failure.
+    /// - `.notAttempted`: trust-skip, autoupdate-disabled, a headless operator-update
+    ///   handoff, an invalid/unparseable recommended version, or `target_not_newer`.
+    ///   Not counted, not reset — the recommendation never engaged a real target
+    ///   and recorded no failure.
     /// - `.missingTarget`: the coordinator advertised a `recommended_binary_version`
     ///   with no installable compatibility-set target
     ///   (`coordinator_compatibility_target_missing`).
@@ -191,6 +192,18 @@ struct AutoUpdater: Sendable {
 
         guard SelfUpdate.compareSemver(currentVersion, target) == .orderedAscending else {
             await record(updateID: updateID, target: target, phase: .eligibility, outcome: .noop, reason: "target_not_newer", attempt: 1)
+            return .notAttempted
+        }
+        guard !Self.requiresHeadlessOperatorUpdate(config: config) else {
+            print("A newer version is available (v\(target)), but headless_fleet updates require the signed headless installer acceptance bundle.")
+            await record(
+                updateID: updateID,
+                target: target,
+                phase: .eligibility,
+                outcome: .skipped,
+                reason: "headless_operator_update_required",
+                attempt: 1
+            )
             return .notAttempted
         }
         guard AutoUpdateConfig.enabled(config) else {
@@ -390,6 +403,15 @@ struct AutoUpdater: Sendable {
         }
         guard !SessionAutoupdateGate.shared.isDisabled else {
             await recordR005(target: "<session-disabled>", phase: .eligibility, outcome: .skipped, reason: "signed_policy_persist_failed")
+            return
+        }
+        guard !Self.requiresHeadlessOperatorUpdate(config: config) else {
+            await recordR005(
+                target: "<headless-operator-update>",
+                phase: .eligibility,
+                outcome: .skipped,
+                reason: "headless_operator_update_required"
+            )
             return
         }
         guard AutoUpdateConfig.enabled(config) else {
@@ -1033,6 +1055,15 @@ struct AutoUpdater: Sendable {
             return true
         }
         return launchdProviderAvailable()
+    }
+
+    static func requiresHeadlessOperatorUpdate(
+        config: AppConfig,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Bool {
+        config.credentialStore == .protectedFile
+            || environment["MACPROVIDER_HEADLESS"] == "1"
+            || environment["MACPROVIDER_LAUNCHD_DOMAIN"] == "system"
     }
 
     static func defaultLaunchdProviderAvailable() -> Bool {

--- a/phase3-binary/Tests/macprovider-cliTests/AutoUpdateTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/AutoUpdateTests.swift
@@ -3254,6 +3254,106 @@ final class AutoUpdateTests: XCTestCase {
         XCTAssertEqual(outcome, .forwardProgressFailure)
     }
 
+    func testHeadlessRecommendationRequiresOperatorUpdateWithoutFailureCooldown() async throws {
+        let fixture = try TempHome()
+        let store = AutoUpdateMarkerStore(homeDirectory: fixture.url)
+        await AutoUpdateEventStore.shared.clear()
+        SessionAutoupdateGate.shared.resetForTest()
+        defer { SessionAutoupdateGate.shared.resetForTest() }
+        var config = AppConfig.defaults(configPath: fixture.url.appendingPathComponent("config.yaml").path)
+        config.credentialStore = .protectedFile
+        config.autoUpdateEnabled = false
+        let updater = AutoUpdater(
+            config: config,
+            currentVersion: "1.8.109",
+            providerStatus: r005Status(),
+            markerStore: store,
+            trustProvider: { self.r005PinnedTrust() },
+            drain: { _ in
+                XCTFail("headless operator handoff must not drain")
+                return false
+            },
+            sendReady: {},
+            restartLaunchd: { XCTFail("headless operator handoff must not restart launchd") },
+            fenceReloadJobs: { XCTFail("headless operator handoff must not fence consumer reload jobs") },
+            currentBinaryURL: { nil },
+            rollbackObserverAvailable: { true },
+            launchdProviderAvailable: {
+                XCTFail("headless operator handoff must run before consumer launchd topology probing")
+                return false
+            }
+        )
+
+        let outcome = await updater.handleCoordinatorRecommendation("1.8.117")
+
+        XCTAssertEqual(outcome, .notAttempted)
+        XCTAssertNil(store.activeCooldown(target: "1.8.117"))
+        let event = await AutoUpdateEventStore.shared.lastWireObject()
+        XCTAssertEqual(event?["target_version"] as? String, "1.8.117")
+        XCTAssertEqual(event?["phase"] as? String, "eligibility")
+        XCTAssertEqual(event?["outcome"] as? String, "skipped")
+        XCTAssertEqual(event?["reason"] as? String, "headless_operator_update_required")
+    }
+
+    func testHeadlessSignedDiscoveryPreservesR005AttributionAndDoesNotProbeConsumerTopology() async throws {
+        let fixture = try TempHome()
+        let store = AutoUpdateMarkerStore(homeDirectory: fixture.url)
+        await AutoUpdateEventStore.shared.clear()
+        SessionAutoupdateGate.shared.resetForTest()
+        defer { SessionAutoupdateGate.shared.resetForTest() }
+        var config = AppConfig.defaults(configPath: fixture.url.appendingPathComponent("config.yaml").path)
+        config.credentialStore = .protectedFile
+        config.autoUpdateEnabled = false
+        let updater = AutoUpdater(
+            config: config,
+            currentVersion: "1.8.109",
+            providerStatus: r005Status(),
+            markerStore: store,
+            trustProvider: { self.r005PinnedTrust() },
+            drain: { _ in false },
+            sendReady: {},
+            restartLaunchd: {},
+            fenceReloadJobs: {},
+            currentBinaryURL: { nil },
+            rollbackObserverAvailable: { true },
+            launchdProviderAvailable: {
+                XCTFail("headless signed-discovery handoff must not probe consumer launchd topology")
+                return false
+            }
+        )
+
+        await updater.handleSignedReleaseDiscovery(attribution: [
+            "accepted_session_recovery": "true",
+            "recommendation_identity": "1.8.117|<none>",
+            "consecutive_failure_count": "3",
+        ])
+
+        let event = await AutoUpdateEventStore.shared.lastWireObject()
+        XCTAssertEqual(event?["target_version"] as? String, "<headless-operator-update>")
+        XCTAssertEqual(event?["outcome"] as? String, "skipped")
+        XCTAssertEqual(event?["reason"] as? String, "headless_operator_update_required")
+        let metadata = event?["extra_metadata"] as? [String: String]
+        XCTAssertEqual(metadata?["accepted_session_recovery"], "true")
+        XCTAssertEqual(metadata?["consecutive_failure_count"], "3")
+    }
+
+    func testHeadlessOperatorUpdateDetectionUsesExplicitProfileSignals() {
+        var protectedConfig = AppConfig.defaults(configPath: "/tmp/config.yaml")
+        protectedConfig.credentialStore = .protectedFile
+        XCTAssertTrue(AutoUpdater.requiresHeadlessOperatorUpdate(config: protectedConfig, environment: [:]))
+
+        let consumerConfig = AppConfig.defaults(configPath: "/tmp/config.yaml")
+        XCTAssertTrue(AutoUpdater.requiresHeadlessOperatorUpdate(
+            config: consumerConfig,
+            environment: ["MACPROVIDER_HEADLESS": "1"]
+        ))
+        XCTAssertTrue(AutoUpdater.requiresHeadlessOperatorUpdate(
+            config: consumerConfig,
+            environment: ["MACPROVIDER_LAUNCHD_DOMAIN": "system"]
+        ))
+        XCTAssertFalse(AutoUpdater.requiresHeadlessOperatorUpdate(config: consumerConfig, environment: [:]))
+    }
+
     func testHandleCoordinatorRecommendationReturnsCooldownActive() async throws {
         let fixture = try TempHome()
         let store = AutoUpdateMarkerStore(homeDirectory: fixture.url)

--- a/phase3-binary/dist/install.sh
+++ b/phase3-binary/dist/install.sh
@@ -50,6 +50,8 @@ PROVIDER_MUTATION_PENDING_PATH="$PROVIDER_MUTATION_ROOT/pending.json"
 INSTALL_RECOVERY_LABEL="live.malibu.provider-install-recovery"
 HEADLESS="${MACPROVIDER_HEADLESS:-0}"
 HEADLESS_USER="${MACPROVIDER_HEADLESS_USER:-}"
+ADOPT_HEADLESS_INCUMBENT="${MACPROVIDER_ADOPT_HEADLESS_INCUMBENT:-0}"
+unset MACPROVIDER_ADOPT_HEADLESS_INCUMBENT
 if [ "$HEADLESS" = "1" ]; then
   LAUNCHD_DOMAIN="system"
   LAUNCHD_MANAGED_DIR="$CONFIG_DIR/launchd"
@@ -188,6 +190,12 @@ validate_provider_token_environment() {
 }
 
 validate_launchd_mode() {
+  case "$ADOPT_HEADLESS_INCUMBENT" in
+    0|1) ;;
+    *) die 7 "MACPROVIDER_ADOPT_HEADLESS_INCUMBENT must be 0 or 1" ;;
+  esac
+  [ "$ADOPT_HEADLESS_INCUMBENT" != "1" ] || [ "$HEADLESS" = "1" ] \
+    || die 7 "headless incumbent adoption requires MACPROVIDER_HEADLESS=1"
   case "$HEADLESS" in
     0) return 0 ;;
     1) ;;
@@ -466,6 +474,153 @@ if label == "live.malibu.provider-watchdog" and environment.get("MACPROVIDER_LAU
     raise SystemExit("unexpected watchdog launchctl path")
 sys.stdout.write(base64.b64encode(data).decode("ascii"))
 PY
+}
+
+# A small number of pre-release SSH smoke nodes were installed before the
+# headless installer kept a user-owned managed plist beside the root-published
+# LaunchDaemon.  A normal transaction cannot safely displace such a running
+# service because it has no rollback input.  This reader accepts only the exact
+# historical smoke shape, through a root descriptor, and returns its immutable
+# bytes for adoption into the managed path.  Production always requires uid 0;
+# the optional uid is solely for the unprivileged regression harness.
+snapshot_published_headless_incumbent_plist() {
+  bootstrap_path="$1"
+  expected_owner_uid="${2:-0}"
+  [ "$HEADLESS" = "1" ] || return 70
+  [ "$bootstrap_path" = "${SYSTEM_LAUNCHD_DIR:-/Library/LaunchDaemons}/live.malibu.provider.plist" ] || return 70
+  "${SUDO_BIN:-/usr/bin/sudo}" -n "${ROOT_PYTHON3_BIN:-/usr/bin/python3}" - \
+    "$bootstrap_path" "$expected_owner_uid" "$HEADLESS_USER" \
+    "$INSTALL_DIR/macprovider-cli" "$CONFIG_PATH" "$HOME" <<'PY'
+import base64
+import ctypes
+import errno
+import os
+import plistlib
+import stat
+import sys
+
+path, expected_uid, user, program, config, home = sys.argv[1:]
+expected_uid = int(expected_uid)
+max_bytes = 1024 * 1024
+fd = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0))
+try:
+    before = os.fstat(fd)
+    if (
+        not stat.S_ISREG(before.st_mode)
+        or before.st_uid != expected_uid
+        or before.st_nlink != 1
+        or stat.S_IMODE(before.st_mode) != 0o644
+        or before.st_size > max_bytes
+    ):
+        raise SystemExit("unsafe historical LaunchDaemon source")
+    if sys.platform == "darwin":
+        try:
+            libc = ctypes.CDLL(None, use_errno=True)
+            acl_get_fd_np = libc.acl_get_fd_np
+            acl_get_fd_np.argtypes = [ctypes.c_int, ctypes.c_int]
+            acl_get_fd_np.restype = ctypes.c_void_p
+            acl_free = libc.acl_free
+            acl_free.argtypes = [ctypes.c_void_p]
+            acl_free.restype = ctypes.c_int
+        except (AttributeError, OSError):
+            raise SystemExit("historical LaunchDaemon ACL is uninspectable")
+        ctypes.set_errno(0)
+        acl = acl_get_fd_np(fd, 0x00000100)
+        if acl:
+            acl_free(acl)
+            raise SystemExit("historical LaunchDaemon has an extended ACL")
+        if ctypes.get_errno() != errno.ENOENT:
+            raise SystemExit("historical LaunchDaemon ACL is uninspectable")
+    data = os.read(fd, before.st_size + 1)
+    if len(data) != before.st_size:
+        raise SystemExit("historical LaunchDaemon changed while reading")
+    after = os.fstat(fd)
+    identity = lambda info: (
+        info.st_dev, info.st_ino, info.st_mode, info.st_uid, info.st_nlink,
+        info.st_size, info.st_mtime_ns, info.st_ctime_ns,
+    )
+    if identity(after) != identity(before):
+        raise SystemExit("historical LaunchDaemon metadata changed while reading")
+    path_info = os.lstat(path)
+    if stat.S_ISLNK(path_info.st_mode) or identity(path_info) != identity(before):
+        raise SystemExit("historical LaunchDaemon path was replaced")
+finally:
+    os.close(fd)
+
+try:
+    payload = plistlib.loads(data)
+except Exception:
+    raise SystemExit("historical LaunchDaemon is malformed")
+expected_keys = {
+    "Label", "UserName", "ProgramArguments", "WorkingDirectory", "RunAtLoad",
+    "KeepAlive", "StandardOutPath", "StandardErrorPath", "EnvironmentVariables",
+}
+if set(payload) != expected_keys:
+    raise SystemExit("historical LaunchDaemon contains unexpected fields")
+if payload.get("Label") != "live.malibu.provider" or payload.get("UserName") != user:
+    raise SystemExit("historical LaunchDaemon identity does not match")
+arguments = payload.get("ProgramArguments")
+allowed_arguments = (
+    [program, "serve", "--config", config],
+    [program, "serve", "--config", config, "--log-level", "debug"],
+)
+if arguments not in allowed_arguments:
+    raise SystemExit("historical LaunchDaemon arguments do not match")
+if payload.get("WorkingDirectory") != os.path.dirname(program) or payload.get("RunAtLoad") is not True:
+    raise SystemExit("historical LaunchDaemon working directory or RunAtLoad does not match")
+keep_alive = payload.get("KeepAlive")
+if keep_alive is not True and keep_alive != {"SuccessfulExit": False}:
+    raise SystemExit("historical LaunchDaemon KeepAlive does not match")
+log_dir = os.path.join(home, "Library", "Logs", os.path.basename(os.path.dirname(program)))
+if payload.get("StandardOutPath") != os.path.join(log_dir, "macprovider.out.log"):
+    raise SystemExit("historical LaunchDaemon stdout path does not match")
+if payload.get("StandardErrorPath") != os.path.join(log_dir, "macprovider.err.log"):
+    raise SystemExit("historical LaunchDaemon stderr path does not match")
+expected_environment = {
+    "HOME": home,
+    "PATH": f"/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:{home}/.local/bin",
+    "MACPROVIDER_CONFIG": config,
+    "MACPROVIDER_CREDENTIAL_STORE": "protected_file",
+    "MACPROVIDER_PROTECTED_CREDENTIAL_ROOT": os.path.join(os.path.dirname(config), "protected-credentials"),
+    "MACPROVIDER_HEADLESS": "1",
+    "MACPROVIDER_HEADLESS_USER": user,
+    "MACPROVIDER_LAUNCHD_DOMAIN": "system",
+}
+if payload.get("EnvironmentVariables") != expected_environment:
+    raise SystemExit("historical LaunchDaemon environment does not match")
+sys.stdout.write(base64.b64encode(data).decode("ascii"))
+PY
+}
+
+adopt_headless_incumbent_metadata() {
+  expected_owner_uid="${1:-0}"
+  case "$ADOPT_HEADLESS_INCUMBENT" in
+    0) return 0 ;;
+    1) ;;
+    *) die 7 "MACPROVIDER_ADOPT_HEADLESS_INCUMBENT must be 0 or 1" ;;
+  esac
+  [ "$HEADLESS" = "1" ] \
+    || die 7 "headless incumbent adoption requires MACPROVIDER_HEADLESS=1"
+  [ -n "${MACPROVIDER_ACCEPTANCE_ASSET_DIR:-}" ] \
+    || die 7 "headless incumbent adoption requires a signed acceptance asset bundle"
+  [ ! -e "$PLIST_PATH" ] && [ ! -L "$PLIST_PATH" ] \
+    || die 7 "headless incumbent adoption requires the managed provider plist to be absent"
+  [ ! -e "$MANIFEST_PATH" ] && [ ! -L "$MANIFEST_PATH" ] \
+    || die 7 "headless incumbent adoption refuses an installation that already has a manifest"
+  [ ! -e "$WATCHDOG_PLIST_BOOTSTRAP_PATH" ] && [ ! -L "$WATCHDOG_PLIST_BOOTSTRAP_PATH" ] \
+    || die 7 "headless incumbent adoption cannot infer an unmanaged root watchdog"
+  launchctl_service print "$LAUNCHD_DOMAIN/$PROVIDER_LABEL" >/dev/null 2>&1 \
+    || die 7 "headless incumbent adoption requires the historical system provider service to be loaded"
+  incumbent_plist_b64="$(snapshot_published_headless_incumbent_plist "$PLIST_BOOTSTRAP_PATH" "$expected_owner_uid")" \
+    || die 7 "published headless incumbent is not the exact supported historical smoke topology"
+  mkdir -p "$LAUNCHD_MANAGED_DIR" \
+    || die 70 "could not create the managed headless launchd directory"
+  printf '%s' "$incumbent_plist_b64" | python3 -c 'import base64,sys; sys.stdout.buffer.write(base64.b64decode(sys.stdin.read(), validate=True))' \
+    | write_atomic_install_file "$PLIST_PATH" 0600 \
+    || die 70 "could not persist the verified historical LaunchDaemon rollback copy"
+  verify_published_launchd_plist "$PLIST_PATH" "$PLIST_BOOTSTRAP_PATH" \
+    || die 70 "adopted managed plist does not match the published historical LaunchDaemon"
+  log "Adopted the exact historical headless provider plist as rollback metadata; the live service and install manifest were not changed."
 }
 
 publish_root_file_from_base64() {
@@ -1127,6 +1282,11 @@ Environment overrides:
   MACPROVIDER_HEADLESS_USER      named non-root account that owns protected
                                  provider data and runs both LaunchDaemons;
                                  defaults to the invoking non-root account
+  MACPROVIDER_ADOPT_HEADLESS_INCUMBENT=1
+                                 signed-acceptance-only bridge for an exact
+                                 historical smoke LaunchDaemon that lacks its
+                                 user-owned managed plist; never creates an
+                                 install manifest or changes the live service
   MACPROVIDER_NO_LAUNCHD=1       expert/debug only: skip BOTH the provider
                                  launchd service and its companion watchdog
   MACPROVIDER_NO_WATCHDOG=1      expert/debug only: install the provider
@@ -12747,6 +12907,11 @@ main() {
     validate_release_payload
   fi
   check_install_dir_clean
+  # The adoption bridge is intentionally after signed candidate verification
+  # and before the transaction snapshot. It only supplies exact rollback bytes
+  # for the historical service; begin_install_transaction remains the sole
+  # authority that may arm recovery and begin live cutover.
+  adopt_headless_incumbent_metadata
   begin_install_transaction
   stage_release_payload
   validate_acceptance_staged_identity

--- a/phase3-binary/dist/test/install_headless_fleet.test.sh
+++ b/phase3-binary/dist/test/install_headless_fleet.test.sh
@@ -16,6 +16,8 @@ names = [
     "launchctl_service",
     "validate_headless_launchdaemon_plist",
     "snapshot_headless_launchdaemon_plist",
+    "snapshot_published_headless_incumbent_plist",
+    "adopt_headless_incumbent_metadata",
     "publish_root_file_from_base64",
     "verify_published_launchd_payload",
     "run_macprovider_cli_with_amfi_retry",
@@ -297,7 +299,7 @@ FUNCTION_PATH="$TMP/functions.sh" SYSTEM_DIR="$TMP/system" USERS_DIR="$TMP/users
   LEGACY_PROVIDER_LABEL=live.streamvc.macprovider
   WATCHDOG_LABEL=live.malibu.provider-watchdog
   LEGACY_WATCHDOG_LABEL=live.streamvc.macprovider-watchdog
-  DRY_RUN=0 NO_LAUNCHD=0 NO_WATCHDOG=0
+  DRY_RUN=0 NO_LAUNCHD=0 NO_WATCHDOG=0 ADOPT_HEADLESS_INCUMBENT=0
   INSTALL_TX_ACTIVE=1 INSTALL_TX_BACKUP="$CONFIG_DIR/install-recovery-fixture"
   INSTALL_TX_HAD_PLIST=0 INSTALL_TX_HAD_WATCHDOG_PLIST=0
   LAUNCHD_INSTALLED=0 WATCHDOG_INSTALLED=0
@@ -311,6 +313,123 @@ FUNCTION_PATH="$TMP/functions.sh" SYSTEM_DIR="$TMP/system" USERS_DIR="$TMP/users
     echo "headless mode unexpectedly accepted MACPROVIDER_NO_WATCHDOG=1" >&2
     exit 1
   fi
+  if (ADOPT_HEADLESS_INCUMBENT=invalid validate_launchd_mode); then
+    echo "headless mode unexpectedly accepted an invalid incumbent-adoption flag" >&2
+    exit 1
+  fi
+  if (HEADLESS=0 ADOPT_HEADLESS_INCUMBENT=1 validate_launchd_mode); then
+    echo "consumer mode unexpectedly accepted headless incumbent adoption" >&2
+    exit 1
+  fi
+
+  # #1324: accept only the exact historical SSH-smoke LaunchDaemon as
+  # rollback input. The bridge copies its bytes into the user-owned managed
+  # path, does not touch the published service, and never invents a manifest.
+  mkdir -p "$INSTALL_DIR" "$LOG_DIR/$(basename "$INSTALL_DIR")"
+  python3 - "$PLIST_BOOTSTRAP_PATH" "$HEADLESS_USER" "$INSTALL_DIR/macprovider-cli" \
+    "$CONFIG_PATH" "$HOME" <<PY
+import os
+import plistlib
+import sys
+
+path, user, program, config, home = sys.argv[1:]
+payload = {
+    "Label": "live.malibu.provider",
+    "UserName": user,
+    "ProgramArguments": [program, "serve", "--config", config, "--log-level", "debug"],
+    "WorkingDirectory": os.path.dirname(program),
+    "RunAtLoad": True,
+    "KeepAlive": {"SuccessfulExit": False},
+    "StandardOutPath": os.path.join(home, "Library", "Logs", os.path.basename(os.path.dirname(program)), "macprovider.out.log"),
+    "StandardErrorPath": os.path.join(home, "Library", "Logs", os.path.basename(os.path.dirname(program)), "macprovider.err.log"),
+    "EnvironmentVariables": {
+        "HOME": home,
+        "PATH": f"/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:{home}/.local/bin",
+        "MACPROVIDER_CONFIG": config,
+        "MACPROVIDER_CREDENTIAL_STORE": "protected_file",
+        "MACPROVIDER_PROTECTED_CREDENTIAL_ROOT": os.path.join(os.path.dirname(config), "protected-credentials"),
+        "MACPROVIDER_HEADLESS": "1",
+        "MACPROVIDER_HEADLESS_USER": user,
+        "MACPROVIDER_LAUNCHD_DOMAIN": "system",
+    },
+}
+with open(path, "wb") as handle:
+    plistlib.dump(payload, handle, sort_keys=False)
+os.chmod(path, 0o644)
+PY
+  incumbent_bytes="$(snapshot_published_headless_incumbent_plist "$PLIST_BOOTSTRAP_PATH" "$(id -u)")"
+  [ -n "$incumbent_bytes" ]
+
+  cp "$PLIST_BOOTSTRAP_PATH" "$PLIST_BOOTSTRAP_PATH.valid"
+  python3 - "$PLIST_BOOTSTRAP_PATH" <<PY
+import plistlib
+import sys
+path = sys.argv[1]
+with open(path, "rb") as handle:
+    payload = plistlib.load(handle)
+payload["ProgramArguments"].extend(["--unexpected", "value"])
+with open(path, "wb") as handle:
+    plistlib.dump(payload, handle)
+PY
+  chmod 0644 "$PLIST_BOOTSTRAP_PATH"
+  if snapshot_published_headless_incumbent_plist "$PLIST_BOOTSTRAP_PATH" "$(id -u)" >/dev/null 2>&1; then
+    echo "incumbent adoption unexpectedly accepted altered arguments" >&2
+    exit 1
+  fi
+  mv "$PLIST_BOOTSTRAP_PATH.valid" "$PLIST_BOOTSTRAP_PATH"
+  chmod 0644 "$PLIST_BOOTSTRAP_PATH"
+
+  cp "$PLIST_BOOTSTRAP_PATH" "$PLIST_BOOTSTRAP_PATH.valid"
+  python3 - "$PLIST_BOOTSTRAP_PATH" <<PY
+import plistlib
+import sys
+path = sys.argv[1]
+with open(path, "rb") as handle:
+    payload = plistlib.load(handle)
+payload["EnvironmentVariables"]["MACPROVIDER_LAUNCHD_DOMAIN"] = "gui/501"
+with open(path, "wb") as handle:
+    plistlib.dump(payload, handle)
+PY
+  chmod 0644 "$PLIST_BOOTSTRAP_PATH"
+  if snapshot_published_headless_incumbent_plist "$PLIST_BOOTSTRAP_PATH" "$(id -u)" >/dev/null 2>&1; then
+    echo "incumbent adoption unexpectedly accepted a user-domain environment" >&2
+    exit 1
+  fi
+  mv "$PLIST_BOOTSTRAP_PATH.valid" "$PLIST_BOOTSTRAP_PATH"
+  chmod 0644 "$PLIST_BOOTSTRAP_PATH"
+
+  cp "$PLIST_BOOTSTRAP_PATH" "$PLIST_BOOTSTRAP_PATH.valid"
+  printf 'not a plist\n' > "$PLIST_BOOTSTRAP_PATH"
+  chmod 0644 "$PLIST_BOOTSTRAP_PATH"
+  if snapshot_published_headless_incumbent_plist "$PLIST_BOOTSTRAP_PATH" "$(id -u)" >/dev/null 2>&1; then
+    echo "incumbent adoption unexpectedly accepted malformed plist data" >&2
+    exit 1
+  fi
+  mv "$PLIST_BOOTSTRAP_PATH.valid" "$PLIST_BOOTSTRAP_PATH"
+  chmod 0644 "$PLIST_BOOTSTRAP_PATH"
+
+  ln "$PLIST_BOOTSTRAP_PATH" "$PLIST_BOOTSTRAP_PATH.hardlink"
+  if snapshot_published_headless_incumbent_plist "$PLIST_BOOTSTRAP_PATH" "$(id -u)" >/dev/null 2>&1; then
+    echo "incumbent adoption unexpectedly accepted a hard-linked plist" >&2
+    exit 1
+  fi
+  rm -f "$PLIST_BOOTSTRAP_PATH.hardlink"
+
+  if (ADOPT_HEADLESS_INCUMBENT=1 MACPROVIDER_ACCEPTANCE_ASSET_DIR= LAUNCHD_PRINT_STATUS=0 \
+      adopt_headless_incumbent_metadata "$(id -u)"); then
+    echo "incumbent adoption unexpectedly accepted a non-acceptance source" >&2
+    exit 1
+  fi
+  ADOPT_HEADLESS_INCUMBENT=1
+  MACPROVIDER_ACCEPTANCE_ASSET_DIR=/tmp/signed-acceptance-fixture
+  LAUNCHD_PRINT_STATUS=0
+  adopt_headless_incumbent_metadata "$(id -u)"
+  cmp -s "$PLIST_PATH" "$PLIST_BOOTSTRAP_PATH"
+  [ ! -e "$MANIFEST_PATH" ]
+  rm -f "$PLIST_PATH" "$PLIST_BOOTSTRAP_PATH"
+  ADOPT_HEADLESS_INCUMBENT=0
+  unset MACPROVIDER_ACCEPTANCE_ASSET_DIR
+  LAUNCHD_PRINT_STATUS=1
 
   mkdir -p "$INSTALL_TX_BACKUP"
   printf "state=fixture\n" > "$INSTALL_TX_BACKUP/state.sh"

--- a/specs/README.md
+++ b/specs/README.md
@@ -28,7 +28,7 @@ it can no longer drift. Do not hand-edit the table; edit each spec's
 | SPEC-017 | Network Stats API | 0.2.0 | normative | pending | pending: 1 | [SPEC-017-network-stats-api.md](SPEC-017-network-stats-api.md) |
 | SPEC-018 | Agentic tool calling (provider-side response synthesis) | 0.2.7 | normative | pending | conformant: 1, pending: 1 | [SPEC-018-agentic-tool-calling.md](SPEC-018-agentic-tool-calling.md) |
 | SPEC-019 | Structured output (`response_format: json_schema`) | 0.2.5 | normative | pending | pending corpus migration | [SPEC-019-structured-output.md](SPEC-019-structured-output.md) |
-| SPEC-020 | Provider autoupdate | v0.1.15 | normative | pending | pending: 5 | [SPEC-020-provider-autoupdate.md](SPEC-020-provider-autoupdate.md) |
+| SPEC-020 | Provider autoupdate | v0.1.16 | normative | pending | pending: 5 | [SPEC-020-provider-autoupdate.md](SPEC-020-provider-autoupdate.md) |
 | SPEC-021 | MALIBU rewards emission ledger | 0.4.0 | draft | complete | pending: 10 | [SPEC-021-malibu-emission-ledger.md](SPEC-021-malibu-emission-ledger.md) |
 | SPEC-022 | Verified model settlement | v0.1.7 | draft | complete | conformant: 11 | [SPEC-022-verified-model-settlement.md](SPEC-022-verified-model-settlement.md) |
 | SPEC-023 | Installer-Integrated Autotune Recommend | v0.9.4 | normative | pending | conformant: 2 | [SPEC-023-installer-autotune-recommend.md](SPEC-023-installer-autotune-recommend.md) |

--- a/specs/SPEC-020-provider-autoupdate.md
+++ b/specs/SPEC-020-provider-autoupdate.md
@@ -1,6 +1,6 @@
 # SPEC-020 - Provider autoupdate
 
-Version: v0.1.15
+Version: v0.1.16
 Status: Normative; coordinator-independent recovery is reconciled and
 implementation remains nonconformant under issue #610. The production path ran
 the 2026-07-10 incident-recovery
@@ -37,6 +37,11 @@ v0.1.13 removes watchdog rollback ownership. The companion watchdog remains a
 local liveness monitor only; installer, Malibu repair, and CLI startup recovery
 are the only transaction owners allowed to mutate pending markers, rollback
 backups, live release bytes, watchdog scripts, plists, or Malibu app artifacts.
+v0.1.16 makes the existing headless boundary operator-actionable: a
+`headless_fleet` provider records a stable skipped event instead of entering the
+consumer-user failure/cooldown or accepted-session recovery loops, while the
+signed headless installer acceptance path remains the sole update/migration
+authority for this profile.
 
 ## Goal
 
@@ -871,6 +876,16 @@ recovery supplies an allowed signed set.
 R-4.13. Reserved for future headless system-domain update and rollback
 semantics. Until that version lands, `headless_fleet` is outside the autoupdate
 convergence population and MUST NOT be driven by the consumer-user reload helper.
+When a newer coordinator recommendation or signed-discovery target is observed
+for a `headless_fleet` process, the provider MUST record an eligibility event
+with `outcome:"skipped"` and
+`reason:"headless_operator_update_required"`, MUST NOT create a cooldown or
+count the observation as accepted-session recovery failure progress, and MUST
+leave the running provider untouched. The operator handoff is the protected,
+provenance-pinned headless installer acceptance bundle. That installer flow
+MUST preserve the provider ID, protected-file credentials, model/config state,
+receipts, and earnings history, and MUST fail closed rather than infer a
+manifest or adopt an unvalidated system LaunchDaemon topology.
 
 ### R-5. Opt-out
 
@@ -1228,6 +1243,17 @@ executable. Missing, expired, cross-boot, malformed, path-mismatched,
 hash-mismatched, owner-mismatched, or launchd-PID-mismatched authority fails
 closed without fencing.
 
+AC-V0.1-31. Headless operator-update handoff: given a buyer-serving
+`headless_fleet` provider and a strictly newer coordinator recommendation, the
+provider remains running, performs no drain/download/swap/reload operation,
+creates no failure cooldown, and emits a redacted
+`headless_operator_update_required` skipped event. An accepted-session R005
+signed-discovery invocation produces the same terminal reason while preserving
+its attribution metadata and does not increment the stuck-failure counter.
+Physical acceptance then uses a strictly newer, signed, provenance-pinned
+headless installer bundle and proves the same provider ID and protected
+credential generations before and after the installer-owned migration.
+
 After an authorized launchd target adopts the startup handoff, it MUST retain
 that authority while the exact pending marker remains armed. A crash, logout,
 or reboot before commit MAY recover the adopted authority only when the same
@@ -1427,6 +1453,12 @@ Deferred to v0.3.0 or later:
   blocks a later rollout. This reconciles the renewal prose with SPEC-020-R001
   (discovery MUST NOT derive its target from mutable `latest` ordering); no
   requirement, conformance, or authority binding changed.
+- v0.1.16 (2026-09-02): Made the reserved headless autoupdate boundary
+  operator-actionable. Headless recommendations and signed-discovery attempts
+  now terminate as `headless_operator_update_required` skips without cooldown,
+  mutation, or R005 failure counting; signed headless installer acceptance
+  remains the only update/migration authority until system-domain rollback
+  semantics are specified.
 - v0.1.14 (2026-08-28): Added SPEC-020-R005, accepted-but-stuck session recovery.
   v0.1.8 scoped coordinator-independent recovery to providers that cannot
   establish a session; R005 closes the residual gap where an admitted provider


### PR DESCRIPTION
## Summary

- classify system-domain/protected-file providers as `headless_fleet` before the consumer autoupdate opt-out/topology gates;
- emit the stable `headless_operator_update_required` skipped event without cooldown, drain, download, swap, or reload;
- add an explicit signed-acceptance-only migration bridge for the exact historical SSH-smoke LaunchDaemon shape;
- preserve the existing provider identity, protected credentials, config, and rollback bytes without fabricating an install manifest;
- document the operator handoff and update SPEC-020 to v0.1.16.

## Why

Issue #1324 reproduced a healthy v1.8.109 headless provider receiving a newer coordinator recommendation and reporting `unsupported_install_topology`. The rejection protected the system LaunchDaemon correctly, but it treated an intentional product boundary as a failed consumer update and provided no bounded migration path for the historical smoke topology.

## Safety boundary

The consumer updater still cannot mutate `/Library/LaunchDaemons`.

The migration bridge requires explicit `MACPROVIDER_ADOPT_HEADLESS_INCUMBENT=1`, headless mode, a protected signed acceptance bundle with exact provenance pins, a loaded system provider, no managed plist, no install manifest, and no unmanaged root watchdog. It descriptor-validates the root-owned `0644` plist against the exact historical identity, argv, user, config, credential root, environment, working directory, log paths, and keepalive shape. It writes only a byte-identical user-owned rollback copy before the existing installer transaction; it does not modify the live service or create a manifest. Any mismatch fails before cutover.

## Verification

- `swift test --filter AutoUpdateTests` on Apple M4/macOS: 96 tests passed, 0 failures.
- `bash phase3-binary/dist/test/install_headless_fleet.test.sh` on macOS: passed.
- `bash -n phase3-binary/dist/install.sh phase3-binary/dist/test/install_headless_fleet.test.sh`: passed.
- `python scripts/gen_spec_index.py --check`: passed.
- `python scripts/gen_spec_index.py --lint`: passed.
- `git diff --check`: passed.

`make test-dist` was also attempted on the rented Mac, but its first Python test cannot import under the host's Python 3.9 because the existing code uses `dict[...] | None`; this is unrelated to the changed files. A loop over every installer test is not valid on that live host because the fresh-Mac test correctly detects its real `/Library/LaunchDaemons/live.malibu.provider.plist`. CI remains the authoritative clean-host broad lane.

Closes #1324.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R001"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "phase3-binary/Tests/macprovider-cliTests/AutoUpdateTests.swift",
    "phase3-binary/dist/test/install_headless_fleet.test.sh"
  ],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/1324"
}
SPEC-GOVERNANCE-DECLARATION-END
