### PR TITLE
Bump GitHub Actions: checkout v4->v7, download-artifact 4.3.0->8.0.1

### DIFF
--- a/.github/workflows/acceptance-candidate.yml
+++ b/.github/workflows/acceptance-candidate.yml
@@ -51,7 +51,7 @@ jobs:
       promotion_ready: ${{ steps.source.outputs.promotion_ready }}
     steps:
       - name: Checkout main-owned workflow controls
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ github.sha }}
           path: control
@@ -59,7 +59,7 @@ jobs:
           persist-credentials: false
 
       - name: Checkout candidate as untrusted build data
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           repository: ${{ github.repository }}
           ref: ${{ github.event.inputs.candidate_sha }}
@@ -297,7 +297,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout only the main-owned signer
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ github.sha }}
           fetch-depth: 1
@@ -322,7 +322,7 @@ jobs:
           sudo test -x /private/var/macprovider-go-verifier/bin/go
 
       - name: Download unsigned candidate build data
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: unsigned-acceptance-${{ needs.build_candidate.outputs.candidate_commit }}
           path: ${{ runner.temp }}/unsigned-acceptance-inputs

--- a/.github/workflows/autotune-feed-freshness-alarm.yml
+++ b/.github/workflows/autotune-feed-freshness-alarm.yml
@@ -38,7 +38,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout freshness check
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           fetch-depth: 1
           persist-credentials: false

--- a/.github/workflows/build-signed-pool-promotion-transition.yml
+++ b/.github/workflows/build-signed-pool-promotion-transition.yml
@@ -59,7 +59,7 @@ jobs:
     environment: production-release
     steps:
       - name: Checkout reviewed main controls
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0

--- a/.github/workflows/build-signed-trusted-pool-creator-mvp-journey.yml
+++ b/.github/workflows/build-signed-trusted-pool-creator-mvp-journey.yml
@@ -35,7 +35,7 @@ jobs:
     environment: production-release
     steps:
       - name: Checkout reviewed main controls
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0

--- a/.github/workflows/build-signed-trusted-pool-layer2-journey.yml
+++ b/.github/workflows/build-signed-trusted-pool-layer2-journey.yml
@@ -35,7 +35,7 @@ jobs:
     environment: production-release
     steps:
       - name: Checkout reviewed main controls
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout
         # Pinned to actions/checkout v6 (df4cb1c0). Re-resolve deliberately
         # when upgrading the action rather than trusting a mutable tag.
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -76,7 +76,7 @@ jobs:
       - name: Checkout
         # Pinned to actions/checkout v6 (df4cb1c0). Re-resolve deliberately
         # when upgrading the action rather than trusting a mutable tag.
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
 
@@ -101,7 +101,7 @@ jobs:
       - name: Checkout
         # Pinned to actions/checkout v6 (df4cb1c0). Re-resolve deliberately
         # when upgrading the action rather than trusting a mutable tag.
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
 
@@ -125,7 +125,7 @@ jobs:
       - name: Checkout
         # Pinned to actions/checkout v6 (df4cb1c0). Re-resolve deliberately
         # when upgrading the action rather than trusting a mutable tag.
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
 
@@ -162,7 +162,7 @@ jobs:
     timeout-minutes: 2
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
 
@@ -199,7 +199,7 @@ jobs:
     # toolchain excludes by convention.
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
       - name: Set up Go
@@ -234,7 +234,7 @@ jobs:
     # daemon-less host does not fail.
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
       - name: Set up Go
@@ -262,7 +262,7 @@ jobs:
     # 22-AC sweep.
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
       - name: Verify docker daemon
@@ -285,7 +285,7 @@ jobs:
       - name: Checkout
         # Pinned to actions/checkout v6 (df4cb1c0). Re-resolve deliberately
         # when upgrading the action rather than trusting a mutable tag.
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
 
@@ -320,7 +320,7 @@ jobs:
       - name: Checkout
         # Pinned to actions/checkout v6 (df4cb1c0). Re-resolve deliberately
         # when upgrading the action rather than trusting a mutable tag.
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
 
@@ -361,7 +361,7 @@ jobs:
       - name: Checkout
         # Pinned to actions/checkout v6 (df4cb1c0). Re-resolve deliberately
         # when upgrading the action rather than trusting a mutable tag.
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -400,7 +400,7 @@ jobs:
       - name: Checkout
         # Pinned to actions/checkout v6 (df4cb1c0). Re-resolve deliberately
         # when upgrading the action rather than trusting a mutable tag.
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
 
