### PR TITLE
Make warm-up capability gate fail-open observe-only; fix onboarding deadlock (#1354)

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -454,7 +454,28 @@ actor CoordinatorClient {
         guard let rawURL = config.coordinatorURL, let url = URL(string: rawURL) else {
             return nil
         }
-        guard url.scheme == "wss" else {
+        // #1354 S2: production coordinators require `wss`, but an insecure `ws`
+        // scheme is allowed for loopback hosts only (localhost/127.0.0.1/::1) so
+        // isolated test/staging coordinators can be reached — matching the
+        // loopback exemption already honored by CoordinatorReadinessClient. Any
+        // other rejection is reported explicitly instead of a silent nil, which
+        // previously surfaced as a misleading "check this Mac's internet
+        // connection" status with no log line.
+        let scheme = url.scheme?.lowercased()
+        let host = url.host?.lowercased()
+        let isLoopback = host == "localhost" || host == "127.0.0.1" || host == "::1"
+        switch scheme {
+        case "wss":
+            break
+        case "ws" where isLoopback:
+            break
+        case "ws":
+            FileHandle.standardError.write(Data(
+                "FATAL coordinator URL uses insecure ws:// for non-loopback host \(host ?? "?"); use wss:// (ws:// is permitted only for localhost/127.0.0.1/::1)\n".utf8))
+            return nil
+        default:
+            FileHandle.standardError.write(Data(
+                "FATAL coordinator URL scheme \(scheme ?? "nil") is not supported; expected wss:// (or ws:// for a loopback coordinator)\n".utf8))
             return nil
         }
         self.coordinatorURL = url

--- a/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
+++ b/phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift
@@ -461,8 +461,22 @@ actor CoordinatorClient {
         // other rejection is reported explicitly instead of a silent nil, which
         // previously surfaced as a misleading "check this Mac's internet
         // connection" status with no log line.
-        let scheme = url.scheme?.lowercased()
-        let host = url.host?.lowercased()
+        //
+        // Parse with URLComponents so we can reject embedded userinfo and a
+        // missing host, matching CoordinatorReadinessClient.readinessURL — a bare
+        // `wss:///path` (no host) or a `ws://user@localhost` credential smuggle
+        // must not slip through to fail later on the socket.
+        guard let components = URLComponents(string: rawURL),
+              components.user == nil,
+              components.password == nil,
+              let host = components.host?.lowercased(),
+              !host.isEmpty
+        else {
+            FileHandle.standardError.write(Data(
+                "FATAL coordinator URL is missing a host or embeds userinfo; expected wss://host[:port]/path (or ws://<loopback> for an isolated coordinator)\n".utf8))
+            return nil
+        }
+        let scheme = components.scheme?.lowercased()
         let isLoopback = host == "localhost" || host == "127.0.0.1" || host == "::1"
         switch scheme {
         case "wss":
@@ -471,7 +485,7 @@ actor CoordinatorClient {
             break
         case "ws":
             FileHandle.standardError.write(Data(
-                "FATAL coordinator URL uses insecure ws:// for non-loopback host \(host ?? "?"); use wss:// (ws:// is permitted only for localhost/127.0.0.1/::1)\n".utf8))
+                "FATAL coordinator URL uses insecure ws:// for non-loopback host \(host); use wss:// (ws:// is permitted only for localhost/127.0.0.1/::1)\n".utf8))
             return nil
         default:
             FileHandle.standardError.write(Data(

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -2231,21 +2231,38 @@ final class CoordinatorClientTests: XCTestCase {
         XCTAssertNil(acceptedKeyID)
     }
 
-    func testWSScheme_MustBeWSS_NotWS() async throws {
+    // #1354 S2: `wss` is required for production, but an insecure `ws` scheme is
+    // allowed for loopback hosts only so isolated test/staging coordinators can be
+    // reached (matching CoordinatorReadinessClient's loopback exemption). Any
+    // other scheme is rejected — now with an explicit stderr diagnostic rather
+    // than the previous misleading "check this Mac's internet connection".
+    func testWSScheme_AllowsWSForLoopback_RejectsWSForRemote() async throws {
         let status = ProviderStatus(
             modelID: "model-a",
             modelLoaded: true,
             capacity: ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
         )
         let runtime = try await ModelRuntime(modelID: nil)
-        var insecure = AppConfig.defaults(configPath: "/tmp/macprovider-test.yaml")
-        insecure.coordinatorURL = "ws://127.0.0.1:8444/ws/provider"
-        insecure.providerID = "provider-test"
-        insecure.model = "model-a"
+        var base = AppConfig.defaults(configPath: "/tmp/macprovider-test.yaml")
+        base.providerID = "provider-test"
+        base.model = "model-a"
 
-        XCTAssertNil(CoordinatorClient(config: insecure, modelRuntime: runtime, providerStatus: status))
+        // ws:// to a loopback coordinator is now accepted (isolated-coordinator onboarding).
+        for loopback in ["ws://127.0.0.1:8444/ws/provider", "ws://localhost:8444/ws/provider"] {
+            var cfg = base
+            cfg.coordinatorURL = loopback
+            XCTAssertNotNil(
+                CoordinatorClient(config: cfg, modelRuntime: runtime, providerStatus: status),
+                "expected ws:// loopback URL \(loopback) to be accepted")
+        }
 
-        var secure = insecure
+        // ws:// to a non-loopback host is still rejected.
+        var remote = base
+        remote.coordinatorURL = "ws://coordinator.malibu.tech/ws/provider"
+        XCTAssertNil(CoordinatorClient(config: remote, modelRuntime: runtime, providerStatus: status))
+
+        // wss:// is always accepted.
+        var secure = base
         secure.coordinatorURL = "wss://127.0.0.1:8444/ws/provider"
         XCTAssertNotNil(CoordinatorClient(config: secure, modelRuntime: runtime, providerStatus: status))
     }

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -2248,6 +2248,10 @@ final class CoordinatorClientTests: XCTestCase {
         base.model = "model-a"
 
         // ws:// to a loopback coordinator is now accepted (isolated-coordinator onboarding).
+        // NOTE: bracketed IPv6 `ws://[::1]` is intentionally NOT accepted — URLComponents
+        // reports its host as "[::1]", and CoordinatorReadinessClient uses the identical
+        // unbracketed "::1" loopback check, so accepting it only here would reintroduce the
+        // WS-vs-readiness asymmetry S2 fixes. Loopback coordinators use 127.0.0.1/localhost.
         for loopback in ["ws://127.0.0.1:8444/ws/provider", "ws://localhost:8444/ws/provider"] {
             var cfg = base
             cfg.coordinatorURL = loopback
@@ -2256,15 +2260,31 @@ final class CoordinatorClientTests: XCTestCase {
                 "expected ws:// loopback URL \(loopback) to be accepted")
         }
 
-        // ws:// to a non-loopback host is still rejected.
-        var remote = base
-        remote.coordinatorURL = "ws://coordinator.malibu.tech/ws/provider"
-        XCTAssertNil(CoordinatorClient(config: remote, modelRuntime: runtime, providerStatus: status))
-
-        // wss:// is always accepted.
+        // wss:// with a host is always accepted.
         var secure = base
         secure.coordinatorURL = "wss://127.0.0.1:8444/ws/provider"
         XCTAssertNotNil(CoordinatorClient(config: secure, modelRuntime: runtime, providerStatus: status))
+
+        // Every rejection case returns nil (with an explicit stderr diagnostic).
+        let rejected = [
+            "ws://coordinator.malibu.tech/ws/provider", // remote plaintext downgrade
+            "wss:///ws/provider",                        // missing host
+            "http://127.0.0.1:8444/ws/provider",         // unsupported scheme
+            "ws://user@localhost:8444/ws/provider",      // userinfo smuggle on loopback
+            "wss://user:pw@coordinator.malibu.tech/ws",  // userinfo smuggle on wss
+        ]
+        for bad in rejected {
+            var cfg = base
+            cfg.coordinatorURL = bad
+            XCTAssertNil(
+                CoordinatorClient(config: cfg, modelRuntime: runtime, providerStatus: status),
+                "expected coordinator URL \(bad) to be rejected")
+        }
+
+        // A nil coordinator URL is rejected.
+        var missing = base
+        missing.coordinatorURL = nil
+        XCTAssertNil(CoordinatorClient(config: missing, modelRuntime: runtime, providerStatus: status))
     }
 
     func testRequestPairOT_NeverEmitted_OnAdmissionFrames() async throws {

--- a/phase4-coordinator/coordinator.yaml.example
+++ b/phase4-coordinator/coordinator.yaml.example
@@ -31,6 +31,7 @@ pool:
   heartbeat_miss_threshold_s: 90
   wake_gap_threshold_s: 120
   warmup_fallback_s: 60
+  # FR-P8a (SPEC-002 v1.6.0): observe-only fitness probe; fail-open, never blocks onboarding.
   warmup_gate_enabled: false
   warmup_gate_timeout_s: 90
   warmup_gate_max_tokens: 2

--- a/phase4-coordinator/dist/coordinator.yaml
+++ b/phase4-coordinator/dist/coordinator.yaml
@@ -44,6 +44,9 @@ pool:
   # 2026-07-28 / #784: align the checked-in Pearl template with the live
   # overlay's resolved posture. Re-enable only through a fresh live-pool
   # survey + normal deploy path.
+  # 2026-09-03 / #1354: FR-P8a is now fail-open observe-only (SPEC-002 v1.6.0),
+  # so `true` no longer blocks onboarding — it only runs an advisory probe.
+  # Kept `false` here to match the live overlay; flip via the normal deploy path.
   warmup_gate_enabled: false
   warmup_gate_timeout_s: 90
   warmup_gate_max_tokens: 2

--- a/phase4-coordinator/internal/ws/capacity_clamp_test.go
+++ b/phase4-coordinator/internal/ws/capacity_clamp_test.go
@@ -15,8 +15,9 @@ import (
 func capacityTestConfig(ceiling int) config.Config {
 	cfg := config.Default()
 	cfg.Pool.MaxConcurrencyCeiling = ceiling
-	// The warm-up gate would admit the provider as degraded, which is
-	// orthogonal to the capacity clamp under test.
+	// The warm-up probe (observe-only since SPEC-002 v1.6.0) would dispatch a
+	// background inference that is orthogonal to the capacity clamp under test;
+	// disable it so the clamp assertions are not perturbed.
 	cfg.Pool.WarmupGateEnabled = false
 	return cfg
 }

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -4024,6 +4024,14 @@ func (s *Server) Preflight(provider pool.Provider, requestID string, estimatedTo
 	}
 }
 
+// startWarmupGate records a per-session marker and launches the observe-only
+// probe. Since SPEC-002 v1.6.0 the marker (`warmups` / warmupGatePending) is NOT
+// a routing gate — the provider is already `ready`. It survives only to (a)
+// de-duplicate concurrent probes for the same session and (b) avoid overlapping
+// an OPoI canary probe with the admission probe (canaryProbeEligible). The
+// marker clears when the probe finishes (bounded by DegradedMaxRetries ×
+// backoff), so any canary suppression is a short, bounded window on an
+// already-routable provider, not an eligibility hold.
 func (s *Server) startWarmupGate(provider pool.Provider) {
 	s.warmups.Store(provider.ProviderID, provider.AssignedID)
 	go s.runWarmupGate(provider)
@@ -5101,7 +5109,13 @@ func (s *Server) handleHeartbeat(conn net.Conn, providerID, assignedID string, p
 			Diagnostic:    "heartbeat_gap",
 		})
 	}
-	if gap > s.wakeGapThreshold() && !s.warmupGatePending(providerID) {
+	// #1354 / SPEC-002 v1.6.0: the admission warm-up probe is now observe-only and
+	// never blocks routing, so it must not suppress the independent wake-from-sleep
+	// (FR-P8) fallback. Previously `!warmupGatePending` deferred wake handling to the
+	// blocking admission gate; with fail-open there is no gate to defer to, and
+	// leaving the guard here would route a cold first request to a provider that
+	// woke mid-probe. Wake detection now runs independently of the admission probe.
+	if gap > s.wakeGapThreshold() {
 		s.log.Info().Str("provider_id", providerID).Dur("gap", gap).Msg("provider wake detected")
 		s.markDegradedForWarmup(providerID, assignedID)
 		session, ok := s.sessionFor(providerID, assignedID)
@@ -5520,10 +5534,11 @@ func (s *Server) markDegradedForWarmup(providerID, assignedID string) {
 		timer.(*time.Timer).Stop()
 	}
 	timer := time.AfterFunc(s.warmupFallback(), func() {
-		if s.warmupGatePending(providerID) {
-			s.timers.Delete(providerID)
-			return
-		}
+		// #1354 / SPEC-002 v1.6.0: the wake fallback promotes independently of the
+		// admission observe-probe. The former `warmupGatePending` early-return here
+		// deferred promotion to the (now-removed) blocking admission gate; keeping it
+		// would strand a wake-degraded provider in `degraded` whenever an observe
+		// probe was still in flight when the fallback fired.
 		if s.pool.MarkState(providerID, assignedID, pool.StateReady) {
 			s.log.Warn().Str("provider_id", providerID).Dur("timeout", s.warmupFallback()).Msg("warm_up timed out; allowing routing")
 		}

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -2815,10 +2815,15 @@ func (s *Server) prepareProviderAdmissionWithQuotaCheck(conn net.Conn, auth prov
 		admittedTuple = admissionObservation.AdmittedTuple
 		admissionSandboxed = admissionObservation.Sandboxed
 	}
+	// #1354 / SPEC-002 v1.6.0: the warm-up capability gate is now fail-open and
+	// observe-only. A provider that clears the trust/identity admission gates is
+	// admitted `ready` and immediately routable; the warm-up probe (started by
+	// the caller when WarmupGateEnabled) runs in the background purely for a
+	// fitness verdict and never withholds routing. Admitting `degraded` here was
+	// the onboarding deadlock: the released CLI awaits buyer-serving readiness
+	// before it starts reading the WS, so the probe frame was never answered and
+	// the provider could never leave `degraded`.
 	initialState := pool.StateReady
-	if s.cfg.Pool.WarmupGateEnabled {
-		initialState = pool.StateDegraded
-	}
 	// Issue #764: clamp the reported capacity BEFORE it enters the registry, so
 	// no downstream consumer ever sees the raw claim. A fresh session starts
 	// fully free, so the reported triple is (max, max, max).
@@ -4024,6 +4029,13 @@ func (s *Server) startWarmupGate(provider pool.Provider) {
 	go s.runWarmupGate(provider)
 }
 
+// runWarmupGate runs the FR-P8a warm-up capability probe as a fail-open,
+// observe-only background observation (SPEC-002 v1.6.0, issue #1354). The
+// provider is already admitted `ready` and buyer-routable; this probe records a
+// fitness verdict for telemetry/connection-event history but MUST NOT change
+// routing state. It never marks the provider `ready` (it already is) and never
+// marks it `degraded`/`unavailable`. A provider that genuinely cannot serve is
+// removed by the in-flight circuit breaker (FR-P11a) on real buyer traffic.
 func (s *Server) runWarmupGate(provider pool.Provider) {
 	defer s.clearWarmupGate(provider.ProviderID, provider.AssignedID)
 	attempts := s.cfg.Pool.DegradedMaxRetries
@@ -4040,13 +4052,12 @@ func (s *Server) runWarmupGate(provider pool.Provider) {
 			return
 		}
 		if s.runWarmupGateAttempt(provider, attempt) {
-			s.clearWarmupGate(provider.ProviderID, provider.AssignedID)
-			if s.pool.MarkState(provider.ProviderID, provider.AssignedID, pool.StateReady) {
-				s.log.Info().Str("provider_id", provider.ProviderID).Int("attempt", attempt).Msg("warmup gate passed")
-			}
+			// Observe-only: no state transition — the provider is already
+			// `ready`. Record the positive fitness verdict for observability.
+			s.log.Info().Str("provider_id", provider.ProviderID).Int("attempt", attempt).Msg("warmup probe observed token production (advisory)")
 			return
 		}
-		s.log.Warn().Str("provider_id", provider.ProviderID).Int("attempt", attempt).Str("reason", "warmup_failed").Msg("warmup gate attempt failed")
+		s.log.Warn().Str("provider_id", provider.ProviderID).Int("attempt", attempt).Str("reason", "warmup_failed").Msg("warmup probe attempt observed no token production (advisory)")
 		s.recordConnectionEvent(providerevents.Event{
 			ProviderID:    provider.ProviderID,
 			SessionID:     provider.AssignedID,
@@ -4059,20 +4070,21 @@ func (s *Server) runWarmupGate(provider pool.Provider) {
 			Diagnostic:    "warmup_attempt_failed",
 		})
 	}
-	if s.pool.MarkState(provider.ProviderID, provider.AssignedID, pool.StateUnavailable) {
-		s.log.Warn().Str("provider_id", provider.ProviderID).Str("reason", "warmup_failed").Msg("provider marked unavailable after warmup gate failures")
-		s.recordConnectionEvent(providerevents.Event{
-			ProviderID:    provider.ProviderID,
-			SessionID:     provider.AssignedID,
-			Kind:          providerevents.KindWarmupFailed,
-			Outcome:       providerevents.OutcomeFailure,
-			FailureReason: providerevents.ReasonWarmupFailed,
-			AuthStage:     providerevents.AuthStageWarmup,
-			MessageFamily: providerevents.MessageFamilyNone,
-			BinaryVersion: provider.BinaryVersion,
-			Diagnostic:    "warmup_gate_exhausted",
-		})
-	}
+	// Fail-open: the probe never observed token production, but this is advisory
+	// only — the provider stays `ready` and buyer-routable. Record the exhausted
+	// verdict for telemetry; do NOT mark the provider unavailable.
+	s.log.Warn().Str("provider_id", provider.ProviderID).Str("reason", "warmup_failed").Msg("warmup probe exhausted without observed token production; provider remains routable (advisory only)")
+	s.recordConnectionEvent(providerevents.Event{
+		ProviderID:    provider.ProviderID,
+		SessionID:     provider.AssignedID,
+		Kind:          providerevents.KindWarmupFailed,
+		Outcome:       providerevents.OutcomeFailure,
+		FailureReason: providerevents.ReasonWarmupFailed,
+		AuthStage:     providerevents.AuthStageWarmup,
+		MessageFamily: providerevents.MessageFamilyNone,
+		BinaryVersion: provider.BinaryVersion,
+		Diagnostic:    "warmup_gate_exhausted_observe_only",
+	})
 }
 
 func (s *Server) runWarmupGateAttempt(provider pool.Provider, attempt int) bool {
@@ -4993,9 +5005,10 @@ func (s *Server) handleHeartbeat(conn net.Conn, providerID, assignedID string, p
 		s.log.Warn().Str("state", hb.Status).Str("provider_id", providerID).Msg("invalid heartbeat state")
 		return
 	}
-	if state == pool.StateReady && s.warmupGatePending(providerID) {
-		state = pool.StateDegraded
-	}
+	// #1354 / SPEC-002 v1.6.0: the warm-up probe is observe-only and fail-open,
+	// so a heartbeat `ready` is no longer clamped to `degraded` while a probe is
+	// in flight — that clamp was part of the blocking gate that deadlocked
+	// onboarding. Trust/identity gates still constrain routing independently.
 	if hb.SafetyTelemetry != nil && hb.SafetyTelemetry.ProviderID != providerID {
 		s.log.Warn().Str("provider_id", providerID).Msg("heartbeat safety telemetry provider_id mismatch")
 		return
@@ -5467,9 +5480,9 @@ func (s *Server) handleStateUpdate(providerID, assignedID string, payload []byte
 		s.log.Warn().Str("state", update.State).Str("provider_id", providerID).Msg("invalid provider state")
 		return
 	}
-	if state == pool.StateReady && s.warmupGatePending(providerID) {
-		state = pool.StateDegraded
-	}
+	// #1354 / SPEC-002 v1.6.0: observe-only warm-up probe — a state_update
+	// `ready` is no longer clamped to `degraded` while a probe is in flight.
+	// Trust/identity gates still constrain routing independently.
 	// Issue #764: state_update is the THIRD provider-controlled capacity ingest
 	// (after hello and heartbeat) — it writes SlotsFree/SlotsTotal straight onto
 	// the pool entry. Leaving it unclamped would let a provider restore an

--- a/phase4-coordinator/internal/ws/server_test.go
+++ b/phase4-coordinator/internal/ws/server_test.go
@@ -1377,9 +1377,17 @@ func TestWarmupProbeTimeoutLeavesProviderRoutable(t *testing.T) {
 		t.Fatal("warmup request_id is empty")
 	}
 
-	// Never answer the probe. It exhausts and times out, but the provider stays
-	// ready and routable throughout — it is never parked unavailable.
-	eventuallyWithin(t, 4*time.Second, func() bool {
+	// Provider is routable immediately.
+	eventually(t, func() bool {
+		provider, ok := h.Registry.Resolve("m4-anon", assignedID)
+		return ok && provider.State == pool.StateReady
+	})
+	// Never answer the probe. It must exhaust and time out — but the provider stays
+	// ready and routable across the entire timeout + exhaustion window. This span
+	// (2s) deliberately exceeds WarmupGateTimeoutS (1s) so that a regression which
+	// re-introduced MarkState(StateUnavailable) after the timeout would flip the
+	// state mid-window and fail this assertion, instead of passing at admission.
+	consistently(t, 2*time.Second, func() bool {
 		provider, ok := h.Registry.Resolve("m4-anon", assignedID)
 		return ok && provider.State == pool.StateReady
 	})

--- a/phase4-coordinator/internal/ws/server_test.go
+++ b/phase4-coordinator/internal/ws/server_test.go
@@ -16,6 +16,7 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1291,7 +1292,11 @@ func TestProviderWebSocketRejectsOversizeInitialFrame(t *testing.T) {
 	}
 }
 
-func TestWarmupGateHoldsProviderUntilTokenProducingProbe(t *testing.T) {
+// #1354 / SPEC-002 v1.6.0: the warm-up gate is now fail-open and observe-only.
+// A fresh provider is admitted `ready` and immediately routable; the probe still
+// runs (for a fitness verdict) but never withholds routing. This test replaces
+// the old blocking-gate test (TestWarmupGateHoldsProviderUntilTokenProducingProbe).
+func TestWarmupProbeAdmitsProviderReadyAndObservesOnly(t *testing.T) {
 	h := newProviderHarness(t, func(cfg *config.Config) {
 		cfg.Pool.WarmupGateEnabled = true
 		cfg.Pool.WarmupGateTimeoutS = 2
@@ -1308,11 +1313,14 @@ func TestWarmupGateHoldsProviderUntilTokenProducingProbe(t *testing.T) {
 	defer conn.Close()
 	assignedID := assertHelloAck(t, conn)
 
+	// Fail-open: the provider is routable the moment it is admitted, before the
+	// probe is answered — it is NEVER parked in degraded by the warm-up gate.
 	eventually(t, func() bool {
 		provider, ok := h.Registry.Resolve("m4-anon", assignedID)
-		return ok && provider.State == pool.StateDegraded
+		return ok && provider.State == pool.StateReady
 	})
 
+	// The observe-only probe is still dispatched over the WS.
 	req := readInferenceRequest(t, conn)
 	if !strings.HasPrefix(req.RequestID, "req-warmup-gate-"+assignedID+"-1") {
 		t.Fatalf("request_id = %q, want warmup gate prefix for assigned_id %q", req.RequestID, assignedID)
@@ -1338,14 +1346,18 @@ func TestWarmupGateHoldsProviderUntilTokenProducingProbe(t *testing.T) {
 		t.Fatal("warmup body stream = true, want false")
 	}
 
+	// Answering the probe leaves the provider ready (it already was).
 	writeWarmupCompletion(t, conn, req.RequestID, 1)
-	eventually(t, func() bool {
+	consistently(t, 300*time.Millisecond, func() bool {
 		provider, ok := h.Registry.Resolve("m4-anon", assignedID)
 		return ok && provider.State == pool.StateReady
 	})
 }
 
-func TestWarmupGateTimeoutMarksProviderUnavailable(t *testing.T) {
+// #1354: a probe that times out with no token production must NOT mark the
+// provider unavailable — fail-open leaves it routable (replaces the old
+// TestWarmupGateTimeoutMarksProviderUnavailable).
+func TestWarmupProbeTimeoutLeavesProviderRoutable(t *testing.T) {
 	h := newProviderHarness(t, func(cfg *config.Config) {
 		cfg.Pool.WarmupGateEnabled = true
 		cfg.Pool.WarmupGateTimeoutS = 1
@@ -1365,23 +1377,27 @@ func TestWarmupGateTimeoutMarksProviderUnavailable(t *testing.T) {
 		t.Fatal("warmup request_id is empty")
 	}
 
+	// Never answer the probe. It exhausts and times out, but the provider stays
+	// ready and routable throughout — it is never parked unavailable.
 	eventuallyWithin(t, 4*time.Second, func() bool {
 		provider, ok := h.Registry.Resolve("m4-anon", assignedID)
-		return ok && provider.State == pool.StateUnavailable
+		return ok && provider.State == pool.StateReady
 	})
 	hb := heartbeat()
 	hb["status"] = "ready"
 	hb["slots_free"] = 0
 	if err := wsutil.WriteClientText(conn, mustJSON(hb)); err != nil {
-		t.Fatalf("write ready heartbeat after warmup failure: %v", err)
+		t.Fatalf("write ready heartbeat after warmup timeout: %v", err)
 	}
 	eventually(t, func() bool {
 		provider, ok := h.Registry.Resolve("m4-anon", assignedID)
-		return ok && provider.State == pool.StateUnavailable && provider.SlotsFree == 0
+		return ok && provider.State == pool.StateReady && provider.SlotsFree == 0
 	})
 }
 
-func TestWarmupGateRejectsZeroTokenCompletion(t *testing.T) {
+// #1354: a zero-token completion records a negative fitness verdict but must not
+// change routing state (replaces TestWarmupGateRejectsZeroTokenCompletion).
+func TestWarmupProbeZeroTokenLeavesProviderRoutable(t *testing.T) {
 	h := newProviderHarness(t, func(cfg *config.Config) {
 		cfg.Pool.WarmupGateEnabled = true
 		cfg.Pool.WarmupGateTimeoutS = 2
@@ -1396,16 +1412,24 @@ func TestWarmupGateRejectsZeroTokenCompletion(t *testing.T) {
 	}
 	defer conn.Close()
 	assignedID := assertHelloAck(t, conn)
+	// Provider is admitted ready before the probe is even answered.
+	eventually(t, func() bool {
+		provider, ok := h.Registry.Resolve("m4-anon", assignedID)
+		return ok && provider.State == pool.StateReady
+	})
 	req := readInferenceRequest(t, conn)
 
 	writeWarmupCompletion(t, conn, req.RequestID, 0)
-	eventually(t, func() bool {
+	consistently(t, 300*time.Millisecond, func() bool {
 		provider, ok := h.Registry.Resolve("m4-anon", assignedID)
-		return ok && provider.State == pool.StateUnavailable
+		return ok && provider.State == pool.StateReady
 	})
 }
 
-func TestWarmupGateRejectsUsageWithoutObservedOutput(t *testing.T) {
+// #1354: usage metadata without observed output records a negative verdict but
+// must not change routing state (replaces
+// TestWarmupGateRejectsUsageWithoutObservedOutput).
+func TestWarmupProbeUsageWithoutOutputLeavesProviderRoutable(t *testing.T) {
 	h := newProviderHarness(t, func(cfg *config.Config) {
 		cfg.Pool.WarmupGateEnabled = true
 		cfg.Pool.WarmupGateTimeoutS = 2
@@ -1420,6 +1444,10 @@ func TestWarmupGateRejectsUsageWithoutObservedOutput(t *testing.T) {
 	}
 	defer conn.Close()
 	assignedID := assertHelloAck(t, conn)
+	eventually(t, func() bool {
+		provider, ok := h.Registry.Resolve("m4-anon", assignedID)
+		return ok && provider.State == pool.StateReady
+	})
 	req := readInferenceRequest(t, conn)
 
 	if err := wsutil.WriteClientText(conn, mustJSON(providerws.InferenceResponseEnd{
@@ -1435,9 +1463,9 @@ func TestWarmupGateRejectsUsageWithoutObservedOutput(t *testing.T) {
 	})); err != nil {
 		t.Fatalf("write warmup end: %v", err)
 	}
-	eventually(t, func() bool {
+	consistently(t, 300*time.Millisecond, func() bool {
 		provider, ok := h.Registry.Resolve("m4-anon", assignedID)
-		return ok && provider.State == pool.StateUnavailable
+		return ok && provider.State == pool.StateReady
 	})
 }
 
@@ -1494,8 +1522,16 @@ func TestWarmupGateUsesHTTPForHTTPForwardingProvider(t *testing.T) {
 	})
 }
 
-func TestWarmupGateDoesNotFollowHTTPForwardingRedirects(t *testing.T) {
+// #1354 / SPEC-002 v1.6.0: the coordinator still MUST NOT follow HTTP-forwarding
+// redirects during the warm-up probe (the security property is unchanged), but
+// under fail-open the resulting negative verdict no longer parks the provider
+// unavailable — it stays routable and a real buyer request would be governed by
+// the circuit breaker. Replaces TestWarmupGateDoesNotFollowHTTPForwardingRedirects'
+// unavailable assertion.
+func TestWarmupProbeDoesNotFollowHTTPForwardingRedirectsAndStaysRoutable(t *testing.T) {
+	var targetHits int32
 	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&targetHits, 1)
 		_, _ = w.Write([]byte(`{"id":"redirected","choices":[{"message":{"content":"ok"}}],"usage":{"completion_tokens":1}}`))
 	}))
 	defer target.Close()
@@ -1519,13 +1555,26 @@ func TestWarmupGateDoesNotFollowHTTPForwardingRedirects(t *testing.T) {
 	defer conn.Close()
 	assignedID := assertHelloAck(t, conn)
 
+	// The provider is admitted ready and stays ready across the probe window.
 	eventually(t, func() bool {
 		provider, ok := h.Registry.Resolve("m4-anon", assignedID)
-		return ok && provider.State == pool.StateUnavailable
+		return ok && provider.State == pool.StateReady
 	})
+	consistently(t, 400*time.Millisecond, func() bool {
+		provider, ok := h.Registry.Resolve("m4-anon", assignedID)
+		return ok && provider.State == pool.StateReady
+	})
+	// Security property preserved: the redirect target was never followed.
+	if got := atomic.LoadInt32(&targetHits); got != 0 {
+		t.Fatalf("redirect target hit %d times; coordinator must not follow provider redirects", got)
+	}
 }
 
-func TestWarmupGateSuppressesReadyProviderUpdates(t *testing.T) {
+// #1354 / SPEC-002 v1.6.0: under fail-open observe-only, heartbeat and
+// state_update `ready` reports are NO LONGER clamped to degraded while the probe
+// is in flight (that clamp was part of the blocking gate). Replaces
+// TestWarmupGateSuppressesReadyProviderUpdates, which asserted the opposite.
+func TestWarmupProbeDoesNotClampReadyProviderUpdates(t *testing.T) {
 	h := newProviderHarness(t, func(cfg *config.Config) {
 		cfg.Pool.WarmupGateEnabled = true
 		cfg.Pool.WarmupGateTimeoutS = 2
@@ -1543,6 +1592,7 @@ func TestWarmupGateSuppressesReadyProviderUpdates(t *testing.T) {
 	assignedID := assertHelloAck(t, conn)
 	req := readInferenceRequest(t, conn)
 
+	// A ready heartbeat mid-probe is honored, not clamped to degraded.
 	hb := heartbeat()
 	hb["status"] = "ready"
 	hb["slots_free"] = 0
@@ -1551,13 +1601,14 @@ func TestWarmupGateSuppressesReadyProviderUpdates(t *testing.T) {
 	}
 	eventually(t, func() bool {
 		provider, ok := h.Registry.Resolve("m4-anon", assignedID)
-		return ok && provider.State == pool.StateDegraded && provider.SlotsFree == 0
+		return ok && provider.State == pool.StateReady && provider.SlotsFree == 0
 	})
 
+	// A ready state_update mid-probe is likewise honored.
 	if err := wsutil.WriteClientText(conn, mustJSON(map[string]any{
 		"type":   "state_update",
 		"state":  "ready",
-		"reason": "provider says ready while gate is pending",
+		"reason": "provider reports ready while the observe-only probe is in flight",
 		"since":  "2026-05-30T00:00:00Z",
 		"metrics_snapshot": map[string]any{
 			"slots_free":  1,
@@ -1568,11 +1619,11 @@ func TestWarmupGateSuppressesReadyProviderUpdates(t *testing.T) {
 	}
 	eventually(t, func() bool {
 		provider, ok := h.Registry.Resolve("m4-anon", assignedID)
-		return ok && provider.State == pool.StateDegraded && provider.SlotsFree == 1
+		return ok && provider.State == pool.StateReady && provider.SlotsFree == 1
 	})
 
 	writeWarmupCompletion(t, conn, req.RequestID, 1)
-	eventually(t, func() bool {
+	consistently(t, 300*time.Millisecond, func() bool {
 		provider, ok := h.Registry.Resolve("m4-anon", assignedID)
 		return ok && provider.State == pool.StateReady
 	})
@@ -4580,6 +4631,23 @@ func eventuallyWithin(t *testing.T, timeout time.Duration, f func() bool) {
 		}
 		if time.Now().After(deadline) {
 			t.Fatal("condition did not become true before deadline")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// consistently asserts f() holds true continuously across the window. Used to
+// prove the observe-only warm-up probe (#1354) never transitions a routable
+// provider out of ready as a delayed side effect.
+func consistently(t *testing.T, window time.Duration, f func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(window)
+	for {
+		if !f() {
+			t.Fatal("condition did not hold for the full window")
+		}
+		if time.Now().After(deadline) {
+			return
 		}
 		time.Sleep(10 * time.Millisecond)
 	}

--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -35,7 +35,7 @@
     {
       "spec_id": "SPEC-002",
       "title": "Phase 4 Coordinator: Mac Provider Request Router",
-      "version": "1.5.8",
+      "version": "1.6.0",
       "path": "specs/SPEC-002-coordinator.md",
       "status": "normative",
       "owner": "@Augustas11",
@@ -90,7 +90,7 @@
     {
       "spec_id": "SPEC-004",
       "title": "Smart Router",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "path": "specs/SPEC-004-smart-router.md",
       "status": "normative",
       "owner": "@Augustas11",

--- a/specs/README.md
+++ b/specs/README.md
@@ -10,9 +10,9 @@ it can no longer drift. Do not hand-edit the table; edit each spec's
 | SPEC | Title | Version | Lifecycle | ID migration | Conformance | Link |
 |---|---|---|---|---|---|---|
 | SPEC-001 | Phase 3 Binary: Mac Provider Inference CLI | 1.9.2 | normative | pending | pending: 1 | [SPEC-001-phase3-binary.md](SPEC-001-phase3-binary.md) |
-| SPEC-002 | Phase 4 Coordinator: Mac Provider Request Router | 1.5.8 | normative | pending | pending: 2 | [SPEC-002-coordinator.md](SPEC-002-coordinator.md) |
+| SPEC-002 | Phase 4 Coordinator: Mac Provider Request Router | 1.6.0 | normative | pending | pending: 2 | [SPEC-002-coordinator.md](SPEC-002-coordinator.md) |
 | SPEC-003 | Open Onboarding: Distribution, Lifecycle & Onboarding UX | 0.11.1 | normative | pending | pending: 1 | [SPEC-003-open-onboarding.md](SPEC-003-open-onboarding.md) |
-| SPEC-004 | Smart Router | 0.3.3 | normative | pending | pending corpus migration | [SPEC-004-smart-router.md](SPEC-004-smart-router.md) |
+| SPEC-004 | Smart Router | 0.3.4 | normative | pending | pending corpus migration | [SPEC-004-smart-router.md](SPEC-004-smart-router.md) |
 | SPEC-005 | Billing, Settlement, and Provider Rewards | 0.6.4 | normative | complete | conformant: 3, pending: 6 | [SPEC-005-billing.md](SPEC-005-billing.md) |
 | SPEC-006 | Buyer API Gateway: Mac Provider's first public buyer surface | 0.9.21 | normative | complete | conformant: 3, pending: 6 | [SPEC-006-buyer-api.md](SPEC-006-buyer-api.md) |
 | SPEC-007 | Internal Operator Protocol Explorer | 0.5.1 | normative | pending | pending corpus migration | [SPEC-007-explorer.md](SPEC-007-explorer.md) |

--- a/specs/SPEC-002-coordinator.md
+++ b/specs/SPEC-002-coordinator.md
@@ -1,7 +1,44 @@
 # SPEC-002 — Phase 4 Coordinator: Mac Provider Request Router
 
-**Version:** 1.5.8 (2026-08-13, rewards-trusted routing quota custody proof)
+**Version:** 1.6.0 (2026-09-03, warm-up capability gate becomes fail-open observe-only)
 **Depends on:** SPEC-001 v1.4 (Phase 3 binary wire protocol, locked; v1.4 adds installer custom-model selection + `models browse` + fit guard on top of the v1.3 absorbed in §7.8/§7.9); SPEC-003 FR-C9.4 composed contract — base AuthState enum (`bearer_validated`, `self_minted`, `bearerless_duplicate`) introduced in v0.8.3; `mint_failed` reserved value added in v0.8.4.
+
+**Change log v1.6.0 (2026-09-03, warm-up capability gate becomes fail-open observe-only):**
+- Reverses the **FR-P8a** admission posture after the #1346 candidate E2E
+  surfaced a fresh-provider onboarding deadlock (issue #1354). The warm-up
+  capability gate was a *blocking* admission gate: a newly connected provider
+  was registered `degraded` and withheld from buyer routing until a
+  token-producing probe passed. Combined with the released provider CLI, which
+  waits on coordinator buyer-serving readiness (`/v1/pool/check`) **before** it
+  installs its inference relay and starts reading the WebSocket, the probe frame
+  was never read — the provider could never leave `degraded`, readiness never
+  confirmed, and the CLI reconnect-looped forever. The deadlock only reproduced
+  with `pool.warmup_gate_enabled: true` (production runs it `false`), but the
+  binary default ships it on, so any coordinator stood up from `config.Default()`
+  bricked fresh providers.
+- **New posture (fail-open, observe-only):** when `pool.warmup_gate_enabled` is
+  true the coordinator now admits a valid-`hello` provider as `ready` and
+  immediately buyer-routable, then runs the warm-up probe as a **non-blocking
+  background observation**. The probe records a fitness verdict (pass / fail /
+  timeout) for connection-event history and telemetry, but a warm-up outcome
+  **MUST NOT** by itself withhold, degrade, or mark `unavailable` a provider,
+  and heartbeat/`state_update` `ready` reports are **no longer** clamped to
+  `degraded` while a probe is in flight. Onboarding is therefore never blocked
+  by the fitness probe. A provider that genuinely cannot serve is still removed
+  by the in-flight circuit breaker (FR-P11a) on real buyer traffic, which is the
+  authoritative fitness signal; the admission probe is now advisory only.
+- **Scope guard:** this reversal applies ONLY to the warm-up *fitness* verdict.
+  Trust and identity admission gates are unchanged and continue to gate routing
+  per their own requirements — catalog/autotune hello admission, model-hash
+  verification and `require_hash_verified`, attestation, encrypted-leg, and the
+  model-version floor still exclude a provider from routing independently of the
+  warm-up probe. The wake-from-sleep `warm_up` fallback (FR-P8, `warmup_fallback_s`)
+  is likewise unchanged.
+- **Default is now safe.** Because the gate can no longer block onboarding,
+  `config.Default().Pool.WarmupGateEnabled` remains `true` without the footgun;
+  a coordinator stood up from defaults no longer bricks fresh providers. No
+  SPEC-001 / phase3-binary wire change (WS-tunneled probing still reuses
+  `inference_request` / `inference_response_chunk` / `inference_response_end`).
 
 **Change log v1.5.8 (2026-08-13, rewards-trusted routing quota custody proof):**
 - Tightens rewards-trusted routing custody continuity: matching bearer auth and
@@ -1043,12 +1080,17 @@ before routing. If no `state_update` arrives within
 `pool.warmup_fallback_s` (default 60s), log a warning and allow routing
 anyway.
 
-**FR-P8a. Admission warm-up capability gate.**
-If `pool.warmup_gate_enabled` is true (default), a newly connected
-provider MUST NOT be buyer-routable immediately after `hello`. The
-coordinator registers it as `degraded`, sends `hello_ack`, then starts a
-capability probe. Probe transport follows the provider's forwarding
-mode:
+**FR-P8a. Admission warm-up capability probe (fail-open, observe-only).**
+*(v1.6.0 reverses the blocking posture this requirement carried from v1.3.0
+through v1.5.x; see the v1.6.0 change log and issue #1354.)*
+
+If `pool.warmup_gate_enabled` is true (default), a newly connected provider
+that passes all trust/identity admission gates is registered `ready` and is
+immediately buyer-routable after `hello_ack`. The coordinator then runs a
+capability probe as a **non-blocking background observation**. The probe MUST
+NOT delay admission, and its outcome MUST NOT by itself withhold, degrade, or
+mark `unavailable` the provider. Probe transport follows the provider's
+forwarding mode:
 
 - WS-tunneled providers: send a minimal SPEC-001 `inference_request`
   over the provider WebSocket.
@@ -1064,29 +1106,38 @@ Probe payload:
 - `max_tokens`: `pool.warmup_gate_max_tokens` (default 2).
 - non-streaming mode.
 
-The provider passes only if the probe observes non-empty assistant
-output and positive token usage (`usage.completion_tokens > 0`) within
-`pool.warmup_gate_timeout_s` (default 90s). For WS-tunneled providers,
-the terminal frame must be `inference_response_end` with
-`status: "complete"`; for HTTP-forwarding providers, the HTTP response
-must be 200 with an OpenAI-compatible response body. A self-reported
-`throughput_tps_estimate`, a `ready` heartbeat/state update, or usage
-metadata without observed output is never sufficient. A provider that
-reports `ready` through heartbeat or `state_update` while the gate is
-pending MUST remain non-routable until the token-producing probe passes.
+The probe records a **fitness verdict** — `pass` when it observes non-empty
+assistant output and positive token usage (`usage.completion_tokens > 0`)
+within `pool.warmup_gate_timeout_s` (default 90s) with a terminal
+`inference_response_end` `status: "complete"` (WS) or an OpenAI-compatible
+HTTP 200 (HTTP-forwarding); otherwise `fail`/`timeout`. The verdict is written
+to connection-event history and telemetry (`reason = "warmup_failed"` on a
+negative verdict) for observability and reward/fitness signals only. Because
+the probe is observe-only:
 
-On pass, coordinator marks the provider `ready` and buyer routing may
-select it. On failure, timeout, provider disconnect, or zero-token
-completion, coordinator logs `reason = "warmup_failed"`, leaves the
-provider non-routable, and retries after `pool.degraded_backoff_s`,
-doubling backoff between attempts up to `pool.degraded_max_retries`.
-After all attempts fail, coordinator marks the provider `unavailable`.
+- The provider stays `ready` and buyer-routable regardless of the verdict.
+- Heartbeat and `state_update` `ready` reports are **not** clamped to
+  `degraded` while a probe is in flight.
+- A negative verdict is logged but never transitions the provider to
+  `degraded` or `unavailable`; retries, if any, are for observation quality
+  and never gate routing.
 
-If `pool.warmup_gate_enabled` is false, the coordinator preserves the
-pre-v1.3.0 behavior: valid `hello` registers the provider as `ready`.
-Operators MAY disable the gate only for trusted/pinned providers or
-debug sessions where admission latency is more harmful than a false
-ready signal.
+A provider that genuinely cannot serve is removed by the in-flight circuit
+breaker (FR-P11a) when it fails real buyer traffic — that remains the
+authoritative fitness gate. The admission probe is advisory and never blocks
+onboarding.
+
+**Scope guard.** This fail-open posture applies ONLY to the warm-up *fitness*
+verdict. Trust and identity admission gates are unaffected and continue to
+withhold routing independently: catalog/autotune `hello` admission (FR-P8),
+model-hash verification and `require_hash_verified`, attestation and
+encrypted-leg requirements, and the model-version floor still exclude a
+provider that fails them, irrespective of the warm-up probe. The
+wake-from-sleep `warm_up` fallback (`pool.warmup_fallback_s`) is likewise
+unchanged.
+
+If `pool.warmup_gate_enabled` is false, no probe is sent: a valid `hello`
+(subject to the trust/identity gates above) registers the provider as `ready`.
 
 **FR-P9. Send drain command on shutdown / blacklisting.**
 The coordinator sends `{"type": "drain"}` when: (1) coordinator SIGTERM
@@ -4846,7 +4897,8 @@ pool:
                                     # in-flight response chunks count as activity (F-4 liveness)
   wake_gap_threshold_s: 120
   warmup_fallback_s: 60          # Wake warm_up fallback before allowing routing if provider sends no ready state_update
-  warmup_gate_enabled: true      # (v1.3.0 FR-P8a) Gate new connections on a token-producing self-test
+  warmup_gate_enabled: true      # (v1.6.0 FR-P8a) Run an observe-only token-producing probe on new connections;
+                                    # fail-open — never blocks onboarding or routing (was blocking v1.3.0–v1.5.x)
   warmup_gate_timeout_s: 90      # Max seconds for each warm-up gate inference attempt
   warmup_gate_max_tokens: 2      # Max tokens requested by the warm-up gate self-test
   degraded_backoff_s: 30      # Initial recovery backoff after 502/504 OR a breaker trip (FR-P11a)

--- a/specs/SPEC-002-coordinator.md
+++ b/specs/SPEC-002-coordinator.md
@@ -1110,22 +1110,32 @@ The probe records a **fitness verdict** — `pass` when it observes non-empty
 assistant output and positive token usage (`usage.completion_tokens > 0`)
 within `pool.warmup_gate_timeout_s` (default 90s) with a terminal
 `inference_response_end` `status: "complete"` (WS) or an OpenAI-compatible
-HTTP 200 (HTTP-forwarding); otherwise `fail`/`timeout`. The verdict is written
-to connection-event history and telemetry (`reason = "warmup_failed"` on a
-negative verdict) for observability and reward/fitness signals only. Because
-the probe is observe-only:
+HTTP 200 (HTTP-forwarding); otherwise `fail`/`timeout`. A negative verdict is
+recorded to connection-event history and telemetry (`reason = "warmup_failed"`,
+`KindWarmupFailed`) for observability and reward/fitness signals; a positive
+verdict is logged. Because the probe is observe-only:
 
 - The provider stays `ready` and buyer-routable regardless of the verdict.
 - Heartbeat and `state_update` `ready` reports are **not** clamped to
   `degraded` while a probe is in flight.
-- A negative verdict is logged but never transitions the provider to
+- A negative verdict is recorded but never transitions the provider to
   `degraded` or `unavailable`; retries, if any, are for observation quality
   and never gate routing.
 
-A provider that genuinely cannot serve is removed by the in-flight circuit
-breaker (FR-P11a) when it fails real buyer traffic — that remains the
-authoritative fitness gate. The admission probe is advisory and never blocks
-onboarding.
+Providers that fail real buyer traffic with *abnormal* in-flight faults (WS
+disconnect mid-inference, relay timeout, or a qualified abnormal
+zero-token completion) are removed by the in-flight circuit breaker
+(FR-P11a). The breaker is the network's primary runtime fitness signal, but it
+is deliberately **not** a universal one: by FR-P11a a clean empty completion
+(`finish_reason: "stop"` with zero tokens) is a valid response and does not
+count as a fault. A provider that only ever returns well-formed empty
+completions therefore passes trust admission, fails the observe-only warm-up
+probe, and can remain routable. This is an accepted consequence of the
+fail-open posture chosen for #1354 (never block onboarding on a fitness
+signal); a future bounded quality path — e.g. counting repeated clean-empty
+real completions only for providers whose warm-up verdict was negative — may
+close it without re-introducing an admission block. The admission probe itself
+is advisory and never blocks onboarding.
 
 **Scope guard.** This fail-open posture applies ONLY to the warm-up *fitness*
 verdict. Trust and identity admission gates are unaffected and continue to
@@ -1306,9 +1316,11 @@ degradation in WS-tunneled mode** and supersedes FR-P20's former
   `inference_response_chunk` count) all already exist in SPEC-001 v1.2.4. The
   provider binary needs no change.
 
-This is the runtime (reactive) half of provider fitness. The proactive half is
-FR-P8a's admission-time warm-up capability gate, which withholds `ready` until
-a provider proves it can produce a token.
+This is the runtime (reactive) half of provider fitness, and — subject to the
+FR-P11a fault qualification above — the primary one. The proactive half is
+FR-P8a's admission-time warm-up capability probe, which since v1.6.0 is
+fail-open and observe-only: it records a fitness verdict but never withholds
+`ready`, so it advises rather than gates.
 
 **FR-P12. Identify provider; configurable bearer-token check.**
 

--- a/specs/SPEC-004-smart-router.md
+++ b/specs/SPEC-004-smart-router.md
@@ -1,7 +1,7 @@
 # SPEC-004 — Smart Router
 
-**Version:** 0.3.3 (2026-07-28, #784 SPEC-002 routing-eligibility composition reconciliation)
-**Extends:** SPEC-002 v1.5.5 § 5 (routing algorithm)
+**Version:** 0.3.4 (2026-09-03, #1354 FR-P8a fail-open observe-only reconciliation)
+**Extends:** SPEC-002 v1.6.0 § 5 (routing algorithm)
 **Depends on:** SPEC-001 v1.2.4 (Phase 3 binary wire protocol, locked), SPEC-003 v0.7, SPEC-006 v0.9.8 (Pillar A gated on SPEC-006 v0.8; the v0.3.2 FR-SR-2 provider-visibility carve-out is coordinated with SPEC-006 v0.9.8 / SPEC-008 v0.4.1)
 
 SPEC-004 is additive. With every new `routing.*` key at its default value,
@@ -11,12 +11,28 @@ model ID routing, and no sticky affinity.
 
 ## Changelog
 
+### v0.3.4 (2026-09-03)
+
+- **#1354 FR-P8a fail-open reconciliation.** SPEC-002 v1.6.0 made the FR-P8a
+  admission warm-up gate fail-open and observe-only: a newly connected provider
+  is admitted `ready` and immediately routable, and the warm-up probe no longer
+  withholds routing. SPEC-004 no longer lists FR-P8a admission warm-up as a
+  routing-eligibility gate. The substantive rule is unchanged — SPEC-004 still
+  routes only to providers SPEC-002 considers eligible — but FR-P5 `state must
+  be ready` (which still excludes wake-from-sleep `warm_up` degraded providers,
+  FR-P8) and FR-P11a breaker/recovery holds are the fitness-related exclusions,
+  not the admission warm-up probe. No routing-key or provider-wire change.
+
 ### v0.3.3 (2026-07-28)
 
 - **#784 SPEC-002 composition reconciliation.** Tightens FR-SR-18 so SPEC-004
   routing features compose only after every current SPEC-002 eligibility gate
   has passed, including FR-P8a warm-up admission, capacity, quota, context, and
   FR-P11a breaker/recovery holds. No routing-key or provider-wire change.
+  *(Superseded by v0.3.4: SPEC-002 v1.6.0 made FR-P8a admission warm-up
+  fail-open and observe-only, so it is no longer an eligibility gate — see
+  #1354. The FR-P5 `ready` state check, which still excludes wake-from-sleep
+  `warm_up` degraded providers, and the FR-P11a holds remain the gates.)*
 
 ### v0.3.2 (2026-07-12)
 
@@ -179,9 +195,12 @@ Ordered pipeline:
    selected objective, promote it to position 0 as a soft preference. If not,
    continue with normal selection and log `sticky_miss`.
 5. Build candidates from the pool using SPEC-002 filters:
-   - FR-P5 state must be `ready`.
+   - FR-P5 state must be `ready` (this excludes wake-from-sleep `warm_up`
+     degraded providers, FR-P8).
    - `slots_free > 0`.
-   - FR-P8a admission warm-up gate must have passed.
+   - The FR-P8a admission warm-up probe is observe-only (SPEC-002 v1.6.0) and
+     is NOT a candidate filter — a provider is routable regardless of its
+     warm-up verdict.
    - FR-P11a breaker/recovery holds must exclude held providers.
    - context capacity must fit the estimated token count.
    - provisional quota and admission-tier weighting still apply.
@@ -263,8 +282,9 @@ independently from SPEC-004 v0.2.
 A sticky entry points to a stable `provider_id`, not an `assigned_id`. The
 coordinator MAY route to the provider's current active session after reconnect,
 but only if the provider passes the full SPEC-002 eligibility filter. If the
-sticky provider is absent, `busy`, `degraded`, `draining`, `unavailable`,
-warming, breaker-held, quota-blocked, context-too-small, or serving a model
+sticky provider is absent, `busy`, `degraded` (including wake-from-sleep
+`warm_up`), `draining`, `unavailable`, breaker-held, quota-blocked,
+context-too-small, or serving a model
 outside the requested class, the coordinator MUST ignore the sticky entry for
 that request, log `reason = "sticky_miss"` with a specific miss cause, and
 fall back to normal selection. Sticky affinity MUST NOT trap a session on a
@@ -418,7 +438,8 @@ Objective semantics:
 
 **FR-SR-9. Model-class no-provider behavior.**
 If a class exists but no eligible provider remains after SPEC-002 filters,
-quota checks, context capacity, warm-up, and breaker holds, the coordinator
+quota checks, context capacity, wake-from-sleep `warm_up` degradation, and
+breaker holds, the coordinator
 MUST return HTTP 503 using the same OpenAI-compatible error shape as
 FR-B4/no_provider_available. The error message SHOULD name the requested class
 and MAY include the count of configured concrete models. It MUST NOT expose
@@ -568,11 +589,14 @@ The coordinator MAY use cryptographic randomness or a per-process PRNG, but the
 chosen provider MUST be explainable from the recorded candidate set and recorded
 draw/seed. Randomization MUST NOT be enabled by default.
 
-**FR-SR-18. Composition with FR-P5, FR-P8a, and FR-P11a.**
+**FR-SR-18. Composition with FR-P5 and FR-P11a.**
 No SPEC-004 feature may route to a provider that SPEC-002 considers
 ineligible. Sticky affinity, class expansion, retry, and randomized tiebreak
-operate only after FR-P5 state eligibility, FR-P8a warm-up admission, capacity,
-quota, context, and FR-P11a breaker/recovery-hold checks.
+operate only after FR-P5 state eligibility, capacity, quota, context, and
+FR-P11a breaker/recovery-hold checks. The FR-P8a admission warm-up probe is
+observe-only (SPEC-002 v1.6.0) and is not an eligibility gate; a provider is
+routable irrespective of its warm-up verdict (wake-from-sleep `warm_up`
+degradation, FR-P8, is covered by FR-P5 state eligibility).
 
 **FR-SR-19. Composition with F-4.**
 F-4 remains the base dead-WS failover rule. SPEC-004 retry is opt-in and
@@ -732,8 +756,10 @@ Required fields where applicable:
 - `sticky_miss_reason`
 - `candidate_count_before_filters`
 - `candidate_count_after_filters`
-- `filtered_counts` by reason (`model_mismatch`, `not_ready`, `warming`,
-  `breaker_held`, `busy`, `context_too_small`, `quota_blocked`, `excluded_retry`)
+- `filtered_counts` by reason (`model_mismatch`, `not_ready`, `breaker_held`,
+  `busy`, `context_too_small`, `quota_blocked`, `excluded_retry`). FR-P8a
+  admission warm-up is observe-only (SPEC-002 v1.6.0) and is not a filter
+  reason; a wake-from-sleep `warm_up` degraded provider surfaces as `not_ready`.
 - `candidate_set` for randomized decisions and SHOULD for class decisions
 - `tiebreak_mode`: `deterministic` or `random_epsilon`
 - `tiebreak_epsilon`
@@ -788,13 +814,14 @@ With sticky enabled and SPEC-006 v0.8 supplying
 `routing_internal.conversation_key: conv:S`, a first successful request routes
 normally and records provider `A`. A follow-up request with the same internal
 key, same concrete model or compatible class, routes to `A` while `A` remains
-ready, not breaker-held, not warming, has free slots, and is inside the
+ready (FR-P5), not breaker-held, has free slots, and is inside the
 objective's epsilon cohort. Logs include `sticky_hit`.
 
 **AC-SR-3. Sticky miss falls back gracefully.**
-After `conv:S` sticks to provider `A`, mark `A` `degraded`, breaker-held,
-warming, unavailable, full, context-too-small, outside the requested class, or
-outside the objective's epsilon cohort. The next request for `conv:S` does not
+After `conv:S` sticks to provider `A`, mark `A` `degraded` (e.g. wake-from-sleep
+`warm_up`), breaker-held, unavailable, full, context-too-small, outside the
+requested class, or outside the objective's epsilon cohort. The next request for
+`conv:S` does not
 fail solely because of affinity; it selects eligible provider `B` or returns
 the normal no-provider error if no provider exists. Logs include `sticky_miss`
 and the specific miss reason.
@@ -820,8 +847,9 @@ count, context, and slot ratios. The test MUST compute the v0.2 normalized
 balanced formula and assert the selected provider and logged component scores.
 
 **AC-SR-6. Empty class returns clean 503.**
-Configure a class whose concrete providers are all absent, warming, degraded,
-breaker-held, busy, or context-too-small. A class request returns HTTP 503 with
+Configure a class whose concrete providers are all absent, `degraded`
+(including wake-from-sleep `warm_up`), breaker-held, busy, or
+context-too-small. A class request returns HTTP 503 with
 OpenAI-compatible `no_provider_available` shape and logs the class resolution
 plus filter counts.
 
@@ -870,10 +898,12 @@ metric values, epsilon, random seed/draw, and chosen provider. A test can replay
 or explain the selected provider from the log record without hidden state.
 
 **AC-SR-14. Composition gates hold.**
-For sticky, class, retry, and randomization paths, providers in `degraded`,
-`draining`, `unavailable`, warming, breaker-held, full, quota-blocked, or
-context-too-small states are never selected. Tests include at least one
-FR-P8a warming exclusion and one FR-P11a breaker-held exclusion.
+For sticky, class, retry, and randomization paths, providers in `degraded`
+(including wake-from-sleep `warm_up`), `draining`, `unavailable`, breaker-held,
+full, quota-blocked, or context-too-small states are never selected. Tests
+include at least one wake-from-sleep `warm_up` degraded exclusion and one
+FR-P11a breaker-held exclusion. (A provider whose observe-only FR-P8a warm-up
+verdict was negative is NOT excluded — it stays routable per SPEC-002 v1.6.0.)
 
 **AC-SR-15. Session hard-pin is never sticky.**
 With sticky enabled and no `routing_internal.conversation_key`, send
@@ -899,9 +929,13 @@ attempted provider.
   committed. Buyers still receive one coherent response or one clean error.
 - **FR-P5 is not weakened.** Only `ready` providers with free slots are
   routable. Sticky and class aliases never override state eligibility.
-- **FR-P8a is not weakened.** Warming providers are not buyer-routable for
-  sticky hits, class requests, retry attempts, or randomized cohorts until the
-  token-producing warm-up gate passes.
+- **FR-P8a is observe-only (SPEC-002 v1.6.0), not weakened.** The admission
+  warm-up probe never gated SPEC-004 routing and now formally does not: a
+  provider is buyer-routable for sticky hits, class requests, retry attempts,
+  and randomized cohorts regardless of its warm-up verdict. Providers that are
+  degraded by the wake-from-sleep `warm_up` fallback (FR-P8) remain excluded by
+  FR-P5 state eligibility, and genuinely faulty providers are excluded by the
+  FR-P11a breaker on real buyer traffic.
 - **FR-P11a is not weakened.** Breaker-held and recovery-held providers remain
   non-routable, provider-originated state updates cannot clear coordinator
   holds, and retries charge faults to the provider whose relay produced them.
@@ -976,8 +1010,8 @@ Primary files:
 - Inline fault doubles in `phase4-coordinator/internal/buyer/server_test.go`
   (see `deadMidInferenceRelay` and neighbors; wired via `WithRelay`)
   - Add deterministic provider-disconnect, 502, 504, pre-commit stream failure,
-    post-commit stream failure, buyer cancel, warm-up-held, and breaker-held
-    scenarios alongside the existing dead-WS/failover doubles.
+    post-commit stream failure, buyer cancel, wake-from-sleep `warm_up` degraded,
+    and breaker-held scenarios alongside the existing dead-WS/failover doubles.
 - `phase4-coordinator/tools/mockprovider/`
   - Reuse mock providers for multi-provider routing, class, retry, and
     randomized-distribution acceptance tests.
@@ -1009,8 +1043,9 @@ Test plan:
 5. Randomized tiebreak tests: default deterministic behavior unchanged;
    randomization distributes over an epsilon cohort; every randomized decision
    log is replay/explanation-ready.
-6. Composition tests: each smart feature excludes FR-P5-ineligible,
-   FR-P8a-warming, and FR-P11a-held providers.
+6. Composition tests: each smart feature excludes FR-P5-ineligible (including
+   wake-from-sleep `warm_up` degraded) and FR-P11a-held providers. FR-P8a
+   admission warm-up is observe-only and does not exclude (SPEC-002 v1.6.0).
 7. Slowest-realistic-provider audit: each timeout/window acceptance test names
    the slowest-realistic-provider margin required by SPEC-002 audit category
    J.1.


### PR DESCRIPTION
## Summary

Fixes the fresh-provider onboarding deadlock from issue #1354 by making the
FR-P8a admission warm-up gate **fail-open and observe-only** (SPEC-002 v1.6.0),
so onboarding is **never blocked** by the fitness probe — the explicit product
requirement for this change.

### The problem

The warm-up gate admitted a newly connected provider as `StateDegraded` (when
`pool.warmup_gate_enabled: true`) and withheld it from buyer routing until a
token-producing WS probe passed. The released provider CLI, however, awaits
coordinator buyer-serving readiness (`/v1/pool/check`) **before** it installs
its inference relay and starts reading the WebSocket — so the probe frame was
never answered, the provider could never leave `degraded`, readiness never
confirmed, and the CLI reconnect-looped forever.

Production runs the gate `false`, so the live fleet is unaffected — but
`config.Default()` ships it `true`, so any coordinator stood up from defaults
(test/staging, a new contributor) bricks fresh providers. Critically, the gate
runs at **admission on every `hello`**, so enabling it would also drain the
existing fleet out of routing as providers reconnect (deploys, updates, blips).

### The fix (fail-open, observe-only)

A provider that clears the trust/identity admission gates is now admitted
`ready` and immediately buyer-routable. The warm-up probe still runs in the
background and records a fitness verdict for telemetry / connection-event
history, but it **never** withholds, degrades, or marks a provider
`unavailable`, and heartbeat / `state_update` `ready` reports are no longer
clamped to `degraded` while a probe is in flight. Because the gate can no longer
block onboarding, `config.Default().Pool.WarmupGateEnabled` stays `true` safely
(no footgun, no change to the normative default).

**Scope guard — only the fitness verdict is fail-open.** Trust/identity gates
still withhold routing independently and were verified end-to-end (security
lane): catalog/autotune `hello` admission, model-hash + `require_hash_verified`,
attestation, encrypted-leg, admission ceiling/stale/sandboxed, and the
model-version floor all still exclude a provider at buyer-routing time
(`buyer/server.go` `handlePoolCheck` and candidate selection via
`tier2ProviderExcludedForConfig`) and at admission (`ws/server.go`). A provider
that genuinely cannot serve is removed by the in-flight circuit breaker
(FR-P11a) on real buyer traffic. The wake-from-sleep `warm_up` fallback (FR-P8)
is unchanged and now runs independently of the admission probe.

### Also in this PR

- **S2 — `ws://` no longer silently refused.** `CoordinatorClient.init?` now
  accepts `ws://` for loopback coordinators only (localhost/127.0.0.1/::1),
  matching `CoordinatorReadinessClient`, and emits an explicit stderr diagnostic
  instead of a silent `nil` (which surfaced as a misleading "check this Mac's
  internet connection"). Also rejects hostless `wss:///` and embedded userinfo.
- **SPEC-004 (smart router) reconciled to v0.3.4** so FR-P8a admission warm-up
  is no longer described as a routing-eligibility gate anywhere; wake-from-sleep
  `warm_up` degradation is attributed to FR-P5.

### Deferred (not onboarding blockers)

The issue's S5 config foot-guns are intentionally **not** in this PR: S5a
(compat-set `accepted_ids ≥ 2`) is intentional rollback-safety with a clear
error, not a bug; S5b (global YAML strict-decode) is genuinely risky on the live
money-path config loader and should not be rushed in.

### Known accepted limitation

Under fail-open, a provider that returns only well-formed empty completions
(`finish_reason: "stop"`, zero tokens) can remain routable: FR-P11a
deliberately does not count a clean empty `stop` as a fault. This is the
accepted trade-off of "never block onboarding on a fitness signal"; SPEC-002
documents it and notes a future bounded quality-path.

## Audit

Three-lane codex audit (code / security / architecture) over the full fix diff,
to the repo bar of 0 CRITICAL / 0 HIGH / 0 MEDIUM. Security lane: 0/0/0/0 and
independently verified trust-gate independence, ws:// masquerade resistance, the
redirect-not-followed property, and billing/quota interaction. Code and
architecture MEDIUM findings (wake-path decoupling, breaker-claim honesty,
stale SPEC-004/SPEC-002 wording, a weak timeout test, CLI URL hardening) were
all resolved and re-audited to 0 C/H/M.

## Testing

- `make test` (coordinator, gateway, integration, dist)
- `cd phase3-binary && swift test`
- Full `internal/ws` suite incl. rewritten warm-up/wake tests; targeted
  `internal/buyer` trust/routing tests.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "issue": "https://github.com/Augustas11/macprovider/issues/1354",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": ["SPEC-002", "SPEC-004"],
  "requirements": ["SPEC-002-R002"],
  "authority_domains": ["coordinator-admission-routing"],
  "arbitration": ["SPEC_BUG"],
  "tests": ["phase4-coordinator/internal/ws/server_test.go:TestWarmupProbeAdmitsProviderReadyAndObservesOnly"],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
