### PR TITLE
Fix provider-prebeta signer schema normalization

### DIFF
--- a/scripts/build-provider-prebeta-journey-result.py
+++ b/scripts/build-provider-prebeta-journey-result.py
@@ -219,6 +219,58 @@ def require_redaction(value: Any) -> dict[str, bool]:
     return {key: True for key in required}
 
 
+def require_environment(value: Any) -> dict[str, Any]:
+    environment = require_object(value, "environment")
+    for field in ("class", "hardware_profile", "candidate"):
+        require_string(environment.get(field), None, f"environment.{field}")
+    if environment.get("class") != EXECUTION_MODE:
+        die(f"environment.class must equal {EXECUTION_MODE!r}")
+
+    allowed = {
+        "class",
+        "hardware_profile",
+        "candidate",
+        "binary_version",
+        "compatibility_set",
+        "operating_system",
+        "production_equivalent_conditions",
+    }
+    output = {key: deepcopy(environment[key]) for key in environment if key in allowed}
+    for field in ("binary_version", "compatibility_set", "operating_system"):
+        if field in output:
+            require_string(output.get(field), None, f"environment.{field}")
+    if "production_equivalent_conditions" in output:
+        production_equivalent = require_object(
+            output.get("production_equivalent_conditions"),
+            "environment.production_equivalent_conditions",
+        )
+        string_fields = {
+            "provider_service",
+            "network_state_before",
+            "network_state_after",
+            "thermal_state",
+            "memory_pressure",
+        }
+        bool_fields = {
+            "coordinator_connected_before",
+            "coordinator_connected_after",
+            "model_loaded_before",
+            "model_loaded_after",
+            "thermally_throttled",
+        }
+        for field in string_fields:
+            require_string(production_equivalent.get(field), None, f"environment.production_equivalent_conditions.{field}")
+        for field in bool_fields:
+            if not isinstance(production_equivalent.get(field), bool):
+                die(f"environment.production_equivalent_conditions.{field} must be boolean")
+        output["production_equivalent_conditions"] = {
+            key: deepcopy(production_equivalent[key])
+            for key in production_equivalent
+            if key in string_fields or key in bool_fields
+        }
+    return output
+
+
 def require_result(value: Any) -> dict[str, Any]:
     result = deepcopy(require_object(value, "result"))
     if result.get("status") != "pass":
