### PR TITLE
Add resolve job for phase3-binary Package.resolved under release toolchain (#1360)

### DIFF
--- a/.github/workflows/resolve-package-lock.yml
+++ b/.github/workflows/resolve-package-lock.yml
@@ -1,0 +1,47 @@
+name: Resolve CLI Package.resolved (release toolchain)
+
+# Regenerate phase3-binary/Package.resolved under the pinned release toolchain
+# (Xcode 16.4), so the lock matches what the locked candidate/release build
+# (`-onlyUsePackageVersionsFromResolvedFile`) requires. Newer local toolchains
+# (Xcode 26.x) resolve the graph differently and cannot reproduce the correct
+# lock. See issue #1360 (async-http-client unpinned after #1336). Manual only;
+# uploads the corrected Package.resolved as an artifact — it does not commit.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch/ref to regenerate phase3-binary/Package.resolved on"
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  resolve:
+    name: Resolve under the pinned release toolchain
+    runs-on: macos-15
+    steps:
+      - name: Checkout target ref
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ github.event.inputs.ref }}
+      - name: Select Xcode 16.4 (match acceptance-candidate / release toolchain)
+        run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+      - name: Regenerate phase3-binary/Package.resolved
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd phase3-binary
+          xcodebuild -version
+          cp Package.resolved /tmp/Package.resolved.before
+          xcodebuild -resolvePackageDependencies -scheme macprovider-cli -configuration Release || true
+          swift package resolve
+          echo "=== Package.resolved diff (committed -> regenerated) ==="
+          diff -u /tmp/Package.resolved.before Package.resolved || true
+      - name: Upload corrected Package.resolved
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: phase3-package-resolved
+          path: phase3-binary/Package.resolved
+          if-no-files-found: error


### PR DESCRIPTION
## What

Add a `workflow_dispatch` job that regenerates `phase3-binary/Package.resolved`
under the **pinned release toolchain (Xcode 16.4)** and uploads it as an artifact.

## Why

The locked candidate/release build (`-onlyUsePackageVersionsFromResolvedFile`)
fails because `async-http-client` is required by the graph under Xcode 16.4 but
not pinned — a `Package.resolved`/`Package.swift` drift introduced by #1336
(swift-transformers 1.0.0 → 1.3.3). See **#1360**. Newer local toolchains
(Xcode 26.x) resolve the graph without it and cannot reproduce the correct lock,
so the lock must be regenerated on the release toolchain. This job does that;
it uploads the corrected lock (does not commit), and is reusable for future
dep bumps.

## Governance note

`behavior_change: none` — CI tooling only; no product behavior, spec, or contract
change. The advisory `spec-index` declaration check has no passing declaration for
a non-governance CI-path change (same as the install.sh and version-bump PRs); it
is not `ci-required` and does not block merge.

<!-- SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "none",
  "contract_change": "none",
  "specs": [],
  "requirements": [],
  "authority_domains": [],
  "arbitration": [],
  "tests": ["workflow_dispatch: resolve-package-lock.yml (manual)"],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
