### PR TITLE
Report actionable headless operator-update skip instead of topology failure

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/AutoUpdater.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutoUpdater.swift
@@ -69,6 +69,12 @@ struct AutoUpdater: Sendable {
     let currentBinaryURL: @Sendable () -> URL?
     let rollbackObserverAvailable: Availability
     let launchdProviderAvailable: Availability
+    /// True when this node is a headless_fleet / system-domain provider whose
+    /// updates flow through the signed operator installer acceptance bundle
+    /// (SPEC-020 R-4.13), not the consumer autoupdate path. Used to report the
+    /// actionable `headless_operator_update_required` skip instead of a bare
+    /// `unsupported_install_topology` forward-progress failure.
+    let headlessOperatorManagedTopology: Availability
     let lifecycleLeaseStore: ProviderLifecycleLeaseStore
     let evictStaleLocalStatusOwner: EvictStaleLocalStatusOwner
 
@@ -92,6 +98,7 @@ struct AutoUpdater: Sendable {
         },
         rollbackObserverAvailable: @escaping Availability = { AutoUpdater.defaultRollbackObserverAvailable() },
         launchdProviderAvailable: @escaping Availability = { AutoUpdater.defaultLaunchdProviderAvailable() },
+        headlessOperatorManagedTopology: Availability? = nil,
         lifecycleLeaseStore: ProviderLifecycleLeaseStore = ProviderLifecycleLeaseStore(),
         evictStaleLocalStatusOwner: @escaping EvictStaleLocalStatusOwner = { targetVersion, expectedExecutablePath in
             await SelfUpdate.evictStaleLocalStatusOwnerIfManaged(
@@ -115,6 +122,8 @@ struct AutoUpdater: Sendable {
         self.currentBinaryURL = currentBinaryURL
         self.rollbackObserverAvailable = rollbackObserverAvailable
         self.launchdProviderAvailable = launchdProviderAvailable
+        self.headlessOperatorManagedTopology = headlessOperatorManagedTopology
+            ?? { AutoUpdater.defaultHeadlessOperatorManagedTopology(config: config) }
         self.lifecycleLeaseStore = lifecycleLeaseStore
         self.evictStaleLocalStatusOwner = evictStaleLocalStatusOwner
     }
@@ -122,7 +131,8 @@ struct AutoUpdater: Sendable {
     /// Lightweight outcome of a single coordinator-recommendation cycle, used by
     /// the caller (CoordinatorClient) to drive SPEC-020-R005 accepted-session
     /// recovery. The mapping to exit points is:
-    /// - `.notAttempted`: trust-skip, autoupdate-disabled, an invalid/unparseable
+    /// - `.notAttempted`: trust-skip, autoupdate-disabled, a headless operator-update
+    ///   handoff (`headless_operator_update_required`), an invalid/unparseable
     ///   recommended version, or `target_not_newer`. Not counted, not reset — the
     ///   recommendation never engaged a real target and recorded no failure.
     /// - `.missingTarget`: the coordinator advertised a `recommended_binary_version`
@@ -203,9 +213,25 @@ struct AutoUpdater: Sendable {
             if let minimum = policy.minimum, SelfUpdate.compareSemver(target, minimum) == .orderedAscending || policy.revoked.contains(target) {
                 // fail(...) records a cooldown/failure for this target, so per
                 // SPEC-020-R005 this is a recorded forward-progress failure cycle
-                // and MUST increment the counter (not .notAttempted).
+                // and MUST increment the counter (not .notAttempted). A revoked or
+                // below-minimum target is refused for every profile, so it wins
+                // ahead of the headless handoff.
                 await fail(updateID: updateID, target: target, phase: .eligibility, failure: .targetRevokedOrBelowMinimum, reason: "target_revoked_or_below_minimum")
                 return .forwardProgressFailure
+            }
+            // A headless_fleet / system-domain provider is operator-managed: SPEC-020
+            // R-4.13 forbids the consumer autoupdate path from driving it. Divert
+            // BEFORE the install-topology gate and every later mutating gate
+            // (cooldown/download/swap) so it is never driven even when a stale or
+            // loaded consumer LaunchAgent would make launchdProviderAvailable()
+            // true, and so it never records a topology forward-progress failure
+            // that would strand it into the R005 signed recovery rail (which hits
+            // the same operator boundary). Placed after the revoked/minimum policy
+            // check, which is non-mutating and still wins.
+            guard !headlessOperatorManagedTopology() else {
+                print("A newer version is available (v\(target)), but headless_fleet providers update through the signed operator installer acceptance bundle, not consumer autoupdate.")
+                await record(updateID: updateID, target: target, phase: .eligibility, outcome: .skipped, reason: "headless_operator_update_required", attempt: 1)
+                return .notAttempted
             }
             guard launchdProviderAvailable() else {
                 await fail(updateID: updateID, target: target, phase: .eligibility, failure: .other, reason: "unsupported_install_topology")
@@ -394,6 +420,14 @@ struct AutoUpdater: Sendable {
         }
         guard AutoUpdateConfig.enabled(config) else {
             await recordR005(target: "<disabled>", phase: .eligibility, outcome: .skipped, reason: "autoupdate_disabled")
+            return
+        }
+        // Same operator-managed boundary as the coordinator path: the signed
+        // recovery rail cannot converge a headless_fleet / system-domain provider
+        // either, so divert to the actionable skip before any mutating gate rather
+        // than emitting a topology failure. See SPEC-020 R-4.13.
+        guard !headlessOperatorManagedTopology() else {
+            await recordR005(target: "<headless-operator-update>", phase: .eligibility, outcome: .skipped, reason: "headless_operator_update_required")
             return
         }
         let commitTracker = AutoUpdateCommitTracker()
@@ -1047,6 +1081,69 @@ struct AutoUpdater: Sendable {
         ].contains { label, plist in
             FileManager.default.fileExists(atPath: plist.path)
                 && launchctlServiceLoaded(label: label)
+        }
+    }
+
+    /// Positive determination that this node is a headless_fleet / system-domain
+    /// provider whose updates are operator-managed through the signed installer
+    /// acceptance bundle rather than the consumer autoupdate path (SPEC-020
+    /// R-4.13). Grounded in the same authorities the mutating-update gate uses
+    /// (`MacProviderCLI.validateHeadlessUpdateMode`): `protected_file` credential
+    /// custody, an install manifest declaring the `headless_fleet` profile or
+    /// `system` launchd domain, or a managed system LaunchDaemon present on disk,
+    /// loaded in launchd, or in an indeterminate launchd state. Read-only and
+    /// non-mutating, but NOT free: reaching the system-artifact check runs
+    /// `launchctl print` (via `validateNoHeadlessSystemArtifactsPresent`), so keep
+    /// it off hot paths. The cheap `protected_file` and manifest signals
+    /// short-circuit before any `launchctl` call.
+    static func defaultHeadlessOperatorManagedTopology(
+        config: AppConfig,
+        fileExists: (String) -> Bool = { FileManager.default.fileExists(atPath: $0) },
+        loadInstallManifest: () -> UninstallCommand.ManifestLoadResult? = {
+            try? UninstallCommand.loadManifest(home: FileManager.default.homeDirectoryForCurrentUser)
+        },
+        runLaunchctl: ([String]) throws -> Int32 = { arguments in
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+            process.arguments = arguments
+            process.standardOutput = Pipe()
+            process.standardError = Pipe()
+            try process.run()
+            process.waitUntilExit()
+            return process.terminationStatus
+        }
+    ) -> Bool {
+        // Canonical headless custody marker (same as validateHeadlessUpdateMode).
+        if config.credentialStore == .protectedFile {
+            return true
+        }
+        // Install manifest declaring the headless profile / system domain. A
+        // manifest that fails to load (nil) is invalid/indeterminate — fail closed
+        // to headless so an unprovable topology is never driven by the consumer
+        // path (SPEC-020 R-4.13).
+        switch loadInstallManifest() {
+        case .some(.loaded(let manifest)):
+            if manifest.installProfile == "headless_fleet" || manifest.launchdDomain == "system" {
+                return true
+            }
+        case .some(.missing):
+            break
+        case .none:
+            return true
+        }
+        // Managed system-domain LaunchDaemon present on disk, loaded in launchd, or
+        // in an indeterminate launchd state: validateNoHeadlessSystemArtifactsPresent
+        // throws for any of these (parity with validateHeadlessUpdateMode), so a
+        // throw means headless / fail closed and a clean return means a proven
+        // consumer topology.
+        do {
+            try UninstallCommand.validateNoHeadlessSystemArtifactsPresent(
+                fileExists: fileExists,
+                run: runLaunchctl
+            )
+            return false
+        } catch {
+            return true
         }
     }
 

--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -269,6 +269,10 @@ actor CoordinatorClient {
     // Test-only trust override, compiled out of release builds so it can never
     // bypass the real autoupdate trust gate in production.
     private var autoupdateTrustOverrideForTest: (@Sendable () -> AutoUpdateTrustState)?
+    // Test-only headless-topology override so consumer-path R005 re-observation
+    // tests do not depend on the host's real launchd/manifest state. Compiled out
+    // of release builds.
+    private var headlessTopologyOverrideForTest: (@Sendable () -> Bool)?
     #endif
     private var testSignedRecoveryInvocationCount = 0
     private var testLastSignedRecoveryWasAcceptedRecovery: Bool?
@@ -2368,6 +2372,10 @@ actor CoordinatorClient {
     #if DEBUG
     func setAutoupdateTrustOverrideForTest(_ override: (@Sendable () -> AutoUpdateTrustState)?) {
         autoupdateTrustOverrideForTest = override
+    }
+
+    func setHeadlessTopologyOverrideForTest(_ override: (@Sendable () -> Bool)?) {
+        headlessTopologyOverrideForTest = override
     }
     #endif
 
@@ -4495,12 +4503,31 @@ actor CoordinatorClient {
     /// `.cooldownActive` when a recorded cooldown/failure keeps the target
     /// unusable; `nil` (observe nothing) otherwise. NEVER mutates, NEVER acquires
     /// the mutation lock, NEVER runs the installer.
+    /// Whether this provider is a headless_fleet / system-domain node whose
+    /// updates are operator-managed (SPEC-020 R-4.13). Wraps the shared
+    /// determination so tests can pin it without depending on host launchd state.
+    private func isHeadlessOperatorManagedTopology() -> Bool {
+        #if DEBUG
+        if let headlessTopologyOverrideForTest {
+            return headlessTopologyOverrideForTest()
+        }
+        #endif
+        return AutoUpdater.defaultHeadlessOperatorManagedTopology(config: appConfig)
+    }
+
     private func observeAcceptedSessionRecoveryStuckState(
         normalizedVersion: String
     ) -> AutoUpdater.RecommendationOutcome? {
         // A disabled provider is intentionally not updating — not stuck — and the
         // signed rail would no-op anyway.
         guard AutoUpdateConfig.enabled(appConfig) else { return nil }
+        // A headless_fleet / system-domain provider is operator-managed (SPEC-020
+        // R-4.13): neither the consumer nor the signed-recovery rail can converge
+        // it, so it is not "stuck." Never let re-observation increment R005 for it
+        // — otherwise the counter climbs to threshold and pointlessly invokes the
+        // signed rail every interval even though the primary path already emitted
+        // the headless_operator_update_required skip.
+        guard !isHeadlessOperatorManagedTopology() else { return nil }
         // round-6 MEDIUM: R005 eligibility is for a CURRENT recommendation that
         // cannot make forward progress, NOT a not-newer / no-op target. A
         // recommendation that is not strictly newer than the running binary is a

--- a/phase3-binary/Tests/macprovider-cliTests/AutoUpdateTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/AutoUpdateTests.swift
@@ -1323,7 +1323,8 @@ final class AutoUpdateTests: XCTestCase {
                 store.resolveCanonicalInstallBinary(launchedExecutableURL: entrypoint)
             },
             rollbackObserverAvailable: { true },
-            launchdProviderAvailable: { false }
+            launchdProviderAvailable: { false },
+            headlessOperatorManagedTopology: { false }
         )
 
         do {
@@ -2013,7 +2014,8 @@ final class AutoUpdateTests: XCTestCase {
             fenceReloadJobs: {},
             currentBinaryURL: { nil },
             rollbackObserverAvailable: { true },
-            launchdProviderAvailable: { true }
+            launchdProviderAvailable: { true },
+            headlessOperatorManagedTopology: { false }
         )
 
         await updater.handleCoordinatorRecommendation("1.7.0")
@@ -2085,7 +2087,8 @@ final class AutoUpdateTests: XCTestCase {
             fenceReloadJobs: {},
             currentBinaryURL: { binary },
             rollbackObserverAvailable: { true },
-            launchdProviderAvailable: { true }
+            launchdProviderAvailable: { true },
+            headlessOperatorManagedTopology: { false }
         )
 
         await updater.handleCoordinatorRecommendation("1.7.0")
@@ -2200,7 +2203,8 @@ final class AutoUpdateTests: XCTestCase {
             fenceReloadJobs: {},
             currentBinaryURL: { binary },
             rollbackObserverAvailable: { true },
-            launchdProviderAvailable: { true }
+            launchdProviderAvailable: { true },
+            headlessOperatorManagedTopology: { false }
         )
 
         try await updater.preserveMarkerAndSwapForTest(
@@ -2314,7 +2318,8 @@ final class AutoUpdateTests: XCTestCase {
             fenceReloadJobs: {},
             currentBinaryURL: { binary },
             rollbackObserverAvailable: { true },
-            launchdProviderAvailable: { true }
+            launchdProviderAvailable: { true },
+            headlessOperatorManagedTopology: { false }
         )
 
         do {
@@ -2446,7 +2451,8 @@ final class AutoUpdateTests: XCTestCase {
             fenceReloadJobs: {},
             currentBinaryURL: { binary },
             rollbackObserverAvailable: { true },
-            launchdProviderAvailable: { true }
+            launchdProviderAvailable: { true },
+            headlessOperatorManagedTopology: { false }
         )
 
         do {
@@ -2512,7 +2518,8 @@ final class AutoUpdateTests: XCTestCase {
             },
             currentBinaryURL: { nil },
             rollbackObserverAvailable: { true },
-            launchdProviderAvailable: { true }
+            launchdProviderAvailable: { true },
+            headlessOperatorManagedTopology: { false }
         )
 
         let lock = try updater.acquireUpdateLockAndFenceReloadJobsForTest()
@@ -2574,7 +2581,8 @@ final class AutoUpdateTests: XCTestCase {
             fenceReloadJobs: {},
             currentBinaryURL: { nil },
             rollbackObserverAvailable: { true },
-            launchdProviderAvailable: { true }
+            launchdProviderAvailable: { true },
+            headlessOperatorManagedTopology: { false }
         )
 
         await updater.handleSignedReleaseDiscovery()
@@ -2642,7 +2650,8 @@ final class AutoUpdateTests: XCTestCase {
             },
             currentBinaryURL: { binary },
             rollbackObserverAvailable: { true },
-            launchdProviderAvailable: { true }
+            launchdProviderAvailable: { true },
+            headlessOperatorManagedTopology: { false }
         )
         let lock = try store.acquireRecoveryLock()
         defer { withExtendedLifetime(lock) {} }
@@ -2717,7 +2726,8 @@ final class AutoUpdateTests: XCTestCase {
             },
             currentBinaryURL: { binary },
             rollbackObserverAvailable: { true },
-            launchdProviderAvailable: { true }
+            launchdProviderAvailable: { true },
+            headlessOperatorManagedTopology: { false }
         )
         let lock = try store.acquireRecoveryLock()
         defer { withExtendedLifetime(lock) {} }
@@ -2778,7 +2788,8 @@ final class AutoUpdateTests: XCTestCase {
             },
             currentBinaryURL: { binary },
             rollbackObserverAvailable: { true },
-            launchdProviderAvailable: { true }
+            launchdProviderAvailable: { true },
+            headlessOperatorManagedTopology: { false }
         )
         let lock = try updater.acquireUpdateLockAndFenceReloadJobsForTest()
         defer { withExtendedLifetime(lock) {} }
@@ -2850,7 +2861,8 @@ final class AutoUpdateTests: XCTestCase {
             fenceReloadJobs: {},
             currentBinaryURL: { binary },
             rollbackObserverAvailable: { true },
-            launchdProviderAvailable: { true }
+            launchdProviderAvailable: { true },
+            headlessOperatorManagedTopology: { false }
         )
 
         updater.rollbackCommittedSwapAfterRestartFailureForTest(marker)
@@ -2899,7 +2911,8 @@ final class AutoUpdateTests: XCTestCase {
             fenceReloadJobs: {},
             currentBinaryURL: { binary },
             rollbackObserverAvailable: { true },
-            launchdProviderAvailable: { true }
+            launchdProviderAvailable: { true },
+            headlessOperatorManagedTopology: { false }
         )
 
         updater.rollbackCommittedSwapAfterRestartFailureForTest(marker)
@@ -2951,7 +2964,8 @@ final class AutoUpdateTests: XCTestCase {
             },
             currentBinaryURL: { binary },
             rollbackObserverAvailable: { true },
-            launchdProviderAvailable: { true }
+            launchdProviderAvailable: { true },
+            headlessOperatorManagedTopology: { false }
         )
 
         updater.rollbackCommittedSwapAfterRestartFailureForTest(marker)
@@ -3239,7 +3253,8 @@ final class AutoUpdateTests: XCTestCase {
             fenceReloadJobs: {},
             currentBinaryURL: { binary },
             rollbackObserverAvailable: { true },
-            launchdProviderAvailable: { true }
+            launchdProviderAvailable: { true },
+            headlessOperatorManagedTopology: { false }
         )
 
         let outcome = await updater.handleCoordinatorRecommendation("1.7.0")
@@ -3266,7 +3281,8 @@ final class AutoUpdateTests: XCTestCase {
             fenceReloadJobs: {},
             currentBinaryURL: { nil },
             rollbackObserverAvailable: { true },
-            launchdProviderAvailable: { true }
+            launchdProviderAvailable: { true },
+            headlessOperatorManagedTopology: { false }
         )
 
         let outcome = await updater.handleCoordinatorRecommendation("1.7.0")
@@ -3303,7 +3319,8 @@ final class AutoUpdateTests: XCTestCase {
             fenceReloadJobs: {},
             currentBinaryURL: { nil },
             rollbackObserverAvailable: { true },
-            launchdProviderAvailable: { true }
+            launchdProviderAvailable: { true },
+            headlessOperatorManagedTopology: { false }
         )
 
         let outcome = await updater.handleCoordinatorRecommendation("1.7.0")
@@ -3327,11 +3344,171 @@ final class AutoUpdateTests: XCTestCase {
             fenceReloadJobs: {},
             currentBinaryURL: { nil },
             rollbackObserverAvailable: { true },
-            launchdProviderAvailable: { false }
+            launchdProviderAvailable: { false },
+            headlessOperatorManagedTopology: { false }
         )
 
         let outcome = await updater.handleCoordinatorRecommendation("1.7.0")
         XCTAssertEqual(outcome, .forwardProgressFailure)
+    }
+
+    // A headless_fleet / system-domain provider has no consumer LaunchAgent, so
+    // it lands on the same topology gate — but it is healthy, not broken. It MUST
+    // report the actionable `headless_operator_update_required` skip (.notAttempted,
+    // NOT a forward-progress failure) so it never accrues R005 failures. SPEC-020
+    // R-4.13.
+    func testHandleCoordinatorRecommendationSkipsHeadlessOperatorUpdateWithoutForwardProgressFailure() async throws {
+        let fixture = try TempHome()
+        let store = AutoUpdateMarkerStore(homeDirectory: fixture.url)
+        await AutoUpdateEventStore.shared.clear()
+        SessionAutoupdateGate.shared.resetForTest()
+        defer { SessionAutoupdateGate.shared.resetForTest() }
+        var config = AppConfig.defaults(configPath: fixture.url.appendingPathComponent("config.yaml").path)
+        config.credentialStore = .protectedFile
+        let updater = AutoUpdater(
+            config: config,
+            currentVersion: "1.6.0",
+            providerStatus: r005Status(),
+            markerStore: store,
+            trustProvider: { self.r005PinnedTrust() },
+            drain: { _ in true },
+            sendReady: {},
+            restartLaunchd: {},
+            fenceReloadJobs: {},
+            currentBinaryURL: { nil },
+            rollbackObserverAvailable: { true },
+            // Safety boundary (SPEC-020 R-4.13): even with a stale/loaded consumer
+            // LaunchAgent present (launchdProviderAvailable == true), a headless
+            // provider MUST be diverted to the operator-handoff skip and never
+            // driven into consumer autoupdate mutation.
+            launchdProviderAvailable: { true }
+        )
+
+        // No injected topology closure: exercise the real determination via
+        // `credentialStore == .protectedFile`.
+        let outcome = await updater.handleCoordinatorRecommendation("1.7.0")
+        XCTAssertEqual(outcome, .notAttempted)
+
+        let event = await AutoUpdateEventStore.shared.lastWireObject()
+        XCTAssertEqual(event?["reason"] as? String, "headless_operator_update_required")
+        XCTAssertEqual(event?["outcome"] as? String, "skipped")
+    }
+
+    // The signed recovery rail (R005) also cannot converge a system-domain
+    // provider, so it must emit the same actionable skip rather than a topology
+    // failure — otherwise a stranded headless node loops failure→R005→failure.
+    // SPEC-020 R-4.13.
+    func testSignedReleaseDiscoverySkipsHeadlessOperatorUpdate() async throws {
+        let fixture = try TempHome()
+        let store = AutoUpdateMarkerStore(homeDirectory: fixture.url)
+        await AutoUpdateEventStore.shared.clear()
+        SessionAutoupdateGate.shared.resetForTest()
+        defer { SessionAutoupdateGate.shared.resetForTest() }
+        var config = AppConfig.defaults(configPath: fixture.url.appendingPathComponent("config.yaml").path)
+        config.credentialStore = .protectedFile
+        let updater = AutoUpdater(
+            config: config,
+            currentVersion: "1.6.0",
+            providerStatus: r005Status(),
+            markerStore: store,
+            trustProvider: { self.r005PinnedTrust() },
+            drain: { _ in true },
+            sendReady: {},
+            restartLaunchd: {},
+            fenceReloadJobs: {},
+            currentBinaryURL: { nil },
+            rollbackObserverAvailable: { true },
+            // Same safety boundary on the R005 signed-recovery path.
+            launchdProviderAvailable: { true }
+        )
+
+        await updater.handleSignedReleaseDiscovery(attribution: [:])
+
+        let event = await AutoUpdateEventStore.shared.lastWireObject()
+        XCTAssertEqual(event?["reason"] as? String, "headless_operator_update_required")
+        XCTAssertEqual(event?["outcome"] as? String, "skipped")
+    }
+
+    func testDefaultHeadlessOperatorManagedTopologyDetermination() {
+        let config = AppConfig.defaults(configPath: "/tmp/does-not-exist/config.yaml")
+        let noManifest: () -> UninstallCommand.ManifestLoadResult? = { UninstallCommand.ManifestLoadResult.missing }
+        // launchctl "print" absent status (isLaunchdAbsentStatus): no system daemon.
+        let launchdAbsent: ([String]) throws -> Int32 = { _ in 113 }
+        func manifest(profile: String?, domain: String?) -> UninstallCommand.InstallManifest {
+            UninstallCommand.InstallManifest(
+                installPrefix: "/opt/macprovider",
+                launchdLabels: ["live.malibu.provider"],
+                dataDirs: [],
+                version: nil,
+                binaryPath: nil,
+                symlinkPath: nil,
+                launchdPlists: [],
+                installProfile: profile,
+                launchdDomain: domain
+            )
+        }
+
+        // protected_file custody is the canonical headless_fleet marker.
+        var headless = config
+        headless.credentialStore = .protectedFile
+        XCTAssertTrue(AutoUpdater.defaultHeadlessOperatorManagedTopology(
+            config: headless,
+            fileExists: { _ in false },
+            loadInstallManifest: noManifest,
+            runLaunchctl: launchdAbsent
+        ))
+        // consumer_user keychain custody, no manifest, no plist, no loaded daemon.
+        XCTAssertFalse(AutoUpdater.defaultHeadlessOperatorManagedTopology(
+            config: config,
+            fileExists: { _ in false },
+            loadInstallManifest: noManifest,
+            runLaunchctl: launchdAbsent
+        ))
+        // Manifest declaring the headless_fleet profile qualifies even without
+        // protected_file custody or a plist (parity with validateHeadlessUpdateMode).
+        XCTAssertTrue(AutoUpdater.defaultHeadlessOperatorManagedTopology(
+            config: config,
+            fileExists: { _ in false },
+            loadInstallManifest: { UninstallCommand.ManifestLoadResult.loaded(manifest(profile: "headless_fleet", domain: nil)) },
+            runLaunchctl: launchdAbsent
+        ))
+        // Manifest declaring the system launchd domain also qualifies.
+        XCTAssertTrue(AutoUpdater.defaultHeadlessOperatorManagedTopology(
+            config: config,
+            fileExists: { _ in false },
+            loadInstallManifest: { UninstallCommand.ManifestLoadResult.loaded(manifest(profile: nil, domain: "system")) },
+            runLaunchctl: launchdAbsent
+        ))
+        // An invalid/indeterminate manifest (load threw -> nil) fails closed.
+        XCTAssertTrue(AutoUpdater.defaultHeadlessOperatorManagedTopology(
+            config: config,
+            fileExists: { _ in false },
+            loadInstallManifest: { nil },
+            runLaunchctl: launchdAbsent
+        ))
+        // A managed system LaunchDaemon plist physically present also qualifies.
+        let firstManagedPlist = UninstallCommand.managedSystemLaunchDaemonPlists[0]
+        XCTAssertTrue(AutoUpdater.defaultHeadlessOperatorManagedTopology(
+            config: config,
+            fileExists: { $0 == firstManagedPlist },
+            loadInstallManifest: noManifest,
+            runLaunchctl: launchdAbsent
+        ))
+        // No plist on disk, but the system daemon is still LOADED (launchctl print
+        // returns 0): fail closed to headless (parity with the mutating gate).
+        XCTAssertTrue(AutoUpdater.defaultHeadlessOperatorManagedTopology(
+            config: config,
+            fileExists: { _ in false },
+            loadInstallManifest: noManifest,
+            runLaunchctl: { _ in 0 }
+        ))
+        // An indeterminate launchd status (not absent, not loaded) also fails closed.
+        XCTAssertTrue(AutoUpdater.defaultHeadlessOperatorManagedTopology(
+            config: config,
+            fileExists: { _ in false },
+            loadInstallManifest: noManifest,
+            runLaunchctl: { _ in 5 }
+        ))
     }
 
     func testHandleCoordinatorRecommendationReturnsCooldownActive() async throws {
@@ -3353,7 +3530,8 @@ final class AutoUpdateTests: XCTestCase {
             fenceReloadJobs: {},
             currentBinaryURL: { nil },
             rollbackObserverAvailable: { true },
-            launchdProviderAvailable: { true }
+            launchdProviderAvailable: { true },
+            headlessOperatorManagedTopology: { false }
         )
 
         let outcome = await updater.handleCoordinatorRecommendation("1.7.0")
@@ -3381,7 +3559,8 @@ final class AutoUpdateTests: XCTestCase {
             fenceReloadJobs: {},
             currentBinaryURL: { nil },
             rollbackObserverAvailable: { true },
-            launchdProviderAvailable: { true }
+            launchdProviderAvailable: { true },
+            headlessOperatorManagedTopology: { false }
         )
 
         // Target 1.7.0 is below the persisted minimum 1.8.0.
@@ -3412,7 +3591,8 @@ final class AutoUpdateTests: XCTestCase {
             fenceReloadJobs: {},
             currentBinaryURL: { nil },
             rollbackObserverAvailable: { true },
-            launchdProviderAvailable: { true }
+            launchdProviderAvailable: { true },
+            headlessOperatorManagedTopology: { false }
         )
         let attribution = [
             "accepted_session_recovery": "true",

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -525,6 +525,9 @@ final class CoordinatorClientTests: XCTestCase {
         // .missingTarget without touching the installer.
         await client.configureAcceptedRecoveryForTest(accepted: true, recommendation: "v99.9.9", compatibilitySetID: nil)
         await client.setAutoupdateTrustOverrideForTest { CoordinatorClientTests.r005EligibleTrust() }
+        // consumer_user topology: pin off the headless divert so this exercises the
+        // real missing-target accrual regardless of host launchd/manifest state.
+        await client.setHeadlessTopologyOverrideForTest { false }
         await client.stubSignedRecoveryInvocationForTest()
 
         let base = Date()
@@ -551,6 +554,41 @@ final class CoordinatorClientTests: XCTestCase {
         XCTAssertTrue(eligible)
         XCTAssertGreaterThanOrEqual(invocations, 1)
         XCTAssertEqual(lastWasAccepted, true)
+    }
+
+    // SPEC-020 R-4.13: a headless_fleet / system-domain provider is operator-managed,
+    // never "stuck." Its accepted-session re-observation MUST classify no stuck signal
+    // (even a newer missing-target recommendation that would otherwise count), so the
+    // R005 counter never increments and the signed rail is never pointlessly invoked —
+    // matching the primary path's headless_operator_update_required skip.
+    func testAcceptedSessionHeadlessProviderNeverAccruesR005() async throws {
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
+        )
+        let client = try await makeClient(
+            status: status,
+            recorder: CoordinatorFrameRecorder(),
+            credentialStore: .protectedFile
+        )
+        // Same newer + missing-target shape that reaches eligibility for a
+        // consumer_user provider; the headless guard must suppress it entirely.
+        await client.configureAcceptedRecoveryForTest(accepted: true, recommendation: "v99.9.9", compatibilitySetID: nil)
+        await client.setAutoupdateTrustOverrideForTest { CoordinatorClientTests.r005EligibleTrust() }
+        await client.stubSignedRecoveryInvocationForTest()
+
+        let base = Date()
+        await client.reobserveAcceptedSessionRecoveryForTest(now: base)
+        await client.reobserveAcceptedSessionRecoveryForTest(now: base.addingTimeInterval(400))
+        await client.reobserveAcceptedSessionRecoveryForTest(now: base.addingTimeInterval(800))
+
+        let count = await client.acceptedSessionRecoveryFailureCountForTest()
+        let eligible = await client.acceptedSessionRecoveryEligibleForTest()
+        let invocations = await client.signedRecoveryInvocationCountForTest()
+        XCTAssertEqual(count, 0)
+        XCTAssertFalse(eligible)
+        XCTAssertEqual(invocations, 0)
     }
 
     // SPEC-020-R005: a recorded cooldown for the recommended target is also a pure
@@ -585,6 +623,7 @@ final class CoordinatorClientTests: XCTestCase {
         // cooldown keeps it unusable => .cooldownActive observation.
         await client.configureAcceptedRecoveryForTest(accepted: true, recommendation: "v99.9.9", compatibilitySetID: "set-x")
         await client.setRecordedCooldownForTest(target: "99.9.9", failureClass: .other)
+        await client.setHeadlessTopologyOverrideForTest { false }
         await client.stubSignedRecoveryInvocationForTest()
 
         let base = Date()
@@ -5911,11 +5950,13 @@ final class CoordinatorClientTests: XCTestCase {
         autoupdateReloadHelperFence: @escaping CoordinatorClient.ReloadHelperFence = {},
         configPath: String = "/tmp/macprovider-test.yaml",
         providerToken: String? = nil,
+        credentialStore: ProviderCredentialStoreKind = .keychain,
         providerCredentialStore: any ProviderCredentialStoring = KeychainProviderCredentialStore(),
         credentialStatusRuntime: ProviderCredentialStatusRuntime = ProviderCredentialStatusRuntime(.unconfigured),
         admissionIdentityStatusRuntime: ProviderAdmissionIdentityStatusRuntime = ProviderAdmissionIdentityStatusRuntime()
     ) async throws -> CoordinatorClient {
         var config = AppConfig.defaults(configPath: configPath)
+        config.credentialStore = credentialStore
         config.coordinatorURL = "wss://127.0.0.1:8444/ws/provider"
         config.providerID = "provider-test"
         config.providerToken = providerToken

--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -561,7 +561,7 @@
     {
       "spec_id": "SPEC-020",
       "title": "Provider autoupdate",
-      "version": "v0.1.15",
+      "version": "v0.1.16",
       "path": "specs/SPEC-020-provider-autoupdate.md",
       "status": "normative",
       "owner": "@Augustas11",

--- a/specs/README.md
+++ b/specs/README.md
@@ -28,7 +28,7 @@ it can no longer drift. Do not hand-edit the table; edit each spec's
 | SPEC-017 | Network Stats API | 0.2.0 | normative | pending | pending: 1 | [SPEC-017-network-stats-api.md](SPEC-017-network-stats-api.md) |
 | SPEC-018 | Agentic tool calling (provider-side response synthesis) | 0.2.7 | normative | pending | conformant: 1, pending: 1 | [SPEC-018-agentic-tool-calling.md](SPEC-018-agentic-tool-calling.md) |
 | SPEC-019 | Structured output (`response_format: json_schema`) | 0.2.5 | normative | pending | pending corpus migration | [SPEC-019-structured-output.md](SPEC-019-structured-output.md) |
-| SPEC-020 | Provider autoupdate | v0.1.15 | normative | pending | pending: 5 | [SPEC-020-provider-autoupdate.md](SPEC-020-provider-autoupdate.md) |
+| SPEC-020 | Provider autoupdate | v0.1.16 | normative | pending | pending: 5 | [SPEC-020-provider-autoupdate.md](SPEC-020-provider-autoupdate.md) |
 | SPEC-021 | MALIBU rewards emission ledger | 0.4.0 | draft | complete | pending: 10 | [SPEC-021-malibu-emission-ledger.md](SPEC-021-malibu-emission-ledger.md) |
 | SPEC-022 | Verified model settlement | v0.1.7 | draft | complete | conformant: 11 | [SPEC-022-verified-model-settlement.md](SPEC-022-verified-model-settlement.md) |
 | SPEC-023 | Installer-Integrated Autotune Recommend | v0.9.5 | normative | pending | conformant: 2, pending: 1 | [SPEC-023-installer-autotune-recommend.md](SPEC-023-installer-autotune-recommend.md) |

--- a/specs/SPEC-020-provider-autoupdate.md
+++ b/specs/SPEC-020-provider-autoupdate.md
@@ -1,6 +1,6 @@
 # SPEC-020 - Provider autoupdate
 
-Version: v0.1.15
+Version: v0.1.16
 Status: Normative; coordinator-independent recovery is reconciled and
 implementation remains nonconformant under issue #610. The production path ran
 the 2026-07-10 incident-recovery
@@ -102,8 +102,19 @@ The literal `$HOME/.config/macprovider` and
 selected `consumer_user` profile owner. A provider installed as
 `headless_fleet` MUST NOT be updated by the v0.1.12 consumer LaunchAgent
 autoupdate path, because that path cannot safely prove or recover a system-domain
-service. It MUST fail closed as `unsupported_install_topology` or require a
-separately specified operator update flow. A user-domain helper MUST NOT bootout,
+service. When the consumer autoupdate path recognizes such a provider (v0.1.16:
+`protected_file` credential custody, an install manifest declaring the
+`headless_fleet` profile or `system` launchd domain, or a managed system-domain
+provider LaunchDaemon present on disk / loaded / in an indeterminate launchd
+state — full parity with the mutating-update gate), it MUST report the
+actionable, terminal skip `reason:"headless_operator_update_required"` with
+`outcome:"skipped"`, directing the operator to the separately specified signed
+installer acceptance flow. This skip is NOT a forward-progress failure for
+SPEC-020-R005 accounting (see R-4.13).
+A proven consumer-user topology continues on the normal path; an invalid or
+indeterminate topology fails closed to the headless handoff (R-4.13), while a
+topology that is unrecognized and non-headless MUST still fail closed as
+`unsupported_install_topology`. A user-domain helper MUST NOT bootout,
 bootstrap, prove absence of, or authorize rollback for a system-domain provider.
 
 ## Cross-spec amendment and trust state
@@ -871,6 +882,30 @@ recovery supplies an allowed signed set.
 R-4.13. Reserved for future headless system-domain update and rollback
 semantics. Until that version lands, `headless_fleet` is outside the autoupdate
 convergence population and MUST NOT be driven by the consumer-user reload helper.
+v0.1.16: when the coordinator-recommendation path or the SPEC-020-R005
+signed-recovery path evaluates a recognized `headless_fleet` / system-domain
+provider, it MUST divert to `reason:"headless_operator_update_required"`
+(`outcome:"skipped"`) BEFORE the install-topology gate and every later mutating
+gate (cooldown, download, swap), so the consumer path never drives the node even
+when a stale or loaded consumer LaunchAgent would otherwise make it appear
+installable. The divert is placed AFTER the non-mutating `target_revoked` /
+below-minimum policy check, which still wins (a revoked or below-minimum target
+is refused for every profile). The diverted cycle MUST NOT record a
+forward-progress failure, and R005 accepted-session re-observation MUST NOT count
+such a provider as stuck (it never accrues toward the recovery threshold).
+Recognition MUST use the same authorities as the mutating-update gate
+(`MacProviderCLI.validateHeadlessUpdateMode`): `protected_file` credential
+custody; an install manifest declaring the `headless_fleet` profile or `system`
+launchd domain; or a managed system-domain provider LaunchDaemon that is present
+on disk, loaded in launchd, or in an indeterminate launchd state. An invalid or
+indeterminate topology MUST fail closed to the headless handoff rather than the
+consumer path. This keeps a healthy operator-managed node from looping
+`failure → R005 → failure` and gives the operator one stable, actionable reason
+instead of a repeated `unsupported_install_topology` failure. The determination
+MUST NOT relax any R-2 safety invariant, mutate the live service, or authorize
+rollback; it only changes eligibility diversion, the reported reason, and failure
+accounting. A proven consumer topology continues on the normal path; a genuinely
+unrecognized topology still fails closed as `unsupported_install_topology`.
 
 ### R-5. Opt-out
 
@@ -1417,6 +1452,28 @@ Deferred to v0.3.0 or later:
 
 ## Change log
 
+- v0.1.16 (2026-09-02): Consumer and R005 autoupdate paths now divert a
+  recognized `headless_fleet` / system-domain provider to the actionable terminal
+  skip `reason:"headless_operator_update_required"` (`outcome:"skipped"`) before
+  the install-topology gate and every later mutating gate — but after the
+  non-mutating `target_revoked` / below-minimum check, which still wins — instead
+  of a bare `unsupported_install_topology` forward-progress failure. Recognition
+  matches the mutating-update gate `validateHeadlessUpdateMode` at full parity:
+  `protected_file` custody, an install manifest declaring the `headless_fleet`
+  profile or `system` launchd domain, or a managed system-domain provider
+  LaunchDaemon present on disk, loaded in launchd, or in an indeterminate launchd
+  state; an invalid/indeterminate topology fails closed to the headless handoff.
+  Diverting before the topology gate closes the R-4.13 safety hole where a
+  headless node with a stale/loaded consumer LaunchAgent could still be driven
+  into consumer autoupdate mutation. The skip is not counted for SPEC-020-R005
+  accounting, and accepted-session re-observation also treats such a provider as
+  not-stuck, so a healthy operator-managed node no longer loops
+  `failure → R005 → failure` into the signed-recovery rail that hits the same
+  operator boundary. A proven consumer topology continues normally; a genuinely
+  unrecognized topology still fails closed as `unsupported_install_topology`. No
+  R-2 safety invariant, live-service mutation, or rollback authority changed.
+  Addresses issue #1324 (updater actionable-reason gap left open by the
+  installer-side repair rail).
 - v0.1.15 (2026-08-31): Corrected the append-only head renewal description to
   freshness-only. The `renew-release-discovery-head.yml` signer binds the target
   the current signed head already points at (resolved from the live transport


### PR DESCRIPTION
## Summary

- Both the coordinator-recommendation and SPEC-020-R005 autoupdate paths now divert a recognized `headless_fleet` / system-domain provider to the terminal skip `reason:"headless_operator_update_required"` (`outcome:"skipped"`, `.notAttempted`) — instead of a bare `unsupported_install_topology` forward-progress failure.
- The divert sits **after** the non-mutating `target_revoked` / below-minimum policy check (which still wins) and **before** the install-topology gate and every later mutating gate, so a headless node is never driven into consumer autoupdate mutation even with a stale/loaded consumer LaunchAgent.
- `CoordinatorClient` accepted-session re-observation no longer counts a headless provider as stuck, so it never accrues toward the R005 threshold.
- Recognition is at full parity with the mutating-update gate `validateHeadlessUpdateMode` (`protected_file` custody; install manifest `headless_fleet`/`system`; or a managed system LaunchDaemon present/loaded/indeterminate), failing closed on an invalid/indeterminate topology.
- Amends SPEC-020 to v0.1.16 (profile section, R-4.13, change log); version-syncs CONFORMANCE and the generated index.

## Why

Issue #1324's installer-side signed repair rail (#1334, `7931dfaf`) adopted stranded headless providers but left the updater's actionable-reason gap open (the issue's investigation question #4). On main, a healthy system-domain provider (no consumer LaunchAgent) reaching the topology gate records `unsupported_install_topology` as a **forward-progress failure**. That accounting trips the SPEC-020-R005 threshold and invokes the signed-recovery rail — which hits the **same** gate and fails again: a `failure → R005 → failure` loop that never converges. The caller's accepted-session re-observation counter compounded it, climbing every interval regardless of the primary outcome. Reporting the operator handoff as a non-failure skip stops the loop and gives the operator one stable, actionable reason.

## Safety boundary

SPEC-020 keeps `headless_fleet` outside consumer recurring autoupdate (R-4.13). This changes only eligibility diversion, the reported reason, and R005 failure accounting — not eligibility of consumer nodes, not any R-2 safety invariant, not the live service, not rollback. Diverting before the topology gate closes the R-4.13 hole where a headless node with a stale/loaded consumer LaunchAgent could be driven into mutation. A proven consumer topology continues normally; a genuinely unrecognized non-headless topology still fails closed as `unsupported_install_topology`.

## Verification

- `swift build`: passed.
- `swift test --filter AutoUpdateTests`: 98 passed, 0 failures.
- `swift test` CoordinatorClient accepted-session suite: passed, incl. new `testAcceptedSessionHeadlessProviderNeverAccruesR005` (headless counter stays 0) with consumer accrual unaffected.
- `testDefaultHeadlessOperatorManagedTopologyDetermination` covers custody / manifest headless / manifest system-domain / invalid-manifest fail-closed / plist-present / launchd-loaded / launchd-indeterminate.
- `python3 scripts/check_spec_governance.py --base-ref origin/main`, `gen_spec_index.py --check` / `--lint`: passed.
- Three independent 3-lane codex audit rounds (code / security / architecture) over the full combined diff, folded to **0 CRITICAL / 0 HIGH / 0 MEDIUM**.

### Carried LOW / out-of-scope

- Installer/watchdog-side recovery in `phase3-binary/dist/install.sh` still logs `unsupported_install_topology profile=headless_fleet` for the local watchdog path. Left as-is here to avoid colliding with #1334's installer rewrite; the provider autoupdate **event** stream now uses the actionable reason. Follow-up candidate.

Supersedes the updater portion of the parallel proposal in #1326 (closed). Closes the updater actionable-reason gap left open by #1324/#1334.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R005"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "phase3-binary/Tests/macprovider-cliTests/AutoUpdateTests.swift",
    "phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift"
  ],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/1324"
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
