### PR TITLE
Adopt stranded headless providers through signed repair

### DIFF
--- a/phase3-binary/dist/install.sh
+++ b/phase3-binary/dist/install.sh
@@ -22,6 +22,8 @@ REPAIR_EXISTING_INSTALL="${MACPROVIDER_REPAIR_EXISTING_INSTALL:-0}"
 BUNDLED_CLI="${MACPROVIDER_BUNDLED_CLI:-}"
 BUNDLED_APP="${MACPROVIDER_BUNDLED_APP:-}"
 REFERRAL_BOOTSTRAP_COMPLETED=0
+HEADLESS_REPAIR_INCUMBENT_BINARY=""
+HEADLESS_REPAIR_INCUMBENT_SHA256=""
 unset MACPROVIDER_REFERRAL_CODE_FILE
 unset MACPROVIDER_REFERRAL_REPLACE_INCUMBENT
 unset MACPROVIDER_REPAIR_EXISTING_INSTALL
@@ -591,8 +593,89 @@ verify_published_launchd_plist() {
   source_path="$1"
   bootstrap_path="$2"
   [ "$HEADLESS" = "1" ] || return 0
-  "${SUDO_BIN:-/usr/bin/sudo}" -n /usr/bin/test -f "$bootstrap_path" \
-    && "${SUDO_BIN:-/usr/bin/sudo}" -n /usr/bin/cmp -s "$source_path" "$bootstrap_path"
+  "${SUDO_BIN:-/usr/bin/sudo}" -n /usr/bin/python3 - "$source_path" "$bootstrap_path" "$(id -u)" <<'PY'
+import ctypes
+import errno
+import os
+import stat
+import sys
+
+source_path, bootstrap_path, source_uid_text = sys.argv[1:]
+source_uid = int(source_uid_text)
+max_bytes = 1024 * 1024
+nofollow = getattr(os, "O_NOFOLLOW", 0)
+nonblock = getattr(os, "O_NONBLOCK", 0)
+
+
+def no_acl(fd):
+    if sys.platform != "darwin":
+        return True
+    try:
+        libc = ctypes.CDLL(None, use_errno=True)
+        acl_get_fd_np = libc.acl_get_fd_np
+        acl_get_fd_np.argtypes = [ctypes.c_int, ctypes.c_int]
+        acl_get_fd_np.restype = ctypes.c_void_p
+        acl_free = libc.acl_free
+        acl_free.argtypes = [ctypes.c_void_p]
+        acl_free.restype = ctypes.c_int
+    except (AttributeError, OSError):
+        return False
+    ctypes.set_errno(0)
+    acl = acl_get_fd_np(fd, 0x00000100)  # ACL_TYPE_EXTENDED
+    if acl:
+        acl_free(acl)
+        return False
+    return ctypes.get_errno() in (0, errno.ENOENT)
+
+
+def expected_bootstrap_uid(path):
+    if path.startswith("/Library/LaunchDaemons/"):
+        return 0
+    return source_uid
+
+
+def read_checked(path, expected_uid):
+    try:
+        fd = os.open(path, os.O_RDONLY | nonblock | nofollow)
+    except OSError:
+        raise SystemExit(1)
+    try:
+        before = os.fstat(fd)
+        if (
+            not stat.S_ISREG(before.st_mode)
+            or before.st_uid != expected_uid
+            or before.st_nlink != 1
+            or before.st_mode & (stat.S_IWGRP | stat.S_IWOTH)
+            or before.st_size < 0
+            or before.st_size > max_bytes
+            or not no_acl(fd)
+        ):
+            raise SystemExit(1)
+        payload = bytearray()
+        while len(payload) < before.st_size:
+            chunk = os.read(fd, min(65536, before.st_size - len(payload)))
+            if not chunk:
+                raise SystemExit(1)
+            payload.extend(chunk)
+        after = os.fstat(fd)
+        path_info = os.lstat(path)
+        if (
+            (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns, after.st_ctime_ns)
+            != (before.st_dev, before.st_ino, before.st_size, before.st_mtime_ns, before.st_ctime_ns)
+            or stat.S_ISLNK(path_info.st_mode)
+            or (path_info.st_dev, path_info.st_ino) != (before.st_dev, before.st_ino)
+        ):
+            raise SystemExit(1)
+        return bytes(payload)
+    finally:
+        os.close(fd)
+
+
+source = read_checked(source_path, source_uid)
+bootstrap = read_checked(bootstrap_path, expected_bootstrap_uid(bootstrap_path))
+if source != bootstrap:
+    raise SystemExit(1)
+PY
 }
 
 record_lifecycle_state() {
@@ -2853,6 +2936,7 @@ write_install_recovery_artifacts() {
   recovery_dir="$1"
   state_path="$recovery_dir/state.sh"
   recovery_script="$recovery_dir/recover.sh"
+  recovery_headless_incumbent_sha256=""
   : "${LAUNCHD_DOMAIN:=gui/$UID}"
   : "${HEADLESS:=0}"
   : "${HEADLESS_USER:=}"
@@ -2860,6 +2944,14 @@ write_install_recovery_artifacts() {
   : "${LEGACY_PLIST_BOOTSTRAP_PATH:=$LEGACY_PLIST_PATH}"
   : "${WATCHDOG_PLIST_BOOTSTRAP_PATH:=$WATCHDOG_PLIST_PATH}"
   : "${LEGACY_WATCHDOG_PLIST_BOOTSTRAP_PATH:=$LEGACY_WATCHDOG_PLIST_PATH}"
+  if headless_acceptance_repair_mode; then
+    [ -n "${HEADLESS_REPAIR_INCUMBENT_BINARY:-}" ] || return 1
+    recovery_headless_incumbent_sha256="${HEADLESS_REPAIR_INCUMBENT_SHA256:-}"
+    case "$recovery_headless_incumbent_sha256" in
+      [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]) ;;
+      *) return 1 ;;
+    esac
+  fi
 
   {
     printf 'REC_INSTALL_DIR=%q\n' "$INSTALL_DIR"
@@ -2886,6 +2978,13 @@ write_install_recovery_artifacts() {
     printf 'REC_LAUNCHD_DOMAIN=%q\n' "$LAUNCHD_DOMAIN"
     printf 'REC_HEADLESS=%q\n' "$HEADLESS"
     printf 'REC_HEADLESS_USER=%q\n' "$HEADLESS_USER"
+    if headless_acceptance_repair_mode; then
+      printf 'REC_HEADLESS_REPAIR_INCUMBENT_BINARY=%q\n' "${HEADLESS_REPAIR_INCUMBENT_BINARY:-}"
+      printf 'REC_HEADLESS_REPAIR_INCUMBENT_SHA256=%q\n' "$recovery_headless_incumbent_sha256"
+    else
+      printf 'REC_HEADLESS_REPAIR_INCUMBENT_BINARY=%q\n' ""
+      printf 'REC_HEADLESS_REPAIR_INCUMBENT_SHA256=%q\n' ""
+    fi
     printf 'REC_INSTALL_LOCK_PATH=%q\n' "$INSTALL_LOCK_PATH"
     printf 'REC_INSTALL_LOCK_TOKEN=%q\n' "$INSTALL_LOCK_TOKEN"
     printf 'REC_INSTALLER_PID=%q\n' "$$"
@@ -3012,6 +3111,9 @@ REC_LEGACY_WATCHDOG_WAS_ACTIVE="${REC_LEGACY_WATCHDOG_WAS_ACTIVE:-0}"
 REC_HAD_LEGACY_WATCHDOG_PLIST="${REC_HAD_LEGACY_WATCHDOG_PLIST:-0}"
 REC_LAUNCHD_DOMAIN="${REC_LAUNCHD_DOMAIN:-gui/$REC_UID}"
 REC_HEADLESS="${REC_HEADLESS:-0}"
+REC_BINARY_PATH="${REC_BINARY_PATH:-}"
+REC_HEADLESS_REPAIR_INCUMBENT_BINARY="${REC_HEADLESS_REPAIR_INCUMBENT_BINARY:-}"
+REC_HEADLESS_REPAIR_INCUMBENT_SHA256="${REC_HEADLESS_REPAIR_INCUMBENT_SHA256:-}"
 REC_PLIST_BOOTSTRAP_PATH="${REC_PLIST_BOOTSTRAP_PATH:-$REC_PLIST_PATH}"
 REC_LEGACY_PLIST_BOOTSTRAP_PATH="${REC_LEGACY_PLIST_BOOTSTRAP_PATH:-$REC_LEGACY_PLIST_PATH}"
 REC_WATCHDOG_PLIST_BOOTSTRAP_PATH="${REC_WATCHDOG_PLIST_BOOTSTRAP_PATH:-$REC_WATCHDOG_PLIST_PATH}"
@@ -3035,9 +3137,94 @@ validate_headless_recovery_targets() {
   [ "$REC_LEGACY_PLIST_BOOTSTRAP_PATH" = "/Library/LaunchDaemons/live.streamvc.macprovider.plist" ] || return 70
   [ "$REC_WATCHDOG_PLIST_BOOTSTRAP_PATH" = "/Library/LaunchDaemons/live.malibu.provider-watchdog.plist" ] || return 70
   [ "$REC_LEGACY_WATCHDOG_PLIST_BOOTSTRAP_PATH" = "/Library/LaunchDaemons/live.streamvc.macprovider-watchdog.plist" ] || return 70
+  if [ -n "$REC_HEADLESS_REPAIR_INCUMBENT_BINARY" ]; then
+    [ "$REC_HEADLESS_REPAIR_INCUMBENT_SHA256" != "" ] || return 70
+    case "$REC_HEADLESS_REPAIR_INCUMBENT_SHA256" in
+      [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]) ;;
+      *) return 70 ;;
+    esac
+    case "$REC_HEADLESS_REPAIR_INCUMBENT_BINARY" in
+      "$HOME"/*) ;;
+      *) return 70 ;;
+    esac
+  fi
 }
 validate_headless_recovery_targets || {
   printf '[macprovider-recovery] Headless recovery state contains an unsafe privileged launchd target.\n' >&2
+  exit 70
+}
+
+validate_recovery_incumbent_provider_binary() {
+  [ -n "$REC_HEADLESS_REPAIR_INCUMBENT_BINARY" ] || return 0
+  [ "$REC_HEADLESS" = "1" ] || return 70
+  [ "$REC_LAUNCHD_DOMAIN" = "system" ] || return 70
+  python3 - "$REC_HEADLESS_REPAIR_INCUMBENT_BINARY" "$REC_HEADLESS_REPAIR_INCUMBENT_SHA256" <<'PY'
+import ctypes
+import errno
+import hashlib
+import os
+import stat
+import sys
+
+path, expected_sha256 = sys.argv[1:]
+if not os.path.isabs(path):
+    raise SystemExit("incumbent binary path is not absolute")
+if len(expected_sha256) != 64 or any(character not in "0123456789abcdef" for character in expected_sha256):
+    raise SystemExit("incumbent binary digest is invalid")
+nofollow = getattr(os, "O_NOFOLLOW", 0)
+fd = os.open(path, os.O_RDONLY | getattr(os, "O_NONBLOCK", 0) | nofollow)
+try:
+    info = os.fstat(fd)
+    path_info = os.lstat(path)
+    if (
+        not stat.S_ISREG(info.st_mode)
+        or path_info.st_dev != info.st_dev
+        or path_info.st_ino != info.st_ino
+        or stat.S_ISLNK(path_info.st_mode)
+        or info.st_uid != os.getuid()
+        or info.st_nlink != 1
+        or info.st_mode & (stat.S_IWGRP | stat.S_IWOTH)
+        or not info.st_mode & stat.S_IXUSR
+    ):
+        raise SystemExit("unsafe incumbent binary")
+    if sys.platform == "darwin":
+        try:
+            libc = ctypes.CDLL(None, use_errno=True)
+            acl_get_fd_np = libc.acl_get_fd_np
+            acl_get_fd_np.argtypes = [ctypes.c_int, ctypes.c_int]
+            acl_get_fd_np.restype = ctypes.c_void_p
+            acl_free = libc.acl_free
+            acl_free.argtypes = [ctypes.c_void_p]
+            acl_free.restype = ctypes.c_int
+        except (AttributeError, OSError):
+            raise SystemExit("incumbent binary ACL API is unavailable")
+        ctypes.set_errno(0)
+        acl = acl_get_fd_np(fd, 0x00000100)  # ACL_TYPE_EXTENDED
+        if acl:
+            acl_free(acl)
+            raise SystemExit("incumbent binary has an extended ACL")
+        if ctypes.get_errno() != errno.ENOENT:
+            raise SystemExit("incumbent binary ACL verification failed")
+    digest = hashlib.sha256()
+    while True:
+        chunk = os.read(fd, 65536)
+        if not chunk:
+            break
+        digest.update(chunk)
+    after = os.fstat(fd)
+    if (
+        (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns, after.st_ctime_ns)
+        != (info.st_dev, info.st_ino, info.st_size, info.st_mtime_ns, info.st_ctime_ns)
+    ):
+        raise SystemExit("incumbent binary changed during verification")
+    if digest.hexdigest() != expected_sha256:
+        raise SystemExit("incumbent binary digest changed")
+finally:
+    os.close(fd)
+PY
+}
+validate_recovery_incumbent_provider_binary || {
+  printf '[macprovider-recovery] Headless recovery state contains an unsafe incumbent provider binary.\n' >&2
   exit 70
 }
 
@@ -3053,18 +3240,25 @@ validate_recovery_launchdaemon_plist() {
   managed_path="$1"
   bootstrap_path="$2"
   python3 - "$managed_path" "$bootstrap_path" "$REC_HEADLESS_USER" \
-    "$REC_INSTALL_DIR/macprovider-cli" "/Library/Application Support/macprovider/macprovider-health-monitor" \
-    "$REC_CONFIG_PATH" <<'PY'
+    "$REC_INSTALL_DIR/macprovider-cli" "$REC_BINARY_PATH" "$REC_HEADLESS_REPAIR_INCUMBENT_BINARY" \
+    "/Library/Application Support/macprovider/macprovider-health-monitor" "$REC_CONFIG_PATH" <<'PY'
 import os
 import plistlib
 import sys
 
-path, bootstrap_path, user, provider_program, watchdog_program, config_path = sys.argv[1:]
+path, bootstrap_path, user, provider_program, provider_alternate, provider_alternate_2, watchdog_program, config_path = sys.argv[1:]
+provider_programs = [provider_program]
+legacy_provider_programs = [provider_program]
+if provider_alternate:
+    provider_programs.append(provider_alternate)
+    legacy_provider_programs.append(provider_alternate)
+if provider_alternate_2:
+    provider_programs.append(provider_alternate_2)
 allowed = {
-    "/Library/LaunchDaemons/live.malibu.provider.plist": ("live.malibu.provider", provider_program),
-    "/Library/LaunchDaemons/live.streamvc.macprovider.plist": ("live.streamvc.macprovider", provider_program),
-    "/Library/LaunchDaemons/live.malibu.provider-watchdog.plist": ("live.malibu.provider-watchdog", watchdog_program),
-    "/Library/LaunchDaemons/live.streamvc.macprovider-watchdog.plist": ("live.streamvc.macprovider-watchdog", watchdog_program),
+    "/Library/LaunchDaemons/live.malibu.provider.plist": ("live.malibu.provider", provider_programs),
+    "/Library/LaunchDaemons/live.streamvc.macprovider.plist": ("live.streamvc.macprovider", legacy_provider_programs),
+    "/Library/LaunchDaemons/live.malibu.provider-watchdog.plist": ("live.malibu.provider-watchdog", [watchdog_program]),
+    "/Library/LaunchDaemons/live.streamvc.macprovider-watchdog.plist": ("live.streamvc.macprovider-watchdog", [watchdog_program]),
 }
 expected = allowed.get(bootstrap_path)
 if expected is None:
@@ -3075,7 +3269,7 @@ arguments = payload.get("ProgramArguments")
 environment = payload.get("EnvironmentVariables")
 if payload.get("Label") != expected[0]:
     raise SystemExit("unexpected LaunchDaemon identity")
-if not isinstance(arguments, list) or not arguments or arguments[0] != expected[1]:
+if not isinstance(arguments, list) or not arguments or arguments[0] not in expected[1]:
     raise SystemExit("unexpected LaunchDaemon program")
 if expected[0].endswith("-watchdog"):
     if "UserName" in payload:
@@ -3102,20 +3296,27 @@ snapshot_recovery_launchdaemon_plist() {
   managed_path="$1"
   bootstrap_path="$2"
   python3 - "$managed_path" "$bootstrap_path" "$REC_HEADLESS_USER" \
-    "$REC_INSTALL_DIR/macprovider-cli" "/Library/Application Support/macprovider/macprovider-health-monitor" \
-    "$REC_CONFIG_PATH" <<'PY'
+    "$REC_INSTALL_DIR/macprovider-cli" "$REC_BINARY_PATH" "$REC_HEADLESS_REPAIR_INCUMBENT_BINARY" \
+    "/Library/Application Support/macprovider/macprovider-health-monitor" "$REC_CONFIG_PATH" <<'PY'
 import base64
 import os
 import plistlib
 import stat
 import sys
 
-path, bootstrap_path, user, provider_program, watchdog_program, config_path = sys.argv[1:]
+path, bootstrap_path, user, provider_program, provider_alternate, provider_alternate_2, watchdog_program, config_path = sys.argv[1:]
+provider_programs = [provider_program]
+legacy_provider_programs = [provider_program]
+if provider_alternate:
+    provider_programs.append(provider_alternate)
+    legacy_provider_programs.append(provider_alternate)
+if provider_alternate_2:
+    provider_programs.append(provider_alternate_2)
 allowed = {
-    "/Library/LaunchDaemons/live.malibu.provider.plist": ("live.malibu.provider", provider_program),
-    "/Library/LaunchDaemons/live.streamvc.macprovider.plist": ("live.streamvc.macprovider", provider_program),
-    "/Library/LaunchDaemons/live.malibu.provider-watchdog.plist": ("live.malibu.provider-watchdog", watchdog_program),
-    "/Library/LaunchDaemons/live.streamvc.macprovider-watchdog.plist": ("live.streamvc.macprovider-watchdog", watchdog_program),
+    "/Library/LaunchDaemons/live.malibu.provider.plist": ("live.malibu.provider", provider_programs),
+    "/Library/LaunchDaemons/live.streamvc.macprovider.plist": ("live.streamvc.macprovider", legacy_provider_programs),
+    "/Library/LaunchDaemons/live.malibu.provider-watchdog.plist": ("live.malibu.provider-watchdog", [watchdog_program]),
+    "/Library/LaunchDaemons/live.streamvc.macprovider-watchdog.plist": ("live.streamvc.macprovider-watchdog", [watchdog_program]),
 }
 expected = allowed.get(bootstrap_path)
 if expected is None:
@@ -3135,7 +3336,7 @@ arguments = payload.get("ProgramArguments")
 environment = payload.get("EnvironmentVariables")
 if payload.get("Label") != expected[0]:
     raise SystemExit("unexpected LaunchDaemon identity")
-if not isinstance(arguments, list) or not arguments or arguments[0] != expected[1]:
+if not isinstance(arguments, list) or not arguments or arguments[0] not in expected[1]:
     raise SystemExit("unexpected LaunchDaemon program")
 if expected[0].endswith("-watchdog"):
     if "UserName" in payload:
@@ -5819,7 +6020,7 @@ if [ ! -e "$RECOVERY_DIR/cutover-started" ] && [ ! -L "$RECOVERY_DIR/cutover-sta
         || recovery_failed "could not start the unexpectedly inactive pre-cutover provider service"
     fi
     service_identity_matches "$REC_PROVIDER_LABEL" "$REC_PLIST_BOOTSTRAP_PATH" \
-      "$REC_INSTALL_DIR/macprovider-cli" "$REC_BINARY_PATH" \
+      "$REC_INSTALL_DIR/macprovider-cli" "$REC_BINARY_PATH" "$REC_HEADLESS_REPAIR_INCUMBENT_BINARY" \
       || recovery_failed "pre-cutover provider service has an unexpected identity"
   fi
   if [ "$REC_LEGACY_SERVICE_WAS_ACTIVE" -eq 1 ]; then
@@ -5886,13 +6087,20 @@ stop_owned_manual_provider() {
   candidate_pid="$1"
   expected_executable="$2"
   alternate_executable="${3:-}"
+  second_alternate_executable=""
   expected_port="${4:-}"
+  if [ "$#" -ge 5 ]; then
+    second_alternate_executable="${4:-}"
+    expected_port="${5:-}"
+  fi
   if [ -n "$expected_port" ]; then
     observed_port_pids="$(lsof -nP -iTCP:"$expected_port" -sTCP:LISTEN -t 2>/dev/null || true)"
     printf '%s\n' "$observed_port_pids" | grep -Fxq "$candidate_pid" || return 1
   fi
   observed_executable="$(lsof -nP -a -p "$candidate_pid" -d txt -Fn 2>/dev/null | sed -n 's/^n//p' | head -n 1)"
-  if [ "$observed_executable" != "$expected_executable" ] && { [ -z "$alternate_executable" ] || [ "$observed_executable" != "$alternate_executable" ]; }; then
+  if [ "$observed_executable" != "$expected_executable" ] \
+    && { [ -z "$alternate_executable" ] || [ "$observed_executable" != "$alternate_executable" ]; } \
+    && { [ -z "$second_alternate_executable" ] || [ "$observed_executable" != "$second_alternate_executable" ]; }; then
     return 1
   fi
   kill -TERM "$candidate_pid" >/dev/null 2>&1 || return 1
@@ -5903,7 +6111,9 @@ stop_owned_manual_provider() {
   done
   if pid_is_live_non_zombie "$candidate_pid"; then
     observed_executable="$(lsof -nP -a -p "$candidate_pid" -d txt -Fn 2>/dev/null | sed -n 's/^n//p' | head -n 1)"
-    if [ "$observed_executable" != "$expected_executable" ] && { [ -z "$alternate_executable" ] || [ "$observed_executable" != "$alternate_executable" ]; }; then
+    if [ "$observed_executable" != "$expected_executable" ] \
+      && { [ -z "$alternate_executable" ] || [ "$observed_executable" != "$alternate_executable" ]; } \
+      && { [ -z "$second_alternate_executable" ] || [ "$observed_executable" != "$second_alternate_executable" ]; }; then
       return 1
     fi
     kill -KILL "$candidate_pid" >/dev/null 2>&1 || return 1
@@ -6109,17 +6319,17 @@ if [ "$REC_SERVICE_WAS_ACTIVE" -eq 1 ]; then
   [ "$REC_HAD_PLIST" -eq 1 ] || recovery_failed "the prior provider service was active but no recoverable plist was preserved"
   if [ -f "$RECOVERY_DIR/provider-service-created" ] && [ ! -L "$RECOVERY_DIR/provider-service-created" ]; then
     stop_loaded_service "$REC_PROVIDER_LABEL" "$REC_PLIST_BOOTSTRAP_PATH" \
-      "$REC_INSTALL_DIR/macprovider-cli" "$REC_BINARY_PATH" \
+      "$REC_INSTALL_DIR/macprovider-cli" "$REC_BINARY_PATH" "$REC_HEADLESS_REPAIR_INCUMBENT_BINARY" \
       "the transaction provider service"
   else
     stop_loaded_service "$REC_PROVIDER_LABEL" "$REC_PLIST_BOOTSTRAP_PATH" \
-      "$REC_INSTALL_DIR/macprovider-cli" "$REC_BINARY_PATH" \
+      "$REC_INSTALL_DIR/macprovider-cli" "$REC_BINARY_PATH" "$REC_HEADLESS_REPAIR_INCUMBENT_BINARY" \
       "the incumbent provider service"
   fi
 else
   if [ -f "$RECOVERY_DIR/provider-service-created" ] && [ ! -L "$RECOVERY_DIR/provider-service-created" ]; then
     stop_loaded_service "$REC_PROVIDER_LABEL" "$REC_PLIST_BOOTSTRAP_PATH" \
-      "$REC_INSTALL_DIR/macprovider-cli" "$REC_BINARY_PATH" \
+      "$REC_INSTALL_DIR/macprovider-cli" "$REC_BINARY_PATH" "$REC_HEADLESS_REPAIR_INCUMBENT_BINARY" \
       "the transaction provider service"
   fi
   service_loaded "$REC_PROVIDER_LABEL" && recovery_failed "provider service is active even though it was inactive before the failed install"
@@ -6227,7 +6437,7 @@ if [ "$REC_SERVICE_WAS_ACTIVE" -eq 1 ]; then
   recovery_launchctl bootstrap "$REC_LAUNCHD_DOMAIN" "$REC_PLIST_BOOTSTRAP_PATH" >/dev/null 2>&1 || recovery_failed "could not bootstrap the previous provider service"
   recovery_launchctl kickstart -k "$REC_LAUNCHD_DOMAIN/$REC_PROVIDER_LABEL" >/dev/null 2>&1 || recovery_failed "could not kickstart the previous provider service"
   service_identity_matches "$REC_PROVIDER_LABEL" "$REC_PLIST_BOOTSTRAP_PATH" \
-    "$REC_INSTALL_DIR/macprovider-cli" "$REC_BINARY_PATH" \
+    "$REC_INSTALL_DIR/macprovider-cli" "$REC_BINARY_PATH" "$REC_HEADLESS_REPAIR_INCUMBENT_BINARY" \
     || recovery_failed "previous provider service has an unexpected identity"
 elif [ "$REC_LEGACY_SERVICE_WAS_ACTIVE" -eq 1 ]; then
   [ "$REC_HAD_LEGACY_PLIST" -eq 1 ] || recovery_failed "previous legacy service was active but no previous plist was preserved"
@@ -6789,13 +6999,20 @@ stop_owned_manual_provider() {
   candidate_pid="$1"
   expected_executable="$2"
   alternate_executable="${3:-}"
+  second_alternate_executable=""
   expected_port="${4:-}"
+  if [ "$#" -ge 5 ]; then
+    second_alternate_executable="${4:-}"
+    expected_port="${5:-}"
+  fi
   if [ -n "$expected_port" ]; then
     observed_port_pids="$(lsof -nP -iTCP:"$expected_port" -sTCP:LISTEN -t 2>/dev/null || true)"
     printf '%s\n' "$observed_port_pids" | grep -Fxq "$candidate_pid" || return 1
   fi
   observed_executable="$(lsof -nP -a -p "$candidate_pid" -d txt -Fn 2>/dev/null | sed -n 's/^n//p' | head -n 1)"
-  if [ "$observed_executable" != "$expected_executable" ] && { [ -z "$alternate_executable" ] || [ "$observed_executable" != "$alternate_executable" ]; }; then
+  if [ "$observed_executable" != "$expected_executable" ] \
+    && { [ -z "$alternate_executable" ] || [ "$observed_executable" != "$alternate_executable" ]; } \
+    && { [ -z "$second_alternate_executable" ] || [ "$observed_executable" != "$second_alternate_executable" ]; }; then
     return 1
   fi
   kill -TERM "$candidate_pid" >/dev/null 2>&1 || return 1
@@ -6806,7 +7023,9 @@ stop_owned_manual_provider() {
   done
   if pid_is_live_non_zombie "$candidate_pid"; then
     observed_executable="$(lsof -nP -a -p "$candidate_pid" -d txt -Fn 2>/dev/null | sed -n 's/^n//p' | head -n 1)"
-    if [ "$observed_executable" != "$expected_executable" ] && { [ -z "$alternate_executable" ] || [ "$observed_executable" != "$alternate_executable" ]; }; then
+    if [ "$observed_executable" != "$expected_executable" ] \
+      && { [ -z "$alternate_executable" ] || [ "$observed_executable" != "$alternate_executable" ]; } \
+      && { [ -z "$second_alternate_executable" ] || [ "$observed_executable" != "$second_alternate_executable" ]; }; then
       return 1
     fi
     kill -KILL "$candidate_pid" >/dev/null 2>&1 || return 1
@@ -6828,7 +7047,7 @@ begin_install_transaction() {
   assert_install_lock_ownership
   validate_transaction_path_kinds
   if [ "${REPAIR_EXISTING_INSTALL:-0}" -eq 1 ]; then
-    repair_safe_incumbent_present \
+    repair_incumbent_present_for_current_mode \
       || die 28 "trusted existing-install evidence changed before the transaction snapshot"
   fi
   recovery_id="$(date -u +%Y%m%dT%H%M%SZ)-$$"
@@ -6875,8 +7094,12 @@ begin_install_transaction() {
   if [ -f "$PLIST_PATH" ]; then
     verify_published_launchd_plist "$PLIST_PATH" "$PLIST_BOOTSTRAP_PATH" \
       || die 70 "managed provider plist does not match the published LaunchDaemon plist; current install was not changed"
+    provider_snapshot_alternate=""
+    if headless_acceptance_repair_mode; then
+      provider_snapshot_alternate="${HEADLESS_REPAIR_INCUMBENT_BINARY:-}"
+    fi
     stage_install_tx_plist "$PLIST_PATH" "$recovery_staging/provider.plist" \
-      "$PROVIDER_LABEL" "$INSTALL_DIR/macprovider-cli" "$BINARY_PATH" "${HEADLESS_USER:-}" \
+      "$PROVIDER_LABEL" "$INSTALL_DIR/macprovider-cli" "$BINARY_PATH" "$provider_snapshot_alternate" "${HEADLESS_USER:-}" \
       || die 70 "could not stage and verify the previous launchd plist; current install was not changed (partial recovery data: $recovery_staging)"
     INSTALL_TX_HAD_PLIST=1
   fi
@@ -7594,6 +7817,330 @@ if plist_raw is not None:
 PY
 }
 
+headless_acceptance_repair_mode() {
+  [ "${REPAIR_EXISTING_INSTALL:-0}" -eq 1 ] || return 1
+  [ "${HEADLESS:-0}" = "1" ] || return 1
+  [ "${LAUNCHD_DOMAIN:-}" = "system" ] || return 1
+  [ -n "${MACPROVIDER_ACCEPTANCE_ASSET_DIR:-}" ] || return 1
+  [ -z "${BUNDLED_APP:-}" ] || return 1
+}
+
+provider_executable_owned_for_current_mode() {
+  local candidate="$1"
+  [ "$candidate" = "$INSTALL_DIR/macprovider-cli" ] && return 0
+  [ -n "${BINARY_PATH:-}" ] && [ "$candidate" = "$BINARY_PATH" ] && return 0
+  if headless_acceptance_repair_mode \
+    && [ -n "${HEADLESS_REPAIR_INCUMBENT_BINARY:-}" ] \
+    && [ "$candidate" = "$HEADLESS_REPAIR_INCUMBENT_BINARY" ]; then
+    return 0
+  fi
+  return 1
+}
+
+headless_acceptance_repair_safe_incumbent_present() {
+  local incumbent_binary
+  local incumbent_evidence
+  local incumbent_sha256
+  headless_acceptance_repair_mode || return 1
+  [ -f "$PLIST_PATH" ] || return 1
+  [ -f "$PLIST_BOOTSTRAP_PATH" ] || return 1
+  verify_published_launchd_plist "$PLIST_PATH" "$PLIST_BOOTSTRAP_PATH" || return 1
+  launchctl_service print "$LAUNCHD_DOMAIN/$PROVIDER_LABEL" >/dev/null 2>&1 || return 1
+  incumbent_evidence="$(python3 - \
+    "$CONFIG_PATH" \
+    "$PROVIDER_ID_PATH" \
+    "$PLIST_PATH" \
+    "$HEADLESS_USER" \
+    "$PROVIDER_LABEL" \
+    "$CONFIG_DIR" <<'PY' 2>/dev/null
+import ctypes
+import errno
+import grp
+import hashlib
+import os
+import plistlib
+import re
+import stat
+import sys
+
+config_path, provider_id_path, plist_path, headless_user, label, config_dir = sys.argv[1:]
+uid = os.getuid()
+nofollow = getattr(os, "O_NOFOLLOW", 0)
+nonblock = getattr(os, "O_NONBLOCK", 0)
+max_bytes = 1024 * 1024
+
+
+def no_acl(fd):
+    if sys.platform != "darwin":
+        return True
+    try:
+        libc = ctypes.CDLL(None, use_errno=True)
+        acl_get_fd_np = libc.acl_get_fd_np
+        acl_get_fd_np.argtypes = [ctypes.c_int, ctypes.c_int]
+        acl_get_fd_np.restype = ctypes.c_void_p
+        acl_free = libc.acl_free
+        acl_free.argtypes = [ctypes.c_void_p]
+        acl_free.restype = ctypes.c_int
+    except (AttributeError, OSError):
+        return False
+    ctypes.set_errno(0)
+    acl = acl_get_fd_np(fd, 0x00000100)
+    if acl:
+        acl_free(acl)
+        return False
+    return ctypes.get_errno() in (0, errno.ENOENT)
+
+
+def safe_directory_acl(fd):
+    if sys.platform != "darwin":
+        return True
+    try:
+        libc = ctypes.CDLL(None, use_errno=True)
+        acl_get_fd_np = libc.acl_get_fd_np
+        acl_get_fd_np.argtypes = [ctypes.c_int, ctypes.c_int]
+        acl_get_fd_np.restype = ctypes.c_void_p
+        acl_to_text = libc.acl_to_text
+        acl_to_text.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_long)]
+        acl_to_text.restype = ctypes.c_void_p
+        acl_free = libc.acl_free
+        acl_free.argtypes = [ctypes.c_void_p]
+        acl_free.restype = ctypes.c_int
+    except (AttributeError, OSError):
+        return False
+    ctypes.set_errno(0)
+    acl = acl_get_fd_np(fd, 0x00000100)
+    if not acl:
+        return ctypes.get_errno() in (0, errno.ENOENT)
+    try:
+        text_length = ctypes.c_long()
+        text_pointer = acl_to_text(acl, ctypes.byref(text_length))
+        if not text_pointer:
+            return False
+        try:
+            lines = ctypes.string_at(text_pointer, text_length.value).decode(
+                "utf-8", errors="strict"
+            ).splitlines()
+        finally:
+            acl_free(text_pointer)
+        everyone_gid = grp.getgrnam("everyone").gr_gid
+        if len(lines) < 2 or lines[0] != "!#acl 1":
+            return False
+        uuid_pattern = re.compile(
+            r"^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-"
+            r"[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$"
+        )
+        return all(
+            (fields := line.split(":"))
+            and len(fields) == 6
+            and fields[0] == "group"
+            and bool(uuid_pattern.fullmatch(fields[1]))
+            and fields[2] == "everyone"
+            and fields[3] == str(everyone_gid)
+            and fields[4] == "deny"
+            and fields[5] == "delete"
+            for line in lines[1:]
+        )
+    finally:
+        acl_free(acl)
+
+
+def safe_parent_chain(path):
+    home = os.path.normpath(os.path.expanduser("~"))
+    parent = os.path.normpath(os.path.dirname(path))
+    try:
+        if os.path.commonpath([home, parent]) != home:
+            return False
+    except ValueError:
+        return False
+    home_fd = os.open(
+        home,
+        os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | nofollow,
+    )
+    try:
+        home_info = os.fstat(home_fd)
+        if (
+            not stat.S_ISDIR(home_info.st_mode)
+            or home_info.st_uid != uid
+            or home_info.st_mode & (stat.S_IWGRP | stat.S_IWOTH)
+        ):
+            return False
+    finally:
+        os.close(home_fd)
+    current = home
+    relative = os.path.relpath(parent, home)
+    components = [] if relative == "." else relative.split(os.sep)
+    for component in components:
+        current = os.path.join(current, component)
+        directory_fd = os.open(
+            current,
+            os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | nofollow,
+        )
+        try:
+            info = os.fstat(directory_fd)
+            if (
+                not stat.S_ISDIR(info.st_mode)
+                or info.st_uid != uid
+                or info.st_mode & (stat.S_IWGRP | stat.S_IWOTH)
+                or not safe_directory_acl(directory_fd)
+            ):
+                return False
+        finally:
+            os.close(directory_fd)
+    return True
+
+
+def read_owned(path):
+    if not safe_parent_chain(path):
+        raise RuntimeError("unsafe headless repair evidence parent chain")
+    fd = os.open(path, os.O_RDONLY | nonblock | nofollow)
+    try:
+        before = os.fstat(fd)
+        if (
+            not stat.S_ISREG(before.st_mode)
+            or before.st_uid != uid
+            or before.st_nlink != 1
+            or stat.S_IMODE(before.st_mode) & (stat.S_IWGRP | stat.S_IWOTH)
+            or before.st_size < 0
+            or before.st_size > max_bytes
+            or not no_acl(fd)
+        ):
+            raise RuntimeError("unsafe headless repair evidence")
+        payload = bytearray()
+        while len(payload) < before.st_size:
+            chunk = os.read(fd, min(65536, before.st_size - len(payload)))
+            if not chunk:
+                raise RuntimeError("headless repair evidence truncated")
+            payload.extend(chunk)
+        after = os.fstat(fd)
+        path_info = os.lstat(path)
+        if (
+            (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns, after.st_ctime_ns)
+            != (before.st_dev, before.st_ino, before.st_size, before.st_mtime_ns, before.st_ctime_ns)
+            or stat.S_ISLNK(path_info.st_mode)
+            or (path_info.st_dev, path_info.st_ino) != (before.st_dev, before.st_ino)
+        ):
+            raise RuntimeError("headless repair evidence changed during read")
+        return bytes(payload)
+    finally:
+        os.close(fd)
+
+
+def simple_values(config, key):
+    pattern = re.compile(rf'^{re.escape(key)}:\s*"?([^"\s]+)"?\s*$')
+    values = []
+    for line in config.splitlines():
+        match = pattern.match(line)
+        if match:
+            values.append(match.group(1))
+    return values
+
+
+config = read_owned(config_path).decode("utf-8")
+provider_id = read_owned(provider_id_path).decode("utf-8").strip()
+if simple_values(config, "provider_id") != [provider_id]:
+    raise SystemExit(1)
+if simple_values(config, "credential_store") != ["protected_file"]:
+    raise SystemExit(1)
+if simple_values(config, "auto_update_enabled") != ["false"]:
+    raise SystemExit(1)
+provider_token_patterns = [
+    re.compile(r"^provider_token[ \t]*:"),
+    re.compile(r"^'provider_token'[ \t]*:"),
+    re.compile(r'^"provider_token"[ \t]*:'),
+    re.compile(r'^"provider\\u005ftoken"[ \t]*:'),
+]
+if any(any(pattern.match(line) for pattern in provider_token_patterns) for line in config.splitlines()):
+    raise SystemExit(1)
+
+plist = plistlib.loads(read_owned(plist_path))
+arguments = plist.get("ProgramArguments")
+environment = plist.get("EnvironmentVariables")
+if plist.get("Label") != label:
+    raise SystemExit(1)
+if plist.get("UserName") != headless_user:
+    raise SystemExit(1)
+if (
+    not isinstance(arguments, list)
+    or not arguments
+    or arguments != [arguments[0], "serve", "--config", config_path]
+):
+    raise SystemExit(1)
+program = plist.get("Program")
+if program is not None and program != arguments[0]:
+    raise SystemExit(1)
+incumbent_binary = arguments[0]
+if not os.path.isabs(incumbent_binary) or not safe_parent_chain(incumbent_binary):
+    raise SystemExit(1)
+if not isinstance(environment, dict):
+    raise SystemExit(1)
+if environment.get("MACPROVIDER_CREDENTIAL_STORE") != "protected_file":
+    raise SystemExit(1)
+if environment.get("MACPROVIDER_PROTECTED_CREDENTIAL_ROOT") != os.path.join(config_dir, "protected-credentials"):
+    raise SystemExit(1)
+if environment.get("MACPROVIDER_HEADLESS") != "1":
+    raise SystemExit(1)
+if environment.get("MACPROVIDER_HEADLESS_USER") != headless_user:
+    raise SystemExit(1)
+if environment.get("MACPROVIDER_LAUNCHD_DOMAIN") != "system":
+    raise SystemExit(1)
+binary_fd = os.open(incumbent_binary, os.O_RDONLY | nonblock | nofollow)
+try:
+    binary_info = os.fstat(binary_fd)
+    if (
+        not stat.S_ISREG(binary_info.st_mode)
+        or binary_info.st_uid != uid
+        or binary_info.st_nlink != 1
+        or stat.S_IMODE(binary_info.st_mode) & (stat.S_IWGRP | stat.S_IWOTH)
+        or not no_acl(binary_fd)
+        or not (stat.S_IMODE(binary_info.st_mode) & stat.S_IXUSR)
+    ):
+        raise SystemExit(1)
+    digest = hashlib.sha256()
+    while True:
+        chunk = os.read(binary_fd, 65536)
+        if not chunk:
+            break
+        digest.update(chunk)
+    after_binary_info = os.fstat(binary_fd)
+    path_info = os.lstat(incumbent_binary)
+    if (
+        (after_binary_info.st_dev, after_binary_info.st_ino, after_binary_info.st_size, after_binary_info.st_mtime_ns, after_binary_info.st_ctime_ns)
+        != (binary_info.st_dev, binary_info.st_ino, binary_info.st_size, binary_info.st_mtime_ns, binary_info.st_ctime_ns)
+        or stat.S_ISLNK(path_info.st_mode)
+        or (path_info.st_dev, path_info.st_ino) != (binary_info.st_dev, binary_info.st_ino)
+    ):
+        raise SystemExit(1)
+finally:
+    os.close(binary_fd)
+print(incumbent_binary)
+print(digest.hexdigest())
+PY
+  )" || return 1
+  incumbent_binary="$(printf '%s\n' "$incumbent_evidence" | sed -n '1p')"
+  incumbent_sha256="$(printf '%s\n' "$incumbent_evidence" | sed -n '2p')"
+  [ -n "$incumbent_binary" ] || return 1
+  case "$incumbent_sha256" in
+    [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]) ;;
+    *) return 1 ;;
+  esac
+  MACPROVIDER_CREDENTIAL_STORE=protected_file \
+  MACPROVIDER_PROTECTED_CREDENTIAL_ROOT="$CONFIG_DIR/protected-credentials" \
+  MACPROVIDER_HEADLESS=1 \
+  MACPROVIDER_HEADLESS_USER="$HEADLESS_USER" \
+  MACPROVIDER_LAUNCHD_DOMAIN=system \
+    "$incumbent_binary" credentials verify --config "$CONFIG_PATH" >/dev/null 2>&1 || return 1
+  HEADLESS_REPAIR_INCUMBENT_BINARY="$incumbent_binary"
+  HEADLESS_REPAIR_INCUMBENT_SHA256="$incumbent_sha256"
+}
+
+repair_incumbent_present_for_current_mode() {
+  if headless_acceptance_repair_mode; then
+    headless_acceptance_repair_safe_incumbent_present
+  else
+    repair_safe_incumbent_present
+  fi
+}
+
 validate_supplied_referral_code_file() {
   referral_source_rc=0
   python3 - "$REFERRAL_CODE_SOURCE_FILE" <<'PY' || referral_source_rc=$?
@@ -7663,7 +8210,7 @@ prepare_fresh_referral_code() {
   case "$REPAIR_EXISTING_INSTALL" in
     0) ;;
     1)
-      repair_safe_incumbent_present \
+      repair_incumbent_present_for_current_mode \
         || die 28 "trusted existing-install evidence is required for Malibu repair"
       log "Trusted existing-install evidence found; repairing without a referral code."
       return 0
@@ -7755,7 +8302,7 @@ ensure_port_free() {
   own_provider_holds_port=0
   for holding_pid in $holding_pids; do
     holding_executable="$(lsof -a -p "$holding_pid" -d txt -Fn 2>/dev/null | sed -n 's/^n//p' | head -n 1)"
-    if [ "$holding_executable" = "$INSTALL_DIR/macprovider-cli" ]; then
+    if provider_executable_owned_for_current_mode "$holding_executable"; then
       own_provider_holds_port=1
       break
     fi
@@ -7781,7 +8328,7 @@ ensure_port_free() {
       log "Port $PORT still held after launchctl bootout; stopping each revalidated macprovider-cli PID."
       for holding_pid in $holding_pids; do
         if lsof -nP -iTCP:"$PORT" -sTCP:LISTEN -t 2>/dev/null | grep -Fxq "$holding_pid"; then
-          stop_owned_manual_provider "$holding_pid" "$INSTALL_DIR/macprovider-cli" "$BINARY_PATH" "$PORT" \
+          stop_owned_manual_provider "$holding_pid" "$INSTALL_DIR/macprovider-cli" "$BINARY_PATH" "${HEADLESS_REPAIR_INCUMBENT_BINARY:-}" "$PORT" \
             || die 70 "could not safely stop macprovider-cli pid $holding_pid after revalidating executable and port ownership"
         fi
       done
@@ -7812,12 +8359,17 @@ reclaim_launchd_service() {
   local service_target="$LAUNCHD_DOMAIN/$label"
   local expected_program
   local legacy_program
+  local repair_program
   local expected_plist
   local had_plist
+  repair_program=""
   case "$label" in
     "$PROVIDER_LABEL")
       expected_program="$INSTALL_DIR/macprovider-cli"
       legacy_program="$BINARY_PATH"
+      if headless_acceptance_repair_mode; then
+        repair_program="${HEADLESS_REPAIR_INCUMBENT_BINARY:-}"
+      fi
       expected_plist="$PLIST_BOOTSTRAP_PATH"
       had_plist="${INSTALL_TX_HAD_PLIST:-0}"
       ;;
@@ -7871,7 +8423,9 @@ reclaim_launchd_service() {
     log "Refusing to reclaim $label because launchd plist identity is unexpected: ${plist_path:-<missing>}"
     return 1
   fi
-  if [ "$program_line" != "$expected_program" ] && [ "$program_line" != "$legacy_program" ]; then
+  if [ "$program_line" != "$expected_program" ] \
+    && [ "$program_line" != "$legacy_program" ] \
+    && { [ -z "$repair_program" ] || [ "$program_line" != "$repair_program" ]; }; then
     log "Refusing to reclaim $label with unexpected executable: $program_line"
     return 1
   fi
@@ -8810,6 +9364,9 @@ validate_headless_acceptance_source() {
 validate_repair_privilege_domain() {
   [ "${REPAIR_EXISTING_INSTALL:-0}" -eq 1 ] || return 0
   if [ "${HEADLESS:-0}" = "1" ] || [ "${LAUNCHD_DOMAIN:-}" = "system" ]; then
+    if headless_acceptance_repair_mode; then
+      return 0
+    fi
     die 7 "Malibu.app repair supports user-domain LaunchAgents only; headless/system LaunchDaemon repair requires the signed acceptance fallback"
   fi
 }
@@ -9848,7 +10405,11 @@ ensure_provider_credentials() {
         [ -n "${REFERRAL_CODE_SOURCE_FILE:-}" ] || return 0
         credential_already_present=1
         ;;
-      3) ;;
+      3)
+        if headless_acceptance_repair_mode; then
+          die 6 "headless acceptance repair credential custody changed after incumbent verification; refusing to bootstrap over protected-file state"
+        fi
+        ;;
       *) die 6 "existing CLI Keychain credential is unavailable or invalid; refusing unsafe bootstrap" ;;
     esac
   fi
@@ -9914,6 +10475,11 @@ ensure_replacement_referral_preflight_before_cutover() {
   persist_replacement_candidate_provider_id
   [ "${REFERRAL_BOOTSTRAP_COMPLETED:-0}" -eq 0 ] || return 0
   log "Validating the fresh-provider invite before stopping the incumbent provider."
+  ensure_provider_credentials
+}
+
+ensure_headless_acceptance_credentials_before_cutover() {
+  headless_acceptance_repair_mode || return 0
   ensure_provider_credentials
 }
 
@@ -10080,7 +10646,7 @@ own_macprovider_cli_holds_live_port() {
   [ -n "$holding_pids" ] || return 1
   for holding_pid in $holding_pids; do
     holding_executable="$(lsof -a -p "$holding_pid" -d txt -Fn 2>/dev/null | sed -n 's/^n//p' | head -n 1)"
-    if [ "$holding_executable" = "$INSTALL_DIR/macprovider-cli" ]; then
+    if provider_executable_owned_for_current_mode "$holding_executable"; then
       return 0
     fi
   done
@@ -11693,7 +12259,11 @@ print_autotune_handoff() {
 }
 
 installed_provider_binary_path() {
-  if [ -x "$INSTALL_DIR/macprovider-cli" ]; then
+  if headless_acceptance_repair_mode \
+      && [ -n "${HEADLESS_REPAIR_INCUMBENT_BINARY:-}" ] \
+      && [ -x "$HEADLESS_REPAIR_INCUMBENT_BINARY" ]; then
+    printf '%s\n' "$HEADLESS_REPAIR_INCUMBENT_BINARY"
+  elif [ -x "$INSTALL_DIR/macprovider-cli" ]; then
     printf '%s\n' "$INSTALL_DIR/macprovider-cli"
   elif [ -x "$BINARY_PATH" ]; then
     printf '%s\n' "$BINARY_PATH"
@@ -12740,7 +13310,7 @@ main() {
     asset_kind="bundled"
     log "Repairing from Malibu.app bundled provider CLI (no GitHub download)."
   else
-    [ "${REPAIR_EXISTING_INSTALL:-0}" -eq 0 ] \
+    [ "${REPAIR_EXISTING_INSTALL:-0}" -eq 0 ] || headless_acceptance_repair_mode \
       || die 7 "existing-install repair requires MACPROVIDER_BUNDLED_APP from Malibu.app"
     download_release "$tag"
     verify_sha256
@@ -12783,6 +13353,7 @@ main() {
       prefetch_upgrade_autotune_model
     fi
   fi
+  ensure_headless_acceptance_credentials_before_cutover
   if [ "$SKIP_PROVIDER_START" -eq 1 ]; then
     if restore_existing_provider_if_start_skipped; then
       log "Re-run macprovider-cli autotune --recommend --apply when you want to change the active provider model."

--- a/phase3-binary/dist/test/install_fresh_evidence.test.sh
+++ b/phase3-binary/dist/test/install_fresh_evidence.test.sh
@@ -12,6 +12,7 @@ names = {
     "read_config_provider_token_line", "read_config_model",
     "read_config_provider_id", "read_config_artifact_path", "read_config_artifact_sha",
     "is_bootstrap_principal",
+    "headless_acceptance_repair_mode",
     "ensure_provider_credentials", "submit_required_hardware_evidence",
     "run_autotune_recommend_apply",
 }
@@ -71,8 +72,18 @@ EOF
     DRY_RUN=0
     SKIP_PROVIDER_START=0
     HEADLESS=0
+    REPAIR_EXISTING_INSTALL=0
+    LAUNCHD_DOMAIN="gui/$UID"
+    BUNDLED_APP=""
+    MACPROVIDER_ACCEPTANCE_ASSET_DIR=""
     model="seed"
     REFERRAL_CODE_SOURCE_FILE=""
+    if [ "$CASE_MODE" = "headless-repair-credential-drift" ]; then
+      HEADLESS=1
+      REPAIR_EXISTING_INSTALL=1
+      LAUNCHD_DOMAIN=system
+      MACPROVIDER_ACCEPTANCE_ASSET_DIR="$CASE_ROOT/acceptance"
+    fi
     case "$CASE_MODE" in
       referral-success|referral-expired|existing-referral-retry|existing-referral-import) REFERRAL_CODE_SOURCE_FILE="$CASE_ROOT/referral-code" ;;
     esac
@@ -205,6 +216,18 @@ EOF
         exit 1
       fi
       ;;
+    headless-repair-credential-drift)
+      [ "$rc" -ne 0 ]
+      grep -F "credentials verify" "$root/calls" >/dev/null
+      if grep -F "bootstrap-auth" "$root/calls" >/dev/null; then
+        echo "$mode bootstrapped after protected-file credential custody drifted" >&2
+        exit 1
+      fi
+      if grep -F "service-start" "$root/calls" >/dev/null; then
+        echo "$mode started service after protected-file credential custody drifted" >&2
+        exit 1
+      fi
+      ;;
     receipt-probe-fails)
       [ "$rc" -ne 0 ]
       grep -F -- "--prefetch-receipt $root/prefetch-receipt.json" "$root/calls" >/dev/null
@@ -231,6 +254,7 @@ run_case existing-legacy
 run_case existing-referral-retry
 run_case existing-referral-import
 run_case store-unavailable
+run_case headless-repair-credential-drift
 run_case receipt-probe-fails
 
 # The durable upgrade transaction must remain live through every service-file

--- a/phase3-binary/dist/test/install_headless_fleet.test.sh
+++ b/phase3-binary/dist/test/install_headless_fleet.test.sh
@@ -48,7 +48,9 @@ names = [
     "write_install_manifest",
     "arm_install_recovery_agent",
     "recover_orphaned_install_transactions",
+    "validate_recovery_incumbent_provider_binary",
     "validate_recovery_launchdaemon_plist",
+    "snapshot_recovery_launchdaemon_plist",
 ]
 lines = open(sys.argv[1], encoding="utf-8").read().splitlines()
 for name in names:
@@ -405,9 +407,86 @@ FUNCTION_PATH="$TMP/functions.sh" SYSTEM_DIR="$TMP/system" USERS_DIR="$TMP/users
   REC_HEADLESS_USER="$HEADLESS_USER"
   REC_INSTALL_DIR="$INSTALL_DIR"
   REC_WATCHDOG_DIR="$WATCHDOG_DIR"
+  REC_BINARY_PATH="$BINARY_PATH"
+  REC_HEADLESS_REPAIR_INCUMBENT_BINARY=""
+  REC_HEADLESS_REPAIR_INCUMBENT_SHA256=""
   REC_CONFIG_PATH="$CONFIG_PATH"
   validate_recovery_launchdaemon_plist \
     "$PLIST_PATH" "/Library/LaunchDaemons/live.malibu.provider.plist"
+  recovery_alt_dir="$HOME/headless-recovery-alt"
+  recovery_alt_binary="$recovery_alt_dir/macprovider-cli"
+  mkdir -m 700 -p "$recovery_alt_dir"
+  printf "%s\n%s\n" "#!/usr/bin/env bash" "exit 0" > "$recovery_alt_binary"
+  chmod 700 "$recovery_alt_binary"
+  recovery_provider_alt_plist="$CONFIG_DIR/launchd/recovery-provider-alt.plist"
+  python3 - "$recovery_provider_alt_plist" "$recovery_alt_binary" "$CONFIG_PATH" "$CONFIG_DIR/protected-credentials" <<PY
+import plistlib
+import sys
+
+path, binary, config_path, credential_root = sys.argv[1:]
+payload = {
+    "Label": "live.malibu.provider",
+    "UserName": "$(id -un)",
+    "ProgramArguments": [binary, "serve", "--config", config_path],
+    "EnvironmentVariables": {
+        "MACPROVIDER_CONFIG": config_path,
+        "MACPROVIDER_HEADLESS": "1",
+        "MACPROVIDER_HEADLESS_USER": "$(id -un)",
+        "MACPROVIDER_LAUNCHD_DOMAIN": "system",
+        "MACPROVIDER_PROTECTED_CREDENTIAL_ROOT": credential_root,
+    },
+}
+with open(path, "wb") as handle:
+    plistlib.dump(payload, handle)
+PY
+  if (validate_recovery_launchdaemon_plist "$recovery_provider_alt_plist" "/Library/LaunchDaemons/live.malibu.provider.plist"); then
+    echo "headless recovery unexpectedly accepted alternate incumbent binary without persisted recovery state" >&2
+    exit 1
+  fi
+  REC_HEADLESS_REPAIR_INCUMBENT_BINARY="$recovery_alt_binary"
+  REC_HEADLESS_REPAIR_INCUMBENT_SHA256="$(shasum -a 256 "$recovery_alt_binary" | awk "{print \$1}")"
+  validate_recovery_incumbent_provider_binary
+  REC_HEADLESS_REPAIR_INCUMBENT_SHA256=0000000000000000000000000000000000000000000000000000000000000000
+  if (validate_recovery_incumbent_provider_binary); then
+    echo "headless recovery unexpectedly accepted a changed incumbent binary digest" >&2
+    exit 1
+  fi
+  REC_HEADLESS_REPAIR_INCUMBENT_SHA256="$(shasum -a 256 "$recovery_alt_binary" | awk "{print \$1}")"
+  validate_recovery_launchdaemon_plist \
+    "$recovery_provider_alt_plist" "/Library/LaunchDaemons/live.malibu.provider.plist"
+  snapshot_recovery_launchdaemon_plist \
+    "$recovery_provider_alt_plist" "/Library/LaunchDaemons/live.malibu.provider.plist" >/dev/null
+  recovery_empty_program_plist="$CONFIG_DIR/launchd/recovery-empty-program.plist"
+  python3 - "$recovery_empty_program_plist" "$CONFIG_PATH" "$CONFIG_DIR/protected-credentials" <<PY
+import plistlib
+import sys
+
+path, config_path, credential_root = sys.argv[1:]
+payload = {
+    "Label": "live.streamvc.macprovider",
+    "UserName": "$(id -un)",
+    "ProgramArguments": [""],
+    "EnvironmentVariables": {
+        "MACPROVIDER_CONFIG": config_path,
+        "MACPROVIDER_HEADLESS": "1",
+        "MACPROVIDER_HEADLESS_USER": "$(id -un)",
+        "MACPROVIDER_LAUNCHD_DOMAIN": "system",
+        "MACPROVIDER_PROTECTED_CREDENTIAL_ROOT": credential_root,
+    },
+}
+with open(path, "wb") as handle:
+    plistlib.dump(payload, handle)
+PY
+  REC_BINARY_PATH=""
+  REC_HEADLESS_REPAIR_INCUMBENT_BINARY=""
+  REC_HEADLESS_REPAIR_INCUMBENT_SHA256=""
+  if (validate_recovery_launchdaemon_plist "$recovery_empty_program_plist" "/Library/LaunchDaemons/live.streamvc.macprovider.plist"); then
+    echo "headless recovery unexpectedly accepted an empty provider program alternate" >&2
+    exit 1
+  fi
+  REC_BINARY_PATH="$BINARY_PATH"
+  REC_HEADLESS_REPAIR_INCUMBENT_BINARY="$recovery_alt_binary"
+  REC_HEADLESS_REPAIR_INCUMBENT_SHA256="$(shasum -a 256 "$recovery_alt_binary" | awk "{print \$1}")"
   recovery_watchdog_plist="$CONFIG_DIR/launchd/recovery-watchdog.plist"
   python3 - "$recovery_watchdog_plist" "$CONFIG_PATH" "$CONFIG_DIR/protected-credentials" <<PY
 import plistlib

--- a/phase3-binary/dist/test/install_launchd_migration.test.sh
+++ b/phase3-binary/dist/test/install_launchd_migration.test.sh
@@ -18,6 +18,7 @@ names = [
     "publish_root_file_from_base64",
     "verify_published_launchd_payload",
     "publish_launchd_plist",
+    "headless_acceptance_repair_mode",
     "reclaim_launchd_service",
     "reclaim_legacy_launchd_service",
     "render_plist",
@@ -27,9 +28,12 @@ names = [
 ]
 lines = open(sys.argv[1], encoding="utf-8").read().splitlines()
 for name in names:
-    for index, line in enumerate(lines):
-        if line != f"{name}() {{":
-            continue
+    matches = [index for index, line in enumerate(lines) if line == f"{name}() {{"]
+    if not matches:
+        raise SystemExit(f"could not extract {name}")
+    # The installer embeds recovery helpers before the live runtime helpers.
+    # Port migration must exercise the live copy used by ensure_port_free.
+    for index in [matches[-1]]:
         depth = 0
         while index < len(lines):
             current = lines[index]
@@ -39,8 +43,6 @@ for name in names:
             if depth == 0:
                 break
         break
-    else:
-        raise SystemExit(f"could not extract {name}")
 PY
 printf '%s\n' 'PROVIDER_LABEL="${PROVIDER_LABEL:-live.malibu.provider}"' >> "$TMP/functions.sh"
 printf '%s\n' 'LEGACY_PROVIDER_LABEL="${LEGACY_PROVIDER_LABEL:-live.streamvc.macprovider}"' >> "$TMP/functions.sh"
@@ -51,6 +53,10 @@ printf '%s\n' 'LEGACY_WATCHDOG_PLIST_PATH="${LEGACY_WATCHDOG_PLIST_PATH:-$HOME/L
 printf '%s\n' 'HEADLESS="${HEADLESS:-0}"' >> "$TMP/functions.sh"
 printf '%s\n' 'HEADLESS_USER="${HEADLESS_USER:-}"' >> "$TMP/functions.sh"
 printf '%s\n' 'LAUNCHD_DOMAIN="${LAUNCHD_DOMAIN:-gui/$UID}"' >> "$TMP/functions.sh"
+printf '%s\n' 'REPAIR_EXISTING_INSTALL="${REPAIR_EXISTING_INSTALL:-0}"' >> "$TMP/functions.sh"
+printf '%s\n' 'MACPROVIDER_ACCEPTANCE_ASSET_DIR="${MACPROVIDER_ACCEPTANCE_ASSET_DIR:-}"' >> "$TMP/functions.sh"
+printf '%s\n' 'BUNDLED_APP="${BUNDLED_APP:-}"' >> "$TMP/functions.sh"
+printf '%s\n' 'HEADLESS_REPAIR_INCUMBENT_BINARY="${HEADLESS_REPAIR_INCUMBENT_BINARY:-}"' >> "$TMP/functions.sh"
 printf '%s\n' 'PLIST_BOOTSTRAP_PATH="${PLIST_BOOTSTRAP_PATH:-${PLIST_PATH:-}}"' >> "$TMP/functions.sh"
 printf '%s\n' 'LEGACY_PLIST_BOOTSTRAP_PATH="${LEGACY_PLIST_BOOTSTRAP_PATH:-${LEGACY_PLIST_PATH:-}}"' >> "$TMP/functions.sh"
 printf '%s\n' 'WATCHDOG_PLIST_BOOTSTRAP_PATH="${WATCHDOG_PLIST_BOOTSTRAP_PATH:-${WATCHDOG_PLIST_PATH:-}}"' >> "$TMP/functions.sh"
@@ -113,6 +119,16 @@ case "${1:-}" in
 esac
 EOF
 chmod 0755 "$TMP/bin/launchctl"
+cat > "$TMP/bin/sudo" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" = "-n" ]; then
+  shift
+fi
+exec "$@"
+EOF
+chmod 0755 "$TMP/bin/sudo"
 
 run_reclaim() {
   LAUNCHD_STATE="$TMP/launchd-state"
@@ -128,9 +144,17 @@ run_reclaim() {
     CONFIG_PATH="$TMP/home/.config/macprovider/config.yaml" \
     PLIST_PATH="$TMP/home/Library/LaunchAgents/live.malibu.provider.plist" \
     WATCHDOG_PLIST_PATH="$TMP/home/Library/LaunchAgents/live.malibu.provider-watchdog.plist" \
-    PROVIDER_PROGRAM="$TMP/home/.local/bin/macprovider-cli" \
-    WATCHDOG_PROGRAM="$TMP/home/.local/share/macprovider-watchdog/watchdog.sh" \
+    PROVIDER_PROGRAM="${PROVIDER_PROGRAM:-$TMP/home/.local/bin/macprovider-cli}" \
+    WATCHDOG_PROGRAM="${WATCHDOG_PROGRAM:-$TMP/home/.local/share/macprovider-watchdog/watchdog.sh}" \
     PATH="$TMP/bin:$PATH" \
+    SUDO_BIN="$TMP/bin/sudo" \
+    LAUNCHCTL_BIN="$TMP/bin/launchctl" \
+    HEADLESS="${HEADLESS:-0}" \
+    LAUNCHD_DOMAIN="${LAUNCHD_DOMAIN:-gui/$UID}" \
+    REPAIR_EXISTING_INSTALL="${REPAIR_EXISTING_INSTALL:-0}" \
+    MACPROVIDER_ACCEPTANCE_ASSET_DIR="${MACPROVIDER_ACCEPTANCE_ASSET_DIR:-}" \
+    BUNDLED_APP="${BUNDLED_APP:-}" \
+    HEADLESS_REPAIR_INCUMBENT_BINARY="${HEADLESS_REPAIR_INCUMBENT_BINARY:-}" \
     LAUNCHD_STATE="$LAUNCHD_STATE" \
     LAUNCHD_LOG="$LAUNCHD_LOG" \
     PRINTED_PLIST_PATH="${PRINTED_PLIST_PATH:-}" \
@@ -262,6 +286,30 @@ set -e
 [ "$unexpected_rc" -ne 0 ]
 [ -f "$TMP/launchd-state" ]
 
+rm -f "$TMP/launchd.log"
+touch "$TMP/launchd-state"
+HEADLESS=1 \
+  LAUNCHD_DOMAIN=system \
+  REPAIR_EXISTING_INSTALL=1 \
+  MACPROVIDER_ACCEPTANCE_ASSET_DIR="$TMP/acceptance" \
+  HEADLESS_REPAIR_INCUMBENT_BINARY="$TMP/manual-stage/macprovider-cli" \
+  PROVIDER_PROGRAM="$TMP/manual-stage/macprovider-cli" \
+  run_reclaim
+grep -Fx "bootout system/live.malibu.provider" "$TMP/launchd.log" >/dev/null
+rm -f "$TMP/launchd-state" "$TMP/launchd.log"
+touch "$TMP/launchd-state"
+HEADLESS=0 \
+  LAUNCHD_DOMAIN=system \
+  REPAIR_EXISTING_INSTALL=0 \
+  MACPROVIDER_ACCEPTANCE_ASSET_DIR="$TMP/acceptance" \
+  HEADLESS_REPAIR_INCUMBENT_BINARY="$TMP/manual-stage/macprovider-cli" \
+  PROVIDER_PROGRAM="$TMP/manual-stage/macprovider-cli" \
+  run_reclaim && {
+    echo "normal launchd reclaim accepted a manual-stage provider binary" >&2
+    exit 1
+  }
+[ -f "$TMP/launchd-state" ]
+
 grep -F 'reclaim_launchd_service "$PROVIDER_LABEL"' "$INSTALL_SH" >/dev/null
 grep -F 'reclaim_launchd_service "$WATCHDOG_LABEL"' "$INSTALL_SH" >/dev/null
 grep -F 'service_identity_matches' "$INSTALL_SH" >/dev/null
@@ -277,6 +325,10 @@ import sys
 
 names = [
     "validate_port_value",
+    "headless_acceptance_repair_mode",
+    "provider_executable_owned_for_current_mode",
+    "pid_is_live_non_zombie",
+    "stop_owned_manual_provider",
     "ensure_port_free",
     "launchctl_service",
     "reclaim_launchd_service",
@@ -304,6 +356,10 @@ printf '%s\n' 'LEGACY_PROVIDER_LABEL="${LEGACY_PROVIDER_LABEL:-live.streamvc.mac
 printf '%s\n' 'LEGACY_PLIST_PATH="${LEGACY_PLIST_PATH:-$HOME/Library/LaunchAgents/live.streamvc.macprovider.plist}"' >> "$TMP/port-functions.sh"
 printf '%s\n' 'HEADLESS="${HEADLESS:-0}"' >> "$TMP/port-functions.sh"
 printf '%s\n' 'LAUNCHD_DOMAIN="${LAUNCHD_DOMAIN:-gui/$UID}"' >> "$TMP/port-functions.sh"
+printf '%s\n' 'REPAIR_EXISTING_INSTALL="${REPAIR_EXISTING_INSTALL:-0}"' >> "$TMP/port-functions.sh"
+printf '%s\n' 'MACPROVIDER_ACCEPTANCE_ASSET_DIR="${MACPROVIDER_ACCEPTANCE_ASSET_DIR:-}"' >> "$TMP/port-functions.sh"
+printf '%s\n' 'BUNDLED_APP="${BUNDLED_APP:-}"' >> "$TMP/port-functions.sh"
+printf '%s\n' 'HEADLESS_REPAIR_INCUMBENT_BINARY="${HEADLESS_REPAIR_INCUMBENT_BINARY:-}"' >> "$TMP/port-functions.sh"
 printf '%s\n' 'PLIST_BOOTSTRAP_PATH="${PLIST_BOOTSTRAP_PATH:-${PLIST_PATH:-}}"' >> "$TMP/port-functions.sh"
 printf '%s\n' 'LEGACY_PLIST_BOOTSTRAP_PATH="${LEGACY_PLIST_BOOTSTRAP_PATH:-${LEGACY_PLIST_PATH:-}}"' >> "$TMP/port-functions.sh"
 
@@ -312,12 +368,18 @@ cat > "$TMP/port-bin/lsof" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 case "$*" in
-  *"-d txt"*) printf 'p4242\nn%s/macprovider/macprovider-cli\n' "$HOME" ;;
+  *"-d txt"*) printf 'p4242\nn%s\n' "${LSOF_EXECUTABLE:-$HOME/macprovider/macprovider-cli}" ;;
   *-t*)
+    count=0
     if [ -f "$LSOF_T_SEEN" ]; then
+      count="$(cat "$LSOF_T_SEEN")"
+    fi
+    count=$((count + 1))
+    printf '%s\n' "$count" > "$LSOF_T_SEEN"
+    limit="${LSOF_T_LIMIT:-1}"
+    if [ "$count" -gt "$limit" ]; then
       exit 0
     fi
-    : > "$LSOF_T_SEEN"
     printf '4242\n'
     ;;
   *) printf "COMMAND PID\nmacprovider-cli 4242\n" ;;
@@ -331,6 +393,7 @@ HOME="$TMP/home" \
   PATH="$TMP/port-bin:/usr/bin:/bin" \
   LEGACY_UPGRADE_LOG="$TMP/legacy-upgrade.log" \
   LSOF_T_SEEN="$TMP/lsof-t-seen" \
+  LSOF_T_LIMIT=1 \
   bash -c '
     set -euo pipefail
     die() { printf "ERR:%s\n" "$*" >&2; exit "$1"; }
@@ -358,3 +421,52 @@ if grep -Fx "captured" "$TMP/legacy-upgrade.log" >/dev/null; then
   exit 1
 fi
 echo "legacy launchd upgrade skips manual capture ok"
+
+mkdir -p "$TMP/manual-stage"
+printf 'manual\n' > "$TMP/manual-stage/macprovider-cli"
+chmod +x "$TMP/manual-stage/macprovider-cli"
+: > "$TMP/headless-upgrade.log"
+rm -f "$TMP/lsof-t-seen"
+HOME="$TMP/home" \
+  FUNCTION_PATH="$TMP/port-functions.sh" \
+  PATH="$TMP/port-bin:/usr/bin:/bin" \
+  LEGACY_UPGRADE_LOG="$TMP/headless-upgrade.log" \
+  LSOF_T_SEEN="$TMP/lsof-t-seen" \
+  LSOF_T_LIMIT=4 \
+  LSOF_EXECUTABLE="$TMP/manual-stage/macprovider-cli" \
+  bash -c '
+    set -euo pipefail
+    die() { printf "ERR:%s\n" "$*" >&2; exit "$1"; }
+    log() { printf "LOG:%s\n" "$*" >&2; }
+    assert_install_lock_ownership() { :; }
+    capture_manual_provider_for_recovery() {
+      printf "captured\n" >> "$LEGACY_UPGRADE_LOG"
+      die 70 "manual capture should not run for a loaded accepted headless LaunchDaemon"
+    }
+    DRY_RUN=0
+    PORT=18080
+    INSTALL_DIR="$HOME/macprovider"
+    BINARY_PATH="$HOME/.local/bin/macprovider-cli"
+    HEADLESS=1
+    LAUNCHD_DOMAIN=system
+    REPAIR_EXISTING_INSTALL=1
+    MACPROVIDER_ACCEPTANCE_ASSET_DIR="$HOME/acceptance"
+    BUNDLED_APP=""
+    HEADLESS_REPAIR_INCUMBENT_BINARY="'$TMP'/manual-stage/macprovider-cli"
+    INSTALL_TX_SERVICE_WAS_ACTIVE=1
+    INSTALL_TX_LEGACY_SERVICE_WAS_ACTIVE=0
+    INSTALL_TX_ACTIVE=1
+    source "$FUNCTION_PATH"
+    kill() { :; }
+    pid_is_live_non_zombie() { return 1; }
+    reclaim_launchd_service() { printf "reclaim-current\n" >> "$LEGACY_UPGRADE_LOG"; }
+    reclaim_legacy_launchd_service() { printf "reclaim-legacy\n" >> "$LEGACY_UPGRADE_LOG"; }
+    ensure_port_free 1
+  '
+grep -Fx "reclaim-current" "$TMP/headless-upgrade.log" >/dev/null
+[ "$(cat "$TMP/lsof-t-seen")" -ge 4 ]
+if grep -Fx "captured" "$TMP/headless-upgrade.log" >/dev/null; then
+  echo "accepted headless LaunchDaemon was treated as a manual provider capture" >&2
+  exit 1
+fi
+echo "accepted headless LaunchDaemon reclaim ok"

--- a/phase3-binary/dist/test/install_port_validation.test.sh
+++ b/phase3-binary/dist/test/install_port_validation.test.sh
@@ -10,17 +10,21 @@ awk '/^validate_port_value\(\)/ { inside=1 } inside { print } inside && /^}/ { e
 python3 - "$INSTALL_SH" > "$TMP/ensure_port.sh" <<'PY'
 import sys
 lines = open(sys.argv[1], encoding="utf-8").read().splitlines()
-inside = False
-depth = 0
-for line in lines:
-    if line.startswith("ensure_port_free()"):
-        inside = True
-    if not inside:
-        continue
-    print(line)
-    depth += line.count("{") - line.count("}")
-    if inside and depth == 0:
-        break
+names = ["headless_acceptance_repair_mode", "provider_executable_owned_for_current_mode", "ensure_port_free"]
+for name in names:
+    inside = False
+    depth = 0
+    for line in lines:
+        if line.startswith(f"{name}()"):
+            inside = True
+        if not inside:
+            continue
+        print(line)
+        depth += line.count("{") - line.count("}")
+        if inside and depth == 0:
+            break
+    else:
+        raise SystemExit(f"could not extract {name}")
 PY
 cat > "$TMP/harness.sh" <<'HARNESS'
 set -euo pipefail
@@ -29,6 +33,13 @@ log() { printf "LOG:%s\n" "$*" >&2; }
 DRY_RUN=0
 PORT=18080
 INSTALL_DIR="$HOME/macprovider"
+BINARY_PATH="$HOME/.local/bin/macprovider-cli"
+HEADLESS=0
+REPAIR_EXISTING_INSTALL=0
+LAUNCHD_DOMAIN="gui/$UID"
+MACPROVIDER_ACCEPTANCE_ASSET_DIR=""
+BUNDLED_APP=""
+HEADLESS_REPAIR_INCUMBENT_BINARY=""
 PLIST_PATH="/tmp/provider.plist"
 HARNESS
 cat "$TMP/validate_port.sh" >> "$TMP/harness.sh"

--- a/phase3-binary/dist/test/install_upgrade_evidence_rollback.test.sh
+++ b/phase3-binary/dist/test/install_upgrade_evidence_rollback.test.sh
@@ -61,6 +61,7 @@ names = {
     "publish_launchd_plist", "verify_published_launchd_plist",
     "publish_headless_recovery_trust", "verify_headless_recovery_trust",
     "retire_headless_recovery_trust",
+    "headless_acceptance_repair_mode", "provider_executable_owned_for_current_mode",
     "write_install_recovery_artifacts", "begin_install_transaction",
     "mark_install_cutover_started", "discard_install_transaction_before_cutover",
     "rollback_install_transaction", "commit_install_transaction",

--- a/phase3-binary/dist/test/provider_upgrade_transaction.test.sh
+++ b/phase3-binary/dist/test/provider_upgrade_transaction.test.sh
@@ -22,10 +22,13 @@ extract_function() {
 for function_name in \
   validate_install_dir validate_port_value \
   release_install_lock acquire_install_lock \
-  validate_repair_privilege_domain \
+  launchctl_service verify_published_launchd_plist validate_repair_privilege_domain \
   read_config_provider_id read_config_provider_token_line \
   installed_provider_binary_path restart_safe_incumbent_present \
-  repair_safe_incumbent_present prepare_fresh_referral_code \
+  repair_safe_incumbent_present headless_acceptance_repair_mode \
+  provider_executable_owned_for_current_mode \
+  headless_acceptance_repair_safe_incumbent_present \
+  repair_incumbent_present_for_current_mode prepare_fresh_referral_code \
   quiesce_repair_watchdog_label_for_transaction quiesce_repair_watchdogs_for_transaction \
   remediate_repair_home_write_acl \
   repair_autoupdate_recovery_preflight autoupdate_recovery_supported autoupdate_recovery_tick \
@@ -61,20 +64,33 @@ snapshot = main.index("begin_install_transaction")
 stage = main.index("stage_release_payload", snapshot)
 prepare = main.index("prepare_staged_config", stage)
 freshness = main.index("use_fresh_recommendation_if_available", stage)
-recommend_gate = main.index('if [ "$AUTOTUNE_RECOMMENDATION_REQUIRED" -eq 1 ]', freshness)
 prefetch = main.index("prefetch_upgrade_autotune_model", freshness)
+headless_credentials = main.index("ensure_headless_acceptance_credentials_before_cutover", prefetch)
+recommend_gate = main.index('if [ "$AUTOTUNE_RECOMMENDATION_REQUIRED" -eq 1 ]', headless_credentials)
 cutover_marker = main.index("mark_install_cutover_started", recommend_gate)
 stop = main.index("ensure_port_free 1", recommend_gate)
 recommend = main.index("run_autotune_recommend_apply", stop)
 install = main.index("install_binary", recommend)
 activate = main.index("activate_staged_config", install)
-if not validate_dir < repair_home_acl < repair_recovery < acquire_lock < snapshot < stage < prepare < freshness < prefetch < recommend_gate < cutover_marker < stop < recommend < install < activate:
+if not validate_dir < repair_home_acl < repair_recovery < acquire_lock < snapshot < stage < prepare < freshness < prefetch < headless_credentials < recommend_gate < cutover_marker < stop < recommend < install < activate:
     raise SystemExit("benchmarks are not isolated from the live provider and staged cutover")
+credential_helper = source[source.index("ensure_headless_acceptance_credentials_before_cutover() {"):source.index("submit_required_hardware_evidence() {")]
+if "headless_acceptance_repair_mode || return 0" not in credential_helper or "ensure_provider_credentials" not in credential_helper:
+    raise SystemExit("headless acceptance repair credentials must be revalidated before cutover")
 transaction = source[source.index("begin_install_transaction() {"):source.index("mark_install_cutover_started() {")]
 strict = transaction.index("quiesce_repair_watchdog_label_for_transaction")
 generic = transaction.index("reclaim_launchd_service")
 if not strict < generic:
     raise SystemExit("repair watchdog shutdown must use strict liveness proof before generic reclaim")
+if 'provider_snapshot_alternate="${HEADLESS_REPAIR_INCUMBENT_BINARY:-}"' not in transaction:
+    raise SystemExit("headless acceptance repair must snapshot only the proven incumbent LaunchDaemon binary")
+recovery = source[source.index("write_install_recovery_artifacts() {"):source.index("recovery_log() {", source.index("write_install_recovery_artifacts() {"))]
+if "REC_HEADLESS_REPAIR_INCUMBENT_BINARY" not in recovery:
+    raise SystemExit("headless acceptance repair must persist the proven incumbent binary in recovery state")
+if "REC_HEADLESS_REPAIR_INCUMBENT_SHA256" not in recovery:
+    raise SystemExit("headless acceptance repair must persist the proven incumbent binary digest in recovery state")
+if '"$REC_INSTALL_DIR/macprovider-cli" "$REC_BINARY_PATH" "$REC_HEADLESS_REPAIR_INCUMBENT_BINARY"' not in recovery:
+    raise SystemExit("headless recovery must validate plists against the persisted incumbent binary")
 helper = source[source.index("run_macprovider_cli_with_amfi_retry() {"):source.index("detect_existing_port() {")]
 if 'local cli_path="$MACPROVIDER_CLI_EXECUTABLE"' not in helper:
     raise SystemExit("recommendation helper is not routed to the staged CLI")
@@ -256,7 +272,330 @@ if (
   die() { exit "$1"; }
   validate_repair_privilege_domain
 ); then
-  echo "headless/system Malibu bundled repair did not fail closed explicitly" >&2
+  echo "headless/system repair without signed acceptance did not fail closed explicitly" >&2
+  exit 1
+fi
+(
+  REPAIR_EXISTING_INSTALL=1
+  HEADLESS=1
+  LAUNCHD_DOMAIN=system
+  BUNDLED_APP=""
+  MACPROVIDER_ACCEPTANCE_ASSET_DIR="$TMP/acceptance"
+  validate_repair_privilege_domain
+) || {
+  echo "signed headless acceptance repair was blocked by the Malibu.app repair domain gate" >&2
+  exit 1
+}
+HEADLESS_REPAIR_HOME="$TMP/headless-repair-home"
+HEADLESS_REPAIR_CONFIG_DIR="$HEADLESS_REPAIR_HOME/.config/macprovider"
+HEADLESS_REPAIR_INSTALL_DIR="$HEADLESS_REPAIR_HOME/macprovider"
+HEADLESS_REPAIR_MANAGED_DIR="$HEADLESS_REPAIR_CONFIG_DIR/launchd"
+HEADLESS_REPAIR_SYSTEM_DIR="$TMP/headless-system"
+HEADLESS_REPAIR_CONFIG_PATH="$HEADLESS_REPAIR_CONFIG_DIR/config.yaml"
+HEADLESS_REPAIR_PROVIDER_ID_PATH="$HEADLESS_REPAIR_CONFIG_DIR/provider_id"
+HEADLESS_REPAIR_PLIST_PATH="$HEADLESS_REPAIR_MANAGED_DIR/live.malibu.provider.plist"
+HEADLESS_REPAIR_BOOTSTRAP_PLIST_PATH="$HEADLESS_REPAIR_SYSTEM_DIR/live.malibu.provider.plist"
+HEADLESS_REPAIR_INCUMBENT_DIR="$HEADLESS_REPAIR_HOME/headless-acceptance-smoke"
+HEADLESS_REPAIR_INCUMBENT_BINARY="$HEADLESS_REPAIR_INCUMBENT_DIR/macprovider-cli"
+HEADLESS_REPAIR_PROVIDER_ID="mp-fedcba9876543210fedcba9876543210"
+mkdir -m 700 -p \
+  "$HEADLESS_REPAIR_CONFIG_DIR/protected-credentials" \
+  "$HEADLESS_REPAIR_MANAGED_DIR" \
+  "$HEADLESS_REPAIR_SYSTEM_DIR" \
+  "$HEADLESS_REPAIR_INCUMBENT_DIR"
+cat > "$HEADLESS_REPAIR_CONFIG_PATH" <<EOF
+model: "mlx-community/Qwen3-8B-4bit"
+provider_id: "$HEADLESS_REPAIR_PROVIDER_ID"
+credential_store: protected_file
+auto_update_enabled: false
+coordinator_url: "wss://coordinator.example/ws/provider"
+EOF
+printf '%s\n' "$HEADLESS_REPAIR_PROVIDER_ID" > "$HEADLESS_REPAIR_PROVIDER_ID_PATH"
+cat > "$HEADLESS_REPAIR_INCUMBENT_BINARY" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = "--version" ]; then
+  printf 'v1.8.109\n'
+  exit 0
+fi
+if [ "${1:-}" = "credentials" ] && [ "${2:-}" = "verify" ]; then
+  shift 2
+  config=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --config)
+        config="$2"
+        shift 2
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+  [ -n "$config" ] && [ -f "$config" ]
+  [ "${MACPROVIDER_CREDENTIAL_STORE:-}" = "protected_file" ]
+  [ "${MACPROVIDER_HEADLESS:-}" = "1" ]
+  [ "${MACPROVIDER_LAUNCHD_DOMAIN:-}" = "system" ]
+  exit "${MACPROVIDER_TEST_CREDENTIAL_VERIFY_RC:-0}"
+fi
+exit 64
+EOF
+chmod 700 "$HEADLESS_REPAIR_INCUMBENT_BINARY"
+python3 - "$HEADLESS_REPAIR_PLIST_PATH" "$HEADLESS_REPAIR_INCUMBENT_BINARY" "$HEADLESS_REPAIR_CONFIG_PATH" "$HEADLESS_REPAIR_CONFIG_DIR/protected-credentials" <<PY
+import plistlib
+import sys
+
+path, binary, config, credential_root = sys.argv[1:]
+payload = {
+    "Label": "live.malibu.provider",
+    "UserName": "$(id -un)",
+    "ProgramArguments": [binary, "serve", "--config", config],
+    "KeepAlive": True,
+    "EnvironmentVariables": {
+        "MACPROVIDER_CREDENTIAL_STORE": "protected_file",
+        "MACPROVIDER_PROTECTED_CREDENTIAL_ROOT": credential_root,
+        "MACPROVIDER_HEADLESS": "1",
+        "MACPROVIDER_HEADLESS_USER": "$(id -un)",
+        "MACPROVIDER_LAUNCHD_DOMAIN": "system",
+    },
+}
+with open(path, "wb") as handle:
+    plistlib.dump(payload, handle)
+PY
+chmod 600 "$HEADLESS_REPAIR_CONFIG_PATH" "$HEADLESS_REPAIR_PROVIDER_ID_PATH" "$HEADLESS_REPAIR_PLIST_PATH"
+cp "$HEADLESS_REPAIR_PLIST_PATH" "$HEADLESS_REPAIR_BOOTSTRAP_PLIST_PATH"
+(
+  HOME="$HEADLESS_REPAIR_HOME"
+  INSTALL_DIR="$HEADLESS_REPAIR_INSTALL_DIR"
+  CONFIG_DIR="$HEADLESS_REPAIR_CONFIG_DIR"
+  CONFIG_PATH="$HEADLESS_REPAIR_CONFIG_PATH"
+  PROVIDER_ID_PATH="$HEADLESS_REPAIR_PROVIDER_ID_PATH"
+  PLIST_PATH="$HEADLESS_REPAIR_PLIST_PATH"
+  PLIST_BOOTSTRAP_PATH="$HEADLESS_REPAIR_BOOTSTRAP_PLIST_PATH"
+  PROVIDER_LABEL="live.malibu.provider"
+  HEADLESS=1
+  HEADLESS_USER="$(id -un)"
+  LAUNCHD_DOMAIN=system
+  BUNDLED_APP=""
+  MACPROVIDER_ACCEPTANCE_ASSET_DIR="$TMP/acceptance"
+  REPAIR_EXISTING_INSTALL=1
+  DRY_RUN=0
+  EMERGENCY_ROLLBACK=0
+  REFERRAL_REPLACE_INCUMBENT=0
+  REFERRAL_CODE_SOURCE_FILE=""
+  FRESH_REFERRAL_BOOTSTRAP=0
+  NO_PROMPT=1
+  SUDO_BIN="$TMP/sudo"
+  cat > "$SUDO_BIN" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[ "${1:-}" != "-n" ] || shift
+exec "$@"
+EOF
+  chmod 700 "$SUDO_BIN"
+  launchctl_service() {
+    [ "$1" = "print" ] && [ "$2" = "system/live.malibu.provider" ]
+  }
+  log() { :; }
+  die() { exit "$1"; }
+  prepare_fresh_referral_code
+  [ "$HEADLESS_REPAIR_INCUMBENT_BINARY" = "$HEADLESS_REPAIR_INCUMBENT_DIR/macprovider-cli" ]
+  [ -z "$REFERRAL_CODE_SOURCE_FILE" ]
+  [ "$FRESH_REFERRAL_BOOTSTRAP" -eq 0 ]
+) || {
+  echo "signed headless acceptance repair did not admit the validated incumbent without invite" >&2
+  exit 1
+}
+run_headless_acceptance_repair_prepare() {
+  (
+    HOME="$HEADLESS_REPAIR_HOME"
+    INSTALL_DIR="$HEADLESS_REPAIR_INSTALL_DIR"
+    CONFIG_DIR="$HEADLESS_REPAIR_CONFIG_DIR"
+    CONFIG_PATH="$HEADLESS_REPAIR_CONFIG_PATH"
+    PROVIDER_ID_PATH="$HEADLESS_REPAIR_PROVIDER_ID_PATH"
+    PLIST_PATH="$HEADLESS_REPAIR_PLIST_PATH"
+    PLIST_BOOTSTRAP_PATH="$HEADLESS_REPAIR_BOOTSTRAP_PLIST_PATH"
+    PROVIDER_LABEL="live.malibu.provider"
+    HEADLESS=1
+    HEADLESS_USER="$(id -un)"
+    LAUNCHD_DOMAIN=system
+    BUNDLED_APP=""
+    MACPROVIDER_ACCEPTANCE_ASSET_DIR="$TMP/acceptance"
+    REPAIR_EXISTING_INSTALL=1
+    DRY_RUN=0
+    EMERGENCY_ROLLBACK=0
+    REFERRAL_REPLACE_INCUMBENT=0
+    REFERRAL_CODE_SOURCE_FILE=""
+    FRESH_REFERRAL_BOOTSTRAP=0
+    NO_PROMPT=1
+    SUDO_BIN="$TMP/sudo"
+    launchctl_service() {
+      [ "$1" = "print" ] && [ "$2" = "system/live.malibu.provider" ]
+    }
+    log() { :; }
+    die() { exit "$1"; }
+    prepare_fresh_referral_code
+  )
+}
+if chmod +a "group:everyone allow write" "$HEADLESS_REPAIR_INCUMBENT_BINARY" 2>/dev/null; then
+  headless_repair_binary_acl_rc=0
+  run_headless_acceptance_repair_prepare || headless_repair_binary_acl_rc=$?
+  chmod -a "group:everyone allow write" "$HEADLESS_REPAIR_INCUMBENT_BINARY" 2>/dev/null || true
+  if [ "$headless_repair_binary_acl_rc" -ne 28 ]; then
+    echo "signed headless acceptance repair accepted incumbent binary with writable ACL (rc=$headless_repair_binary_acl_rc)" >&2
+    exit 1
+  fi
+fi
+if chmod +a "group:everyone allow add_file,add_subdirectory,writeattr" "$HEADLESS_REPAIR_INCUMBENT_DIR" 2>/dev/null; then
+  headless_repair_binary_parent_acl_rc=0
+  run_headless_acceptance_repair_prepare || headless_repair_binary_parent_acl_rc=$?
+  chmod -a "group:everyone allow add_file,add_subdirectory,writeattr" "$HEADLESS_REPAIR_INCUMBENT_DIR" 2>/dev/null || true
+  if [ "$headless_repair_binary_parent_acl_rc" -ne 28 ]; then
+    echo "signed headless acceptance repair accepted incumbent binary parent with writable ACL (rc=$headless_repair_binary_parent_acl_rc)" >&2
+    exit 1
+  fi
+fi
+ln -s "$HEADLESS_REPAIR_PLIST_PATH" "$HEADLESS_REPAIR_BOOTSTRAP_PLIST_PATH.symlink"
+mv "$HEADLESS_REPAIR_BOOTSTRAP_PLIST_PATH" "$HEADLESS_REPAIR_BOOTSTRAP_PLIST_PATH.real"
+mv "$HEADLESS_REPAIR_BOOTSTRAP_PLIST_PATH.symlink" "$HEADLESS_REPAIR_BOOTSTRAP_PLIST_PATH"
+headless_repair_bootstrap_symlink_rc=0
+run_headless_acceptance_repair_prepare || headless_repair_bootstrap_symlink_rc=$?
+rm -f "$HEADLESS_REPAIR_BOOTSTRAP_PLIST_PATH"
+mv "$HEADLESS_REPAIR_BOOTSTRAP_PLIST_PATH.real" "$HEADLESS_REPAIR_BOOTSTRAP_PLIST_PATH"
+if [ "$headless_repair_bootstrap_symlink_rc" -ne 28 ]; then
+  echo "signed headless acceptance repair accepted symlinked published LaunchDaemon plist (rc=$headless_repair_bootstrap_symlink_rc)" >&2
+  exit 1
+fi
+rm -f "$HEADLESS_REPAIR_BOOTSTRAP_PLIST_PATH"
+ln "$HEADLESS_REPAIR_PLIST_PATH" "$HEADLESS_REPAIR_BOOTSTRAP_PLIST_PATH"
+headless_repair_bootstrap_hardlink_rc=0
+run_headless_acceptance_repair_prepare || headless_repair_bootstrap_hardlink_rc=$?
+rm -f "$HEADLESS_REPAIR_BOOTSTRAP_PLIST_PATH"
+cp "$HEADLESS_REPAIR_PLIST_PATH" "$HEADLESS_REPAIR_BOOTSTRAP_PLIST_PATH"
+if [ "$headless_repair_bootstrap_hardlink_rc" -ne 28 ]; then
+  echo "signed headless acceptance repair accepted hardlinked published LaunchDaemon plist (rc=$headless_repair_bootstrap_hardlink_rc)" >&2
+  exit 1
+fi
+chmod 664 "$HEADLESS_REPAIR_BOOTSTRAP_PLIST_PATH"
+headless_repair_bootstrap_mode_rc=0
+run_headless_acceptance_repair_prepare || headless_repair_bootstrap_mode_rc=$?
+chmod 600 "$HEADLESS_REPAIR_BOOTSTRAP_PLIST_PATH"
+if [ "$headless_repair_bootstrap_mode_rc" -ne 28 ]; then
+  echo "signed headless acceptance repair accepted group-writable published LaunchDaemon plist (rc=$headless_repair_bootstrap_mode_rc)" >&2
+  exit 1
+fi
+if chmod +a "group:everyone allow write" "$HEADLESS_REPAIR_BOOTSTRAP_PLIST_PATH" 2>/dev/null; then
+  headless_repair_bootstrap_acl_rc=0
+  run_headless_acceptance_repair_prepare || headless_repair_bootstrap_acl_rc=$?
+  chmod -a "group:everyone allow write" "$HEADLESS_REPAIR_BOOTSTRAP_PLIST_PATH" 2>/dev/null || true
+  if [ "$headless_repair_bootstrap_acl_rc" -ne 28 ]; then
+    echo "signed headless acceptance repair accepted ACL-bearing published LaunchDaemon plist (rc=$headless_repair_bootstrap_acl_rc)" >&2
+    exit 1
+  fi
+fi
+python3 - "$HEADLESS_REPAIR_PLIST_PATH" <<'PY'
+import plistlib
+import sys
+
+path = sys.argv[1]
+with open(path, "rb") as handle:
+    payload = plistlib.load(handle)
+payload["UserName"] = "some-other-user"
+with open(path, "wb") as handle:
+    plistlib.dump(payload, handle)
+PY
+cp "$HEADLESS_REPAIR_PLIST_PATH" "$HEADLESS_REPAIR_BOOTSTRAP_PLIST_PATH"
+headless_repair_bad_user_rc=0
+(
+  HOME="$HEADLESS_REPAIR_HOME"
+  INSTALL_DIR="$HEADLESS_REPAIR_INSTALL_DIR"
+  CONFIG_DIR="$HEADLESS_REPAIR_CONFIG_DIR"
+  CONFIG_PATH="$HEADLESS_REPAIR_CONFIG_PATH"
+  PROVIDER_ID_PATH="$HEADLESS_REPAIR_PROVIDER_ID_PATH"
+  PLIST_PATH="$HEADLESS_REPAIR_PLIST_PATH"
+  PLIST_BOOTSTRAP_PATH="$HEADLESS_REPAIR_BOOTSTRAP_PLIST_PATH"
+  PROVIDER_LABEL="live.malibu.provider"
+  HEADLESS=1
+  HEADLESS_USER="$(id -un)"
+  LAUNCHD_DOMAIN=system
+  BUNDLED_APP=""
+  MACPROVIDER_ACCEPTANCE_ASSET_DIR="$TMP/acceptance"
+  REPAIR_EXISTING_INSTALL=1
+  DRY_RUN=0
+  EMERGENCY_ROLLBACK=0
+  REFERRAL_REPLACE_INCUMBENT=0
+  REFERRAL_CODE_SOURCE_FILE=""
+  FRESH_REFERRAL_BOOTSTRAP=0
+  NO_PROMPT=1
+  SUDO_BIN="$TMP/sudo"
+  launchctl_service() {
+    [ "$1" = "print" ] && [ "$2" = "system/live.malibu.provider" ]
+  }
+  log() { :; }
+  die() { exit "$1"; }
+  prepare_fresh_referral_code
+) || headless_repair_bad_user_rc=$?
+if [ "$headless_repair_bad_user_rc" -ne 28 ]; then
+  echo "signed headless acceptance repair accepted mismatched LaunchDaemon user (rc=$headless_repair_bad_user_rc)" >&2
+  exit 1
+fi
+python3 - "$HEADLESS_REPAIR_PLIST_PATH" "$HEADLESS_REPAIR_INCUMBENT_BINARY" "$HEADLESS_REPAIR_CONFIG_PATH" "$HEADLESS_REPAIR_CONFIG_DIR/protected-credentials" <<PY
+import plistlib
+import sys
+
+path, binary, config, credential_root = sys.argv[1:]
+payload = {
+    "Label": "live.malibu.provider",
+    "UserName": "$(id -un)",
+    "ProgramArguments": [binary, "serve", "--config", config],
+    "KeepAlive": True,
+    "EnvironmentVariables": {
+        "MACPROVIDER_CREDENTIAL_STORE": "protected_file",
+        "MACPROVIDER_PROTECTED_CREDENTIAL_ROOT": credential_root,
+        "MACPROVIDER_HEADLESS": "1",
+        "MACPROVIDER_HEADLESS_USER": "$(id -un)",
+        "MACPROVIDER_LAUNCHD_DOMAIN": "system",
+    },
+}
+with open(path, "wb") as handle:
+    plistlib.dump(payload, handle)
+PY
+chmod 600 "$HEADLESS_REPAIR_PLIST_PATH"
+cp "$HEADLESS_REPAIR_PLIST_PATH" "$HEADLESS_REPAIR_BOOTSTRAP_PLIST_PATH"
+mv "$HEADLESS_REPAIR_PLIST_PATH" "$HEADLESS_REPAIR_PLIST_PATH.unmanaged"
+headless_repair_unmanaged_rc=0
+(
+  HOME="$HEADLESS_REPAIR_HOME"
+  INSTALL_DIR="$HEADLESS_REPAIR_INSTALL_DIR"
+  CONFIG_DIR="$HEADLESS_REPAIR_CONFIG_DIR"
+  CONFIG_PATH="$HEADLESS_REPAIR_CONFIG_PATH"
+  PROVIDER_ID_PATH="$HEADLESS_REPAIR_PROVIDER_ID_PATH"
+  PLIST_PATH="$HEADLESS_REPAIR_PLIST_PATH"
+  PLIST_BOOTSTRAP_PATH="$HEADLESS_REPAIR_BOOTSTRAP_PLIST_PATH"
+  PROVIDER_LABEL="live.malibu.provider"
+  HEADLESS=1
+  HEADLESS_USER="$(id -un)"
+  LAUNCHD_DOMAIN=system
+  BUNDLED_APP=""
+  MACPROVIDER_ACCEPTANCE_ASSET_DIR="$TMP/acceptance"
+  REPAIR_EXISTING_INSTALL=1
+  DRY_RUN=0
+  EMERGENCY_ROLLBACK=0
+  REFERRAL_REPLACE_INCUMBENT=0
+  REFERRAL_CODE_SOURCE_FILE=""
+  FRESH_REFERRAL_BOOTSTRAP=0
+  NO_PROMPT=1
+  SUDO_BIN="$TMP/sudo"
+  launchctl_service() {
+    [ "$1" = "print" ] && [ "$2" = "system/live.malibu.provider" ]
+  }
+  log() { :; }
+  die() { exit "$1"; }
+  prepare_fresh_referral_code
+) || headless_repair_unmanaged_rc=$?
+mv "$HEADLESS_REPAIR_PLIST_PATH.unmanaged" "$HEADLESS_REPAIR_PLIST_PATH"
+if [ "$headless_repair_unmanaged_rc" -ne 28 ]; then
+  echo "signed headless acceptance repair accepted a published-only LaunchDaemon without managed recovery plist (rc=$headless_repair_unmanaged_rc)" >&2
   exit 1
 fi
 (

--- a/scripts/test-install-version-pin.sh
+++ b/scripts/test-install-version-pin.sh
@@ -81,6 +81,12 @@ awk '
 ' "$INSTALL_SH" >> "$lib"
 
 awk '
+  /^headless_acceptance_repair_mode\(\)/ { emit = 1 }
+  emit { print }
+  emit && /^\}$/ { exit }
+' "$INSTALL_SH" >> "$lib"
+
+awk '
   /^installed_provider_binary_path\(\)/ { emit = 1 }
   /^validate_non_emergency_pinned_target\(\)/ { emit = 0 }
   emit { print }
@@ -92,7 +98,7 @@ awk '
   emit && /^\}$/ { exit }
 ' "$INSTALL_SH" >> "$lib"
 
-for symbol in latest_release_tag validate_macprovider_version_tag resolve_release_tag validated_acceptance_asset_dir download_release verify_sha256 validate_staged_entries installed_provider_binary_path validate_acceptance_upgrade_target validate_acceptance_provider_component_target validate_staged_acceptance_provider_component validate_non_emergency_pinned_target validate_emergency_target verify_emergency_coordinator_advertisement validate_emergency_config_backup stage_emergency_config_backup disable_staged_autoupdate verify_emergency_config_activation config_without_provider_token_sha256 preserve_failed_bootstrap_identity; do
+for symbol in latest_release_tag validate_macprovider_version_tag resolve_release_tag validated_acceptance_asset_dir download_release verify_sha256 validate_staged_entries headless_acceptance_repair_mode installed_provider_binary_path validate_acceptance_upgrade_target validate_acceptance_provider_component_target validate_staged_acceptance_provider_component validate_non_emergency_pinned_target validate_emergency_target verify_emergency_coordinator_advertisement validate_emergency_config_backup stage_emergency_config_backup disable_staged_autoupdate verify_emergency_config_activation config_without_provider_token_sha256 preserve_failed_bootstrap_identity; do
   grep -q "^${symbol}()" "$lib" || fatal "could not extract $symbol from $INSTALL_SH"
 done
 
@@ -639,6 +645,26 @@ EMERGENCY_ROLLBACK=1
 rc=0
 ( validate_acceptance_upgrade_target v1.8.33 && validate_emergency_target v1.8.33 ) >/dev/null 2>&1 || rc=$?
 report "case20-emergency-downgrade-reaches-existing-gate" 0 "$rc"
+rm -f "$BINARY_PATH" "$INSTALL_DIR/macprovider-cli" "$INSTALL_DIR/compatibility-set.json"
+HEADLESS_REPAIR_INCUMBENT_DIR="$workdir/headless-acceptance-smoke"
+mkdir -p "$HEADLESS_REPAIR_INCUMBENT_DIR"
+HEADLESS_REPAIR_INCUMBENT_BINARY="$HEADLESS_REPAIR_INCUMBENT_DIR/macprovider-cli"
+printf '#!/usr/bin/env bash\nprintf "v1.8.109\\n"\n' > "$HEADLESS_REPAIR_INCUMBENT_BINARY"
+chmod +x "$HEADLESS_REPAIR_INCUMBENT_BINARY"
+REPAIR_EXISTING_INSTALL=1
+HEADLESS=1
+LAUNCHD_DOMAIN=system
+BUNDLED_APP=""
+MACPROVIDER_MIN_HEADLESS_VERSION=v1.8.108
+MACPROVIDER_ACCEPTANCE_ASSET_DIR="$acceptance_dir"
+EMERGENCY_ROLLBACK=0
+rc=0
+( validate_acceptance_upgrade_target v1.8.108 ) >/dev/null 2>&1 || rc=$?
+report "case20-headless-repair-downgrade-rejected" 7 "$rc"
+rc=0
+( validate_acceptance_provider_component_target 1.8.108 ) >/dev/null 2>&1 || rc=$?
+report "case20-headless-repair-component-downgrade-rejected" 7 "$rc"
+unset REPAIR_EXISTING_INSTALL HEADLESS LAUNCHD_DOMAIN BUNDLED_APP MACPROVIDER_MIN_HEADLESS_VERSION HEADLESS_REPAIR_INCUMBENT_BINARY
 
 ################################################################
 # Case 21 — validating the installed version must not overwrite


### PR DESCRIPTION
## Summary

Fixes #1324 by adding a narrowly scoped signed operator acceptance repair path for a stranded headless `system/live.malibu.provider` LaunchDaemon incumbent.

The existing autoupdate rejection was valid under SPEC-020: `headless_fleet` remains outside generic recurring consumer autoupdate. The gap was that a healthy manually staged system-domain incumbent had no supported migration back into the installer-managed topology.

This PR:
- proves the incumbent LaunchDaemon, managed/bootstrap plist parity, protected-file credential custody, provider ID continuity, and incumbent binary ownership/digest before adoption
- persists the admitted incumbent binary path and SHA-256 into recovery state and revalidates both before rollback trust
- lets transaction snapshot, cutover reclaim, and residual port-stop paths recognize only that admitted incumbent in signed headless repair mode
- keeps normal non-headless repair and recurring autoupdate trust boundaries unchanged

## Validation

- `bash -n phase3-binary/dist/install.sh phase3-binary/dist/test/install_launchd_migration.test.sh phase3-binary/dist/test/provider_upgrade_transaction.test.sh phase3-binary/dist/test/install_upgrade_evidence_rollback.test.sh phase3-binary/dist/test/install_port_validation.test.sh phase3-binary/dist/test/install_fresh_evidence.test.sh phase3-binary/dist/test/install_headless_fleet.test.sh scripts/test-install-version-pin.sh`
- `git diff --check origin/main`
- `bash phase3-binary/dist/test/install_launchd_migration.test.sh`
- `bash phase3-binary/dist/test/provider_upgrade_transaction.test.sh`
- `bash phase3-binary/dist/test/install_port_validation.test.sh`
- `bash phase3-binary/dist/test/install_fresh_evidence.test.sh`
- `bash phase3-binary/dist/test/install_headless_fleet.test.sh`
- `bash scripts/test-install-version-pin.sh`
- `bash phase3-binary/dist/test/install_upgrade_evidence_rollback.test.sh`
- `make test-dist`

Audit gate:
- Code review: 0 critical / 0 high / 0 medium / 0 low
- Security review: 0 critical / 0 high / 0 medium / 0 low
- Architecture review: 0 critical / 0 high / 0 medium; 1 low note to avoid describing this as generic recurring headless autoupdate

## Notes

This does not make `headless_fleet` eligible for generic recurring autoupdate. It is a signed operator acceptance repair rail for a proven incumbent system LaunchDaemon.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "issue": "https://github.com/Augustas11/macprovider/issues/1324",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": [
    "SPEC-020"
  ],
  "requirements": [
    "SPEC-020-R004",
    "SPEC-020-R005"
  ],
  "authority_domains": [
    "provider-autoupdate"
  ],
  "arbitration": [
    "CODE_BUG"
  ],
  "tests": [
    "bash -n touched installer shell files",
    "git diff --check origin/main",
    "bash phase3-binary/dist/test/install_launchd_migration.test.sh",
    "bash phase3-binary/dist/test/provider_upgrade_transaction.test.sh",
    "bash phase3-binary/dist/test/install_port_validation.test.sh",
    "bash phase3-binary/dist/test/install_fresh_evidence.test.sh",
    "bash phase3-binary/dist/test/install_headless_fleet.test.sh",
    "bash scripts/test-install-version-pin.sh",
    "bash phase3-binary/dist/test/install_upgrade_evidence_rollback.test.sh",
    "make test-dist"
  ],
  "journeys": [
    "not-required: script-level signed repair regression; physical host journey deferred"
  ]
}
SPEC-GOVERNANCE-DECLARATION-END
