### PR TITLE
Enable isolated SPEC-032 physical canary proof

### DIFF
--- a/journeys/evidence/provider-prebeta-admission-spec032-strict-localwifi-20260902T090901Z.partial.json
+++ b/journeys/evidence/provider-prebeta-admission-spec032-strict-localwifi-20260902T090901Z.partial.json
@@ -1,0 +1,215 @@
+{
+  "schema_version": "macprovider.journey-evidence.partial.v1",
+  "journey_id": "JOURNEY-PROVIDER-PREBETA-ADMISSION",
+  "run_id": "provider-prebeta-admission-spec032-strict-localwifi-20260902T090901Z",
+  "requirement_ids": [
+    "SPEC-032-R001",
+    "SPEC-032-R002",
+    "SPEC-032-R003"
+  ],
+  "capture": {
+    "captured_at": "2026-09-02T10:10:28Z",
+    "captured_by": "provider-prebeta-operator",
+    "repository_commit": "47a682678d772f17b473b552176a56beca512f09",
+    "candidate_build_identity": "v1.8.118-24-g47a68267",
+    "artifact_scope": "partial-physical-evidence",
+    "status": "blocked-before-signed-conformance-promotion",
+    "blocking_verdict": "The isolated physical canary captured useful SPEC-032 strict-gate evidence for stale-evidence exclusion, tuple-mismatch exclusion, evidence-absent sandboxing, and reload revalidation. It did not complete the full promotable matrix: R001 over-ceiling/uncatalogued heartbeat transitions were not safely executable through the shipped physical CLI, R002 missing-admitted-tuple was not physically exercised, and R003 hot-enable fail-closed reload from gate-off to gate-on was not physically exercised.",
+    "conformance_promotion": "not-promoted; no specs/CONFORMANCE.json row is updated from this partial artifact.",
+    "redaction": {
+      "provider_ids": "stable sha256 fingerprints retained; raw provider IDs omitted",
+      "assigned_session_ids": "omitted",
+      "machine_identities": "stable sha256 fingerprints retained where needed",
+      "operator_credentials": "omitted",
+      "buyer_tokens": "omitted",
+      "hostnames": "omitted",
+      "lan_ips": "omitted",
+      "secrets": "omitted"
+    }
+  },
+  "environment": {
+    "class": "isolated-local-canary-coordinator",
+    "coordinator_fingerprint": "f5f40c72dff02be3ee2f75c7f422888f2bf2ea6bd8a7f05c672aae581d4c3542",
+    "production_surface": "not touched; Pearl production coordinator and production provider cohort were out of scope",
+    "provider_cohort": {
+      "subject_fingerprint": "010c16fae8c184b9d80c91911ef890838b54dd3a6873f9a9d7b23451d852d181",
+      "control_fingerprint": "af603ab15c3d5e1183dda42fed627c0d4d4e89cc137c7aabf7f3b581976fe704",
+      "sandbox_fingerprint": "dfd70bb11045c87e8cf596285203e328acfa6170e306b3abc1af1b68e4e698c1"
+    },
+    "config_under_test": {
+      "autotune.require_autotune_hello_gate": true,
+      "autotune.enforce_provider_admission": true,
+      "autotune.autotune_evidence_ttl_days": 30,
+      "proof_of_weights.reload_path": "SIGHUP reloadCoordinatorConfig to SetProofOfWeightsConfig and revalidation"
+    },
+    "rollback": {
+      "autotune.require_autotune_hello_gate": false,
+      "coordinator_config_validated_after_rollback": true,
+      "canary_pool_drained_after_run": true,
+      "final_pool_summary": {
+        "total_providers": 0,
+        "ready": 0,
+        "policy_ready": 0,
+        "total_slots": 0,
+        "free_slots": 0
+      }
+    }
+  },
+  "evidence_inputs": {
+    "capture_file_sha256": {
+      "baseline_pool": "eb7c88972c4be9c0beefe8b006a150b1596a2c844a4f73f6fb1ac44ae6891173",
+      "s2_expiry_after": "9c2281f2204b748f7d6aa21c9d1846ba2b29525ef66e4bbfb7270780446854cd",
+      "s2_recover_after": "ac9d328618a0c7b34ed76449be94b5ada6be64eb97c53f8b3a624aafcea5daa4",
+      "s2_tuple_after": "2d732655cde4c6c72b1a276859460c4e43d5c60dc877033f15bd424a7f77115f",
+      "s3_sandbox_after": "320d3e9fd661e61550b2f0a4f6d2dbfdeabbb69418e7010e3be17a5954acd93b",
+      "s3_reload_after": "bfe3bf1a02c8630ca00804dde882542d8f09f14bbd5db34bdc63e24227f85082",
+      "s2_expiry_buyer_smoke": "8848c13816ef9fb5ae2d1e2cda7ed8922750b7bb4aa9cdf69fe65f6118ecf7b3",
+      "s3_control_readiness": "f3a6d735d0ffe4c71377cb41c18f3b10e54ddbd17745be7653291e430f60f830",
+      "s3_sandbox_readiness": "b2ad3aa8d436b638098158d579798d6a2a470a43bf45192214e9ef5fa800b474"
+    },
+    "physical_verifier": {
+      "subject_status": "verified",
+      "control_status": "verified",
+      "decision_reason": "hardware-verifier.v2:verified_trusted_hardware",
+      "sandbox_evidence_rows": 0
+    },
+    "catalog_model": {
+      "model_key": "meta-llama/llama-3.2-3b-instruct",
+      "model_id": "mlx-community/Llama-3.2-3B-Instruct-4bit",
+      "artifact_sha256": "e7e5bff4248768b4db7a53afb3b514ba5867b800f63d1abd0330eaf08e54aa90",
+      "min_ram_gb": 4
+    }
+  },
+  "observations": {
+    "baseline": {
+      "summary": {
+        "total_providers": 2,
+        "ready": 2,
+        "policy_ready": 2,
+        "total_slots": 2,
+        "free_slots": 2
+      },
+      "subject": {
+        "routing_eligible": true,
+        "max_admitted_min_ram_gb": 4
+      },
+      "control": {
+        "routing_eligible": true,
+        "max_admitted_min_ram_gb": 4
+      }
+    },
+    "r002_expiry_subcase": {
+      "trigger": "isolated canary verifier timestamp aged past the configured 30 day TTL for the subject only",
+      "subject_after": {
+        "routing_eligible": false,
+        "admission_evidence_stale": true,
+        "non_admission_reason": "autotune_evidence_expired"
+      },
+      "control_after": {
+        "routing_eligible": true,
+        "buyer_serving": true
+      },
+      "buyer_smoke": {
+        "http_status": 200,
+        "route_excluded_subject_not_selected": true
+      }
+    },
+    "r002_recovery_subcase": {
+      "trigger": "subject verifier generated_at restored from its submitted physical evidence payload",
+      "subject_after": {
+        "routing_eligible": true,
+        "admission_evidence_stale": false
+      },
+      "control_after": {
+        "routing_eligible": true
+      }
+    },
+    "r002_tuple_mismatch_subcase": {
+      "trigger": "isolated canary verified tuple changed to a different unified-memory value for the subject only",
+      "subject_after": {
+        "routing_eligible": false,
+        "admission_evidence_stale": true,
+        "non_admission_reason": "autotune_evidence_tuple_mismatch"
+      },
+      "control_after": {
+        "routing_eligible": true,
+        "buyer_serving": true
+      }
+    },
+    "r003_evidence_absent_sandbox_subcase": {
+      "trigger": "sandbox provider connected under strict hello gate with no verified in-window evidence rows",
+      "sandbox_after": {
+        "routing_eligible": false,
+        "admission_sandboxed": true,
+        "buyer_serving": false,
+        "non_admission_reason": "autotune_evidence_required",
+        "durable_provider_credentials_minted": false
+      },
+      "control_after": {
+        "routing_eligible": true,
+        "buyer_serving": true
+      }
+    },
+    "r003_same_config_reload_subcase": {
+      "trigger": "proof-of-weights SIGHUP reload while the evidence-absent sandbox session was present and strict gate was already enabled",
+      "sandbox_after": {
+        "routing_eligible": false,
+        "admission_sandboxed": true,
+        "buyer_serving": false
+      },
+      "control_after": {
+        "routing_eligible": true
+      },
+      "fail_closed_window_observed": true
+    },
+    "advisory_bench_gate": {
+      "provider_apply_warnings_observed": [
+        "tps_below_gate",
+        "ttft_above_gate"
+      ],
+      "exclusion_or_sandbox_reason_cited_bench_gate": false,
+      "reason": "Captured exclusion/sandbox reasons were autotune_evidence_expired, autotune_evidence_tuple_mismatch, and autotune_evidence_required."
+    }
+  },
+  "requirement_gate_result": {
+    "SPEC-032-R001": {
+      "status": "not_promotable",
+      "missing_physical_subcases": [
+        "over-ceiling heartbeat route-exclusion",
+        "uncatalogued heartbeat route-exclusion",
+        "in-ceiling heartbeat clears exclusion"
+      ],
+      "blocker": "The shipped physical CLI model switch path requires local signed artifact authority and would attempt real model loading; no safe metadata-only heartbeat transition hook exists for the physical canary."
+    },
+    "SPEC-032-R002": {
+      "status": "partial-pass-not-promotable",
+      "passed_physical_subcases": [
+        "expired evidence route-excludes subject while control remains routable",
+        "tuple-mismatched evidence route-excludes subject while control remains routable",
+        "restored evidence clears stale exclusion"
+      ],
+      "missing_physical_subcases": [
+        "missing admitted tuple route-excludes capped subject"
+      ],
+      "blocker": "The missing admitted tuple is an in-memory live-session condition; the physical coordinator API has no safe canary-only mutation hook to clear it after admission."
+    },
+    "SPEC-032-R003": {
+      "status": "partial-pass-not-promotable",
+      "passed_physical_subcases": [
+        "evidence-absent strict-gate provider is sandboxed, unroutable, and not buyer-serving",
+        "sandbox provider did not mint a durable bootstrap identity",
+        "same-config proof-of-weights reload preserved fail-closed routing for the sandbox provider and kept the control routable"
+      ],
+      "missing_physical_subcases": [
+        "hot-enable reload from gate-off to gate-on with an existing unverified session present"
+      ],
+      "blocker": "The physical run did not execute the exact gate-off to gate-on reload sequence required by the promotable harness."
+    }
+  },
+  "promotion": {
+    "signed_journey_result_eligible": false,
+    "protected_acceptance_workflow_run": false,
+    "conformance_json_updated": false,
+    "issue_959_close_eligible": false
+  }
+}