@@ -434,11 +486,7 @@ def build_payload(root: Path, source: str, *, source_sha: str, evidence_sha: str
     operator = deepcopy(require_object(evidence.get("operator"), "operator"))
     require_string(operator.get("role"), None, "operator.role")
     require_string(operator.get("identity_fingerprint"), FINGERPRINT_RE, "operator.identity_fingerprint")
-    environment = deepcopy(require_object(evidence.get("environment"), "environment"))
-    for field in ("class", "hardware_profile", "candidate"):
-        require_string(environment.get(field), None, f"environment.{field}")
-    if environment.get("class") != EXECUTION_MODE:
-        die(f"environment.class must equal {EXECUTION_MODE!r}")
+    environment = require_environment(evidence.get("environment"))
     result = require_result(evidence.get("result"))
     steps = require_steps(evidence.get("steps"), selected_requirements, evidence_ids)
     redaction = require_redaction(evidence.get("redaction"))

--- a/scripts/check_spec_governance.py
+++ b/scripts/check_spec_governance.py
@@ -950,6 +950,83 @@ def _provider_prebeta_normalized_redaction(value: Any, location: str, result: Va
     return output
 
 
+def _provider_prebeta_normalized_environment(value: Any, location: str, result: ValidationResult) -> dict[str, Any] | None:
+    if not _expect_object(value, location, result):
+        return None
+    base_fields = {"class", "hardware_profile", "candidate"}
+    provider_fields = {
+        "binary_version",
+        "compatibility_set",
+        "operating_system",
+        "production_equivalent_conditions",
+    }
+    evidence_only_fields = {
+        "coordinator_identity",
+        "production_target",
+    }
+    _expect_keys(value, base_fields, base_fields | provider_fields | evidence_only_fields, location, result)
+    output: dict[str, Any] = {}
+    for field in ("class", "hardware_profile", "candidate"):
+        text = _string(value.get(field), None, f"{location}.{field}", result)
+        if text is not None:
+            output[field] = text
+    for field in ("binary_version", "compatibility_set", "operating_system"):
+        if field in value:
+            text = _string(value.get(field), None, f"{location}.{field}", result)
+            if text is not None:
+                output[field] = text
+    for field in evidence_only_fields:
+        if field in value:
+            _string(value.get(field), None, f"{location}.{field}", result)
+    production_equivalent = value.get("production_equivalent_conditions")
+    if production_equivalent is not None and _expect_object(
+        production_equivalent,
+        f"{location}.production_equivalent_conditions",
+        result,
+    ):
+        string_fields = {
+            "provider_service",
+            "network_state_before",
+            "network_state_after",
+            "thermal_state",
+            "memory_pressure",
+        }
+        bool_fields = {
+            "coordinator_connected_before",
+            "coordinator_connected_after",
+            "model_loaded_before",
+            "model_loaded_after",
+            "thermally_throttled",
+        }
+        _expect_keys(
+            production_equivalent,
+            string_fields | bool_fields,
+            string_fields | bool_fields,
+            f"{location}.production_equivalent_conditions",
+            result,
+        )
+        normalized_production_equivalent: dict[str, Any] = {}
+        for field in sorted(string_fields):
+            text = _string(
+                production_equivalent.get(field),
+                None,
+                f"{location}.production_equivalent_conditions.{field}",
+                result,
+            )
+            if text is not None:
+                normalized_production_equivalent[field] = text
+        for field in sorted(bool_fields):
+            value_bool = _bool_value(
+                production_equivalent.get(field),
+                f"{location}.production_equivalent_conditions.{field}",
+                result,
+            )
+            if value_bool is not None:
+                normalized_production_equivalent[field] = value_bool
+        output["production_equivalent_conditions"] = normalized_production_equivalent
+    return output
+
+
 def _provider_prebeta_step_order(requirement_ids: list[str], location: str, result: ValidationResult) -> tuple[str, ...]:
     selected = set(requirement_ids)
     if selected & PROVIDER_PREBETA_STRICT_SPEC032_REQUIREMENT_IDS:
@@ -1099,7 +1176,9 @@ def _validate_provider_prebeta_artifact(
     repository = payload.get("repository")
     signed_repository = signed.get("repository")
     if _expect_object(repository, f"{location}.source.repository", result) and isinstance(signed_repository, dict):
-        _expect_keys(repository, {"name", "commit"}, {"name", "commit"}, f"{location}.source.repository", result)
+        _expect_keys(repository, {"name", "commit"}, {"name", "commit", "git_describe"}, f"{location}.source.repository", result)
+        if "git_describe" in repository:
+            _string(repository.get("git_describe"), None, f"{location}.source.repository.git_describe", result)
         if repository.get("name") != signed_repository.get("name"):
             result.error(f"{location}.source.repository.name", "must match signed.repository.name")
         if repository.get("commit") != signed_repository.get("commit"):
@@ -1109,7 +1188,11 @@ def _validate_provider_prebeta_artifact(
     if payload.get("expires_at") != signed.get("expires_at"):
         result.error(f"{location}.source.expires_at", "must match signed.expires_at")
     _provider_prebeta_compare_signed_source(payload.get("run_id"), signed.get("run_id"), f"{location}.source.run_id", result)
-    for field_name in ("operator", "environment", "result"):
+    _provider_prebeta_compare_signed_source(payload.get("operator"), signed.get("operator"), f"{location}.source.operator", result)
+    source_environment = _provider_prebeta_normalized_environment(payload.get("environment"), f"{location}.source.environment", result)
+    signed_environment = _provider_prebeta_normalized_environment(signed.get("environment"), f"{location}.signed.environment", result)
+    _provider_prebeta_compare_signed_source(source_environment, signed_environment, f"{location}.source.environment", result)
+    for field_name in ("result",):
         _provider_prebeta_compare_signed_source(
             payload.get(field_name),
             signed.get(field_name),

--- a/scripts/tests/test_provider_prebeta_journey_result.py
+++ b/scripts/tests/test_provider_prebeta_journey_result.py
@@ -218,8 +218,11 @@ def strict_spec032_steps() -> list[dict]:
 def make_spec032_evidence(evidence: dict) -> None:
     evidence["run_id"] = "provider-prebeta-admission-spec032-strict-canary-20260902T120000Z"
     evidence["requirement_ids"] = ["SPEC-032-R001", "SPEC-032-R002", "SPEC-032-R003"]
+    evidence["repository"]["git_describe"] = "v1.8.118-29-g00000000"
     evidence["result"] = {"status": "pass", "summary": "Physical strict admission-gate matrix passed."}
     evidence["environment"]["class"] = "physical-provider-prebeta-admission"
+    evidence["environment"]["coordinator_identity"] = hashlib.sha256(b"isolated-canary-coordinator").hexdigest()
+    evidence["environment"]["production_target"] = "not coordinator.malibu.tech"
     evidence["steps"] = strict_spec032_steps()
 
 
@@ -1063,6 +1066,9 @@ class ProviderPrebetaJourneyResultTests(unittest.TestCase):
         self.assertEqual(0, completed.returncode, completed.stderr)
         payload = json.loads(output.read_text(encoding="utf-8"))
         self.assertEqual(["SPEC-032-R001", "SPEC-032-R002", "SPEC-032-R003"], payload["requirement_ids"])
+        self.assertEqual({"name": "Augustas11/macprovider", "commit": source_commit}, payload["repository"])
+        self.assertNotIn("coordinator_identity", payload["environment"])
+        self.assertNotIn("production_target", payload["environment"])
         self.assertEqual("r001-over-ceiling", payload["steps"][0]["id"])
         self.assertEqual("r003-recovery-sweep", payload["steps"][-1]["id"])
         self.assertEqual("physical-provider-prebeta-admission", payload["execution_mode"])


### PR DESCRIPTION
Fix the provider-prebeta SPEC-032 protected signing path so redacted evidence can retain isolated-canary context while the signed journey-result payload stays within the strict v1 schema.

Validation:
- `python3 -m unittest scripts.tests.test_provider_prebeta_journey_result scripts.tests.test_journey_result_tools scripts.tests.test_spec_governance`
- `python3 scripts/validate-provider-prebeta-evidence.py --source-sha c3e8ef2f1e59f8ebf711cea4042967ecb410a769 --requirement-ids SPEC-032-R001,SPEC-032-R002,SPEC-032-R003 journeys/evidence/provider-prebeta-admission-spec032-strict-physical-20260902T141932Z.redacted.json`
- Built unsigned payload from the T141932Z physical artifact and verified the signed contract excludes source-only canary context fields.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": ["SPEC-032"],
  "requirements": ["SPEC-032-R001", "SPEC-032-R002", "SPEC-032-R003"],
  "authority_domains": ["hardware-evidence-admission"],
  "arbitration": ["UNKNOWN"],
  "tests": [
    "python3 -m unittest scripts.tests.test_provider_prebeta_journey_result scripts.tests.test_journey_result_tools scripts.tests.test_spec_governance",
    "python3 scripts/validate-provider-prebeta-evidence.py --source-sha c3e8ef2f1e59f8ebf711cea4042967ecb410a769 --requirement-ids SPEC-032-R001,SPEC-032-R002,SPEC-032-R003 journeys/evidence/provider-prebeta-admission-spec032-strict-physical-20260902T141932Z.redacted.json"
  ],
  "journeys": ["JOURNEY-PROVIDER-PREBETA-ADMISSION"]
}
SPEC-GOVERNANCE-DECLARATION-END
