### PR TITLE
Enable SPEC-032 canary heartbeat model switches

### DIFF
--- a/phase4-coordinator/tools/mockprovider/main.go
+++ b/phase4-coordinator/tools/mockprovider/main.go
@@ -7,6 +7,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"flag"
@@ -17,6 +18,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -143,6 +145,7 @@ type config struct {
 	endpointURL     string
 	drainDelayS     int
 	hbOverride      int
+	hbModelFile     string
 }
 
 func parseFlags() config {
@@ -162,8 +165,85 @@ func parseFlags() config {
 	flag.StringVar(&c.endpointURL, "endpoint-url", "", "endpoint_url to advertise in hello; default uses http-port unless omitted")
 	flag.IntVar(&c.drainDelayS, "drain-delay-s", 2, "delay between drain phases in seconds")
 	flag.IntVar(&c.hbOverride, "hb", 0, "heartbeat interval override (seconds); 0 = use coordinator value")
+	flag.StringVar(&c.hbModelFile, "heartbeat-override-file", "", "optional JSON file read before each heartbeat; supports model_id and model_params_b")
 	flag.Parse()
 	return c
+}
+
+type heartbeatOverride struct {
+	ModelID      string   `json:"model_id"`
+	ModelParamsB *float64 `json:"model_params_b"`
+}
+
+const maxHeartbeatOverrideBytes = 8192
+
+func readHeartbeatOverride(path string) (heartbeatOverride, bool, error) {
+	if strings.TrimSpace(path) == "" {
+		return heartbeatOverride{}, false, nil
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return heartbeatOverride{}, false, err
+	}
+	if !info.Mode().IsRegular() {
+		return heartbeatOverride{}, false, fmt.Errorf("override path must be a regular file")
+	}
+	if info.Size() > maxHeartbeatOverrideBytes {
+		return heartbeatOverride{}, false, fmt.Errorf("override file exceeds %d bytes", maxHeartbeatOverrideBytes)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return heartbeatOverride{}, false, err
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return heartbeatOverride{}, false, nil
+	}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	var override heartbeatOverride
+	if err := dec.Decode(&override); err != nil {
+		return heartbeatOverride{}, false, err
+	}
+	if strings.TrimSpace(override.ModelID) == "" && override.ModelParamsB == nil {
+		return heartbeatOverride{}, false, fmt.Errorf("override must set model_id or model_params_b")
+	}
+	override.ModelID = strings.TrimSpace(override.ModelID)
+	if override.ModelParamsB != nil && (*override.ModelParamsB < 0 || *override.ModelParamsB > 10000) {
+		return heartbeatOverride{}, false, fmt.Errorf("model_params_b out of range")
+	}
+	return override, true, nil
+}
+
+func currentHeartbeat(cfg config, logger *log.Logger, drainer *drainController) heartbeat {
+	modelID := cfg.model
+	modelParamsB := 7.0
+	if override, ok, err := readHeartbeatOverride(cfg.hbModelFile); err != nil {
+		logger.Printf("heartbeat override ignored: %v", err)
+	} else if ok {
+		if override.ModelID != "" {
+			modelID = override.ModelID
+		}
+		if override.ModelParamsB != nil {
+			modelParamsB = *override.ModelParamsB
+		}
+	}
+	hb := heartbeat{
+		Type:                  "heartbeat",
+		Status:                "ready",
+		ModelID:               modelID,
+		ModelParamsB:          modelParamsB,
+		RAMGB:                 cfg.ramGB,
+		MaxContextTokens:      cfg.maxContext,
+		MaxConcurrency:        cfg.maxConcurrency,
+		SlotsFree:             cfg.slots,
+		SlotsTotal:            cfg.slots,
+		ThroughputTPSEstimate: 30.0,
+	}
+	if drainer != nil && drainer.isDraining() {
+		hb.Status = "draining"
+		hb.SlotsFree = 0
+	}
+	return hb
 }
 
 // drainController shares drain state between the WS goroutine and the HTTP
@@ -322,22 +402,7 @@ func runWS(cfg config, logger *log.Logger, drainer *drainController) error {
 			case <-stopHB:
 				return
 			case <-t.C:
-				hb := heartbeat{
-					Type:                  "heartbeat",
-					Status:                "ready",
-					ModelID:               cfg.model,
-					ModelParamsB:          7.0,
-					RAMGB:                 cfg.ramGB,
-					MaxContextTokens:      cfg.maxContext,
-					MaxConcurrency:        cfg.maxConcurrency,
-					SlotsFree:             cfg.slots,
-					SlotsTotal:            cfg.slots,
-					ThroughputTPSEstimate: 30.0,
-				}
-				if drainer.isDraining() {
-					hb.Status = "draining"
-					hb.SlotsFree = 0
-				}
+				hb := currentHeartbeat(cfg, logger, drainer)
 				b, _ := json.Marshal(hb)
 				if err := writeText(b); err != nil {
 					logger.Printf("heartbeat write failed: %v", err)
@@ -348,18 +413,7 @@ func runWS(cfg config, logger *log.Logger, drainer *drainController) error {
 	}()
 
 	// Initial immediate heartbeat (don't wait for first tick).
-	hb0 := heartbeat{
-		Type:                  "heartbeat",
-		Status:                "ready",
-		ModelID:               cfg.model,
-		ModelParamsB:          7.0,
-		RAMGB:                 cfg.ramGB,
-		MaxContextTokens:      cfg.maxContext,
-		MaxConcurrency:        cfg.maxConcurrency,
-		SlotsFree:             cfg.slots,
-		SlotsTotal:            cfg.slots,
-		ThroughputTPSEstimate: 30.0,
-	}
+	hb0 := currentHeartbeat(cfg, logger, drainer)
 	hb0Bytes, _ := json.Marshal(hb0)
 	_ = writeText(hb0Bytes)
 
@@ -423,18 +477,7 @@ func handleInbound(cfg config, logger *log.Logger, drainer *drainController,
 		}
 	case "warm_up":
 		logger.Printf("warm_up received; sending fresh heartbeat")
-		hb := heartbeat{
-			Type:                  "heartbeat",
-			Status:                "ready",
-			ModelID:               cfg.model,
-			ModelParamsB:          7.0,
-			RAMGB:                 cfg.ramGB,
-			MaxContextTokens:      cfg.maxContext,
-			MaxConcurrency:        cfg.maxConcurrency,
-			SlotsFree:             cfg.slots,
-			SlotsTotal:            cfg.slots,
-			ThroughputTPSEstimate: 30.0,
-		}
+		hb := currentHeartbeat(cfg, logger, drainer)
 		b, _ := json.Marshal(hb)
 		_ = writeText(b)
 	case "drain":

--- a/phase4-coordinator/tools/mockprovider/main_test.go
+++ b/phase4-coordinator/tools/mockprovider/main_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCurrentHeartbeatUsesOverrideFile(t *testing.T) {
+	dir := t.TempDir()
+	overridePath := filepath.Join(dir, "heartbeat.json")
+	if err := os.WriteFile(overridePath, []byte(`{"model_id":" mlx-community/Canary-32B ","model_params_b":32}`), 0o600); err != nil {
+		t.Fatalf("write override: %v", err)
+	}
+
+	hb := currentHeartbeat(config{
+		model:       "mlx-community/Canary-7B",
+		ramGB:       16,
+		maxContext:  8192,
+		slots:       1,
+		hbModelFile: overridePath,
+	}, log.New(io.Discard, "", 0), nil)
+
+	if hb.ModelID != "mlx-community/Canary-32B" {
+		t.Fatalf("ModelID = %q, want override", hb.ModelID)
+	}
+	if hb.ModelParamsB != 32 {
+		t.Fatalf("ModelParamsB = %v, want 32", hb.ModelParamsB)
+	}
+}
+
+func TestCurrentHeartbeatFallsBackOnEmptyOverrideFile(t *testing.T) {
+	dir := t.TempDir()
+	overridePath := filepath.Join(dir, "heartbeat.json")
+	if err := os.WriteFile(overridePath, []byte(" \n"), 0o600); err != nil {
+		t.Fatalf("write override: %v", err)
+	}
+
+	hb := currentHeartbeat(config{
+		model:       "mlx-community/Canary-7B",
+		ramGB:       16,
+		maxContext:  8192,
+		slots:       1,
+		hbModelFile: overridePath,
+	}, log.New(io.Discard, "", 0), nil)
+
+	if hb.ModelID != "mlx-community/Canary-7B" {
+		t.Fatalf("ModelID = %q, want configured model", hb.ModelID)
+	}
+	if hb.ModelParamsB != 7 {
+		t.Fatalf("ModelParamsB = %v, want default", hb.ModelParamsB)
+	}
+}
+
+func TestReadHeartbeatOverrideRejectsUnknownFields(t *testing.T) {
+	dir := t.TempDir()
+	overridePath := filepath.Join(dir, "heartbeat.json")
+	if err := os.WriteFile(overridePath, []byte(`{"model_id":"model-a","unexpected":true}`), 0o600); err != nil {
+		t.Fatalf("write override: %v", err)
+	}
+
+	if _, _, err := readHeartbeatOverride(overridePath); err == nil {
+		t.Fatal("readHeartbeatOverride accepted an unknown field")
+	}
+}
+
+func TestReadHeartbeatOverrideRejectsNonRegularFile(t *testing.T) {
+	dir := t.TempDir()
+
+	if _, _, err := readHeartbeatOverride(dir); err == nil {
+		t.Fatal("readHeartbeatOverride accepted a directory")
+	}
+}
+
+func TestReadHeartbeatOverrideRejectsOversizedFile(t *testing.T) {
+	dir := t.TempDir()
+	overridePath := filepath.Join(dir, "heartbeat.json")
+	large := make([]byte, maxHeartbeatOverrideBytes+1)
+	if err := os.WriteFile(overridePath, large, 0o600); err != nil {
+		t.Fatalf("write override: %v", err)
+	}
+
+	if _, _, err := readHeartbeatOverride(overridePath); err == nil {
+		t.Fatal("readHeartbeatOverride accepted an oversized file")
+	}
+}


### PR DESCRIPTION
## Summary

- add an opt-in `mockprovider` heartbeat override file for physical SPEC-032 canary runs
- centralize heartbeat construction so periodic, immediate, and warm-up heartbeats use the same model metadata
- add focused tests for override parsing, fallback, and file safety guards

## Validation

- `cd phase4-coordinator && go test ./tools/mockprovider -count=1`
- `cd phase4-coordinator && go vet ./tools/mockprovider`
- `cd phase4-coordinator && go build ./cmd/coordinator ./tools/mockprovider`
- `cd phase4-coordinator && go test ./internal/ws -run 'TestAdmissionCanaryHarness|TestSpec032StrictAdmissionMatrixJourney|TestProviderHello' -count=1`
- `cd phase4-coordinator && go test ./...`
- audit lanes: code review, security review, architecture review; 0 CRITICAL/HIGH/MEDIUM findings

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "issue": "https://github.com/Augustas11/macprovider/issues/959",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-032"],
  "requirements": ["SPEC-032-R001"],
  "authority_domains": ["hardware-evidence-admission"],
  "arbitration": ["UNKNOWN"],
  "tests": [
    "cd phase4-coordinator && go test ./tools/mockprovider -count=1",
    "cd phase4-coordinator && go vet ./tools/mockprovider",
    "cd phase4-coordinator && go build ./cmd/coordinator ./tools/mockprovider",
    "cd phase4-coordinator && go test ./internal/ws -run 'TestAdmissionCanaryHarness|TestSpec032StrictAdmissionMatrixJourney|TestProviderHello' -count=1",
    "cd phase4-coordinator && go test ./..."
  ],
  "journeys": ["JOURNEY-PROVIDER-PREBETA-ADMISSION"]
}
SPEC-GOVERNANCE-DECLARATION-END
