### PR TITLE
Pin Xcode 16.4 SwiftPM lock and gate locked resolve in CI (#1360)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -448,6 +448,30 @@ jobs:
       - name: Verify #1189 repair reproduction (real ACLs, mocked launchd)
         run: bash phase3-binary/dist/test/repair_1189_reproduction.test.sh
 
+  swift-package-lock:
+    name: phase3-binary (locked SwiftPM resolve)
+    runs-on: macos-15
+    timeout-minutes: 15
+    needs: changes
+    # Same path gate as swift-tests: Package.resolved lives under
+    # phase3-binary/, and a Go-only PR cannot drift the Swift lock.
+    # ci-required treats a skip as a pass only when the detector is false.
+    # Must use Xcode 16.4 — the default Xcode.app on macos-15 can resolve a
+    # different graph and would hide the #1360 incomplete-lock failure.
+    if: ${{ needs.changes.outputs.swift == 'true' }}
+    steps:
+      - name: Checkout
+        # Pinned to actions/checkout v6 (df4cb1c0). Re-resolve deliberately
+        # when upgrading the action rather than trusting a mutable tag.
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+
+      - name: Select Xcode 16.4 (match acceptance-candidate / release toolchain)
+        run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+
+      - name: Verify locked Package.resolved under the release toolchain
+        run: bash scripts/verify-swift-package-lock.sh
 
   spec-015-acceptance:
     name: spec-015-acceptance
@@ -493,6 +517,7 @@ jobs:
       - spec-014-v0-2-gate
       - dist-tooling
       - swift-tests
+      - swift-package-lock
       - spec-015-acceptance
     if: always()
     steps:
@@ -513,6 +538,7 @@ jobs:
           SPEC_014_RESULT: ${{ needs.spec-014-v0-2-gate.result }}
           DIST_TOOLING_RESULT: ${{ needs.dist-tooling.result }}
           SWIFT_TESTS_RESULT: ${{ needs.swift-tests.result }}
+          SWIFT_PACKAGE_LOCK_RESULT: ${{ needs.swift-package-lock.result }}
           SPEC_015_RESULT: ${{ needs.spec-015-acceptance.result }}
         run: |
           set -euo pipefail
@@ -564,6 +590,7 @@ jobs:
           require_success "spec-014-v0-2-gate" "$SPEC_014_RESULT"
           require_success "deploy tooling (check-deploy-config gate)" "$DIST_TOOLING_RESULT"
           allow_skip "phase3-binary (swift test)" "$SWIFT_TESTS_RESULT" "$SWIFT_GATE"
+          allow_skip "phase3-binary (locked SwiftPM resolve)" "$SWIFT_PACKAGE_LOCK_RESULT" "$SWIFT_GATE"
           allow_skip "spec-015-acceptance" "$SPEC_015_RESULT" "$CODE_GATE"
 
           exit "$failed"

--- a/.github/workflows/resolve-package-lock.yml
+++ b/.github/workflows/resolve-package-lock.yml
@@ -6,6 +6,7 @@ name: Resolve CLI Package.resolved (release toolchain)
 # (Xcode 26.x) resolve the graph differently and cannot reproduce the correct
 # lock. See issue #1360 (async-http-client unpinned after #1336). Manual only;
 # uploads the corrected Package.resolved as an artifact — it does not commit.
+# PR CI verifies the committed lock via the swift-package-lock job in ci.yml.
 
 on:
   workflow_dispatch:

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ test-dist:
 	bash scripts/test-malibu-bootstrap-bridge.sh
 	bash scripts/test-recover-malibu-publication.sh
 	bash scripts/test-acceptance-candidate-security.sh
+	bash scripts/test-swift-package-lock.sh
 	bash scripts/test-signed-payout-journey-workflow.sh
 	bash scripts/test-signed-provider-prebeta-journey-workflow.sh
 	bash scripts/test-signed-buyer-paid-path-journey-workflow.sh

--- a/phase3-binary/Package.resolved
+++ b/phase3-binary/Package.resolved
@@ -1,6 +1,15 @@
 {
   "pins" : [
     {
+      "identity" : "async-http-client",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/async-http-client.git",
+      "state" : {
+        "revision" : "f95c908967e98c68c5ce3fd61a7974e7e869e303",
+        "version" : "1.36.1"
+      }
+    },
+    {
       "identity" : "eventsource",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattt/EventSource.git",
@@ -28,6 +37,15 @@
       }
     },
     {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms.git",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
+      }
+    },
+    {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
@@ -46,12 +64,30 @@
       }
     },
     {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms.git",
+      "state" : {
+        "revision" : "3da39bbc4e687d4192af7c9cf4eab805745a0b9c",
+        "version" : "1.1.5"
+      }
+    },
+    {
       "identity" : "swift-atomics",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
         "revision" : "0442cb5a3f98ab802acb777929fdb446bda11a34",
         "version" : "1.3.1"
+      }
+    },
+    {
+      "identity" : "swift-certificates",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-certificates.git",
+      "state" : {
+        "revision" : "c8aece90ea05f9866bd392a5bf13b5cae56c0e03",
+        "version" : "1.20.0"
       }
     },
     {
@@ -73,6 +109,33 @@
       }
     },
     {
+      "identity" : "swift-distributed-tracing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-distributed-tracing.git",
+      "state" : {
+        "revision" : "dc4030184203ffafbb2ec614352487235d747fe0",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-http-structured-headers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-structured-headers.git",
+      "state" : {
+        "revision" : "933538faa42c432d385f02e07df0ace7c5ecfc47",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types.git",
+      "state" : {
+        "revision" : "db774a277f60063a32d854f2980299caf06da041",
+        "version" : "1.6.0"
+      }
+    },
+    {
       "identity" : "swift-huggingface",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-huggingface.git",
@@ -91,6 +154,15 @@
       }
     },
     {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "3ffafb9722d5d918c614feb496c8789a3b59d222",
+        "version" : "1.15.0"
+      }
+    },
+    {
       "identity" : "swift-nio",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
@@ -100,12 +172,66 @@
       }
     },
     {
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras.git",
+      "state" : {
+        "revision" : "3078359149adac3dd1255621a041e361e3f0edd1",
+        "version" : "1.35.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "0f3e54e29c944c2e835ad52159da7d9e1c94ac69",
+        "version" : "1.46.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "03827c1a9fdb2b6b00a4e93ede8861520263af8c",
+        "version" : "2.37.4"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "67787bb645a5e67d2edcdfbe48a216cc549222d5",
+        "version" : "1.28.0"
+      }
+    },
+    {
       "identity" : "swift-numerics",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-numerics",
       "state" : {
         "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
         "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-service-context",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-service-context.git",
+      "state" : {
+        "revision" : "d0997351b0c7779017f88e7a93bc30a1878d7f29",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-service-lifecycle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
+      "state" : {
+        "revision" : "7f9326b0326ff86e3646295ea6e891f68c471c5e",
+        "version" : "2.12.0"
       }
     },
     {
@@ -133,6 +259,15 @@
       "state" : {
         "revision" : "2fa33e1f5e7131a7fc64c28e6d161dcec0d24820",
         "version" : "1.3.3"
+      }
+    },
+    {
+      "identity" : "swift-xet",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-xet.git",
+      "state" : {
+        "revision" : "341bfd4172f6a57119bfd49bafa11cf5d21fab75",
+        "version" : "0.2.3"
       }
     },
     {

--- a/scripts/ci-detect-changed-paths.sh
+++ b/scripts/ci-detect-changed-paths.sh
@@ -2,9 +2,9 @@
 #
 # CI macOS path-gate detector.
 #
-# Emits two booleans that gate the two per-PR macOS jobs in
+# Emits two booleans that gate the per-PR macOS jobs in
 # .github/workflows/ci.yml:
-#   swift -> phase3-binary (swift test) job
+#   swift -> phase3-binary (swift test) + locked SwiftPM resolve jobs
 #   code  -> spec-015-acceptance (cross-service money-path acceptance) job
 #
 # Usage: ci-detect-changed-paths.sh <base_sha> <head_sha>
@@ -100,7 +100,7 @@ if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
     echo ""
     echo "- diff resolved: ${resolved}"
     echo "- changed files: ${total}"
-    echo "- swift-tests: **$([ "$swift" = true ] && echo run || echo skip)** (matched ${matched_swift})"
+    echo "- swift-tests / locked SwiftPM resolve: **$([ "$swift" = true ] && echo run || echo skip)** (matched ${matched_swift})"
     echo "- spec-015-acceptance: **$([ "$code" = true ] && echo run || echo skip)** (matched ${matched_code})"
   } >>"$GITHUB_STEP_SUMMARY"
 fi

--- a/scripts/test-swift-package-lock.sh
+++ b/scripts/test-swift-package-lock.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Contract coverage for the #1360 locked SwiftPM resolve gate.
+#
+# Regular `swift test` uses automatic resolution and stays green on a newer
+# default Xcode even when Package.resolved is incomplete for the release
+# toolchain. This test locks the CI wiring so a future dep bump cannot merge
+# without a Xcode 16.4 `-onlyUsePackageVersionsFromResolvedFile` check.
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ci_workflow="$root/.github/workflows/ci.yml"
+verify="$root/scripts/verify-swift-package-lock.sh"
+makefile="$root/Makefile"
+resolved="$root/phase3-binary/Package.resolved"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+[[ -f "$verify" ]] || fail "missing $verify"
+bash -n "$verify"
+
+python3 - "$ci_workflow" "$verify" "$makefile" "$resolved" <<'PY'
+import json
+import pathlib
+import sys
+
+ci_path, verify_path, makefile_path, resolved_path = map(pathlib.Path, sys.argv[1:])
+ci = ci_path.read_text(encoding="utf-8")
+verify = verify_path.read_text(encoding="utf-8")
+makefile = makefile_path.read_text(encoding="utf-8")
+resolved = json.loads(resolved_path.read_text(encoding="utf-8"))
+
+if "scripts/test-swift-package-lock.sh" not in makefile:
+    raise SystemExit("Makefile test-dist must run scripts/test-swift-package-lock.sh")
+
+if "swift-package-lock:" not in ci:
+    raise SystemExit("ci.yml is missing the swift-package-lock job")
+if "phase3-binary (locked SwiftPM resolve)" not in ci:
+    raise SystemExit("ci.yml must name the locked-resolve job for ci-required matching")
+
+lock_job = ci.split("swift-package-lock:", 1)[1].split("\n  spec-015-acceptance:", 1)[0]
+if "runs-on: macos-15" not in lock_job:
+    raise SystemExit("locked-resolve job must run on macos-15")
+if "needs: changes" not in lock_job:
+    raise SystemExit("locked-resolve job must be path-gated by the changes detector")
+if "needs.changes.outputs.swift == 'true'" not in lock_job:
+    raise SystemExit("locked-resolve job must share the swift path gate")
+if "/Applications/Xcode_16.4.app/Contents/Developer" not in lock_job:
+    raise SystemExit("locked-resolve job must select the reviewed Xcode 16.4 path")
+if "/Applications/Xcode.app/Contents/Developer" in lock_job:
+    raise SystemExit("locked-resolve job must not use the default/latest Xcode.app")
+if "scripts/verify-swift-package-lock.sh" not in lock_job:
+    raise SystemExit("locked-resolve job must invoke scripts/verify-swift-package-lock.sh")
+if "|| true" in lock_job:
+    raise SystemExit("locked-resolve job must not swallow resolve failures")
+
+required = ci.split("ci-required:", 1)[1]
+if "- swift-package-lock" not in required:
+    raise SystemExit("ci-required must depend on swift-package-lock")
+if "SWIFT_PACKAGE_LOCK_RESULT" not in required:
+    raise SystemExit("ci-required must consume the locked-resolve job result")
+if (
+    'allow_skip "phase3-binary (locked SwiftPM resolve)" '
+    '"$SWIFT_PACKAGE_LOCK_RESULT" "$SWIFT_GATE"'
+) not in required:
+    raise SystemExit("ci-required must allow-skip locked-resolve only when the swift gate is false")
+
+if "/Applications/Xcode_16.4.app/Contents/Developer" not in verify:
+    raise SystemExit("verify-swift-package-lock.sh must require Xcode 16.4")
+if "-onlyUsePackageVersionsFromResolvedFile" not in verify:
+    raise SystemExit("verify script must use the locked candidate/release resolve flag")
+if "|| true" in verify:
+    raise SystemExit("verify script must not swallow resolve failures")
+if "-resolvePackageDependencies" not in verify:
+    raise SystemExit("verify script must resolve packages without a full Release build")
+if "cmp -s" not in verify or "Package.resolved.before" not in verify:
+    raise SystemExit("verify script must fail if locked resolve rewrites Package.resolved")
+
+pins = resolved.get("pins")
+if resolved.get("version") not in (2, 3) or not isinstance(pins, list) or not pins:
+    raise SystemExit("phase3-binary/Package.resolved is not a valid SwiftPM lock")
+identities = {pin.get("identity") for pin in pins if isinstance(pin, dict)}
+if "async-http-client" not in identities:
+    raise SystemExit(
+        "Package.resolved is missing async-http-client; Xcode 16.4 locked "
+        "resolve requires it after the #1336 swift-transformers bump (#1360)"
+    )
+PY
+
+echo "swift-package-lock CI contract checks passed"

--- a/scripts/verify-swift-package-lock.sh
+++ b/scripts/verify-swift-package-lock.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Fail closed if phase3-binary/Package.resolved is incomplete under the
+# pinned release toolchain (Xcode 16.4). This is the same lock flag the
+# candidate/release path uses (`-onlyUsePackageVersionsFromResolvedFile`).
+# Newer local toolchains (Xcode 26.x) resolve a different graph and cannot
+# reproduce this check — refuse to run unless 16.4 is selected.
+#
+# See issue #1360 (async-http-client unpinned after #1336).
+set -euo pipefail
+
+readonly expected_developer_dir="/Applications/Xcode_16.4.app/Contents/Developer"
+
+die() {
+  printf '[verify-swift-package-lock] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+package_dir="$repo_root/phase3-binary"
+[[ -f "$package_dir/Package.resolved" ]] || die "phase3-binary/Package.resolved is missing"
+[[ -d "$expected_developer_dir" ]] || die "reviewed Xcode app is unavailable: $expected_developer_dir"
+
+developer_dir="$(xcode-select -p)"
+[[ "$developer_dir" == "$expected_developer_dir" ]] ||
+  die "selected Xcode differs from the reviewed app: $developer_dir (need $expected_developer_dir)"
+
+cd "$package_dir"
+work="$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/swift-package-lock.XXXXXX")"
+trap 'rm -rf "$work"' EXIT
+cp Package.resolved "$work/Package.resolved.before"
+
+xcodebuild -version
+xcodebuild \
+  -resolvePackageDependencies \
+  -scheme macprovider-cli \
+  -configuration Release \
+  -onlyUsePackageVersionsFromResolvedFile
+
+cmp -s "$work/Package.resolved.before" Package.resolved ||
+  die "locked resolve mutated Package.resolved; regenerate it under Xcode 16.4"
+
+printf '[verify-swift-package-lock] ok: locked SwiftPM resolve succeeded under Xcode 16.4\n'


### PR DESCRIPTION
## Summary
- Commit the Xcode 16.4-regenerated `phase3-binary/Package.resolved` (from the 1.8.119 resolve job) so locked candidate/release builds pin the `async-http-client` stack that `swift-transformers` 1.3.3 requires under 16.4.
- Add a path-gated CI job that selects Xcode 16.4 and fails closed on `xcodebuild -resolvePackageDependencies -onlyUsePackageVersionsFromResolvedFile`, so a future dep bump cannot merge an incomplete lock the way #1336 did.
- Existing pins are unchanged (add-only). Regular `swift test` stays on default Xcode.app; this job is the release-toolchain lock check.

## Test plan
- [x] `bash scripts/test-swift-package-lock.sh`
- [x] `bash scripts/tests/test-ci-detect-changed-paths.sh`
- [x] Three Codex audit lanes: 0 CRITICAL / 0 HIGH / 0 MEDIUM
- [ ] CI `phase3-binary (locked SwiftPM resolve)` green on this PR (Xcode 16.4 runner)

## Governance note
`behavior_change: none` — lockfile completeness + CI tooling; no product behavior, spec, or contract change. The advisory `spec-index` declaration check has no passing declaration for a non-governance CI/lockfile path (same as #1361 / install.sh / version-bump PRs); it is not `ci-required`.

<!-- SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "none",
  "contract_change": "none",
  "specs": [],
  "requirements": [],
  "authority_domains": [],
  "arbitration": [],
  "tests": ["scripts/test-swift-package-lock.sh", "scripts/tests/test-ci-detect-changed-paths.sh", "CI: phase3-binary (locked SwiftPM resolve)"],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END -->
