### PR TITLE
Enforce SPEC-032 strict evidence before promotion

### DIFF
--- a/scripts/build-provider-prebeta-journey-result.py
+++ b/scripts/build-provider-prebeta-journey-result.py
@@ -28,6 +28,7 @@ JOURNEY_ID = "JOURNEY-PROVIDER-PREBETA-ADMISSION"
 EVIDENCE_SCHEMA = "macprovider.provider-prebeta-admission-evidence.v1"
 REPOSITORY = "Augustas11/macprovider"
 ARTIFACT_ID = "redacted-provider-prebeta-admission"
+EXECUTION_MODE = "physical-provider-prebeta-admission"
 REQUIREMENT_RE = re.compile(r"^SPEC-[0-9]{3}-R[0-9]{3}$")
 COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
 DATETIME_Z_RE = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")
@@ -42,6 +43,49 @@ STEP_IDS = (
     "step-06-provider-runtime-routing",
     "step-07-buyer-serving-smoke",
     "step-08-redaction-and-correlation",
+)
+STRICT_SPEC032_REQUIREMENT_IDS = {
+    "SPEC-032-R001",
+    "SPEC-032-R002",
+    "SPEC-032-R003",
+}
+STRICT_SPEC032_STEP_ID_ORDER = (
+    "r001-over-ceiling",
+    "r001-uncatalogued",
+    "r001-clears",
+    "r002-expired",
+    "r002-tuple-mismatch",
+    "r002-missing-tuple",
+    "r003-sandbox-and-failclosed-reload",
+    "r003-recovery-sweep",
+)
+STRICT_SPEC032_STEP_REQUIREMENTS = {
+    "r001-over-ceiling": "SPEC-032-R001",
+    "r001-uncatalogued": "SPEC-032-R001",
+    "r001-clears": "SPEC-032-R001",
+    "r002-expired": "SPEC-032-R002",
+    "r002-tuple-mismatch": "SPEC-032-R002",
+    "r002-missing-tuple": "SPEC-032-R002",
+    "r003-sandbox-and-failclosed-reload": "SPEC-032-R003",
+    "r003-recovery-sweep": "SPEC-032-R003",
+}
+STRICT_SPEC032_STEP_REASONS = {
+    "r001-over-ceiling": "autotune_model_cap_exceeded",
+    "r001-uncatalogued": "autotune_model_uncatalogued",
+    "r002-expired": "autotune_evidence_stale_or_mismatched",
+    "r002-tuple-mismatch": "autotune_evidence_stale_or_mismatched",
+    "r002-missing-tuple": "autotune_evidence_stale_or_mismatched",
+    "r003-sandbox-and-failclosed-reload": "autotune_evidence_required",
+    "r003-recovery-sweep": "autotune_evidence_required",
+}
+STRICT_SPEC032_REQUIRED_SNAP_FIELDS = (
+    "routing_eligible",
+    "serving_capable",
+)
+STRICT_SPEC032_FORBIDDEN_REASON_FRAGMENTS = (
+    "bench_gate",
+    "min_sustained_tps",
+    "max_4k_ttft_ms",
 )
 FORBIDDEN_KEY_FRAGMENTS = (
     "authorization_header",
@@ -175,6 +219,21 @@ def require_redaction(value: Any) -> dict[str, bool]:
     return {key: True for key in required}
 
 
+def require_result(value: Any) -> dict[str, Any]:
+    result = deepcopy(require_object(value, "result"))
+    if result.get("status") != "pass":
+        die("result.status must equal 'pass'")
+    if result.get("class") == "dry-run" or result.get("promote") is False:
+        die("dry-run provider-prebeta evidence cannot be promoted")
+    allowed = {"status", "summary"}
+    extra = sorted(set(result) - allowed)
+    if extra:
+        die(f"result contains unsupported promotion field(s): {', '.join(extra)}")
+    if "summary" in result:
+        require_string(result.get("summary"), None, "result.summary")
+    return result
+
+
 def parse_requirement_id_values(source: Any, location: str) -> list[str]:
     if isinstance(source, str):
         values = [item.strip() for item in source.split(",") if item.strip()]
@@ -239,9 +298,65 @@ def require_git_file_matches(root: Path, commit: str, source: str, expected: byt
         die("redacted evidence source bytes must match --evidence-sha")
 
 
-def require_steps(value: Any) -> list[dict[str, Any]]:
+def step_order_for_requirements(requirement_ids: list[str]) -> tuple[str, ...]:
+    selected = set(requirement_ids)
+    if selected & STRICT_SPEC032_REQUIREMENT_IDS:
+        if not selected <= STRICT_SPEC032_REQUIREMENT_IDS:
+            die("SPEC-032 strict matrix requirements must not be mixed with other provider-prebeta requirements")
+        return tuple(
+            step_id
+            for step_id in STRICT_SPEC032_STEP_ID_ORDER
+            if STRICT_SPEC032_STEP_REQUIREMENTS[step_id] in selected
+        )
+    return STEP_IDS
+
+
+def require_spec032_step_details(step: dict[str, Any], step_id: str, location: str) -> None:
+    if step.get("requirement") != STRICT_SPEC032_STEP_REQUIREMENTS[step_id]:
+        die(f"{location}.requirement must equal {STRICT_SPEC032_STEP_REQUIREMENTS[step_id]!r}")
+    for field in ("subject_fingerprint", "control_fingerprint"):
+        require_string(step.get(field), FINGERPRINT_RE, f"{location}.{field}")
+    for field in ("subject_before", "subject_after", "control_after"):
+        snap = require_object(step.get(field), f"{location}.{field}")
+        for snap_field in STRICT_SPEC032_REQUIRED_SNAP_FIELDS:
+            if not isinstance(snap.get(snap_field), bool):
+                die(f"{location}.{field}.{snap_field} must be boolean")
+    control_after = require_object(step.get("control_after"), f"{location}.control_after")
+    if control_after.get("routing_eligible") is not True or control_after.get("serving_capable") is not True:
+        die(f"{location}.control_after must remain routing-eligible and serving-capable")
+    subject_after = require_object(step.get("subject_after"), f"{location}.subject_after")
+    if step_id == "r001-clears":
+        if subject_after.get("routing_eligible") is not True or subject_after.get("serving_capable") is not True:
+            die(f"{location}.subject_after must be routing-eligible and serving-capable after the clear step")
+        return
+    if subject_after.get("routing_eligible") is not False or subject_after.get("serving_capable") is not False:
+        die(f"{location}.subject_after must be route-excluded or sandboxed")
+    if STRICT_SPEC032_STEP_REQUIREMENTS[step_id] == "SPEC-032-R003":
+        if subject_after.get("admission_sandboxed") is not True:
+            die(f"{location}.subject_after.admission_sandboxed must be true for R003")
+        if step.get("durable_provider_credentials_minted") is not False:
+            die(f"{location}.durable_provider_credentials_minted must be false for R003")
+        if step_id == "r003-sandbox-and-failclosed-reload" and step.get("fail_closed_reload_observed") is not True:
+            die(f"{location}.fail_closed_reload_observed must be true for R003 reload")
+    expected_reason = STRICT_SPEC032_STEP_REASONS.get(step_id)
+    if expected_reason is not None:
+        reason = require_string(step.get("non_admission_reason"), None, f"{location}.non_admission_reason")
+        lowered = reason.lower()
+        if any(fragment in lowered for fragment in STRICT_SPEC032_FORBIDDEN_REASON_FRAGMENTS):
+            die(f"{location}.non_admission_reason must not cite advisory bench_gate values")
+        if reason != expected_reason:
+            die(f"{location}.non_admission_reason must equal {expected_reason!r}")
+
+
+def require_steps(
+    value: Any,
+    requirement_ids: list[str] | None = None,
+    covered_requirement_ids: list[str] | None = None,
+) -> list[dict[str, Any]]:
     if not isinstance(value, list):
         die("steps must be an array")
+    expected_order = step_order_for_requirements(covered_requirement_ids or requirement_ids) if requirement_ids is not None else STEP_IDS
+    output_order = step_order_for_requirements(requirement_ids) if requirement_ids is not None else expected_order
     by_id: dict[str, dict[str, Any]] = {}
     for index, item in enumerate(value):
         step = require_object(item, f"steps[{index}]")
@@ -256,14 +371,16 @@ def require_steps(value: Any) -> list[dict[str, Any]]:
             artifacts = [ARTIFACT_ID]
         if not isinstance(artifacts, list) or not artifacts or any(item != ARTIFACT_ID for item in artifacts):
             die(f"{step_id}.artifacts must reference {ARTIFACT_ID}")
+        if step_id in STRICT_SPEC032_STEP_REQUIREMENTS:
+            require_spec032_step_details(step, step_id, f"steps[{index}]")
         by_id[step_id] = {"id": step_id, "status": "pass", "assertion": assertion, "artifacts": [ARTIFACT_ID]}
-    missing = [step_id for step_id in STEP_IDS if step_id not in by_id]
-    extra = [step_id for step_id in by_id if step_id not in STEP_IDS]
+    missing = [step_id for step_id in expected_order if step_id not in by_id]
+    extra = [step_id for step_id in by_id if step_id not in expected_order]
     if missing:
         die(f"missing provider-prebeta step(s): {', '.join(missing)}")
     if extra:
         die(f"unknown provider-prebeta step(s): {', '.join(extra)}")
-    return [by_id[step_id] for step_id in STEP_IDS]
+    return [by_id[step_id] for step_id in output_order]
 
 
 def reject_forbidden_secret_keys(value: Any, location: str = "$") -> None:
@@ -303,6 +420,7 @@ def build_payload(root: Path, source: str, *, source_sha: str, evidence_sha: str
         die("repository.commit must exactly match --source-sha")
     require_git_file_matches(root, evidence_sha, source, evidence_bytes)
 
+    evidence_ids = parse_requirement_id_values(evidence.get("requirement_ids"), "evidence.requirement_ids")
     selected_requirements = parse_requirement_ids(requirement_ids, evidence)
     mapped = load_mapped_provider_requirements(root)
     not_mapped = [item for item in selected_requirements if item not in mapped]
@@ -319,12 +437,10 @@ def build_payload(root: Path, source: str, *, source_sha: str, evidence_sha: str
     environment = deepcopy(require_object(evidence.get("environment"), "environment"))
     for field in ("class", "hardware_profile", "candidate"):
         require_string(environment.get(field), None, f"environment.{field}")
-    result = deepcopy(require_object(evidence.get("result"), "result"))
-    if result.get("status") != "pass":
-        die("result.status must equal 'pass'")
-    if "summary" in result:
-        require_string(result.get("summary"), None, "result.summary")
-    steps = require_steps(evidence.get("steps"))
+    if environment.get("class") != EXECUTION_MODE:
+        die(f"environment.class must equal {EXECUTION_MODE!r}")
+    result = require_result(evidence.get("result"))
+    steps = require_steps(evidence.get("steps"), selected_requirements, evidence_ids)
     redaction = require_redaction(evidence.get("redaction"))
     artifact_sha = hashlib.sha256(evidence_bytes).hexdigest()
     run_id = require_string(evidence.get("run_id"), None, "run_id")
@@ -343,7 +459,7 @@ def build_payload(root: Path, source: str, *, source_sha: str, evidence_sha: str
         "steps": steps,
         "redaction": redaction,
         "run_id": run_id,
-        "execution_mode": "physical-provider-prebeta-admission",
+        "execution_mode": EXECUTION_MODE,
     }
 
 

--- a/scripts/check_spec_governance.py
+++ b/scripts/check_spec_governance.py
@@ -58,6 +58,49 @@ PROVIDER_PREBETA_STEP_ID_ORDER = (
     "step-08-redaction-and-correlation",
 )
 PROVIDER_PREBETA_STEP_IDS = set(PROVIDER_PREBETA_STEP_ID_ORDER)
+PROVIDER_PREBETA_STRICT_SPEC032_REQUIREMENT_IDS = {
+    "SPEC-032-R001",
+    "SPEC-032-R002",
+    "SPEC-032-R003",
+}
+PROVIDER_PREBETA_STRICT_SPEC032_STEP_ID_ORDER = (
+    "r001-over-ceiling",
+    "r001-uncatalogued",
+    "r001-clears",
+    "r002-expired",
+    "r002-tuple-mismatch",
+    "r002-missing-tuple",
+    "r003-sandbox-and-failclosed-reload",
+    "r003-recovery-sweep",
+)
+PROVIDER_PREBETA_STRICT_SPEC032_STEP_REQUIREMENTS = {
+    "r001-over-ceiling": "SPEC-032-R001",
+    "r001-uncatalogued": "SPEC-032-R001",
+    "r001-clears": "SPEC-032-R001",
+    "r002-expired": "SPEC-032-R002",
+    "r002-tuple-mismatch": "SPEC-032-R002",
+    "r002-missing-tuple": "SPEC-032-R002",
+    "r003-sandbox-and-failclosed-reload": "SPEC-032-R003",
+    "r003-recovery-sweep": "SPEC-032-R003",
+}
+PROVIDER_PREBETA_STRICT_SPEC032_STEP_REASONS = {
+    "r001-over-ceiling": "autotune_model_cap_exceeded",
+    "r001-uncatalogued": "autotune_model_uncatalogued",
+    "r002-expired": "autotune_evidence_stale_or_mismatched",
+    "r002-tuple-mismatch": "autotune_evidence_stale_or_mismatched",
+    "r002-missing-tuple": "autotune_evidence_stale_or_mismatched",
+    "r003-sandbox-and-failclosed-reload": "autotune_evidence_required",
+    "r003-recovery-sweep": "autotune_evidence_required",
+}
+PROVIDER_PREBETA_STRICT_SPEC032_SNAP_FIELDS = {
+    "routing_eligible",
+    "serving_capable",
+}
+PROVIDER_PREBETA_STRICT_SPEC032_FORBIDDEN_REASON_FRAGMENTS = {
+    "bench_gate",
+    "min_sustained_tps",
+    "max_4k_ttft_ms",
+}
 BUYER_PAID_PATH_JOURNEY_ID = "JOURNEY-BUYER-PAID-PATH"
 BUYER_PAID_PATH_EXECUTION_MODE = "isolated-candidate-paid-path"
 BUYER_PAID_PATH_STEP_ID_ORDER = (
@@ -907,10 +950,77 @@ def _provider_prebeta_normalized_redaction(value: Any, location: str, result: Va
     return output
 
 
-def _provider_prebeta_normalized_steps(value: Any, location: str, result: ValidationResult) -> list[dict[str, Any]]:
+def _provider_prebeta_step_order(requirement_ids: list[str], location: str, result: ValidationResult) -> tuple[str, ...]:
+    selected = set(requirement_ids)
+    if selected & PROVIDER_PREBETA_STRICT_SPEC032_REQUIREMENT_IDS:
+        if not selected <= PROVIDER_PREBETA_STRICT_SPEC032_REQUIREMENT_IDS:
+            result.error(location, "SPEC-032 strict matrix requirements must not be mixed with other provider-prebeta requirements")
+            return ()
+        return tuple(
+            step_id
+            for step_id in PROVIDER_PREBETA_STRICT_SPEC032_STEP_ID_ORDER
+            if PROVIDER_PREBETA_STRICT_SPEC032_STEP_REQUIREMENTS[step_id] in selected
+        )
+    return PROVIDER_PREBETA_STEP_ID_ORDER
+
+
+def _provider_prebeta_validate_spec032_step_details(
+    step: dict[str, Any],
+    step_id: str,
+    location: str,
+    result: ValidationResult,
+) -> None:
+    expected_requirement = PROVIDER_PREBETA_STRICT_SPEC032_STEP_REQUIREMENTS[step_id]
+    if step.get("requirement") != expected_requirement:
+        result.error(f"{location}.requirement", f"must equal {expected_requirement!r}")
+    _string(step.get("subject_fingerprint"), SHA256_HEX_RE, f"{location}.subject_fingerprint", result)
+    _string(step.get("control_fingerprint"), SHA256_HEX_RE, f"{location}.control_fingerprint", result)
+    for field in ("subject_before", "subject_after", "control_after"):
+        snap = step.get(field)
+        if not _expect_object(snap, f"{location}.{field}", result):
+            continue
+        for snap_field in sorted(PROVIDER_PREBETA_STRICT_SPEC032_SNAP_FIELDS):
+            _bool_value(snap.get(snap_field), f"{location}.{field}.{snap_field}", result)
+    control_after = step.get("control_after")
+    if isinstance(control_after, dict):
+        if control_after.get("routing_eligible") is not True or control_after.get("serving_capable") is not True:
+            result.error(f"{location}.control_after", "must remain routing-eligible and serving-capable")
+    subject_after = step.get("subject_after")
+    if isinstance(subject_after, dict):
+        if step_id == "r001-clears":
+            if subject_after.get("routing_eligible") is not True or subject_after.get("serving_capable") is not True:
+                result.error(f"{location}.subject_after", "must be routing-eligible and serving-capable after the clear step")
+        elif subject_after.get("routing_eligible") is not False or subject_after.get("serving_capable") is not False:
+            result.error(f"{location}.subject_after", "must be route-excluded or sandboxed")
+        if PROVIDER_PREBETA_STRICT_SPEC032_STEP_REQUIREMENTS[step_id] == "SPEC-032-R003":
+            if subject_after.get("admission_sandboxed") is not True:
+                result.error(f"{location}.subject_after.admission_sandboxed", "must be true for R003")
+            if step.get("durable_provider_credentials_minted") is not False:
+                result.error(f"{location}.durable_provider_credentials_minted", "must be false for R003")
+            if step_id == "r003-sandbox-and-failclosed-reload" and step.get("fail_closed_reload_observed") is not True:
+                result.error(f"{location}.fail_closed_reload_observed", "must be true for R003 reload")
+    expected_reason = PROVIDER_PREBETA_STRICT_SPEC032_STEP_REASONS.get(step_id)
+    if expected_reason is not None:
+        reason = _string(step.get("non_admission_reason"), None, f"{location}.non_admission_reason", result)
+        if reason and any(fragment in reason.lower() for fragment in PROVIDER_PREBETA_STRICT_SPEC032_FORBIDDEN_REASON_FRAGMENTS):
+            result.error(f"{location}.non_admission_reason", "must not cite advisory bench_gate values")
+        if reason and reason != expected_reason:
+            result.error(f"{location}.non_admission_reason", f"must equal {expected_reason!r}")
+
+
+def _provider_prebeta_normalized_steps(
+    value: Any,
+    expected_order: tuple[str, ...],
+    location: str,
+    result: ValidationResult,
+    *,
+    output_order: tuple[str, ...] | None = None,
+    require_strict_details: bool = False,
+) -> list[dict[str, Any]]:
     if not isinstance(value, list):
         result.error(location, "field 'steps' must be an array")
         return []
+    expected_ids = set(expected_order)
     by_id: dict[str, dict[str, Any]] = {}
     for index, item in enumerate(value):
         loc = f"{location}[{index}]"
@@ -922,7 +1032,7 @@ def _provider_prebeta_normalized_steps(value: Any, location: str, result: Valida
         if step_id in by_id:
             result.error(f"{loc}.id", f"duplicate provider-prebeta physical step {step_id!r}")
             continue
-        if step_id not in PROVIDER_PREBETA_STEP_IDS:
+        if step_id not in expected_ids:
             result.error(f"{loc}.id", f"unexpected provider-prebeta physical step {step_id!r}")
         if item.get("status") != "pass":
             result.error(f"{loc}.status", "must equal 'pass'")
@@ -931,18 +1041,21 @@ def _provider_prebeta_normalized_steps(value: Any, location: str, result: Valida
         artifact_ids = _string_list(artifacts, f"{loc}.artifacts", result)
         if artifact_ids != [PROVIDER_PREBETA_ARTIFACT_ID]:
             result.error(f"{loc}.artifacts", f"must reference {PROVIDER_PREBETA_ARTIFACT_ID!r}")
+        if require_strict_details and step_id in PROVIDER_PREBETA_STRICT_SPEC032_STEP_REQUIREMENTS:
+            _provider_prebeta_validate_spec032_step_details(item, step_id, loc, result)
         by_id[step_id] = {
             "id": step_id,
             "status": "pass",
             "assertion": assertion,
             "artifacts": [PROVIDER_PREBETA_ARTIFACT_ID],
         }
-    missing_steps = PROVIDER_PREBETA_STEP_IDS - by_id.keys()
+    missing_steps = expected_ids - by_id.keys()
     if missing_steps:
         result.error(location, f"missing provider-prebeta physical steps: {sorted(missing_steps)}")
-    if len(by_id) != len(PROVIDER_PREBETA_STEP_IDS):
-        result.error(location, f"must contain exactly {len(PROVIDER_PREBETA_STEP_IDS)} provider-prebeta physical steps")
-    return [by_id[step_id] for step_id in PROVIDER_PREBETA_STEP_ID_ORDER if step_id in by_id]
+    if len(by_id) != len(expected_ids):
+        result.error(location, f"must contain exactly {len(expected_ids)} provider-prebeta physical steps")
+    selected_order = output_order or expected_order
+    return [by_id[step_id] for step_id in selected_order if step_id in by_id]
 
 
 def _provider_prebeta_compare_signed_source(source_value: Any, signed_value: Any, location: str, result: ValidationResult) -> None:
@@ -981,6 +1094,8 @@ def _validate_provider_prebeta_artifact(
     overclaimed = [item for item in signed_requirement_ids if item not in payload_requirement_ids]
     if overclaimed:
         result.error(f"{location}.source.requirement_ids", f"must cover every signed requirement ID: {overclaimed}")
+    source_step_order = _provider_prebeta_step_order(payload_requirement_ids, f"{location}.source.requirement_ids", result)
+    signed_step_order = _provider_prebeta_step_order(signed_requirement_ids, f"{location}.signed.requirement_ids", result)
     repository = payload.get("repository")
     signed_repository = signed.get("repository")
     if _expect_object(repository, f"{location}.source.repository", result) and isinstance(signed_repository, dict):
@@ -1002,10 +1117,20 @@ def _validate_provider_prebeta_artifact(
             result,
         )
     source_result = payload.get("result")
-    if _expect_object(source_result, f"{location}.source.result", result) and source_result.get("status") != "pass":
-        result.error(f"{location}.source.result.status", "must equal 'pass'")
-    source_steps = _provider_prebeta_normalized_steps(payload.get("steps"), f"{location}.source.steps", result)
-    signed_steps = _provider_prebeta_normalized_steps(signed.get("steps"), f"{location}.signed.steps", result)
+    if _expect_object(source_result, f"{location}.source.result", result):
+        if source_result.get("status") != "pass":
+            result.error(f"{location}.source.result.status", "must equal 'pass'")
+        if source_result.get("class") == "dry-run" or source_result.get("promote") is False:
+            result.error(f"{location}.source.result", "dry-run provider-prebeta evidence cannot be promoted")
+    source_steps = _provider_prebeta_normalized_steps(
+        payload.get("steps"),
+        source_step_order,
+        f"{location}.source.steps",
+        result,
+        output_order=signed_step_order,
+        require_strict_details=True,
+    )
+    signed_steps = _provider_prebeta_normalized_steps(signed.get("steps"), signed_step_order, f"{location}.signed.steps", result)
     _provider_prebeta_compare_signed_source(source_steps, signed_steps, f"{location}.source.steps", result)
     source_redaction = _provider_prebeta_normalized_redaction(payload.get("redaction"), f"{location}.source.redaction", result)
     signed_redaction = {
@@ -1031,6 +1156,12 @@ def _validate_provider_prebeta_journey_result(
         result.error(location, f"provider-prebeta requirement journeys must equal [{PROVIDER_PREBETA_JOURNEY_ID!r}]")
     if signed.get("execution_mode") != PROVIDER_PREBETA_EXECUTION_MODE:
         result.error(f"{location}.signed.execution_mode", f"must equal {PROVIDER_PREBETA_EXECUTION_MODE!r}")
+    environment = signed.get("environment")
+    if isinstance(environment, dict) and environment.get("class") != PROVIDER_PREBETA_EXECUTION_MODE:
+        result.error(f"{location}.signed.environment.class", f"must equal {PROVIDER_PREBETA_EXECUTION_MODE!r}")
+    requirement_ids = _string_list(signed.get("requirement_ids"), f"{location}.signed.requirement_ids", result, REQUIREMENT_ID_RE)
+    expected_step_order = _provider_prebeta_step_order(requirement_ids, f"{location}.signed.requirement_ids", result)
+    expected_step_ids = set(expected_step_order)
 
     observed_step_ids: set[str] = set()
     valid_step_count = 0
@@ -1042,14 +1173,14 @@ def _validate_provider_prebeta_journey_result(
         if step_id in observed_step_ids:
             result.error(f"{location}.signed.steps[{index}].id", f"duplicate provider-prebeta physical step {step_id!r}")
         observed_step_ids.add(step_id)
-    missing_steps = PROVIDER_PREBETA_STEP_IDS - observed_step_ids
-    unexpected_steps = observed_step_ids - PROVIDER_PREBETA_STEP_IDS
+    missing_steps = expected_step_ids - observed_step_ids
+    unexpected_steps = observed_step_ids - expected_step_ids
     if missing_steps:
         result.error(f"{location}.signed.steps", f"missing provider-prebeta physical steps: {sorted(missing_steps)}")
     if unexpected_steps:
         result.error(f"{location}.signed.steps", f"unexpected provider-prebeta physical steps: {sorted(unexpected_steps)}")
-    if valid_step_count != len(PROVIDER_PREBETA_STEP_IDS):
-        result.error(f"{location}.signed.steps", f"must contain exactly {len(PROVIDER_PREBETA_STEP_IDS)} provider-prebeta physical steps")
+    if valid_step_count != len(expected_step_ids):
+        result.error(f"{location}.signed.steps", f"must contain exactly {len(expected_step_ids)} provider-prebeta physical steps")
 
     valid_artifacts = [artifact for artifact in artifacts if isinstance(artifact, dict)]
     if len(valid_artifacts) != 1:

--- a/scripts/tests/test_provider_prebeta_journey_result.py
+++ b/scripts/tests/test_provider_prebeta_journey_result.py
@@ -131,6 +131,98 @@ def base_evidence(source_commit: str) -> dict:
     }
 
 
+def add_spec032_conformance(conformance: dict) -> None:
+    conformance["requirements"] = [
+        {
+            "requirement_id": requirement_id,
+            "spec_id": "SPEC-032",
+            "state": "pending",
+            "evidence": [],
+            "journeys": ["JOURNEY-PROVIDER-PREBETA-ADMISSION"],
+            "implementation": ["provider_prebeta_contract.txt:provider-prebeta-current-selector"],
+            "tests": ["provider_prebeta_contract.txt:provider-prebeta-current-selector"],
+            "gap": {
+                "verdict": "UNKNOWN",
+                "owner": "@Augustas11",
+                "issue": "https://github.com/Augustas11/macprovider/issues/959",
+                "rationale": "pending strict admission matrix evidence",
+            },
+        }
+        for requirement_id in ("SPEC-032-R001", "SPEC-032-R002", "SPEC-032-R003")
+    ]
+
+
+def strict_spec032_steps() -> list[dict]:
+    snap_ready = {
+        "admission_ceiling_excluded": False,
+        "admission_evidence_stale": False,
+        "admission_sandboxed": False,
+        "routing_eligible": True,
+        "serving_capable": True,
+    }
+    snap_excluded = {
+        "admission_ceiling_excluded": True,
+        "admission_evidence_stale": False,
+        "admission_sandboxed": False,
+        "routing_eligible": False,
+        "serving_capable": False,
+    }
+    snap_stale = {
+        "admission_ceiling_excluded": False,
+        "admission_evidence_stale": True,
+        "admission_sandboxed": False,
+        "routing_eligible": False,
+        "serving_capable": False,
+    }
+    snap_sandboxed = {
+        "admission_ceiling_excluded": False,
+        "admission_evidence_stale": False,
+        "admission_sandboxed": True,
+        "routing_eligible": False,
+        "serving_capable": False,
+    }
+    control = dict(snap_ready)
+    rows = [
+        ("r001-over-ceiling", "SPEC-032-R001", "over-ceiling heartbeat route-excludes subject", snap_ready, snap_excluded, "autotune_model_cap_exceeded"),
+        ("r001-uncatalogued", "SPEC-032-R001", "uncatalogued heartbeat route-excludes subject", snap_excluded, snap_excluded, "autotune_model_uncatalogued"),
+        ("r001-clears", "SPEC-032-R001", "in-ceiling heartbeat clears the route exclusion", snap_excluded, snap_ready, None),
+        ("r002-expired", "SPEC-032-R002", "expired evidence route-excludes subject", snap_ready, snap_stale, "autotune_evidence_stale_or_mismatched"),
+        ("r002-tuple-mismatch", "SPEC-032-R002", "tuple-mismatched evidence route-excludes subject", snap_ready, snap_stale, "autotune_evidence_stale_or_mismatched"),
+        ("r002-missing-tuple", "SPEC-032-R002", "missing admitted tuple route-excludes capped subject", snap_ready, snap_stale, "autotune_evidence_stale_or_mismatched"),
+        ("r003-sandbox-and-failclosed-reload", "SPEC-032-R003", "evidence-absent subject sandboxed; fail-closed hot-enable reload keeps the evidence-backed control routable", snap_ready, snap_sandboxed, "autotune_evidence_required"),
+        ("r003-recovery-sweep", "SPEC-032-R003", "recovery sweep restores healthy control; evidence-absent subject stays sandboxed", snap_sandboxed, snap_sandboxed, "autotune_evidence_required"),
+    ]
+    steps = []
+    for step_id, requirement, assertion, before, after, reason in rows:
+        step = {
+            "id": step_id,
+            "requirement": requirement,
+            "status": "pass",
+            "assertion": assertion,
+            "subject_fingerprint": hashlib.sha256(f"subject:{step_id}".encode()).hexdigest(),
+            "subject_before": before,
+            "subject_after": after,
+            "control_fingerprint": hashlib.sha256(b"control").hexdigest(),
+            "control_after": control,
+        }
+        if reason is not None:
+            step["non_admission_reason"] = reason
+        if requirement == "SPEC-032-R003":
+            step["durable_provider_credentials_minted"] = False
+        if step_id == "r003-sandbox-and-failclosed-reload":
+            step["fail_closed_reload_observed"] = True
+        steps.append(step)
+    return steps
+
+
+def make_spec032_evidence(evidence: dict) -> None:
+    evidence["run_id"] = "provider-prebeta-admission-spec032-strict-canary-20260902T120000Z"
+    evidence["requirement_ids"] = ["SPEC-032-R001", "SPEC-032-R002", "SPEC-032-R003"]
+    evidence["result"] = {"status": "pass", "summary": "Physical strict admission-gate matrix passed."}
+    evidence["environment"]["class"] = "physical-provider-prebeta-admission"
+    evidence["steps"] = strict_spec032_steps()
+
+
 class ProviderPrebetaJourneyResultTests(unittest.TestCase):
     def make_repo(self, evidence_mutation=None, conformance_mutation=None) -> tuple[tempfile.TemporaryDirectory[str], Path, str, str]:
         directory = tempfile.TemporaryDirectory()
@@ -940,6 +1032,463 @@ class ProviderPrebetaJourneyResultTests(unittest.TestCase):
 
         self.assertNotEqual(0, completed.returncode)
         self.assertIn("step-07-buyer-serving-smoke", completed.stderr)
+
+    def test_builder_emits_spec032_strict_matrix_payload(self) -> None:
+        directory, root, source_commit, evidence_commit = self.make_repo(
+            make_spec032_evidence,
+            add_spec032_conformance,
+        )
+        self.addCleanup(directory.cleanup)
+        output = root / "payload.json"
+
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(BUILDER),
+                "--root",
+                str(root),
+                "--source-sha",
+                source_commit,
+                "--evidence-sha",
+                evidence_commit,
+                "--output",
+                str(output),
+                EVIDENCE_SOURCE,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(0, completed.returncode, completed.stderr)
+        payload = json.loads(output.read_text(encoding="utf-8"))
+        self.assertEqual(["SPEC-032-R001", "SPEC-032-R002", "SPEC-032-R003"], payload["requirement_ids"])
+        self.assertEqual("r001-over-ceiling", payload["steps"][0]["id"])
+        self.assertEqual("r003-recovery-sweep", payload["steps"][-1]["id"])
+        self.assertEqual("physical-provider-prebeta-admission", payload["execution_mode"])
+
+    def test_builder_allows_spec032_subset_from_full_matrix_evidence(self) -> None:
+        directory, root, source_commit, evidence_commit = self.make_repo(
+            make_spec032_evidence,
+            add_spec032_conformance,
+        )
+        self.addCleanup(directory.cleanup)
+        output = root / "payload.json"
+
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(BUILDER),
+                "--root",
+                str(root),
+                "--source-sha",
+                source_commit,
+                "--evidence-sha",
+                evidence_commit,
+                "--requirement-ids",
+                "SPEC-032-R002",
+                "--output",
+                str(output),
+                EVIDENCE_SOURCE,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(0, completed.returncode, completed.stderr)
+        payload = json.loads(output.read_text(encoding="utf-8"))
+        self.assertEqual(["SPEC-032-R002"], payload["requirement_ids"])
+        self.assertEqual(
+            ["r002-expired", "r002-tuple-mismatch", "r002-missing-tuple"],
+            [step["id"] for step in payload["steps"]],
+        )
+
+    def test_validator_rejects_spec032_dry_run_promotion(self) -> None:
+        def dry_run(evidence: dict) -> None:
+            make_spec032_evidence(evidence)
+            evidence["result"]["class"] = "dry-run"
+            evidence["result"]["promote"] = False
+
+        directory, root, source_commit, _ = self.make_repo(dry_run, add_spec032_conformance)
+        self.addCleanup(directory.cleanup)
+
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(VALIDATOR),
+                "--root",
+                str(root),
+                "--source-sha",
+                source_commit,
+                EVIDENCE_SOURCE,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertNotEqual(0, completed.returncode)
+        self.assertIn("dry-run provider-prebeta evidence cannot be promoted", completed.stderr)
+
+    def test_builder_rejects_spec032_non_physical_environment(self) -> None:
+        def non_physical(evidence: dict) -> None:
+            make_spec032_evidence(evidence)
+            evidence["environment"]["class"] = "isolated-in-process-acceptance-harness"
+
+        directory, root, source_commit, evidence_commit = self.make_repo(non_physical, add_spec032_conformance)
+        self.addCleanup(directory.cleanup)
+
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(BUILDER),
+                "--root",
+                str(root),
+                "--source-sha",
+                source_commit,
+                "--evidence-sha",
+                evidence_commit,
+                "--output",
+                str(root / "payload.json"),
+                EVIDENCE_SOURCE,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertNotEqual(0, completed.returncode)
+        self.assertIn("environment.class must equal 'physical-provider-prebeta-admission'", completed.stderr)
+
+    def test_builder_rejects_spec032_result_promotion_marker(self) -> None:
+        def promotion_marker(evidence: dict) -> None:
+            make_spec032_evidence(evidence)
+            evidence["result"]["promote"] = True
+
+        directory, root, source_commit, evidence_commit = self.make_repo(promotion_marker, add_spec032_conformance)
+        self.addCleanup(directory.cleanup)
+
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(BUILDER),
+                "--root",
+                str(root),
+                "--source-sha",
+                source_commit,
+                "--evidence-sha",
+                evidence_commit,
+                "--output",
+                str(root / "payload.json"),
+                EVIDENCE_SOURCE,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertNotEqual(0, completed.returncode)
+        self.assertIn("result contains unsupported promotion field(s): promote", completed.stderr)
+
+    def test_builder_rejects_spec032_collateral_control_failure(self) -> None:
+        def collateral_failure(evidence: dict) -> None:
+            make_spec032_evidence(evidence)
+            evidence["steps"][0]["control_after"]["routing_eligible"] = False
+
+        directory, root, source_commit, evidence_commit = self.make_repo(collateral_failure, add_spec032_conformance)
+        self.addCleanup(directory.cleanup)
+
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(BUILDER),
+                "--root",
+                str(root),
+                "--source-sha",
+                source_commit,
+                "--evidence-sha",
+                evidence_commit,
+                "--output",
+                str(root / "payload.json"),
+                EVIDENCE_SOURCE,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertNotEqual(0, completed.returncode)
+        self.assertIn("control_after must remain routing-eligible and serving-capable", completed.stderr)
+
+    def test_builder_rejects_spec032_raw_provider_fingerprint(self) -> None:
+        def raw_fingerprint(evidence: dict) -> None:
+            make_spec032_evidence(evidence)
+            evidence["steps"][0]["subject_fingerprint"] = "provider:raw-local-machine-id"
+
+        directory, root, source_commit, evidence_commit = self.make_repo(raw_fingerprint, add_spec032_conformance)
+        self.addCleanup(directory.cleanup)
+
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(BUILDER),
+                "--root",
+                str(root),
+                "--source-sha",
+                source_commit,
+                "--evidence-sha",
+                evidence_commit,
+                "--output",
+                str(root / "payload.json"),
+                EVIDENCE_SOURCE,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertNotEqual(0, completed.returncode)
+        self.assertIn("steps[0].subject_fingerprint has invalid format", completed.stderr)
+
+    def test_builder_rejects_spec032_r003_without_sandbox_or_no_credentials(self) -> None:
+        def missing_r003_proof(evidence: dict) -> None:
+            make_spec032_evidence(evidence)
+            evidence["steps"][6]["subject_after"]["admission_sandboxed"] = False
+            evidence["steps"][6]["durable_provider_credentials_minted"] = True
+
+        directory, root, source_commit, evidence_commit = self.make_repo(missing_r003_proof, add_spec032_conformance)
+        self.addCleanup(directory.cleanup)
+
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(BUILDER),
+                "--root",
+                str(root),
+                "--source-sha",
+                source_commit,
+                "--evidence-sha",
+                evidence_commit,
+                "--output",
+                str(root / "payload.json"),
+                EVIDENCE_SOURCE,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertNotEqual(0, completed.returncode)
+        self.assertIn("subject_after.admission_sandboxed must be true for R003", completed.stderr)
+
+    def test_builder_rejects_spec032_advisory_bench_gate_reason(self) -> None:
+        def advisory_reason(evidence: dict) -> None:
+            make_spec032_evidence(evidence)
+            evidence["steps"][0]["non_admission_reason"] = "bench_gate.min_sustained_tps"
+
+        directory, root, source_commit, evidence_commit = self.make_repo(advisory_reason, add_spec032_conformance)
+        self.addCleanup(directory.cleanup)
+
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(BUILDER),
+                "--root",
+                str(root),
+                "--source-sha",
+                source_commit,
+                "--evidence-sha",
+                evidence_commit,
+                "--output",
+                str(root / "payload.json"),
+                EVIDENCE_SOURCE,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertNotEqual(0, completed.returncode)
+        self.assertIn("must not cite advisory bench_gate values", completed.stderr)
+
+    def test_builder_rejects_spec032_wrong_reason_code(self) -> None:
+        def wrong_reason(evidence: dict) -> None:
+            make_spec032_evidence(evidence)
+            evidence["steps"][3]["non_admission_reason"] = "autotune_model_cap_exceeded"
+
+        directory, root, source_commit, evidence_commit = self.make_repo(wrong_reason, add_spec032_conformance)
+        self.addCleanup(directory.cleanup)
+
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(BUILDER),
+                "--root",
+                str(root),
+                "--source-sha",
+                source_commit,
+                "--evidence-sha",
+                evidence_commit,
+                "--output",
+                str(root / "payload.json"),
+                EVIDENCE_SOURCE,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertNotEqual(0, completed.returncode)
+        self.assertIn("non_admission_reason must equal 'autotune_evidence_stale_or_mismatched'", completed.stderr)
+
+    def test_signed_spec032_strict_matrix_payload_passes_canonical_validator(self) -> None:
+        directory, root, source_commit, evidence_commit = self.make_repo(
+            make_spec032_evidence,
+            add_spec032_conformance,
+        )
+        self.addCleanup(directory.cleanup)
+        private_key = generate_acceptance_key(root)
+        trusted_hash = hashlib.sha256((root / "security" / "acceptance-candidate-signing-public.pem").read_bytes()).hexdigest()
+        payload = root / "payload.json"
+        envelope = root / "journeys" / "evidence" / "provider-prebeta-admission-spec032-strict-canary-20260902T120000Z.spec-032-r001-spec-032-r002-spec-032-r003.journey-result.signed.json"
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(BUILDER),
+                "--root",
+                str(root),
+                "--source-sha",
+                source_commit,
+                "--evidence-sha",
+                evidence_commit,
+                "--output",
+                str(payload),
+                EVIDENCE_SOURCE,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(0, completed.returncode, completed.stderr)
+        env = os.environ.copy()
+        env["MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM"] = private_key
+        openssl = shutil.which("openssl")
+        if openssl is None:
+            raise unittest.SkipTest("openssl is required")
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(SIGNER),
+                "--root",
+                str(root),
+                "--input",
+                str(payload),
+                "--output",
+                str(envelope.relative_to(root)),
+                "--verified-at",
+                "2026-08-05T06:05:00Z",
+                "--openssl-bin",
+                openssl,
+            ],
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(0, completed.returncode, completed.stderr)
+
+        result = ValidationResult()
+        self.assertTrue(
+            _validate_signed_journey_result(
+                root,
+                str(envelope.relative_to(root)),
+                "SPEC-032-R002",
+                ["JOURNEY-PROVIDER-PREBETA-ADMISSION"],
+                {source_commit},
+                trusted_hash,
+                openssl,
+                "provider-prebeta-spec032",
+                result,
+            ),
+            result.errors,
+        )
+        self.assertEqual([], result.errors)
+
+    def test_signed_spec032_subset_from_full_matrix_passes_canonical_validator(self) -> None:
+        directory, root, source_commit, evidence_commit = self.make_repo(
+            make_spec032_evidence,
+            add_spec032_conformance,
+        )
+        self.addCleanup(directory.cleanup)
+        private_key = generate_acceptance_key(root)
+        trusted_hash = hashlib.sha256((root / "security" / "acceptance-candidate-signing-public.pem").read_bytes()).hexdigest()
+        payload = root / "payload.json"
+        envelope = root / "journeys" / "evidence" / "provider-prebeta-admission-spec032-strict-canary-20260902T120000Z.spec-032-r002.journey-result.signed.json"
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(BUILDER),
+                "--root",
+                str(root),
+                "--source-sha",
+                source_commit,
+                "--evidence-sha",
+                evidence_commit,
+                "--requirement-ids",
+                "SPEC-032-R002",
+                "--output",
+                str(payload),
+                EVIDENCE_SOURCE,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(0, completed.returncode, completed.stderr)
+        env = os.environ.copy()
+        env["MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM"] = private_key
+        openssl = shutil.which("openssl")
+        if openssl is None:
+            raise unittest.SkipTest("openssl is required")
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(SIGNER),
+                "--root",
+                str(root),
+                "--input",
+                str(payload),
+                "--output",
+                str(envelope.relative_to(root)),
+                "--verified-at",
+                "2026-08-05T06:05:00Z",
+                "--openssl-bin",
+                openssl,
+            ],
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(0, completed.returncode, completed.stderr)
+
+        result = ValidationResult()
+        self.assertTrue(
+            _validate_signed_journey_result(
+                root,
+                str(envelope.relative_to(root)),
+                "SPEC-032-R002",
+                ["JOURNEY-PROVIDER-PREBETA-ADMISSION"],
+                {source_commit},
+                trusted_hash,
+                openssl,
+                "provider-prebeta-spec032-subset",
+                result,
+            ),
+            result.errors,
+        )
+        self.assertEqual([], result.errors)
 
 
 if __name__ == "__main__":

--- a/scripts/validate-provider-prebeta-evidence.py
+++ b/scripts/validate-provider-prebeta-evidence.py
@@ -106,6 +106,7 @@ def validate_redacted_evidence(
         if evidence_source_sha != source_sha:
             die("repository.commit must exactly match --source-sha")
 
+    evidence_requirements = builder.parse_requirement_id_values(evidence.get("requirement_ids"), "evidence.requirement_ids")
     selected_requirements = builder.parse_requirement_ids(requirement_ids, evidence)
     mapped = builder.load_mapped_provider_requirements(root)
     not_mapped = [item for item in selected_requirements if item not in mapped]
@@ -123,12 +124,10 @@ def validate_redacted_evidence(
     environment = builder.require_object(evidence.get("environment"), "environment")
     for field in ("class", "hardware_profile", "candidate"):
         builder.require_string(environment.get(field), None, f"environment.{field}")
-    result = builder.require_object(evidence.get("result"), "result")
-    if result.get("status") != "pass":
-        die("result.status must equal 'pass'")
-    if "summary" in result:
-        builder.require_string(result.get("summary"), None, "result.summary")
-    builder.require_steps(evidence.get("steps"))
+    if environment.get("class") != builder.EXECUTION_MODE:
+        die(f"environment.class must equal {builder.EXECUTION_MODE!r}")
+    builder.require_result(evidence.get("result"))
+    builder.require_steps(evidence.get("steps"), selected_requirements, evidence_requirements)
     builder.require_redaction(evidence.get("redaction"))
     run_id = builder.require_string(evidence.get("run_id"), None, "run_id")
 


### PR DESCRIPTION
## Summary

Implements the provider-prebeta SPEC-032 strict admission-gate evidence contract needed after RUN-PLAN-959 AC #1:

- adds a strict SPEC-032 matrix profile for `SPEC-032-R001` through `SPEC-032-R003` to the provider-prebeta journey-result builder, standalone evidence validator, and canonical governance validator;
- rejects dry-run or non-physical evidence before promotion, while preserving the existing core provider-prebeta eight-step contract;
- enforces exact strict-matrix reason codes, healthy-control invariants, route-excluded/sandboxed subject state, R003 no-durable-credential/fail-closed reload proof, and SHA-256 provider correlation fingerprints;
- allows protected promotion of an exact passing subset from a fuller redacted source artifact by validating full source coverage and signing only the selected subset.

No strict gates were activated, no canary/prod coordinator was touched, and `specs/CONFORMANCE.json` was not promoted.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts.tests.test_provider_prebeta_journey_result` — 33 tests OK
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts.tests.test_spec_governance` — 46 tests OK
- `python3 scripts/check_spec_governance.py --base-ref origin/main` — passed
- `bash scripts/test-signed-provider-prebeta-journey-workflow.sh` — passed
- `go test ./internal/ws -run TestSpec032StrictAdmissionMatrixDryRunJourney -count=1` — passed
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile scripts/build-provider-prebeta-journey-result.py scripts/validate-provider-prebeta-evidence.py scripts/check_spec_governance.py` — passed
- `git diff --check` — passed

## Audit Gate

- Code review: 0 CRITICAL / 0 HIGH / 0 MEDIUM
- Security review: 0 CRITICAL / 0 HIGH / 0 MEDIUM
- Architecture review: 0 CRITICAL / 0 HIGH / 0 MEDIUM

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": ["SPEC-032"],
  "requirements": ["SPEC-032-R001", "SPEC-032-R002", "SPEC-032-R003"],
  "authority_domains": ["hardware-evidence-admission"],
  "arbitration": ["DECISION_REQUIRED"],
  "tests": [
    "PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts.tests.test_provider_prebeta_journey_result",
    "PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts.tests.test_spec_governance",
    "python3 scripts/check_spec_governance.py --base-ref origin/main",
    "bash scripts/test-signed-provider-prebeta-journey-workflow.sh",
    "go test ./internal/ws -run TestSpec032StrictAdmissionMatrixDryRunJourney -count=1"
  ],
  "journeys": ["JOURNEY-PROVIDER-PREBETA-ADMISSION"],
  "issue": "https://github.com/Augustas11/macprovider/issues/959"
}
SPEC-GOVERNANCE-DECLARATION-END