@@ -460,7 +460,7 @@ jobs:
     if: ${{ needs.changes.outputs.code == 'true' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
 

--- a/.github/workflows/discovery-head-freshness-alarm.yml
+++ b/.github/workflows/discovery-head-freshness-alarm.yml
@@ -34,7 +34,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout freshness check
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           fetch-depth: 1
           persist-credentials: false

--- a/.github/workflows/install-sh-parity-alarm.yml
+++ b/.github/workflows/install-sh-parity-alarm.yml
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/malibu-release.yml
+++ b/.github/workflows/malibu-release.yml
@@ -74,7 +74,7 @@ jobs:
       artifact_name: ${{ steps.source.outputs.artifact_name }}
     steps:
       - name: Checkout reviewed main
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ inputs.source_commit }}
           fetch-depth: 1
@@ -186,14 +186,14 @@ jobs:
       contents: read
     steps:
       - name: Checkout reviewed main signer
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ inputs.source_commit }}
           fetch-depth: 1
           persist-credentials: false
 
       - name: Download unsigned reviewed input
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: unsigned-${{ needs.build_candidate.outputs.artifact_name }}
           path: ${{ runner.temp }}/unsigned
@@ -449,7 +449,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout exact release source
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ inputs.source_commit }}
           fetch-depth: 0
@@ -569,7 +569,7 @@ jobs:
           echo "run_attempt=$run_attempt" >> "$GITHUB_OUTPUT"
 
       - name: Download exact private candidate
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: malibu-v${{ inputs.version }}-${{ inputs.source_commit }}
           path: ${{ runner.temp }}/candidate

--- a/.github/workflows/pearl-runtime-release.yml
+++ b/.github/workflows/pearl-runtime-release.yml
@@ -28,7 +28,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout reviewed runtime source
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/promote-acceptance-candidate.yml
+++ b/.github/workflows/promote-acceptance-candidate.yml
@@ -45,7 +45,7 @@ jobs:
       transport_tag: ${{ steps.discovery_base.outputs.transport_tag }}
     steps:
       - name: Checkout reviewed promotion controls
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0
@@ -117,7 +117,7 @@ jobs:
           PY
 
       - name: Download only the exact private acceptance artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           github-token: ${{ github.token }}
           repository: ${{ github.repository }}
@@ -555,7 +555,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout reviewed public verifier
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ github.sha }}
           fetch-depth: 1

--- a/.github/workflows/promote-signed-buyer-crash-recovery-journey.yml
+++ b/.github/workflows/promote-signed-buyer-crash-recovery-journey.yml
@@ -35,7 +35,7 @@ jobs:
     environment: production-release
     steps:
       - name: Checkout reviewed main controls
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0

--- a/.github/workflows/promote-signed-buyer-enforce-journey.yml
+++ b/.github/workflows/promote-signed-buyer-enforce-journey.yml
@@ -35,7 +35,7 @@ jobs:
     environment: production-release
     steps:
       - name: Checkout reviewed main controls
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0

--- a/.github/workflows/promote-signed-buyer-paid-path-journey.yml
+++ b/.github/workflows/promote-signed-buyer-paid-path-journey.yml
@@ -35,7 +35,7 @@ jobs:
     environment: production-release
     steps:
       - name: Checkout reviewed main controls
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0

--- a/.github/workflows/promote-signed-local-consumer-endpoint-journey.yml
+++ b/.github/workflows/promote-signed-local-consumer-endpoint-journey.yml
@@ -35,7 +35,7 @@ jobs:
     environment: production-release
     steps:
       - name: Checkout reviewed main controls
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0

--- a/.github/workflows/promote-signed-payout-journey.yml
+++ b/.github/workflows/promote-signed-payout-journey.yml
@@ -27,7 +27,7 @@ jobs:
     environment: production-release
     steps:
       - name: Checkout reviewed main controls
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0

--- a/.github/workflows/promote-signed-provider-prebeta-journey.yml
+++ b/.github/workflows/promote-signed-provider-prebeta-journey.yml
@@ -35,7 +35,7 @@ jobs:
     environment: production-release
     steps:
       - name: Checkout reviewed main controls
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout
         # Pinned to actions/checkout v4.2.2. Re-resolve deliberately
         # when upgrading the action rather than trusting a mutable tag.
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
 
@@ -119,7 +119,7 @@ jobs:
       - name: Checkout
         # Pinned to actions/checkout v4.2.2. Re-resolve deliberately
         # when upgrading the action rather than trusting a mutable tag.
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Checkout
         # Pinned to actions/checkout v6.0.3. Re-resolve deliberately
         # when upgrading the action rather than trusting a mutable tag.
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           # A promoted candidate is bound to the already-created signed tag.
           # Checkout that immutable source commit while the workflow itself
@@ -411,14 +411,14 @@ jobs:
       contents: read
     steps:
       - name: Checkout reviewed release commit
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ needs.build.outputs.commit }}
           fetch-depth: 0
           persist-credentials: false
 
       - name: Download unsigned build artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: unsigned-release-${{ needs.build.outputs.commit }}
           path: ${{ runner.temp }}/unsigned-release-inputs
