### PR TITLE
Support authenticated SPEC-032 canary providers

### DIFF
--- a/phase4-coordinator/tools/mockprovider/main.go
+++ b/phase4-coordinator/tools/mockprovider/main.go
@@ -16,6 +16,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"strings"
@@ -130,22 +131,23 @@ type cancelRequest struct {
 }
 
 type config struct {
-	coordURL        string
-	providerID      string
-	model           string
-	ramGB           int
-	maxContext      int
-	maxConcurrency  int
-	slots           int
-	httpPort        int
-	streamDelayMS   int
-	rejectPreflight string
-	rejectNAK       bool
-	omitEndpointURL bool
-	endpointURL     string
-	drainDelayS     int
-	hbOverride      int
-	hbModelFile     string
+	coordURL          string
+	providerID        string
+	model             string
+	ramGB             int
+	maxContext        int
+	maxConcurrency    int
+	slots             int
+	httpPort          int
+	streamDelayMS     int
+	rejectPreflight   string
+	rejectNAK         bool
+	omitEndpointURL   bool
+	endpointURL       string
+	drainDelayS       int
+	hbOverride        int
+	hbModelFile       string
+	providerTokenFile string
 }
 
 func parseFlags() config {
@@ -166,6 +168,7 @@ func parseFlags() config {
 	flag.IntVar(&c.drainDelayS, "drain-delay-s", 2, "delay between drain phases in seconds")
 	flag.IntVar(&c.hbOverride, "hb", 0, "heartbeat interval override (seconds); 0 = use coordinator value")
 	flag.StringVar(&c.hbModelFile, "heartbeat-override-file", "", "optional JSON file read before each heartbeat; supports model_id and model_params_b")
+	flag.StringVar(&c.providerTokenFile, "provider-token-file", "", "optional file containing provider bearer token for the websocket handshake")
 	flag.Parse()
 	return c
 }
@@ -176,6 +179,7 @@ type heartbeatOverride struct {
 }
 
 const maxHeartbeatOverrideBytes = 8192
+const maxProviderTokenBytes = 8192
 
 func readHeartbeatOverride(path string) (heartbeatOverride, bool, error) {
 	if strings.TrimSpace(path) == "" {
@@ -212,6 +216,95 @@ func readHeartbeatOverride(path string) (heartbeatOverride, bool, error) {
 		return heartbeatOverride{}, false, fmt.Errorf("model_params_b out of range")
 	}
 	return override, true, nil
+}
+
+func readProviderToken(path string) (string, bool, error) {
+	if strings.TrimSpace(path) == "" {
+		return "", false, nil
+	}
+	f, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW|syscall.O_CLOEXEC, 0)
+	if err != nil {
+		return "", false, err
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		return "", false, err
+	}
+	if !info.Mode().IsRegular() {
+		return "", false, fmt.Errorf("provider token path must be a regular file")
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		return "", false, fmt.Errorf("provider token file must not grant group or other permissions")
+	}
+	if stat, ok := info.Sys().(*syscall.Stat_t); ok && stat.Uid != uint32(os.Geteuid()) {
+		return "", false, fmt.Errorf("provider token file must be owned by the current user")
+	}
+	if info.Size() > maxProviderTokenBytes {
+		return "", false, fmt.Errorf("provider token file exceeds %d bytes", maxProviderTokenBytes)
+	}
+	data, err := io.ReadAll(io.LimitReader(f, maxProviderTokenBytes+1))
+	if err != nil {
+		return "", false, err
+	}
+	if len(data) > maxProviderTokenBytes {
+		return "", false, fmt.Errorf("provider token file exceeds %d bytes", maxProviderTokenBytes)
+	}
+	token, err := parseProviderToken(data)
+	if err != nil {
+		return "", false, err
+	}
+	return token, true, nil
+}
+
+func parseProviderToken(data []byte) (string, error) {
+	if len(data) > 0 && data[len(data)-1] == '\n' {
+		data = data[:len(data)-1]
+		if len(data) > 0 && data[len(data)-1] == '\r' {
+			data = data[:len(data)-1]
+		}
+	}
+	if len(data) == 0 {
+		return "", fmt.Errorf("provider token file is empty")
+	}
+	for _, b := range data {
+		if b < 0x21 || b == 0x7f {
+			return "", fmt.Errorf("provider token file must contain exactly one printable token line")
+		}
+	}
+	return string(data), nil
+}
+
+func providerAuthHeader(token string) gobwas.HandshakeHeader {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return nil
+	}
+	return gobwas.HandshakeHeaderHTTP(http.Header{
+		"Authorization": []string{"Bearer " + token},
+	})
+}
+
+func validateTokenTransport(coordURL string) error {
+	u, err := url.Parse(coordURL)
+	if err != nil {
+		return fmt.Errorf("parse coordinator URL: %w", err)
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "wss":
+		return nil
+	case "ws":
+		host := u.Hostname()
+		if host == "localhost" {
+			return nil
+		}
+		if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
+			return nil
+		}
+		return fmt.Errorf("provider bearer token over ws requires a loopback coordinator host")
+	default:
+		return fmt.Errorf("provider bearer token requires ws or wss coordinator URL")
+	}
 }
 
 func currentHeartbeat(cfg config, logger *log.Logger, drainer *drainController) heartbeat {
@@ -274,7 +367,16 @@ func (d *drainController) inflightCount() int {
 
 func main() {
 	cfg := parseFlags()
-	logger := log.New(os.Stdout, fmt.Sprintf("[mock %s] ", cfg.providerID), log.LstdFlags|log.Lmicroseconds)
+	os.Exit(run(cfg, os.Stdout))
+}
+
+func run(cfg config, output io.Writer) int {
+	logger := log.New(output, fmt.Sprintf("[mock %s] ", cfg.providerID), log.LstdFlags|log.Lmicroseconds)
+
+	if err := validateProviderCredentialConfig(cfg); err != nil {
+		logger.Printf("startup config error: %v", err)
+		return 1
+	}
 
 	drainer := &drainController{}
 
@@ -283,8 +385,10 @@ func main() {
 
 	// Connect to coordinator WS. If it fails, exit non-zero so the bootstrap
 	// script surfaces the problem.
+	exitCode := 0
 	if err := runWS(cfg, logger, drainer); err != nil {
 		logger.Printf("ws loop exited: %v", err)
+		exitCode = 1
 	}
 
 	// On WS exit (drain complete or coordinator gone), tear down HTTP too.
@@ -292,11 +396,34 @@ func main() {
 	defer cancel()
 	_ = httpSrv.Shutdown(ctx)
 	logger.Printf("mockprovider exiting cleanly")
+	return exitCode
+}
+
+func validateProviderCredentialConfig(cfg config) error {
+	_, hasToken, err := readProviderToken(cfg.providerTokenFile)
+	if err != nil {
+		return err
+	}
+	if hasToken {
+		return validateTokenTransport(cfg.coordURL)
+	}
+	return nil
 }
 
 func runWS(cfg config, logger *log.Logger, drainer *drainController) error {
 	ctx := context.Background()
-	conn, _, _, err := gobwas.Dial(ctx, cfg.coordURL)
+	token, hasToken, err := readProviderToken(cfg.providerTokenFile)
+	if err != nil {
+		return fmt.Errorf("read provider token: %w", err)
+	}
+	dialer := gobwas.Dialer{}
+	if hasToken {
+		if err := validateTokenTransport(cfg.coordURL); err != nil {
+			return fmt.Errorf("validate provider token transport: %w", err)
+		}
+		dialer.Header = providerAuthHeader(token)
+	}
+	conn, _, _, err := dialer.Dial(ctx, cfg.coordURL)
 	if err != nil {
 		return fmt.Errorf("dial %s: %w", cfg.coordURL, err)
 	}
@@ -394,6 +521,7 @@ func runWS(cfg config, logger *log.Logger, drainer *drainController) error {
 		return wsutil.WriteClientText(conn, b)
 	}
 	var active sync.Map
+	var cleanShutdown atomic.Bool
 	go func() {
 		t := time.NewTicker(hbInterval)
 		defer t.Stop()
@@ -423,6 +551,7 @@ func runWS(cfg config, logger *log.Logger, drainer *drainController) error {
 	go func() {
 		<-sigs
 		logger.Printf("signal received; emitting drain_status sequence")
+		cleanShutdown.Store(true)
 		runDrain(cfg, logger, drainer, writeText)
 		stopHeartbeat()
 		_ = conn.Close()
@@ -433,12 +562,17 @@ func runWS(cfg config, logger *log.Logger, drainer *drainController) error {
 		payload, op, err := wsutil.ReadServerData(conn)
 		if err != nil {
 			stopHeartbeat()
+			if cleanShutdown.Load() {
+				return nil
+			}
 			return fmt.Errorf("ws read: %w", err)
 		}
 		if op != gobwas.OpText {
 			continue
 		}
 		handleInbound(cfg, logger, drainer, writeText, &active, payload, func() {
+			cleanShutdown.Store(true)
+		}, func() {
 			stopHeartbeat()
 			_ = conn.Close()
 		})
@@ -446,7 +580,7 @@ func runWS(cfg config, logger *log.Logger, drainer *drainController) error {
 }
 
 func handleInbound(cfg config, logger *log.Logger, drainer *drainController,
-	writeText func([]byte) error, active *sync.Map, payload []byte, shutdown func()) {
+	writeText func([]byte) error, active *sync.Map, payload []byte, markClean func(), shutdown func()) {
 
 	var envelope struct {
 		Type      string `json:"type"`
@@ -483,6 +617,7 @@ func handleInbound(cfg config, logger *log.Logger, drainer *drainController,
 	case "drain":
 		logger.Printf("drain received from coordinator")
 		go func() {
+			markClean()
 			runDrain(cfg, logger, drainer, writeText)
 			shutdown()
 		}()

--- a/phase4-coordinator/tools/mockprovider/main_test.go
+++ b/phase4-coordinator/tools/mockprovider/main_test.go
@@ -1,11 +1,21 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"io"
 	"log"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
+
+	gobwas "github.com/gobwas/ws"
+	"github.com/gobwas/ws/wsutil"
 )
 
 func TestCurrentHeartbeatUsesOverrideFile(t *testing.T) {
@@ -84,5 +94,276 @@ func TestReadHeartbeatOverrideRejectsOversizedFile(t *testing.T) {
 
 	if _, _, err := readHeartbeatOverride(overridePath); err == nil {
 		t.Fatal("readHeartbeatOverride accepted an oversized file")
+	}
+}
+
+func TestReadProviderTokenTrimsTokenFile(t *testing.T) {
+	dir := t.TempDir()
+	tokenPath := filepath.Join(dir, "provider.token")
+	if err := os.WriteFile(tokenPath, []byte("canary-token\n"), 0o600); err != nil {
+		t.Fatalf("write token: %v", err)
+	}
+
+	token, ok, err := readProviderToken(tokenPath)
+	if err != nil {
+		t.Fatalf("readProviderToken: %v", err)
+	}
+	if !ok {
+		t.Fatal("readProviderToken did not report a token")
+	}
+	if token != "canary-token" {
+		t.Fatalf("token = %q, want trimmed token", token)
+	}
+}
+
+func TestReadProviderTokenRejectsEmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	tokenPath := filepath.Join(dir, "provider.token")
+	if err := os.WriteFile(tokenPath, []byte(" \n"), 0o600); err != nil {
+		t.Fatalf("write token: %v", err)
+	}
+
+	if _, _, err := readProviderToken(tokenPath); err == nil {
+		t.Fatal("readProviderToken accepted an empty token file")
+	}
+}
+
+func TestReadProviderTokenRejectsNonRegularFile(t *testing.T) {
+	dir := t.TempDir()
+
+	if _, _, err := readProviderToken(dir); err == nil {
+		t.Fatal("readProviderToken accepted a directory")
+	}
+}
+
+func TestReadProviderTokenRejectsOversizedFile(t *testing.T) {
+	dir := t.TempDir()
+	tokenPath := filepath.Join(dir, "provider.token")
+	large := make([]byte, maxProviderTokenBytes+1)
+	if err := os.WriteFile(tokenPath, large, 0o600); err != nil {
+		t.Fatalf("write token: %v", err)
+	}
+
+	if _, _, err := readProviderToken(tokenPath); err == nil {
+		t.Fatal("readProviderToken accepted an oversized file")
+	}
+}
+
+func TestReadProviderTokenRejectsGroupReadableFile(t *testing.T) {
+	dir := t.TempDir()
+	tokenPath := filepath.Join(dir, "provider.token")
+	if err := os.WriteFile(tokenPath, []byte("canary-token\n"), 0o600); err != nil {
+		t.Fatalf("write token: %v", err)
+	}
+	if err := os.Chmod(tokenPath, 0o640); err != nil {
+		t.Fatalf("chmod token: %v", err)
+	}
+
+	if _, _, err := readProviderToken(tokenPath); err == nil {
+		t.Fatal("readProviderToken accepted a group-readable file")
+	}
+}
+
+func TestReadProviderTokenRejectsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	targetPath := filepath.Join(dir, "target.token")
+	linkPath := filepath.Join(dir, "provider.token")
+	if err := os.WriteFile(targetPath, []byte("canary-token\n"), 0o600); err != nil {
+		t.Fatalf("write token: %v", err)
+	}
+	if err := os.Symlink(targetPath, linkPath); err != nil {
+		t.Fatalf("symlink token: %v", err)
+	}
+
+	if _, _, err := readProviderToken(linkPath); err == nil {
+		t.Fatal("readProviderToken accepted a symlink")
+	}
+}
+
+func TestParseProviderTokenRejectsEmbeddedNewline(t *testing.T) {
+	if _, err := parseProviderToken([]byte("first\nsecond\n")); err == nil {
+		t.Fatal("parseProviderToken accepted embedded newline")
+	}
+}
+
+func TestParseProviderTokenRejectsWhitespace(t *testing.T) {
+	if _, err := parseProviderToken([]byte("canary token\n")); err == nil {
+		t.Fatal("parseProviderToken accepted whitespace inside token")
+	}
+}
+
+func TestRunReturnsNonZeroForInvalidProviderTokenFile(t *testing.T) {
+	dir := t.TempDir()
+	var output bytes.Buffer
+
+	code := run(config{
+		providerID:        "mock-A",
+		providerTokenFile: filepath.Join(dir, "missing.token"),
+	}, &output)
+
+	if code == 0 {
+		t.Fatal("run returned 0 for an invalid provider token file")
+	}
+	if !strings.Contains(output.String(), "startup config error:") {
+		t.Fatalf("output = %q, want startup config error", output.String())
+	}
+}
+
+func TestRunReturnsNonZeroForUnsafeProviderTokenTransport(t *testing.T) {
+	dir := t.TempDir()
+	tokenPath := filepath.Join(dir, "provider.token")
+	if err := os.WriteFile(tokenPath, []byte("canary-token\n"), 0o600); err != nil {
+		t.Fatalf("write token: %v", err)
+	}
+	var output bytes.Buffer
+
+	code := run(config{
+		coordURL:          "ws://coordinator.malibu.tech/ws/provider",
+		providerID:        "mock-A",
+		providerTokenFile: tokenPath,
+	}, &output)
+
+	if code == 0 {
+		t.Fatal("run returned 0 for unsafe provider token transport")
+	}
+	if !strings.Contains(output.String(), "startup config error:") {
+		t.Fatalf("output = %q, want startup config error", output.String())
+	}
+}
+
+func TestRunReturnsNonZeroForWebSocketFailure(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	if err := ln.Close(); err != nil {
+		t.Fatalf("close listener: %v", err)
+	}
+	var output bytes.Buffer
+
+	code := run(config{
+		coordURL:   "ws://" + addr + "/ws/provider",
+		providerID: "mock-A",
+		httpPort:   0,
+	}, &output)
+
+	if code == 0 {
+		t.Fatal("run returned 0 for a websocket failure")
+	}
+	if !strings.Contains(output.String(), "ws loop exited:") {
+		t.Fatalf("output = %q, want websocket failure", output.String())
+	}
+}
+
+func TestRunReturnsZeroForCoordinatorDrain(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, _, _, err := gobwas.UpgradeHTTP(r, w)
+		if err != nil {
+			t.Errorf("upgrade: %v", err)
+			return
+		}
+		defer conn.Close()
+
+		if _, _, err := wsutil.ReadClientData(conn); err != nil {
+			t.Errorf("read hello: %v", err)
+			return
+		}
+		ack, _ := json.Marshal(helloAck{
+			Type:               "hello_ack",
+			AssignedID:         "assigned-canary",
+			HeartbeatIntervalS: 1,
+		})
+		if err := wsutil.WriteServerText(conn, ack); err != nil {
+			t.Errorf("write ack: %v", err)
+			return
+		}
+
+		sawComplete := false
+		drain, _ := json.Marshal(map[string]string{"type": "drain"})
+		if err := wsutil.WriteServerText(conn, drain); err != nil {
+			t.Errorf("write drain: %v", err)
+			return
+		}
+		deadline := time.Now().Add(5 * time.Second)
+		for time.Now().Before(deadline) {
+			payload, _, err := wsutil.ReadClientData(conn)
+			if err != nil {
+				break
+			}
+			var status drainStatus
+			if err := json.Unmarshal(payload, &status); err != nil || status.Type != "drain_status" {
+				continue
+			}
+			if status.Phase == "complete" {
+				sawComplete = true
+				break
+			}
+		}
+		if !sawComplete {
+			t.Error("mockprovider did not send drain_status complete")
+		}
+	}))
+	defer srv.Close()
+	coordURL := "ws://" + strings.TrimPrefix(srv.URL, "http://") + "/ws/provider"
+	var output bytes.Buffer
+
+	code := run(config{
+		coordURL:        coordURL,
+		providerID:      "mock-A",
+		httpPort:        0,
+		drainDelayS:     1,
+		maxContext:      8192,
+		slots:           1,
+		omitEndpointURL: true,
+	}, &output)
+
+	if code != 0 {
+		t.Fatalf("run returned %d for coordinator drain; output=%q", code, output.String())
+	}
+}
+
+func TestProviderAuthHeaderWritesBearer(t *testing.T) {
+	header := providerAuthHeader(" canary-token ")
+	if header == nil {
+		t.Fatal("providerAuthHeader returned nil for a token")
+	}
+
+	var buf bytes.Buffer
+	if _, err := header.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+	if got := buf.String(); !strings.Contains(got, "Authorization: Bearer canary-token\r\n") {
+		t.Fatalf("header = %q, want Authorization bearer header", got)
+	}
+}
+
+func TestProviderAuthHeaderSkipsBlankToken(t *testing.T) {
+	if header := providerAuthHeader(" \n"); header != nil {
+		t.Fatal("providerAuthHeader returned a header for a blank token")
+	}
+}
+
+func TestValidateTokenTransportAllowsWSS(t *testing.T) {
+	if err := validateTokenTransport("wss://coordinator.example.test/ws/provider"); err != nil {
+		t.Fatalf("validateTokenTransport rejected wss: %v", err)
+	}
+}
+
+func TestValidateTokenTransportAllowsLoopbackWS(t *testing.T) {
+	for _, coordURL := range []string{
+		"ws://127.0.0.1:8444/ws/provider",
+		"ws://[::1]:8444/ws/provider",
+		"ws://localhost:8444/ws/provider",
+	} {
+		if err := validateTokenTransport(coordURL); err != nil {
+			t.Fatalf("validateTokenTransport rejected %s: %v", coordURL, err)
+		}
+	}
+}
+
+func TestValidateTokenTransportRejectsNonLoopbackWS(t *testing.T) {
+	if err := validateTokenTransport("ws://coordinator.malibu.tech/ws/provider"); err == nil {
+		t.Fatal("validateTokenTransport accepted token-bearing non-loopback ws")
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `mockprovider -provider-token-file` so physical canary providers can authenticate with existing provider bearer tokens without putting tokens in argv.
- Hardens token-file handling: no symlinks, current-user ownership, private permissions, size cap, single printable token line.
- Fails fast for bad token files, unsafe token transport, dead coordinators, and auth failures while preserving clean coordinator-drain exit semantics.

## Production impact
- Tool-only change under `phase4-coordinator/tools/mockprovider`.
- No production coordinator, provider app, admission, routing, pricing, or auth policy changes.
- Bearer over plaintext `ws://` is allowed only for loopback/localhost, which is required for the isolated canary SSH-tunnel setup.

## Validation
- `go test ./tools/mockprovider -count=1`
- `go test -race ./tools/mockprovider -count=1`
- `go vet ./tools/mockprovider`
- `go build ./cmd/coordinator ./tools/mockprovider`
- `go test ./internal/ws -run 'TestProviderHelloAcceptsAuthorizationHeaderInStep2|TestSelfServeProvisionalTokenNotMintedWhenBearerValidated' -count=1`
- `git diff --check`

## Audit
- Code review: 0 CRITICAL/HIGH/MEDIUM; 1 LOW carried for direct SIGTERM subprocess coverage.
- Security review: 0 CRITICAL/HIGH/MEDIUM/LOW.
- Architecture review: 0 CRITICAL/HIGH/MEDIUM/LOW.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "issue": "https://github.com/Augustas11/macprovider/issues/959",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-032"],
  "requirements": ["SPEC-032-R001", "SPEC-032-R002", "SPEC-032-R003"],
  "authority_domains": ["hardware-evidence-admission"],
  "arbitration": ["UNKNOWN"],
  "tests": [
    "go test ./tools/mockprovider -count=1",
    "go test -race ./tools/mockprovider -count=1",
    "go vet ./tools/mockprovider",
    "go build ./cmd/coordinator ./tools/mockprovider",
    "go test ./internal/ws -run 'TestProviderHelloAcceptsAuthorizationHeaderInStep2|TestSelfServeProvisionalTokenNotMintedWhenBearerValidated' -count=1",
    "git diff --check"
  ],
  "journeys": ["JOURNEY-PROVIDER-PREBETA-ADMISSION"]
}
SPEC-GOVERNANCE-DECLARATION-END