--- a/journeys/evidence/provider-prebeta-admission-spec032-strict-localwifi-20260902T090901Z.partial.json
+++ b/journeys/evidence/provider-prebeta-admission-spec032-strict-localwifi-20260902T090901Z.partial.json
@@ -37,13 +37,13 @@
       "sandbox_fingerprint": "dfd70bb11045c87e8cf596285203e328acfa6170e306b3abc1af1b68e4e698c1"
     },
     "config_under_test": {
-      "autotune.require_autotune_hello_gate": true,
+      "proof_of_weights.require_autotune_hello_gate": true,
       "autotune.enforce_provider_admission": true,
-      "autotune.autotune_evidence_ttl_days": 30,
+      "proof_of_weights.autotune_evidence_ttl_days": 30,
       "proof_of_weights.reload_path": "SIGHUP reloadCoordinatorConfig to SetProofOfWeightsConfig and revalidation"
     },
     "rollback": {
-      "autotune.require_autotune_hello_gate": false,
+      "proof_of_weights.require_autotune_hello_gate": false,
       "coordinator_config_validated_after_rollback": true,
       "canary_pool_drained_after_run": true,
       "final_pool_summary": {

--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -148,6 +148,9 @@ actor CoordinatorClient {
 
     static let binaryVersion = "1.8.117"
     private static let keepaliveDebugEnabled = ProcessInfo.processInfo.environment["MACPROVIDER_KEEPALIVE_DEBUG"] == "1"
+    private static let admissionCanaryHeartbeatOverridePathEnv = "MACPROVIDER_CANARY_HEARTBEAT_OVERRIDE_PATH"
+    private static let admissionCanaryCoordinatorHostEnv = "MACPROVIDER_CANARY_COORDINATOR_HOST"
+    private static let productionCoordinatorHosts: Set<String> = ["coordinator.malibu.tech"]
 
     private let coordinatorURL: URL
     private let appConfig: AppConfig
@@ -5199,7 +5202,6 @@ actor CoordinatorClient {
         if let event = await AutoUpdateEventStore.shared.lastWireObject() {
             payload["last_autoupdate_event"] = event
         }
-        try applyAdmissionCanaryHeartbeatOverride(to: &payload)
         let observedAt = Date()
         payload["safety_telemetry"] = snapshot.safetyTelemetry(
             providerID: providerID,
@@ -5217,13 +5219,19 @@ actor CoordinatorClient {
     }
 
     private func applyAdmissionCanaryHeartbeatOverride(to payload: inout [String: Any]) throws {
-        guard let rawPath = Darwin.getenv("MACPROVIDER_CANARY_HEARTBEAT_OVERRIDE_PATH") else {
+        guard payload["type"] as? String == "heartbeat" else {
             return
         }
+        guard let rawPath = Darwin.getenv(Self.admissionCanaryHeartbeatOverridePathEnv) else {
+            return
+        }
+        #if DEBUG || MACPROVIDER_ADMISSION_CANARY
+        try validateAdmissionCanaryOverrideCoordinator()
         let path = String(cString: rawPath).trimmingCharacters(in: .whitespacesAndNewlines)
         guard !path.isEmpty else {
             return
         }
+        try Self.validateAdmissionCanaryOverrideFile(path: path)
         let data = try Data(contentsOf: URL(fileURLWithPath: path))
         guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             throw CoordinatorAuthError.invalidMessage("canary heartbeat override must be a JSON object")
@@ -5267,6 +5275,73 @@ actor CoordinatorClient {
             throw CoordinatorAuthError.invalidMessage("unsupported canary heartbeat override field \(key)")
         }
         payload["type"] = "heartbeat"
+        if var safetyTelemetry = payload["safety_telemetry"] as? [String: Any] {
+            safetyTelemetry["model_id"] = payload["model_id"]
+            if let modelHash = payload["model_hash"] {
+                safetyTelemetry["model_hash"] = modelHash
+            }
+            if let modelHashAlgorithm = payload["model_hash_algorithm"] {
+                safetyTelemetry["model_hash_algorithm"] = modelHashAlgorithm
+            }
+            if let weightsManifestSHA256 = payload["weights_manifest_sha256"] {
+                safetyTelemetry["weights_manifest_sha256"] = weightsManifestSHA256
+                safetyTelemetry["weights_manifest_algorithm"] = payload["weights_manifest_algorithm"] ?? ModelArtifactIdentity.safetensorsManifestV1
+            }
+            payload["safety_telemetry"] = safetyTelemetry
+        }
+        #else
+        _ = rawPath
+        throw CoordinatorAuthError.invalidMessage("canary heartbeat override is not available in production builds")
+        #endif
+    }
+
+    private func validateAdmissionCanaryOverrideCoordinator() throws {
+        guard let rawHost = coordinatorURL.host,
+              let host = Self.canonicalAdmissionCanaryCoordinatorHost(rawHost),
+              !host.isEmpty
+        else {
+            throw CoordinatorAuthError.invalidMessage("canary heartbeat override requires a coordinator host")
+        }
+        guard !Self.productionCoordinatorHosts.contains(host) else {
+            throw CoordinatorAuthError.invalidMessage("canary heartbeat override refuses production coordinator host")
+        }
+        guard let rawExpectedHost = Darwin.getenv(Self.admissionCanaryCoordinatorHostEnv) else {
+            throw CoordinatorAuthError.invalidMessage("canary heartbeat override requires \(Self.admissionCanaryCoordinatorHostEnv)")
+        }
+        guard let expectedHost = Self.canonicalAdmissionCanaryCoordinatorHost(String(cString: rawExpectedHost)),
+              expectedHost == host
+        else {
+            throw CoordinatorAuthError.invalidMessage("canary heartbeat override coordinator host mismatch")
+        }
+    }
+
+    private static func canonicalAdmissionCanaryCoordinatorHost(_ raw: String) -> String? {
+        let host = raw
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .trimmingCharacters(in: CharacterSet(charactersIn: "."))
+        return host.isEmpty ? nil : host
+    }
+
+    private static func validateAdmissionCanaryOverrideFile(path: String) throws {
+        let attrs = try FileManager.default.attributesOfItem(atPath: path)
+        guard attrs[.type] as? FileAttributeType == .typeRegular else {
+            throw CoordinatorAuthError.invalidMessage("canary heartbeat override must be a regular file")
+        }
+        let size = (attrs[.size] as? NSNumber)?.uint64Value ?? 0
+        guard size <= 8_192 else {
+            throw CoordinatorAuthError.invalidMessage("canary heartbeat override file is too large")
+        }
+        #if os(macOS)
+        let owner = (attrs[.ownerAccountID] as? NSNumber)?.uint32Value
+        guard owner == Darwin.geteuid() else {
+            throw CoordinatorAuthError.invalidMessage("canary heartbeat override file must be owned by the current user")
+        }
+        let mode = (attrs[.posixPermissions] as? NSNumber)?.uint16Value ?? 0
+        guard mode & 0o077 == 0 else {
+            throw CoordinatorAuthError.invalidMessage("canary heartbeat override file must not be group/world accessible")
+        }
+        #endif
     }
 
     private func sendStateUpdate(state newState: ProviderHealthState?, reason: String) async throws {
@@ -5576,12 +5651,14 @@ actor CoordinatorClient {
     }
 
     private func send(_ payload: sending [String: Any]) async throws {
+        var outbound = payload
+        try applyAdmissionCanaryHeartbeatOverride(to: &outbound)
         if let sendOverride {
-            try await sendOverride(payload)
+            try await sendOverride(outbound)
             return
         }
         guard let webSocket else { throw CancellationError() }
-        try await Self.send(payload, to: webSocket)
+        try await Self.send(outbound, to: webSocket)
     }
 
     private func send(_ payload: [String: Any], to webSocket: ProviderWebSocketTask) async throws {

--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -5199,6 +5199,7 @@ actor CoordinatorClient {
         if let event = await AutoUpdateEventStore.shared.lastWireObject() {
             payload["last_autoupdate_event"] = event
         }
+        try applyAdmissionCanaryHeartbeatOverride(to: &payload)
         let observedAt = Date()
         payload["safety_telemetry"] = snapshot.safetyTelemetry(
             providerID: providerID,
@@ -5213,6 +5214,59 @@ actor CoordinatorClient {
             validForMS: 90_000
         )
         try await send(payload)
+    }
+
+    private func applyAdmissionCanaryHeartbeatOverride(to payload: inout [String: Any]) throws {
+        guard let rawPath = Darwin.getenv("MACPROVIDER_CANARY_HEARTBEAT_OVERRIDE_PATH") else {
+            return
+        }
+        let path = String(cString: rawPath).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !path.isEmpty else {
+            return
+        }
+        let data = try Data(contentsOf: URL(fileURLWithPath: path))
+        guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw CoordinatorAuthError.invalidMessage("canary heartbeat override must be a JSON object")
+        }
+        let stringFields: Set<String> = [
+            "model_id",
+            "model_hash",
+            "model_hash_algorithm",
+            "weights_manifest_sha256",
+            "weights_manifest_algorithm",
+            "catalog_release_id",
+            "catalog_policy_version",
+            "catalog_candidate_sha256",
+            "catalog_signer_key_id",
+            "catalog_row_identity",
+        ]
+        for (key, value) in object {
+            if key == "type" {
+                continue
+            }
+            if stringFields.contains(key) {
+                guard let string = value as? String,
+                      !string.isEmpty,
+                      string.utf8.count <= 256
+                else {
+                    throw CoordinatorAuthError.invalidMessage("invalid canary heartbeat override string field \(key)")
+                }
+                payload[key] = string
+                continue
+            }
+            if key == "model_params_b" {
+                guard let number = value as? NSNumber,
+                      number.doubleValue >= 0,
+                      number.doubleValue <= 10_000
+                else {
+                    throw CoordinatorAuthError.invalidMessage("invalid canary heartbeat override model_params_b")
+                }
+                payload[key] = number.doubleValue
+                continue
+            }
+            throw CoordinatorAuthError.invalidMessage("unsupported canary heartbeat override field \(key)")
+        }
+        payload["type"] = "heartbeat"
     }
 
     private func sendStateUpdate(state newState: ProviderHealthState?, reason: String) async throws {

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -1,9 +1,62 @@
 import CryptoKit
+import Darwin
 import MacProviderCore
 import XCTest
 @testable import macprovider_cli
 
 final class CoordinatorClientTests: XCTestCase {
+    func testCanaryHeartbeatOverrideRewritesOnlyAdmissionMetadata() async throws {
+        let recorder = CoordinatorFrameRecorder()
+        let overrideURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("macprovider-canary-heartbeat-\(UUID().uuidString).json")
+        let modelHash = String(repeating: "a", count: 64)
+        let override: [String: Any] = [
+            "type": "state_update",
+            "model_id": "spec032/uncatalogued-canary",
+            "model_hash": modelHash,
+            "model_hash_algorithm": ModelArtifactIdentity.snapshotManifestV1,
+            "weights_manifest_sha256": String(repeating: "b", count: 64),
+            "weights_manifest_algorithm": ModelArtifactIdentity.safetensorsManifestV1,
+            "catalog_release_id": "canary-release",
+            "catalog_policy_version": "canary-policy",
+            "catalog_candidate_sha256": String(repeating: "c", count: 64),
+            "catalog_signer_key_id": "canary-signer",
+            "catalog_row_identity": String(repeating: "d", count: 64),
+            "model_params_b": 120.5,
+        ]
+        let data = try JSONSerialization.data(withJSONObject: override, options: [.sortedKeys])
+        try data.write(to: overrideURL, options: .atomic)
+        defer { try? FileManager.default.removeItem(at: overrideURL) }
+
+        setenv("MACPROVIDER_CANARY_HEARTBEAT_OVERRIDE_PATH", overrideURL.path, 1)
+        defer { unsetenv("MACPROVIDER_CANARY_HEARTBEAT_OVERRIDE_PATH") }
+
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 2),
+            modelHash: String(repeating: "e", count: 64),
+            modelHashAlgorithm: ModelArtifactIdentity.snapshotManifestV1
+        )
+        let client = try await makeClient(status: status, recorder: recorder)
+
+        try await client.sendHeartbeatForTest()
+
+        let frames = await recorder.frames
+        let heartbeat = try XCTUnwrap(frames.last)
+        XCTAssertEqual(heartbeat["type"] as? String, "heartbeat")
+        XCTAssertEqual(heartbeat["model_id"] as? String, "spec032/uncatalogued-canary")
+        XCTAssertEqual(heartbeat["model_hash"] as? String, modelHash)
+        XCTAssertEqual(heartbeat["weights_manifest_sha256"] as? String, String(repeating: "b", count: 64))
+        XCTAssertEqual(heartbeat["catalog_release_id"] as? String, "canary-release")
+        XCTAssertEqual(heartbeat["catalog_row_identity"] as? String, String(repeating: "d", count: 64))
+        XCTAssertEqual(heartbeat["model_params_b"] as? Double, 120.5)
+        XCTAssertEqual(heartbeat["status"] as? String, "ready")
+        XCTAssertEqual(heartbeat["slots_total"] as? Int, 2)
+        let safetyTelemetry = try XCTUnwrap(heartbeat["safety_telemetry"] as? [String: Any])
+        XCTAssertEqual(safetyTelemetry["model_id"] as? String, "spec032/uncatalogued-canary")
+    }
+
     func testDiagnosticStatusPayloadIsRedactedAndMatchesProviderSnapshot() async throws {
         let recorder = CoordinatorFrameRecorder()
         let modelHash = String(repeating: "a", count: 64)

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -26,10 +26,15 @@ final class CoordinatorClientTests: XCTestCase {
         ]
         let data = try JSONSerialization.data(withJSONObject: override, options: [.sortedKeys])
         try data.write(to: overrideURL, options: .atomic)
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: overrideURL.path)
         defer { try? FileManager.default.removeItem(at: overrideURL) }
 
         setenv("MACPROVIDER_CANARY_HEARTBEAT_OVERRIDE_PATH", overrideURL.path, 1)
-        defer { unsetenv("MACPROVIDER_CANARY_HEARTBEAT_OVERRIDE_PATH") }
+        setenv("MACPROVIDER_CANARY_COORDINATOR_HOST", "127.0.0.1", 1)
+        defer {
+            unsetenv("MACPROVIDER_CANARY_HEARTBEAT_OVERRIDE_PATH")
+            unsetenv("MACPROVIDER_CANARY_COORDINATOR_HOST")
+        }
 
         let status = ProviderStatus(
             modelID: "model-a",
@@ -55,6 +60,91 @@ final class CoordinatorClientTests: XCTestCase {
         XCTAssertEqual(heartbeat["slots_total"] as? Int, 2)
         let safetyTelemetry = try XCTUnwrap(heartbeat["safety_telemetry"] as? [String: Any])
         XCTAssertEqual(safetyTelemetry["model_id"] as? String, "spec032/uncatalogued-canary")
+    }
+
+    func testCanaryHeartbeatOverrideRequiresCoordinatorHostBinding() async throws {
+        let recorder = CoordinatorFrameRecorder()
+        let overrideURL = try writeMinimalCanaryHeartbeatOverride()
+        defer { try? FileManager.default.removeItem(at: overrideURL) }
+        setenv("MACPROVIDER_CANARY_HEARTBEAT_OVERRIDE_PATH", overrideURL.path, 1)
+        defer {
+            unsetenv("MACPROVIDER_CANARY_HEARTBEAT_OVERRIDE_PATH")
+            unsetenv("MACPROVIDER_CANARY_COORDINATOR_HOST")
+        }
+
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 2)
+        )
+        let client = try await makeClient(status: status, recorder: recorder)
+
+        do {
+            try await client.sendHeartbeatForTest()
+            XCTFail("heartbeat override without host binding should fail")
+        } catch {
+            XCTAssertTrue(String(describing: error).contains("MACPROVIDER_CANARY_COORDINATOR_HOST"), "\(error)")
+        }
+    }
+
+    func testCanaryHeartbeatOverrideRejectsProductionCoordinatorHost() async throws {
+        try await assertCanaryHeartbeatOverrideRejectsProductionCoordinator(
+            coordinatorURL: "wss://coordinator.malibu.tech/ws/provider",
+            expectedHost: "coordinator.malibu.tech"
+        )
+    }
+
+    func testCanaryHeartbeatOverrideRejectsProductionCoordinatorTrailingDotHost() async throws {
+        try await assertCanaryHeartbeatOverrideRejectsProductionCoordinator(
+            coordinatorURL: "wss://coordinator.malibu.tech./ws/provider",
+            expectedHost: "coordinator.malibu.tech."
+        )
+    }
+
+    private func assertCanaryHeartbeatOverrideRejectsProductionCoordinator(
+        coordinatorURL: String,
+        expectedHost: String
+    ) async throws {
+        let recorder = CoordinatorFrameRecorder()
+        let overrideURL = try writeMinimalCanaryHeartbeatOverride()
+        defer { try? FileManager.default.removeItem(at: overrideURL) }
+        setenv("MACPROVIDER_CANARY_HEARTBEAT_OVERRIDE_PATH", overrideURL.path, 1)
+        setenv("MACPROVIDER_CANARY_COORDINATOR_HOST", expectedHost, 1)
+        defer {
+            unsetenv("MACPROVIDER_CANARY_HEARTBEAT_OVERRIDE_PATH")
+            unsetenv("MACPROVIDER_CANARY_COORDINATOR_HOST")
+        }
+
+        let status = ProviderStatus(
+            modelID: "model-a",
+            modelLoaded: true,
+            capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 2)
+        )
+        let client = try await makeClient(
+            status: status,
+            recorder: recorder,
+            coordinatorURL: coordinatorURL
+        )
+
+        do {
+            try await client.sendHeartbeatForTest()
+            XCTFail("heartbeat override against Pearl should fail")
+        } catch {
+            XCTAssertTrue(String(describing: error).contains("production coordinator host"), "\(error)")
+        }
+    }
+
+    private func writeMinimalCanaryHeartbeatOverride() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("macprovider-canary-heartbeat-\(UUID().uuidString).json")
+        let object: [String: Any] = [
+            "model_id": "spec032/canary-small",
+            "model_hash": String(repeating: "a", count: 64),
+        ]
+        let data = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+        try data.write(to: url, options: .atomic)
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+        return url
     }
 
     func testDiagnosticStatusPayloadIsRedactedAndMatchesProviderSnapshot() async throws {
@@ -6006,11 +6096,12 @@ final class CoordinatorClientTests: XCTestCase {
         credentialStore: ProviderCredentialStoreKind = .keychain,
         providerCredentialStore: any ProviderCredentialStoring = KeychainProviderCredentialStore(),
         credentialStatusRuntime: ProviderCredentialStatusRuntime = ProviderCredentialStatusRuntime(.unconfigured),
-        admissionIdentityStatusRuntime: ProviderAdmissionIdentityStatusRuntime = ProviderAdmissionIdentityStatusRuntime()
+        admissionIdentityStatusRuntime: ProviderAdmissionIdentityStatusRuntime = ProviderAdmissionIdentityStatusRuntime(),
+        coordinatorURL: String = "wss://127.0.0.1:8444/ws/provider"
     ) async throws -> CoordinatorClient {
         var config = AppConfig.defaults(configPath: configPath)
         config.credentialStore = credentialStore
-        config.coordinatorURL = "wss://127.0.0.1:8444/ws/provider"
+        config.coordinatorURL = coordinatorURL
         config.providerID = "provider-test"
         config.providerToken = providerToken
         config.model = "model-a"

--- a/phase4-coordinator/internal/config/config.go
+++ b/phase4-coordinator/internal/config/config.go
@@ -88,6 +88,7 @@ type Config struct {
 	MalibuEmission               MalibuEmissionConfig         `yaml:"malibu_emission"`
 	AutotuneFeeds                AutotuneFeedsConfig          `yaml:"autotune"`
 	ProofOfWeights               ProofOfWeightsConfig         `yaml:"proof_of_weights"`
+	AdmissionCanaryHarness       AdmissionCanaryHarnessConfig `yaml:"admission_canary_harness"`
 	Proxy                        ProxyConfig                  `yaml:"proxy"`
 	Providers                    []ProviderConfig             `yaml:"providers"`
 	// Payout is the SPEC-016 payout-pipeline configuration.
@@ -240,6 +241,13 @@ type ProofOfWeightsConfig struct {
 	RequireAutotuneHelloGate bool                 `yaml:"require_autotune_hello_gate"`
 	AutotuneEvidenceTTLDays  int                  `yaml:"autotune_evidence_ttl_days"`
 	TelemetryDrift           TelemetryDriftConfig `yaml:"telemetry_drift"`
+}
+
+// AdmissionCanaryHarness exposes canary-only operator controls used to collect
+// SPEC-032 physical-run evidence. The default is disabled so production
+// coordinators do not mount the endpoints.
+type AdmissionCanaryHarnessConfig struct {
+	Enabled bool `yaml:"enabled"`
 }
 
 // TelemetryDriftConfig enables observe-only operator alerts when live

--- a/phase4-coordinator/internal/pool/provider.go
+++ b/phase4-coordinator/internal/pool/provider.go
@@ -1970,6 +1970,27 @@ func (r *Registry) SetAdmissionGateFlags(providerID, assignedID string, flags Ad
 	return prior, changed, true
 }
 
+// ClearAdmittedTupleForCanary removes only the admitted hardware tuple for a
+// live session so an isolated SPEC-032 canary can prove the missing-tuple
+// revalidation path against a physical provider. It intentionally does not
+// change model, ceiling, health, or routing flags.
+func (r *Registry) ClearAdmittedTupleForCanary(providerID, assignedID string) (before Provider, after Provider, ok bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	p := r.providers[providerID]
+	if p == nil || (assignedID != "" && p.AssignedID != assignedID) {
+		return Provider{}, Provider{}, false
+	}
+	before = *p
+	p.AdmittedHardwareIdentityHash = ""
+	p.AdmittedChipNormalized = ""
+	p.AdmittedUnifiedMemoryGB = 0
+	after = *p
+	before.conn = nil
+	after.conn = nil
+	return before, after, true
+}
+
 // QuarantineForProofOfWeightsReload marks every live session fail-closed before
 // a proof_of_weights hot reload is published. The post-publish revalidation pass
 // clears sessions that prove under the new generation.

--- a/phase4-coordinator/internal/pool/provider.go
+++ b/phase4-coordinator/internal/pool/provider.go
@@ -1978,7 +1978,7 @@ func (r *Registry) ClearAdmittedTupleForCanary(providerID, assignedID string) (b
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	p := r.providers[providerID]
-	if p == nil || (assignedID != "" && p.AssignedID != assignedID) {
+	if p == nil || assignedID == "" || p.AssignedID != assignedID {
 		return Provider{}, Provider{}, false
 	}
 	before = *p

--- a/phase4-coordinator/internal/ws/admission_canary_harness.go
+++ b/phase4-coordinator/internal/ws/admission_canary_harness.go
@@ -1,0 +1,150 @@
+package ws
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/augstar/macprovider-coordinator/internal/config"
+	"github.com/augstar/macprovider-coordinator/internal/pool"
+)
+
+type admissionCanaryProviderSnapshot struct {
+	ProviderID                       string `json:"provider_id"`
+	AssignedID                       string `json:"assigned_id"`
+	ModelID                          string `json:"model_id"`
+	RoutingEligible                  bool   `json:"routing_eligible"`
+	ServingCapable                   bool   `json:"serving_capable"`
+	AdmissionCeilingExcluded         bool   `json:"admission_ceiling_excluded"`
+	AdmissionEvidenceStale           bool   `json:"admission_evidence_stale"`
+	AdmissionSandboxed               bool   `json:"admission_sandboxed"`
+	MaxAdmittedModelID               string `json:"max_admitted_model_id"`
+	MaxAdmittedMinRAMGB              int    `json:"max_admitted_min_ram_gb"`
+	HasAdmittedTuple                 bool   `json:"has_admitted_tuple"`
+	AdmissionSandboxCredentialBypass bool   `json:"admission_sandbox_credential_bypassed"`
+}
+
+func admissionCanarySnapshot(p pool.Provider) admissionCanaryProviderSnapshot {
+	return admissionCanaryProviderSnapshot{
+		ProviderID:                       p.ProviderID,
+		AssignedID:                       p.AssignedID,
+		ModelID:                          p.ModelID,
+		RoutingEligible:                  p.RoutingEligible(),
+		ServingCapable:                   p.ServingCapable(),
+		AdmissionCeilingExcluded:         p.AdmissionCeilingExcluded,
+		AdmissionEvidenceStale:           p.AdmissionEvidenceStale,
+		AdmissionSandboxed:               p.AdmissionSandboxed,
+		MaxAdmittedModelID:               p.MaxAdmittedModelID,
+		MaxAdmittedMinRAMGB:              p.MaxAdmittedMinRAMGB,
+		HasAdmittedTuple:                 providerHasAdmittedTuple(p),
+		AdmissionSandboxCredentialBypass: p.AdmissionSandboxCredentialBypassed,
+	}
+}
+
+func (s *Server) handleAdmissionCanaryClearAdmittedTuple(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !s.cfg.AdmissionCanaryHarness.Enabled {
+		writeJSON(w, http.StatusNotFound, map[string]any{"error": map[string]any{"message": "admission canary harness disabled", "code": "not_found"}})
+		return
+	}
+	if !s.authorizedOperator(r) {
+		writeJSON(w, http.StatusUnauthorized, map[string]any{"error": map[string]any{"message": "unauthorized", "code": "invalid_operator_token"}})
+		return
+	}
+	var req struct {
+		ProviderID string `json:"provider_id"`
+		AssignedID string `json:"assigned_id,omitempty"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": map[string]any{"message": "invalid json", "code": "invalid_request"}})
+		return
+	}
+	req.ProviderID = strings.TrimSpace(req.ProviderID)
+	req.AssignedID = strings.TrimSpace(req.AssignedID)
+	if err := config.ValidateProviderID(req.ProviderID); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": map[string]any{"message": "invalid provider_id", "code": "invalid_provider_id"}})
+		return
+	}
+	before, after, ok := s.pool.ClearAdmittedTupleForCanary(req.ProviderID, req.AssignedID)
+	if !ok {
+		writeJSON(w, http.StatusNotFound, map[string]any{"error": map[string]any{"message": "provider session not found", "code": "provider_not_found"}})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"status":      "ok",
+		"provider_id": req.ProviderID,
+		"assigned_id": after.AssignedID,
+		"before":      admissionCanarySnapshot(before),
+		"after":       admissionCanarySnapshot(after),
+	})
+}
+
+func (s *Server) handleAdmissionCanaryProofOfWeights(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !s.cfg.AdmissionCanaryHarness.Enabled {
+		writeJSON(w, http.StatusNotFound, map[string]any{"error": map[string]any{"message": "admission canary harness disabled", "code": "not_found"}})
+		return
+	}
+	if !s.authorizedOperator(r) {
+		writeJSON(w, http.StatusUnauthorized, map[string]any{"error": map[string]any{"message": "unauthorized", "code": "invalid_operator_token"}})
+		return
+	}
+	var req struct {
+		RequireAutotuneHelloGate *bool `json:"require_autotune_hello_gate"`
+		AutotuneEvidenceTTLDays  *int  `json:"autotune_evidence_ttl_days,omitempty"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": map[string]any{"message": "invalid json", "code": "invalid_request"}})
+		return
+	}
+	if req.RequireAutotuneHelloGate == nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": map[string]any{"message": "require_autotune_hello_gate is required", "code": "invalid_request"}})
+		return
+	}
+	next := s.proofOfWeightsConfig()
+	next.RequireAutotuneHelloGate = *req.RequireAutotuneHelloGate
+	if req.AutotuneEvidenceTTLDays != nil {
+		if *req.AutotuneEvidenceTTLDays < 0 {
+			writeJSON(w, http.StatusBadRequest, map[string]any{"error": map[string]any{"message": "autotune_evidence_ttl_days must be non-negative", "code": "invalid_request"}})
+			return
+		}
+		next.AutotuneEvidenceTTLDays = *req.AutotuneEvidenceTTLDays
+	}
+	before := admissionCanaryPoolSnapshot(s.pool.Snapshot())
+	reload := s.SetProofOfWeightsConfig(next)
+	after := admissionCanaryPoolSnapshot(s.pool.Snapshot())
+	writeJSON(w, http.StatusOK, map[string]any{
+		"status": "ok",
+		"config": map[string]any{
+			"require_autotune_hello_gate": next.RequireAutotuneHelloGate,
+			"autotune_evidence_ttl_days":  next.AutotuneEvidenceTTLDays,
+		},
+		"reload": map[string]any{
+			"generation":              reload.Generation,
+			"pre_quarantined":         reload.PreQuarantined,
+			"revalidated":             reload.Revalidated,
+			"sandboxed":               reload.Sandboxed,
+			"route_excluded":          reload.RouteExcluded,
+			"still_evidence_stale":    reload.StillEvidenceStale,
+			"cleared_gate_exclusions": reload.ClearedGateExclusions,
+		},
+		"before": before,
+		"after":  after,
+	})
+}
+
+func admissionCanaryPoolSnapshot(providers []pool.Provider) []admissionCanaryProviderSnapshot {
+	out := make([]admissionCanaryProviderSnapshot, 0, len(providers))
+	for _, p := range providers {
+		out = append(out, admissionCanarySnapshot(p))
+	}
+	return out
+}

--- a/phase4-coordinator/internal/ws/admission_canary_harness.go
+++ b/phase4-coordinator/internal/ws/admission_canary_harness.go
@@ -70,6 +70,10 @@ func (s *Server) handleAdmissionCanaryClearAdmittedTuple(w http.ResponseWriter, 
 		writeJSON(w, http.StatusBadRequest, map[string]any{"error": map[string]any{"message": "invalid provider_id", "code": "invalid_provider_id"}})
 		return
 	}
+	if req.AssignedID == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": map[string]any{"message": "assigned_id required", "code": "missing_assigned_id"}})
+		return
+	}
 	before, after, ok := s.pool.ClearAdmittedTupleForCanary(req.ProviderID, req.AssignedID)
 	if !ok {
 		writeJSON(w, http.StatusNotFound, map[string]any{"error": map[string]any{"message": "provider session not found", "code": "provider_not_found"}})

--- a/phase4-coordinator/internal/ws/admission_canary_harness.go
+++ b/phase4-coordinator/internal/ws/admission_canary_harness.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/augstar/macprovider-coordinator/internal/config"
 	"github.com/augstar/macprovider-coordinator/internal/pool"
@@ -84,8 +85,8 @@ func (s *Server) handleAdmissionCanaryClearAdmittedTuple(w http.ResponseWriter, 
 }
 
 func (s *Server) handleAdmissionCanaryProofOfWeights(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		w.Header().Set("Allow", http.MethodPost)
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
@@ -97,48 +98,43 @@ func (s *Server) handleAdmissionCanaryProofOfWeights(w http.ResponseWriter, r *h
 		writeJSON(w, http.StatusUnauthorized, map[string]any{"error": map[string]any{"message": "unauthorized", "code": "invalid_operator_token"}})
 		return
 	}
-	var req struct {
-		RequireAutotuneHelloGate *bool `json:"require_autotune_hello_gate"`
-		AutotuneEvidenceTTLDays  *int  `json:"autotune_evidence_ttl_days,omitempty"`
+	current := s.proofOfWeightsConfig()
+	lastConfig, lastReload, lastAt, haveLastReload := s.LastProofOfWeightsReloadResult()
+	last := map[string]any{
+		"present": haveLastReload,
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"error": map[string]any{"message": "invalid json", "code": "invalid_request"}})
-		return
-	}
-	if req.RequireAutotuneHelloGate == nil {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"error": map[string]any{"message": "require_autotune_hello_gate is required", "code": "invalid_request"}})
-		return
-	}
-	next := s.proofOfWeightsConfig()
-	next.RequireAutotuneHelloGate = *req.RequireAutotuneHelloGate
-	if req.AutotuneEvidenceTTLDays != nil {
-		if *req.AutotuneEvidenceTTLDays < 0 {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": map[string]any{"message": "autotune_evidence_ttl_days must be non-negative", "code": "invalid_request"}})
-			return
+	if haveLastReload {
+		last = map[string]any{
+			"present":     true,
+			"observed_at": lastAt.UTC().Format(time.RFC3339Nano),
+			"config": map[string]any{
+				"require_autotune_hello_gate": lastConfig.RequireAutotuneHelloGate,
+				"autotune_evidence_ttl_days":  lastConfig.AutotuneEvidenceTTLDays,
+			},
+			"result": proofOfWeightsReloadResultJSON(lastReload),
 		}
-		next.AutotuneEvidenceTTLDays = *req.AutotuneEvidenceTTLDays
 	}
-	before := admissionCanaryPoolSnapshot(s.pool.Snapshot())
-	reload := s.SetProofOfWeightsConfig(next)
-	after := admissionCanaryPoolSnapshot(s.pool.Snapshot())
 	writeJSON(w, http.StatusOK, map[string]any{
 		"status": "ok",
 		"config": map[string]any{
-			"require_autotune_hello_gate": next.RequireAutotuneHelloGate,
-			"autotune_evidence_ttl_days":  next.AutotuneEvidenceTTLDays,
+			"require_autotune_hello_gate": current.RequireAutotuneHelloGate,
+			"autotune_evidence_ttl_days":  current.AutotuneEvidenceTTLDays,
 		},
-		"reload": map[string]any{
-			"generation":              reload.Generation,
-			"pre_quarantined":         reload.PreQuarantined,
-			"revalidated":             reload.Revalidated,
-			"sandboxed":               reload.Sandboxed,
-			"route_excluded":          reload.RouteExcluded,
-			"still_evidence_stale":    reload.StillEvidenceStale,
-			"cleared_gate_exclusions": reload.ClearedGateExclusions,
-		},
-		"before": before,
-		"after":  after,
+		"last_reload": last,
+		"pool":        admissionCanaryPoolSnapshot(s.pool.Snapshot()),
 	})
+}
+
+func proofOfWeightsReloadResultJSON(reload ProofOfWeightsReloadResult) map[string]any {
+	return map[string]any{
+		"generation":              reload.Generation,
+		"pre_quarantined":         reload.PreQuarantined,
+		"revalidated":             reload.Revalidated,
+		"sandboxed":               reload.Sandboxed,
+		"route_excluded":          reload.RouteExcluded,
+		"still_evidence_stale":    reload.StillEvidenceStale,
+		"cleared_gate_exclusions": reload.ClearedGateExclusions,
+	}
 }
 
 func admissionCanaryPoolSnapshot(providers []pool.Provider) []admissionCanaryProviderSnapshot {

--- a/phase4-coordinator/internal/ws/admission_canary_harness_test.go
+++ b/phase4-coordinator/internal/ws/admission_canary_harness_test.go
@@ -95,46 +95,94 @@ func TestAdmissionCanaryProofOfWeightsHotEnableReturnsFailClosedSnapshots(t *tes
 	s.autotuneEvidence = spec032MapEvidence{byProvider: map[string]autotune.VerifiedEvidence{
 		control.ProviderID: admissionCeilingVerifiedEvidence(t, catalog, "small", "hashC", "apple m4 max", 64),
 	}}
+	next := s.proofOfWeightsConfig()
+	next.RequireAutotuneHelloGate = true
+	reload := s.SetProofOfWeightsConfig(next)
 	ts := httptest.NewServer(s.Handler())
 	defer ts.Close()
 
-	resp := postAdmissionCanaryJSON(t, ts.URL+"/admin/admission-canary/proof-of-weights", "test-operator-key", map[string]any{
-		"require_autotune_hello_gate": true,
-		"autotune_evidence_ttl_days":  30,
-	})
+	resp := getAdmissionCanary(t, ts.URL+"/admin/admission-canary/proof-of-weights", "test-operator-key")
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("proof-of-weights status=%d", resp.StatusCode)
 	}
 	var body struct {
 		Status string `json:"status"`
-		Reload struct {
-			PreQuarantined int `json:"pre_quarantined"`
-			Revalidated    int `json:"revalidated"`
-			Sandboxed      int `json:"sandboxed"`
-		} `json:"reload"`
-		Before []admissionCanaryProviderSnapshot `json:"before"`
-		After  []admissionCanaryProviderSnapshot `json:"after"`
+		Config struct {
+			RequireAutotuneHelloGate bool `json:"require_autotune_hello_gate"`
+		} `json:"config"`
+		LastReload struct {
+			Present bool `json:"present"`
+			Config  struct {
+				RequireAutotuneHelloGate bool `json:"require_autotune_hello_gate"`
+			} `json:"config"`
+			Result struct {
+				Generation         uint64 `json:"generation"`
+				PreQuarantined     int    `json:"pre_quarantined"`
+				Revalidated        int    `json:"revalidated"`
+				Sandboxed          int    `json:"sandboxed"`
+				StillEvidenceStale int    `json:"still_evidence_stale"`
+			} `json:"result"`
+		} `json:"last_reload"`
+		Pool []admissionCanaryProviderSnapshot `json:"pool"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if body.Status != "ok" || body.Reload.PreQuarantined < 2 || body.Reload.Revalidated < 2 || body.Reload.Sandboxed < 1 {
+	if body.Status != "ok" || !body.Config.RequireAutotuneHelloGate || !body.LastReload.Present || !body.LastReload.Config.RequireAutotuneHelloGate {
 		t.Fatalf("unexpected reload body: %+v", body)
 	}
-	subjectAfter, ok := admissionCanaryFindSnapshot(body.After, subject.ProviderID)
+	if body.LastReload.Result.Generation != reload.Generation ||
+		body.LastReload.Result.PreQuarantined != reload.PreQuarantined ||
+		body.LastReload.Result.Revalidated != reload.Revalidated ||
+		body.LastReload.Result.Sandboxed != reload.Sandboxed ||
+		body.LastReload.Result.StillEvidenceStale != reload.StillEvidenceStale {
+		t.Fatalf("last reload result mismatch: got=%+v want=%+v", body.LastReload.Result, reload)
+	}
+	if body.LastReload.Result.PreQuarantined < 2 || body.LastReload.Result.Revalidated < 2 || body.LastReload.Result.Sandboxed < 1 {
+		t.Fatalf("unexpected reload counters: %+v", body.LastReload.Result)
+	}
+	subjectAfter, ok := admissionCanaryFindSnapshot(body.Pool, subject.ProviderID)
 	if !ok {
-		t.Fatalf("subject snapshot missing: %+v", body.After)
+		t.Fatalf("subject snapshot missing: %+v", body.Pool)
 	}
 	if !subjectAfter.AdmissionSandboxed || subjectAfter.RoutingEligible || subjectAfter.ServingCapable {
 		t.Fatalf("subject must be sandboxed and unroutable: %+v", subjectAfter)
 	}
-	controlAfter, ok := admissionCanaryFindSnapshot(body.After, control.ProviderID)
+	controlAfter, ok := admissionCanaryFindSnapshot(body.Pool, control.ProviderID)
 	if !ok {
-		t.Fatalf("control snapshot missing: %+v", body.After)
+		t.Fatalf("control snapshot missing: %+v", body.Pool)
 	}
 	if !controlAfter.RoutingEligible || !controlAfter.ServingCapable || controlAfter.AdmissionEvidenceStale || controlAfter.AdmissionSandboxed {
 		t.Fatalf("control must stay buyer-serving after reload: %+v", controlAfter)
+	}
+}
+
+func TestAdmissionCanaryProofOfWeightsEndpointIsReadOnly(t *testing.T) {
+	t.Parallel()
+	cfg := config.Default()
+	cfg.Auth.OperatorKey = "test-operator-key"
+	cfg.AdmissionCanaryHarness.Enabled = true
+	s, provider, _ := newEncryptedRelayHarnessWithConfig(t, cfg, zerolog.Nop(), time.Now())
+	ts := httptest.NewServer(s.Handler())
+	defer ts.Close()
+
+	resp := postAdmissionCanaryJSON(t, ts.URL+"/admin/admission-canary/proof-of-weights", "test-operator-key", map[string]any{
+		"require_autotune_hello_gate": true,
+	})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("POST status=%d, want 405", resp.StatusCode)
+	}
+	if s.proofOfWeightsConfig().RequireAutotuneHelloGate {
+		t.Fatal("read-only endpoint mutated proof-of-weights config")
+	}
+	snap, ok := s.pool.Resolve(provider.ProviderID, provider.AssignedID)
+	if !ok {
+		t.Fatal("provider missing from registry")
+	}
+	if snap.AdmissionEvidenceStale || snap.AdmissionSandboxed || snap.AdmissionCeilingExcluded {
+		t.Fatalf("read-only endpoint mutated admission flags: %+v", snap)
 	}
 }
 
@@ -153,6 +201,20 @@ func postAdmissionCanaryJSON(t *testing.T, url, token string, body any) *http.Re
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("post request: %v", err)
+	}
+	return resp
+}
+
+func getAdmissionCanary(t *testing.T, url, token string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("get request: %v", err)
 	}
 	return resp
 }

--- a/phase4-coordinator/internal/ws/admission_canary_harness_test.go
+++ b/phase4-coordinator/internal/ws/admission_canary_harness_test.go
@@ -75,6 +75,42 @@ func TestAdmissionCanaryClearAdmittedTupleMutatesOnlyTuple(t *testing.T) {
 	}
 }
 
+func TestAdmissionCanaryClearAdmittedTupleRequiresAssignedID(t *testing.T) {
+	t.Parallel()
+	cfg := config.Default()
+	cfg.Auth.OperatorKey = "test-operator-key"
+	cfg.AdmissionCanaryHarness.Enabled = true
+	s, provider, _ := newEncryptedRelayHarnessWithConfig(t, cfg, zerolog.Nop(), time.Now())
+	setAdmittedTupleValues(provider, "hashA", "apple m4 max", 64)
+	ts := httptest.NewServer(s.Handler())
+	defer ts.Close()
+
+	resp := postAdmissionCanaryJSON(t, ts.URL+"/admin/admission-canary/clear-admitted-tuple", "test-operator-key", map[string]any{
+		"provider_id": provider.ProviderID,
+	})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("missing assigned_id status=%d, want 400", resp.StatusCode)
+	}
+	snap, ok := s.pool.Resolve(provider.ProviderID, provider.AssignedID)
+	if !ok || !providerHasAdmittedTuple(snap) {
+		t.Fatalf("missing assigned_id mutated tuple: ok=%v snap=%+v", ok, snap)
+	}
+
+	resp = postAdmissionCanaryJSON(t, ts.URL+"/admin/admission-canary/clear-admitted-tuple", "test-operator-key", map[string]any{
+		"provider_id": provider.ProviderID,
+		"assigned_id": provider.AssignedID + "-stale",
+	})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("stale assigned_id status=%d, want 404", resp.StatusCode)
+	}
+	snap, ok = s.pool.Resolve(provider.ProviderID, provider.AssignedID)
+	if !ok || !providerHasAdmittedTuple(snap) {
+		t.Fatalf("stale assigned_id mutated tuple: ok=%v snap=%+v", ok, snap)
+	}
+}
+
 func TestAdmissionCanaryProofOfWeightsHotEnableReturnsFailClosedSnapshots(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC)

--- a/phase4-coordinator/internal/ws/admission_canary_harness_test.go
+++ b/phase4-coordinator/internal/ws/admission_canary_harness_test.go
@@ -1,0 +1,167 @@
+package ws
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/autotune"
+	"github.com/augstar/macprovider-coordinator/internal/config"
+	"github.com/rs/zerolog"
+)
+
+func TestAdmissionCanaryHarnessEndpointsAreNotMountedByDefault(t *testing.T) {
+	t.Parallel()
+	s, _, _ := newEncryptedRelayHarness(t)
+	ts := httptest.NewServer(s.Handler())
+	defer ts.Close()
+
+	resp := postAdmissionCanaryJSON(t, ts.URL+"/admin/admission-canary/clear-admitted-tuple", "test-operator-key", map[string]any{
+		"provider_id": "p1",
+	})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("disabled harness status=%d, want 404", resp.StatusCode)
+	}
+}
+
+func TestAdmissionCanaryClearAdmittedTupleMutatesOnlyTuple(t *testing.T) {
+	t.Parallel()
+	cfg := config.Default()
+	cfg.Auth.OperatorKey = "test-operator-key"
+	cfg.AdmissionCanaryHarness.Enabled = true
+	s, provider, _ := newEncryptedRelayHarnessWithConfig(t, cfg, zerolog.Nop(), time.Now())
+	provider.MaxAdmittedModelID = "small-model"
+	provider.MaxAdmittedMinRAMGB = 8
+	provider.CatalogAdmissionMode = "current"
+	setAdmittedTupleValues(provider, "hashA", "apple m4 max", 64)
+	ts := httptest.NewServer(s.Handler())
+	defer ts.Close()
+
+	resp := postAdmissionCanaryJSON(t, ts.URL+"/admin/admission-canary/clear-admitted-tuple", "test-operator-key", map[string]any{
+		"provider_id": provider.ProviderID,
+		"assigned_id": provider.AssignedID,
+	})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("clear tuple status=%d", resp.StatusCode)
+	}
+	var body struct {
+		Status string                          `json:"status"`
+		Before admissionCanaryProviderSnapshot `json:"before"`
+		After  admissionCanaryProviderSnapshot `json:"after"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Status != "ok" {
+		t.Fatalf("status=%q", body.Status)
+	}
+	if !body.Before.HasAdmittedTuple || body.After.HasAdmittedTuple {
+		t.Fatalf("tuple snapshots before=%+v after=%+v", body.Before, body.After)
+	}
+	if body.After.AdmissionEvidenceStale || body.After.AdmissionSandboxed || body.After.AdmissionCeilingExcluded {
+		t.Fatalf("clear tuple should not set admission flags: %+v", body.After)
+	}
+	if !body.After.RoutingEligible || !body.After.ServingCapable {
+		t.Fatalf("clear tuple should not directly route-exclude before sweep: %+v", body.After)
+	}
+	snap, ok := s.pool.Resolve(provider.ProviderID, provider.AssignedID)
+	if !ok || providerHasAdmittedTuple(snap) {
+		t.Fatalf("registry tuple still present: ok=%v snap=%+v", ok, snap)
+	}
+}
+
+func TestAdmissionCanaryProofOfWeightsHotEnableReturnsFailClosedSnapshots(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC)
+	cfg := config.Default()
+	cfg.Auth.OperatorKey = "test-operator-key"
+	cfg.AdmissionCanaryHarness.Enabled = true
+	cfg.ProofOfWeights.RequireAutotuneHelloGate = false
+	cfg.ProofOfWeights.AutotuneEvidenceTTLDays = 30
+	s, subject, _ := newEncryptedRelayHarnessWithConfig(t, cfg, zerolog.Nop(), now)
+	subject.ModelID = "small-model"
+	subject.MaxAdmittedMinRAMGB = 0
+
+	control := spec032ControlProvider("control-r003", "control-r003-s")
+	setAdmittedTupleValues(control, "hashC", "apple m4 max", 64)
+	spec032AddSessionedProvider(t, s, control, now)
+	catalog := admissionCeilingTestCatalog(t)
+	s.autotuneCatalog = catalog
+	s.autotuneEvidence = spec032MapEvidence{byProvider: map[string]autotune.VerifiedEvidence{
+		control.ProviderID: admissionCeilingVerifiedEvidence(t, catalog, "small", "hashC", "apple m4 max", 64),
+	}}
+	ts := httptest.NewServer(s.Handler())
+	defer ts.Close()
+
+	resp := postAdmissionCanaryJSON(t, ts.URL+"/admin/admission-canary/proof-of-weights", "test-operator-key", map[string]any{
+		"require_autotune_hello_gate": true,
+		"autotune_evidence_ttl_days":  30,
+	})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("proof-of-weights status=%d", resp.StatusCode)
+	}
+	var body struct {
+		Status string `json:"status"`
+		Reload struct {
+			PreQuarantined int `json:"pre_quarantined"`
+			Revalidated    int `json:"revalidated"`
+			Sandboxed      int `json:"sandboxed"`
+		} `json:"reload"`
+		Before []admissionCanaryProviderSnapshot `json:"before"`
+		After  []admissionCanaryProviderSnapshot `json:"after"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Status != "ok" || body.Reload.PreQuarantined < 2 || body.Reload.Revalidated < 2 || body.Reload.Sandboxed < 1 {
+		t.Fatalf("unexpected reload body: %+v", body)
+	}
+	subjectAfter, ok := admissionCanaryFindSnapshot(body.After, subject.ProviderID)
+	if !ok {
+		t.Fatalf("subject snapshot missing: %+v", body.After)
+	}
+	if !subjectAfter.AdmissionSandboxed || subjectAfter.RoutingEligible || subjectAfter.ServingCapable {
+		t.Fatalf("subject must be sandboxed and unroutable: %+v", subjectAfter)
+	}
+	controlAfter, ok := admissionCanaryFindSnapshot(body.After, control.ProviderID)
+	if !ok {
+		t.Fatalf("control snapshot missing: %+v", body.After)
+	}
+	if !controlAfter.RoutingEligible || !controlAfter.ServingCapable || controlAfter.AdmissionEvidenceStale || controlAfter.AdmissionSandboxed {
+		t.Fatalf("control must stay buyer-serving after reload: %+v", controlAfter)
+	}
+}
+
+func postAdmissionCanaryJSON(t *testing.T, url, token string, body any) *http.Response {
+	t.Helper()
+	data, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post request: %v", err)
+	}
+	return resp
+}
+
+func admissionCanaryFindSnapshot(snaps []admissionCanaryProviderSnapshot, providerID string) (admissionCanaryProviderSnapshot, bool) {
+	for _, snap := range snaps {
+		if snap.ProviderID == providerID {
+			return snap, true
+		}
+	}
+	return admissionCanaryProviderSnapshot{}, false
+}

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -1329,6 +1329,10 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/admin/provider-admission-identity/recover", s.handleAdmissionIdentityRecoveryRequest)
 	mux.HandleFunc("/admin/provider-admission-identity/recover/", s.handleAdmissionIdentityRecoveryApprove)
 	mux.HandleFunc("/v1/provider/compute-integrity", s.handleProviderComputeIntegrity)
+	if s.cfg.AdmissionCanaryHarness.Enabled {
+		mux.HandleFunc("/admin/admission-canary/clear-admitted-tuple", s.handleAdmissionCanaryClearAdmittedTuple)
+		mux.HandleFunc("/admin/admission-canary/proof-of-weights", s.handleAdmissionCanaryProofOfWeights)
+	}
 	if s.cfg.Auth.GitHubOAuth.Enabled {
 		mux.HandleFunc("/v1/auth/github/start", s.handleGitHubStart)
 		mux.HandleFunc("/v1/auth/github/callback", s.handleGitHubCallback)

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -71,6 +71,10 @@ type Server struct {
 	proofOfWeightsMu          sync.RWMutex
 	proofOfWeights            config.ProofOfWeightsConfig
 	proofOfWeightsGeneration  uint64
+	proofOfWeightsLastMu      sync.RWMutex
+	proofOfWeightsLastResult  ProofOfWeightsReloadResult
+	proofOfWeightsLastConfig  config.ProofOfWeightsConfig
+	proofOfWeightsLastAt      time.Time
 	tier2Mu                   sync.RWMutex
 	tier2                     config.Tier2Config
 	modelHashLegacyMu         sync.Mutex
@@ -1091,6 +1095,9 @@ func (s *Server) SetProofOfWeightsConfig(next config.ProofOfWeightsConfig) Proof
 	defer s.proofOfWeightsAdmissionMu.Unlock()
 
 	result := ProofOfWeightsReloadResult{}
+	defer func() {
+		s.recordProofOfWeightsReloadResult(next, result)
+	}()
 	if next.RequireAutotuneHelloGate && s.pool != nil {
 		result.PreQuarantined = s.pool.QuarantineForProofOfWeightsReload()
 	}
@@ -1119,7 +1126,25 @@ func (s *Server) SetProofOfWeightsConfig(next config.ProofOfWeightsConfig) Proof
 		return result
 	}
 
-	return s.revalidateProofOfWeightsAdmissions(next, result)
+	result = s.revalidateProofOfWeightsAdmissions(next, result)
+	return result
+}
+
+func (s *Server) recordProofOfWeightsReloadResult(cfg config.ProofOfWeightsConfig, result ProofOfWeightsReloadResult) {
+	s.proofOfWeightsLastMu.Lock()
+	defer s.proofOfWeightsLastMu.Unlock()
+	s.proofOfWeightsLastConfig = cfg
+	s.proofOfWeightsLastResult = result
+	s.proofOfWeightsLastAt = s.now()
+}
+
+func (s *Server) LastProofOfWeightsReloadResult() (config.ProofOfWeightsConfig, ProofOfWeightsReloadResult, time.Time, bool) {
+	s.proofOfWeightsLastMu.RLock()
+	defer s.proofOfWeightsLastMu.RUnlock()
+	if s.proofOfWeightsLastAt.IsZero() {
+		return config.ProofOfWeightsConfig{}, ProofOfWeightsReloadResult{}, time.Time{}, false
+	}
+	return s.proofOfWeightsLastConfig, s.proofOfWeightsLastResult, s.proofOfWeightsLastAt, true
 }
 
 func (s *Server) revalidateProofOfWeightsAdmissions(cfg config.ProofOfWeightsConfig, result ProofOfWeightsReloadResult) ProofOfWeightsReloadResult {


### PR DESCRIPTION
## Summary

Adds the default-off canary-only proof controls needed to complete #959's physical SPEC-032 strict admission-gate matrix on redastare/augstar against an isolated coordinator.

- adds `admission_canary_harness.enabled`, which mounts operator-only canary endpoints only when explicitly enabled
- adds `/admin/admission-canary/clear-admitted-tuple` for the R002 missing admitted tuple proof, bound to the exact live `assigned_id`
- adds read-only `/admin/admission-canary/proof-of-weights` evidence capture for current proof config, the last real reload/revalidation result, and pool snapshots
- adds `MACPROVIDER_CANARY_HEARTBEAT_OVERRIDE_PATH` for R001 heartbeat metadata transitions, compiled out of production builds and host-bound away from Pearl
- preserves the prior incomplete run artifact as partial/non-promotional evidence

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "issue": "https://github.com/Augustas11/macprovider/issues/959",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-032"],
  "requirements": ["SPEC-032-R001", "SPEC-032-R002", "SPEC-032-R003"],
  "authority_domains": ["hardware-evidence-admission"],
  "arbitration": ["UNKNOWN"],
  "tests": [
    "go test ./internal/config ./internal/pool ./internal/ws -count=1",
    "swift test --filter CoordinatorClientTests/testCanaryHeartbeatOverride",
    "python3 scripts/check_spec_governance.py --base-ref origin/main",
    "jq empty journeys/evidence/provider-prebeta-admission-spec032-strict-localwifi-20260902T090901Z.partial.json"
  ],
  "journeys": ["JOURNEY-PROVIDER-PREBETA-ADMISSION"]
}
SPEC-GOVERNANCE-DECLARATION-END

## Validation

- `go test ./internal/config ./internal/pool ./internal/ws -count=1`
- `swift test --filter CoordinatorClientTests/testCanaryHeartbeatOverride`
- `python3 scripts/check_spec_governance.py --base-ref origin/main`
- `jq empty journeys/evidence/provider-prebeta-admission-spec032-strict-localwifi-20260902T090901Z.partial.json`

## Operational boundary

These controls are disabled by default. Physical R003 activation still uses a canary config edit plus the real `reloadCoordinatorConfig` / `revalidateProofOfWeightsAdmissions` path; the proof-of-weights endpoint only observes the resulting state. This PR does not activate strict gates on Pearl production, does not change Pearl defaults, and does not mutate active production cohorts.