@@ -477,14 +477,14 @@ jobs:
       contents: write
     steps:
       - name: Checkout reviewed release commit
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ needs.build.outputs.commit }}
           fetch-depth: 0
           persist-credentials: false
 
       - name: Download unsigned build artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: unsigned-release-${{ needs.build.outputs.commit }}
           path: ${{ runner.temp }}/unsigned-release-inputs

--- a/.github/workflows/renew-autotune-static-feed-signed.yml
+++ b/.github/workflows/renew-autotune-static-feed-signed.yml
@@ -36,7 +36,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout reviewed renewal controls
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ github.sha }}
           fetch-depth: 1

--- a/.github/workflows/renew-autotune-static-feed.yml
+++ b/.github/workflows/renew-autotune-static-feed.yml
@@ -43,7 +43,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout cadence check
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           fetch-depth: 1
           persist-credentials: false

--- a/.github/workflows/renew-release-discovery-head.yml
+++ b/.github/workflows/renew-release-discovery-head.yml
@@ -45,7 +45,7 @@ jobs:
       transport_tag: ${{ steps.publish.outputs.transport_tag }}
     steps:
       - name: Checkout reviewed renewal controls
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ github.sha }}
           fetch-depth: 1
@@ -465,7 +465,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout reviewed public verifier
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ github.sha }}
           fetch-depth: 1

--- a/.github/workflows/spec-index.yml
+++ b/.github/workflows/spec-index.yml
@@ -25,7 +25,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/verify-live-coordinator-release-rollout.yml
+++ b/.github/workflows/verify-live-coordinator-release-rollout.yml
@@ -31,7 +31,7 @@ jobs:
       transport_tag: ${{ steps.rollout.outputs.transport_tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: refs/heads/main
           fetch-depth: 0
@@ -266,7 +266,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ github.sha }}
           persist-credentials: false

--- a/scripts/test-autotune-feed-freshness-alarm.sh
+++ b/scripts/test-autotune-feed-freshness-alarm.sh
@@ -27,7 +27,7 @@ import sys
 alarm = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
 renew = pathlib.Path(sys.argv[2]).read_text(encoding="utf-8")
 checker = pathlib.Path(sys.argv[3]).read_text(encoding="utf-8")
-CHECKOUT = "uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10"
+CHECKOUT = "uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
 CHECKER = "python3 scripts/check-autotune-feed-freshness.py"
 
 for name, workflow in (("alarm", alarm), ("renew", renew)):

--- a/scripts/test-renew-autotune-static-feed-signed.sh
+++ b/scripts/test-renew-autotune-static-feed-signed.sh
@@ -55,7 +55,7 @@ for requirement in (
     "scripts/dist/malibu-download-known_hosts",
     "bash scripts/renew-autotune-static-feed.sh --deploy",
     "persist-credentials: false",
-    "uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10",
+    "uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
     "timeout-minutes: 20",
     "unset AUTOTUNE_STATIC_V4_PRIVATE_KEY_BASE64 PEARL_AUTOTUNE_DEPLOY_SSH_KEY",
     'chmod 600 "$key" "$ssh_key"',


### PR DESCRIPTION
## Summary

Splits the two **major-version** GitHub Actions bumps out of the Dependabot
dependency work (Go/Swift bumps are in #1336) so their risk is isolated and
they can be reverted independently.

| Supersedes | Bump |
|---|---|
| #1328 | `actions/checkout` v4 → v7 (45 SHA-pinned refs + 1 tag ref) |
| #1330 | `actions/download-artifact` 4.3.0 → 8.0.1 (6 SHA-pinned refs) |

SHAs match Dependabot's resolved pins. The checkout SHA is asserted by two dist
pin-guard scripts (`test-autotune-feed-freshness-alarm.sh`,
`test-renew-autotune-static-feed-signed.sh`); both updated to the new v7 SHA so
`make test-dist` stays green.

## Why a separate PR

- These are **major-version jumps** (`download-artifact` crosses four majors),
  which carry real breaking-change potential.
- Most refs live in **release, `malibu-release`, deploy, signing, renewal, and
  alarm** workflows that run on tags/schedule/dispatch — **not** on pull
  requests. PR CI does **not** exercise them, so a green check here does not
  validate the release/signing path.
- Isolating them keeps them independently revertible if a later release breaks,
  which a squashed bundle with the Go/Swift bumps would not allow.

## Before relying on this

Confirm the next release / signing / notarization run (and the scheduled
renewal/alarm workflows) actually succeed with checkout v7 and
download-artifact v8 — that is the coverage PR CI cannot provide.

## Verification (local)

- `make test-dist` — pass (incl. both updated pin-guard scripts)
- all 24 changed workflow YAMLs parse
- workflow diffs are action-ref lines only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
