### PR TITLE
Installer/updater recovery net (F2/F3/F5/F6 + F1 docs) — gates 1.8.119 promotion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,6 +184,7 @@ test-dist:
 	bash scripts/test-watchdog-inline-drift.sh
 	bash phase3-binary/dist/test/watchdog_health_scope.test.sh
 	bash phase3-binary/dist/test/watchdog_rollback_paths.test.sh
+	bash phase3-binary/dist/test/install_recovery_bootstrap_retry.test.sh
 	bash phase3-binary/dist/test/repair_1189_reproduction.test.sh
 	bash ops/macprovider-watchdog/Scripts/test-ac-19-20-watchdog-recovery.sh
 	node --test test/e2e/canary-buyer/probe.test.mjs test/e2e/canary-buyer/safety.test.mjs

--- a/docs/runbooks/provider-repair-1189-e2e.md
+++ b/docs/runbooks/provider-repair-1189-e2e.md
@@ -124,6 +124,18 @@ that is NOT the real #1189 provider**.
 
 - A spare Mac (any Apple Silicon Mac not currently in the #1189 provider's
   hands) that you can freely wipe and reinstall.
+- **Use a dedicated spare Mac — never a second macOS user account on a machine
+  that has a live earner.** The updater targets the **global**
+  `/Applications/Malibu.app` first (per
+  `AutoUpdateMarker.malibuAppCandidates()`), which on a shared machine is the
+  *live earner's* app, regardless of which user runs the test. During #1358
+  acceptance (F1) a test run reached the live earner's `/Applications/Malibu.app`
+  and was stopped **only** by POSIX permissions because the test account was
+  Standard; an Administrator test account would have overwritten the live
+  earner. A second user also cannot isolate unified-memory / thermal pressure:
+  sustained cold model loads on an 8 GB box tripped the earner's own liveness
+  watchdog. Tier-C acceptance (deliberate breakage + downgrade) must therefore
+  run on separate hardware, not a second login.
 - The new, notarized provider DMG build that includes both #1208
   (`aee7d157`) and #1228 (`16b0fa4d`).
 - Network access to the live coordinator (`coordinator.malibu.tech`).

--- a/phase3-binary/Sources/macprovider-cli/AutoUpdateMarker.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutoUpdateMarker.swift
@@ -2205,9 +2205,40 @@ struct AutoUpdateMarkerStore: @unchecked Sendable {
         guard let plist = try PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any],
               let environment = plist["EnvironmentVariables"] as? [String: Any],
               let host = environment["MACPROVIDER_COORDINATOR_HOST"] as? String,
-              host.range(of: #"^[A-Za-z0-9.-]{1,253}$"#, options: .regularExpression) != nil
+              Self.isTrustedCoordinatorHostValue(host)
         else { throw AutoUpdateMarkerError.trustedRootInvalid("installed_watchdog_plist_invalid") }
         return host
+    }
+
+    /// The installed watchdog coordinator host may carry an optional `:port`
+    /// suffix (a self-hosted coordinator on a non-default port, e.g.
+    /// `127.0.0.1:18445`). Validate the host and port parts separately: the
+    /// host keeps the original length/charset guard, and a present port must be
+    /// a decimal in `1...65535`. Production uses a portless host, so this only
+    /// widens acceptance for custom-port deployments and never loosens the host
+    /// guard itself. The returned value is compared like-for-like against the
+    /// freshly rendered watchdog plist in `validateWatchdogPlist`, so the full
+    /// `host[:port]` string round-trips unchanged.
+    static func isTrustedCoordinatorHostValue(_ value: String) -> Bool {
+        let hostPart: Substring
+        let portPart: Substring?
+        if let colonIndex = value.lastIndex(of: ":") {
+            hostPart = value[value.startIndex ..< colonIndex]
+            portPart = value[value.index(after: colonIndex)...]
+        } else {
+            hostPart = value[...]
+            portPart = nil
+        }
+        guard hostPart.range(of: #"^[A-Za-z0-9.-]{1,253}$"#, options: .regularExpression) != nil else {
+            return false
+        }
+        guard let portPart else { return true }
+        guard portPart.range(of: #"^[0-9]{1,5}$"#, options: .regularExpression) != nil,
+              let port = Int(portPart), (1 ... 65535).contains(port)
+        else {
+            return false
+        }
+        return true
     }
 
     private func validateProviderPlist(_ data: Data, installDirectory: URL) throws {

--- a/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
+++ b/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
@@ -40,7 +40,7 @@ struct MacProviderCLI: AsyncParsableCommand {
         commandName: "malibu-cli",
         abstract: "OpenAI-compatible Malibu (Mac Provider) inference CLI.",
         version: CoordinatorClient.binaryVersion,
-        subcommands: [ServeCommand.self, SelfTestCommand.self, StatusCommand.self, ClaimCommand.self, UpdateCommand.self, UninstallCommand.self, ModelsCommand.self, AutotuneCommand.self, BootstrapAuthCommand.self, RotateKeyCommand.self, CredentialsCommand.self, LifecycleStateCommand.self, LifecycleLeaseCommand.self, Spec028CanaryCommand.self, Spec028BenchmarkCommand.self, LegacySpec028CanaryCommand.self, LegacySpec028BenchmarkCommand.self, DecodeBenchCommand.self, EnrollCommand.self, ReleasePayloadPreflightCommand.self, KVCacheCommand.self, DoctorCommand.self, PayoutAddressCommand.self, ConsumeCommand.self],
+        subcommands: [ServeCommand.self, SelfTestCommand.self, StatusCommand.self, ClaimCommand.self, UpdateCommand.self, UninstallCommand.self, ModelsCommand.self, AutotuneCommand.self, BootstrapAuthCommand.self, RotateKeyCommand.self, CredentialsCommand.self, LifecycleStateCommand.self, RecoverUpdateCommand.self, LifecycleLeaseCommand.self, Spec028CanaryCommand.self, Spec028BenchmarkCommand.self, LegacySpec028CanaryCommand.self, LegacySpec028BenchmarkCommand.self, DecodeBenchCommand.self, EnrollCommand.self, ReleasePayloadPreflightCommand.self, KVCacheCommand.self, DoctorCommand.self, PayoutAddressCommand.self, ConsumeCommand.self],
         defaultSubcommand: ServeCommand.self
     )
 }
@@ -131,6 +131,75 @@ struct LifecycleStateTransitionCommand: ParsableCommand {
         )
 
         try LifecycleStateStatusCommand.writeJSON(LifecycleStateStatusCommand.jsonObject(record))
+    }
+}
+
+/// F3 (#1363): a first-class, serve-independent escape from a wedged,
+/// abandoned auto-update transaction. A failed self-update can leave
+/// `pending.json` in `restoring_previous` and an updater-owned
+/// `rollback_in_progress` lifecycle record, which fences both `serve` and
+/// `update`. This command recovers the expired transaction in place — restoring
+/// the previous release and translating the dead updater-owned record into an
+/// installer-owned one that `serve` may leave — without needing `serve` to be
+/// up. It never un-fences a genuinely in-progress update/rollback (see
+/// `WedgedUpdateRecovery`).
+struct RecoverUpdateCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "recover-update",
+        abstract: "Clear a wedged, abandoned auto-update transaction (expired restoring_previous / rollback_in_progress) so the provider can serve again. Safe to run from a fresh CLI while serve is down; a genuinely in-progress update/rollback is left untouched."
+    )
+
+    func run() throws {
+        let recovery = WedgedUpdateRecovery(
+            markerStore: AutoUpdateMarkerStore(),
+            lifecycleStore: ProviderLifecycleStateStore()
+        )
+        let outcome = recovery.recover()
+        var payload: [String: Any] = ["command": "recover-update"]
+        var failureExit: Int32?
+        switch outcome {
+        case .noWedge:
+            payload["outcome"] = "no_wedge"
+            payload["recovered"] = false
+            payload["message"] = "no abandoned auto-update transaction was found; nothing to recover"
+        case .ownerLive:
+            payload["outcome"] = "owner_live"
+            payload["recovered"] = false
+            payload["message"] = "a live installer or updater holds the provider mutation lock; retry after it exits"
+            failureExit = 4
+        case .transactionActive:
+            payload["outcome"] = "transaction_active"
+            payload["recovered"] = false
+            payload["message"] = "a pending update/rollback deadline is still in the future; this is not an abandoned wedge"
+            failureExit = 4
+        case let .recovered(markerOutcome, lifecycleUnfenced):
+            payload["outcome"] = "recovered"
+            payload["recovered"] = true
+            payload["marker_recovered"] = markerOutcome != nil
+            payload["lifecycle_unfenced"] = lifecycleUnfenced
+            payload["marker_result"] = Self.describe(markerOutcome)
+            payload["message"] = "recovered the abandoned transaction; run `serve` (or let launchd restart it) to return to serving"
+        }
+        try LifecycleStateStatusCommand.writeJSON(payload)
+        if let failureExit {
+            throw ExitCode(failureExit)
+        }
+    }
+
+    private static func describe(_ outcome: AutoUpdateOrphanRecoveryOutcome?) -> String {
+        guard let outcome else { return "none" }
+        switch outcome {
+        case .restored:
+            return "restored_previous"
+        case .restoredAwaitingReadiness:
+            return "restored_previous_awaiting_readiness"
+        case .markerInvalid:
+            return "marker_invalid_quarantined"
+        case .backupCorrupt:
+            return "backup_corrupt_quarantined"
+        case .rollbackTargetDisallowed:
+            return "rollback_target_disallowed"
+        }
     }
 }
 
@@ -1478,14 +1547,47 @@ struct ServeCommand: AsyncParsableCommand {
         } else {
             startupReason = "launchd_service_started"
         }
-        _ = try lifecycleStateStore.transition(
-            to: .startingProvider,
-            reasonCode: startupReason,
-            writer: .serve,
-            providerID: resolved.providerID,
-            modelID: resolved.model,
-            operationID: lifecycleOperationID
-        )
+        do {
+            _ = try lifecycleStateStore.transition(
+                to: .startingProvider,
+                reasonCode: startupReason,
+                writer: .serve,
+                providerID: resolved.providerID,
+                modelID: resolved.model,
+                operationID: lifecycleOperationID
+            )
+        } catch let fence as ProviderLifecycleStateError {
+            // F3 (#1363): a fresh launchd serve child that inherits an ABANDONED
+            // updater-owned rollback/update state (a failed self-update with no
+            // handoff lease) is fenced here forever, so launchd respawns in a
+            // loop with no in-CLI escape. When the transaction is genuinely
+            // abandoned — expired marker deadline, no live installer/updater
+            // owner — recover it in place and retry the transition once so the
+            // respawn loop self-heals. A legitimate in-flight self-update never
+            // reaches this catch (its matching handoff operation id lets the
+            // transition through above); WedgedUpdateRecovery additionally
+            // refuses to touch a still-live or not-yet-expired transaction.
+            guard case .operationFenced = fence,
+                  !autotuneCandidate,
+                  candidateIsolationRoot == nil,
+                  resolved.credentialStore != .protectedFile
+            else { throw fence }
+            let recovery = WedgedUpdateRecovery(
+                markerStore: AutoUpdateMarkerStore(),
+                lifecycleStore: lifecycleStateStore
+            )
+            guard case .recovered(_, let lifecycleUnfenced) = recovery.recover(),
+                  lifecycleUnfenced
+            else { throw fence }
+            _ = try lifecycleStateStore.transition(
+                to: .startingProvider,
+                reasonCode: startupReason,
+                writer: .serve,
+                providerID: resolved.providerID,
+                modelID: resolved.model,
+                operationID: lifecycleOperationID
+            )
+        }
 
         // AUDIT R1 SECURITY S2 fix (PR #334): drop MACPROVIDER_PROVIDER_TOKEN
         // from the process env immediately after we've resolved it. Under

--- a/phase3-binary/Sources/macprovider-cli/WedgedUpdateRecovery.swift
+++ b/phase3-binary/Sources/macprovider-cli/WedgedUpdateRecovery.swift
@@ -1,0 +1,137 @@
+import Darwin
+import Foundation
+
+/// F3 (#1363): a failed self-update can leave the provider wedged with no
+/// in-CLI escape. The failure leaves `pending.json` in a `restoring_previous`
+/// transaction *and* an updater-owned `rollback_in_progress` lifecycle record.
+/// Two fences then lock the provider, and the only path that clears them runs
+/// inside `serve`, which is itself fenced:
+///
+///  1. `serve`'s `starting_provider` transition is fenced because
+///     `ProviderLifecycleState.validateTransition` only lets `serve` leave an
+///     *updater*-owned rollback/update state when it presents the exact
+///     `operation_id` from that record. A fresh launchd child has no such
+///     handoff lease, so `serve` exits before it can run marker recovery.
+///  2. `pending.json` makes `update` refuse with `.transactionPending`, and the
+///     expired-`marker_deadline` self-clear (`recoverOrphanedMarker`) only runs
+///     from `CoordinatorClient.runStartupAutoupdateRecovery`, reachable only
+///     after `serve` passes fence #1.
+///
+/// This routine recovers exactly that wedge without depending on `serve` being
+/// up. It is driven both from a first-class `macprovider-cli recover-update`
+/// subcommand and from `serve` startup itself (so the launchd respawn loop
+/// self-heals). It mirrors what `install.sh`'s rollback recovery already does:
+/// recover the expired pending marker, then translate the dead updater-owned
+/// `rollback_in_progress` record into an *installer*-owned one, which `serve`
+/// is always permitted to leave.
+///
+/// Safety: a genuinely mid-rollback provider is never un-fenced. The routine
+/// serializes with installers/updaters through the recovery lock (a live owner
+/// refuses the whole operation) and only touches a transaction whose
+/// `marker_deadline` has already expired (a future deadline means a real
+/// update/rollback still owns the provider).
+struct WedgedUpdateRecovery {
+    struct Environment {
+        var now: () -> Date = { Date() }
+        var processID: () -> Int32 = { getpid() }
+    }
+
+    /// Reason code stamped on the translated installer-owned record. Distinct
+    /// from install.sh's `install_rollback_restored_translated` so the CLI
+    /// recovery path is attributable in the lifecycle journal.
+    static let translationReasonCode = "updater_rollback_recovered_by_cli"
+
+    let markerStore: AutoUpdateMarkerStore
+    let lifecycleStore: ProviderLifecycleStateStore
+    var environment = Environment()
+
+    enum Outcome: Equatable {
+        /// No abandoned wedge was found; nothing changed.
+        case noWedge
+        /// A live installer/updater owner holds the mutation lock, so a genuine
+        /// mutation may be in flight; refused without touching any state.
+        case ownerLive
+        /// A pending transaction whose `marker_deadline` is still in the future
+        /// owns the provider; refused so a genuine in-progress update/rollback
+        /// is never silently un-fenced.
+        case transactionActive
+        /// The abandoned wedge was recovered. `markerOutcome` is nil when there
+        /// was no pending marker (only the lifecycle fence was cleared).
+        case recovered(markerOutcome: AutoUpdateOrphanRecoveryOutcome?, lifecycleUnfenced: Bool)
+    }
+
+    /// A lifecycle record fences a fresh `serve` child only when it is an
+    /// updater-owned rollback/update state; an installer-owned maintenance
+    /// state is always leavable by `serve`.
+    static func lifecycleIsFencedUpdaterState(_ record: ProviderLifecycleStateRecord?) -> Bool {
+        guard let record else { return false }
+        return record.writer == .updater
+            && (record.state == .rollbackInProgress || record.state == .updateInProgress)
+    }
+
+    static func markerDeadlineExpired(_ raw: String, now: Date) -> Bool {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        guard let deadline = formatter.date(from: raw) else {
+            // An unparseable deadline is treated as expired, matching
+            // CoordinatorClient.autoupdateMarkerDeadlineExpired.
+            return true
+        }
+        return now >= deadline
+    }
+
+    func recover() -> Outcome {
+        // Serialize with installers/updaters and prove no live owner. The
+        // recovery lock is refused (lockContended) whenever an installer or
+        // updater is alive, so a genuine mutation in flight can never be
+        // clobbered by recovery.
+        let lock: AutoUpdateLock
+        do {
+            lock = try markerStore.acquireRecoveryLock()
+        } catch {
+            return .ownerLive
+        }
+        defer { withExtendedLifetime(lock) {} }
+
+        var markerOutcome: AutoUpdateOrphanRecoveryOutcome?
+        if let marker = try? markerStore.readPending() {
+            // Only an abandoned (expired-deadline) transaction may be recovered.
+            // A future deadline means a genuine in-progress update/rollback owns
+            // the provider; leave every fence intact.
+            guard Self.markerDeadlineExpired(marker.markerDeadline, now: environment.now()) else {
+                return .transactionActive
+            }
+            markerOutcome = markerStore.recoverOrphanedMarker(marker)
+        }
+
+        // Clear the lifecycle fence only for a dead updater-owned maintenance
+        // state, translating it into an installer-owned rollback_in_progress
+        // record so a fresh serve child can leave it. serve is always allowed
+        // to leave an installer-written maintenance state; it is only fenced on
+        // an updater-owned one whose operation id it cannot match.
+        var lifecycleUnfenced = false
+        if let current = try? lifecycleStore.current(),
+           Self.lifecycleIsFencedUpdaterState(current) {
+            let operationID = "install-rollback:\(environment.processID())"
+            if (try? lifecycleStore.transition(
+                to: .rollbackInProgress,
+                reasonCode: Self.translationReasonCode,
+                writer: .installer,
+                providerID: current.providerID,
+                modelID: current.modelID,
+                compatibilitySetID: current.compatibilitySetID,
+                operationID: operationID,
+                operatorPaused: current.operatorPauseRequested,
+                now: environment.now()
+            )) != nil {
+                lifecycleUnfenced = true
+            }
+        }
+
+        if markerOutcome == nil, !lifecycleUnfenced {
+            return .noWedge
+        }
+        return .recovered(markerOutcome: markerOutcome, lifecycleUnfenced: lifecycleUnfenced)
+    }
+}

--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorHostValidationTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorHostValidationTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import XCTest
+@testable import macprovider_cli
+
+/// F2 (#1366): the updater's trusted-root check on the installed watchdog
+/// coordinator host must accept an optional `:port` suffix so a provider
+/// pointed at a non-default-port coordinator can self-update, while keeping the
+/// original host length/charset guard and rejecting a malformed port.
+final class CoordinatorHostValidationTests: XCTestCase {
+    func testAcceptsPortlessHosts() {
+        XCTAssertTrue(AutoUpdateMarkerStore.isTrustedCoordinatorHostValue("coordinator.malibu.tech"))
+        XCTAssertTrue(AutoUpdateMarkerStore.isTrustedCoordinatorHostValue("127.0.0.1"))
+        XCTAssertTrue(AutoUpdateMarkerStore.isTrustedCoordinatorHostValue("localhost"))
+    }
+
+    func testAcceptsHostPort() {
+        XCTAssertTrue(AutoUpdateMarkerStore.isTrustedCoordinatorHostValue("127.0.0.1:18445"))
+        XCTAssertTrue(AutoUpdateMarkerStore.isTrustedCoordinatorHostValue("coordinator.malibu.tech:8443"))
+        XCTAssertTrue(AutoUpdateMarkerStore.isTrustedCoordinatorHostValue("localhost:1"))
+        XCTAssertTrue(AutoUpdateMarkerStore.isTrustedCoordinatorHostValue("localhost:65535"))
+    }
+
+    func testRejectsInvalidPort() {
+        XCTAssertFalse(AutoUpdateMarkerStore.isTrustedCoordinatorHostValue("127.0.0.1:0"))
+        XCTAssertFalse(AutoUpdateMarkerStore.isTrustedCoordinatorHostValue("127.0.0.1:65536"))
+        XCTAssertFalse(AutoUpdateMarkerStore.isTrustedCoordinatorHostValue("127.0.0.1:99999"))
+        XCTAssertFalse(AutoUpdateMarkerStore.isTrustedCoordinatorHostValue("127.0.0.1:abc"))
+        XCTAssertFalse(AutoUpdateMarkerStore.isTrustedCoordinatorHostValue("127.0.0.1:"))
+        XCTAssertFalse(AutoUpdateMarkerStore.isTrustedCoordinatorHostValue("127.0.0.1: 18445"))
+    }
+
+    func testRejectsInvalidHost() {
+        XCTAssertFalse(AutoUpdateMarkerStore.isTrustedCoordinatorHostValue(""))
+        XCTAssertFalse(AutoUpdateMarkerStore.isTrustedCoordinatorHostValue(":18445"))
+        XCTAssertFalse(AutoUpdateMarkerStore.isTrustedCoordinatorHostValue("host_name:8443"))
+        XCTAssertFalse(AutoUpdateMarkerStore.isTrustedCoordinatorHostValue("has space"))
+        // Bare IPv6 (multiple colons) is not a supported coordinator host form.
+        XCTAssertFalse(AutoUpdateMarkerStore.isTrustedCoordinatorHostValue("::1"))
+        XCTAssertFalse(AutoUpdateMarkerStore.isTrustedCoordinatorHostValue("fe80::1:8443"))
+        // Host part longer than 253 chars is rejected.
+        XCTAssertFalse(AutoUpdateMarkerStore.isTrustedCoordinatorHostValue(String(repeating: "a", count: 254)))
+        XCTAssertFalse(AutoUpdateMarkerStore.isTrustedCoordinatorHostValue(String(repeating: "a", count: 254) + ":8443"))
+    }
+}

--- a/phase3-binary/Tests/macprovider-cliTests/WedgedUpdateRecoveryTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/WedgedUpdateRecoveryTests.swift
@@ -1,0 +1,215 @@
+import Darwin
+import Foundation
+import XCTest
+@testable import macprovider_cli
+
+/// F3 (#1363): a failed self-update can wedge the provider — `pending.json` in
+/// `restoring_previous` plus an updater-owned `rollback_in_progress` lifecycle
+/// record fence both `serve` and `update`, and the only in-CLI resolver runs
+/// inside `serve`, which is itself fenced. These tests pin the serve-independent
+/// recovery: an abandoned wedge is cleared and `serve` can start again, while a
+/// genuinely in-progress or live rollback is never un-fenced.
+final class WedgedUpdateRecoveryTests: XCTestCase {
+    // MARK: - fixtures
+
+    private final class TempRoot {
+        let home: URL
+        let lifecycleRecordURL: URL
+
+        init() throws {
+            home = FileManager.default.temporaryDirectory
+                .appendingPathComponent("wedged-update-recovery-\(UUID().uuidString)", isDirectory: true)
+            lifecycleRecordURL = home
+                .appendingPathComponent("lifecycle", isDirectory: true)
+                .appendingPathComponent("state-v1.json")
+            try FileManager.default.createDirectory(
+                at: home, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700]
+            )
+        }
+
+        deinit { try? FileManager.default.removeItem(at: home) }
+    }
+
+    /// Matches `ISO8601DateFormatter.autoupdate` (internet date-time, GMT), so
+    /// the produced deadline round-trips through the marker validator.
+    private func isoDeadline(_ date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        return formatter.string(from: date)
+    }
+
+    private func writeUpdaterRollbackLifecycle(_ store: ProviderLifecycleStateStore) throws {
+        _ = try store.transition(
+            to: .rollbackInProgress,
+            reasonCode: "self_update_rollback",
+            writer: .updater,
+            providerID: "provider-test",
+            modelID: "llama-3.2-3b-instruct",
+            operationID: "self-update:\(UUID().uuidString.lowercased())"
+        )
+    }
+
+    /// The exact serve startup transition. It is fenced while the record is
+    /// updater-owned rollback and only succeeds once recovery has translated
+    /// the record into an installer-owned one.
+    @discardableResult
+    private func attemptServeStart(_ store: ProviderLifecycleStateStore) throws -> ProviderLifecycleStateRecord {
+        try store.transition(
+            to: .startingProvider,
+            reasonCode: "launchd_service_started",
+            writer: .serve,
+            providerID: "provider-test",
+            modelID: "llama-3.2-3b-instruct",
+            operationID: "serve:\(UUID().uuidString.lowercased())"
+        )
+    }
+
+    // MARK: - tests
+
+    func testUnfencesAbandonedUpdaterRollbackWithNoMarker() throws {
+        let root = try TempRoot()
+        let lifecycleStore = ProviderLifecycleStateStore(url: root.lifecycleRecordURL)
+        try writeUpdaterRollbackLifecycle(lifecycleStore)
+
+        // Precondition: a fresh serve child is fenced by the updater-owned
+        // rollback record.
+        XCTAssertThrowsError(try attemptServeStart(lifecycleStore)) { error in
+            guard case .operationFenced = error as? ProviderLifecycleStateError else {
+                return XCTFail("expected operationFenced, got \(error)")
+            }
+        }
+
+        let recovery = WedgedUpdateRecovery(
+            markerStore: AutoUpdateMarkerStore(homeDirectory: root.home),
+            lifecycleStore: lifecycleStore
+        )
+        XCTAssertEqual(recovery.recover(), .recovered(markerOutcome: nil, lifecycleUnfenced: true))
+
+        // The record is now installer-owned rollback, which serve may leave.
+        let translated = try XCTUnwrap(try lifecycleStore.current())
+        XCTAssertEqual(translated.writer, .installer)
+        XCTAssertEqual(translated.state, .rollbackInProgress)
+        XCTAssertEqual(translated.reasonCode, WedgedUpdateRecovery.translationReasonCode)
+
+        // serve can now start.
+        let started = try attemptServeStart(lifecycleStore)
+        XCTAssertEqual(started.state, .startingProvider)
+        XCTAssertEqual(started.writer, .serve)
+    }
+
+    func testRefusesWhenInstallerOwnerLive() throws {
+        let root = try TempRoot()
+        let lifecycleStore = ProviderLifecycleStateStore(url: root.lifecycleRecordURL)
+        try writeUpdaterRollbackLifecycle(lifecycleStore)
+
+        let recovery = WedgedUpdateRecovery(
+            markerStore: AutoUpdateMarkerStore(
+                homeDirectory: root.home,
+                installerOwnerLiveOverride: { true }
+            ),
+            lifecycleStore: lifecycleStore
+        )
+        XCTAssertEqual(recovery.recover(), .ownerLive)
+
+        // A live owner means a genuine mutation may be in flight; the fence
+        // must stay exactly as it was.
+        let unchanged = try XCTUnwrap(try lifecycleStore.current())
+        XCTAssertEqual(unchanged.writer, .updater)
+        XCTAssertEqual(unchanged.state, .rollbackInProgress)
+    }
+
+    func testRefusesFutureDeadlineTransaction() throws {
+        let root = try TempRoot()
+        let lifecycleStore = ProviderLifecycleStateStore(url: root.lifecycleRecordURL)
+        try writeUpdaterRollbackLifecycle(lifecycleStore)
+
+        let store = AutoUpdateMarkerStore(homeDirectory: root.home)
+        try store.ensureTrustedRoot()
+        let marker = AutoUpdatePendingMarker(
+            updateID: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+            targetVersion: "1.8.119",
+            targetPath: root.home.appendingPathComponent("bin/macprovider-cli").path,
+            backupPath: root.home.appendingPathComponent("bin/.macprovider-cli.rollback-aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee").path,
+            size: 3,
+            mode: 0o755,
+            sha256: AutoUpdateEvent.sha256Hex("old"),
+            markerDeadline: isoDeadline(Date().addingTimeInterval(1_800))
+        )
+        try store.writePending(marker)
+
+        let recovery = WedgedUpdateRecovery(markerStore: store, lifecycleStore: lifecycleStore)
+        XCTAssertEqual(recovery.recover(), .transactionActive)
+
+        // Neither the marker nor the fence may be touched for a genuine
+        // in-progress transaction.
+        XCTAssertTrue(FileManager.default.fileExists(atPath: store.pendingURL.path))
+        let unchanged = try XCTUnwrap(try lifecycleStore.current())
+        XCTAssertEqual(unchanged.writer, .updater)
+        XCTAssertEqual(unchanged.state, .rollbackInProgress)
+    }
+
+    func testRecoversExpiredMarkerAndUnfencesLifecycle() throws {
+        let root = try TempRoot()
+        let lifecycleStore = ProviderLifecycleStateStore(url: root.lifecycleRecordURL)
+        try writeUpdaterRollbackLifecycle(lifecycleStore)
+
+        let store = AutoUpdateMarkerStore(homeDirectory: root.home)
+        try store.ensureTrustedRoot()
+        FileManager.default.createFile(atPath: store.lockURL.path, contents: Data(), attributes: [.posixPermissions: 0o600])
+        let binaryDir = root.home.appendingPathComponent("bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: binaryDir, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o700])
+        let binary = binaryDir.appendingPathComponent("macprovider-cli")
+        let backup = binaryDir.appendingPathComponent(".macprovider-cli.rollback-aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee")
+        try Data("new".utf8).write(to: binary)
+        try Data("old".utf8).write(to: backup)
+        let marker = AutoUpdatePendingMarker(
+            updateID: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+            targetVersion: "1.8.119",
+            targetPath: binary.path,
+            backupPath: backup.path,
+            size: 3,
+            mode: 0o755,
+            sha256: AutoUpdateEvent.sha256Hex("old"),
+            markerDeadline: isoDeadline(Date().addingTimeInterval(-3_600))
+        )
+        try store.writePending(marker)
+
+        let recovery = WedgedUpdateRecovery(markerStore: store, lifecycleStore: lifecycleStore)
+        XCTAssertEqual(recovery.recover(), .recovered(markerOutcome: .restored(marker), lifecycleUnfenced: true))
+
+        // The previous binary is restored and the pending marker cleared.
+        XCTAssertEqual(try String(contentsOf: binary), "old")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: store.pendingURL.path))
+
+        // And serve is un-fenced.
+        let translated = try XCTUnwrap(try lifecycleStore.current())
+        XCTAssertEqual(translated.writer, .installer)
+        let started = try attemptServeStart(lifecycleStore)
+        XCTAssertEqual(started.state, .startingProvider)
+    }
+
+    func testNoWedgeWhenLifecycleNotUpdaterOwned() throws {
+        let root = try TempRoot()
+        let lifecycleStore = ProviderLifecycleStateStore(url: root.lifecycleRecordURL)
+        // An installer-owned rollback is not a wedge — serve can already leave it.
+        _ = try lifecycleStore.transition(
+            to: .rollbackInProgress,
+            reasonCode: "install_admission_failed",
+            writer: .installer,
+            providerID: "provider-test",
+            operationID: "install-rollback:1234"
+        )
+        let before = try XCTUnwrap(try lifecycleStore.current())
+
+        let recovery = WedgedUpdateRecovery(
+            markerStore: AutoUpdateMarkerStore(homeDirectory: root.home),
+            lifecycleStore: lifecycleStore
+        )
+        XCTAssertEqual(recovery.recover(), .noWedge)
+
+        let after = try XCTUnwrap(try lifecycleStore.current())
+        XCTAssertEqual(after.sequence, before.sequence)
+        XCTAssertEqual(after.writer, .installer)
+    }
+}

--- a/phase3-binary/dist/install.sh
+++ b/phase3-binary/dist/install.sh
@@ -3239,6 +3239,35 @@ recovery_launchctl() {
   fi
 }
 
+# Sanitize an operator-supplied integer override to a positive decimal (or a
+# non-negative one when allow_zero is passed), falling back to the default for
+# empty, non-numeric, leading-zero-octal, zero (unless allowed), or oversized
+# values, and clamping to `maximum` when one is supplied. Without this a
+# malformed override (e.g. `abc`) makes a later `[ -ge ]` comparison error with
+# status 2, which — inside the retry loop below — would skip the give-up check
+# and spin forever; without the clamp a valid-but-huge override (e.g. 999999)
+# would schedule a practically non-terminating loop or multi-day sleeps.
+recovery_positive_int() {
+  candidate="$1"
+  fallback="$2"
+  allow_zero="${3:-}"
+  maximum="${4:-}"
+  case "$candidate" in
+    ''|*[!0-9]*) printf '%s\n' "$fallback"; return 0 ;;
+  esac
+  if [ "${#candidate}" -gt 9 ]; then
+    printf '%s\n' "$fallback"; return 0
+  fi
+  candidate=$((10#$candidate))
+  if [ "$candidate" -eq 0 ] && [ "$allow_zero" != "allow_zero" ]; then
+    printf '%s\n' "$fallback"; return 0
+  fi
+  if [ -n "$maximum" ] && [ "$candidate" -gt "$maximum" ]; then
+    candidate="$maximum"
+  fi
+  printf '%s\n' "$candidate"
+}
+
 # F6 (#1364): `launchctl bootstrap` can transiently return "Input/output error"
 # on a launchd domain that is briefly refusing new services (observed 6/6 on an
 # isolated GUI domain during acceptance; it cleared only after a re-login). A
@@ -3246,21 +3275,27 @@ recovery_launchctl() {
 # leaving the provider down AND a preserved bundle that hard-blocked the next
 # install. Retry with a short linear backoff, booting out any half-loaded label
 # between attempts, so a transient domain I/O error clears in place instead of
-# wedging recovery. A label that is already loaded (a prior partial bootstrap)
-# is treated as success; the caller still verifies the launchd identity.
+# wedging recovery.
+#
+# Only an actual successful bootstrap of the EXPECTED plist path counts as
+# success. An already-loaded label is NOT trusted: a same-user process could
+# have bootstrapped a foreign plist under it, and the caller kickstarts before
+# it verifies identity. So we always bootout and re-bootstrap the expected
+# plist rather than accepting whatever happens to be loaded; the caller then
+# still verifies the launchd identity of what we bootstrapped.
 recovery_bootstrap_service() {
   bootstrap_domain="$1"
   bootstrap_plist_path="$2"
   bootstrap_label="$3"
   bootstrap_attempt=0
-  bootstrap_max_attempts="${MACPROVIDER_RECOVERY_BOOTSTRAP_ATTEMPTS:-5}"
-  bootstrap_backoff_unit="${MACPROVIDER_RECOVERY_BOOTSTRAP_BACKOFF_SECONDS:-2}"
+  # Clamp to sane maxima so a fat-fingered override cannot schedule a
+  # practically non-terminating retry loop (attempts) or multi-day sleeps
+  # (backoff): at most 20 attempts and a 10s backoff unit.
+  bootstrap_max_attempts="$(recovery_positive_int "${MACPROVIDER_RECOVERY_BOOTSTRAP_ATTEMPTS:-}" 5 '' 20)"
+  bootstrap_backoff_unit="$(recovery_positive_int "${MACPROVIDER_RECOVERY_BOOTSTRAP_BACKOFF_SECONDS:-}" 2 allow_zero 10)"
   while :; do
     bootstrap_attempt=$((bootstrap_attempt + 1))
     if recovery_launchctl bootstrap "$bootstrap_domain" "$bootstrap_plist_path" >/dev/null 2>&1; then
-      return 0
-    fi
-    if recovery_launchctl print "$bootstrap_domain/$bootstrap_label" >/dev/null 2>&1; then
       return 0
     fi
     if [ "$bootstrap_attempt" -ge "$bootstrap_max_attempts" ]; then
@@ -12181,8 +12216,25 @@ wait_for_coordinator() {
   # buyer_serving. Give coordinator admission a generous deadline aligned with
   # the model-load reality (the local /v1/models waits above use 300s/1200s).
   # The exact catalog-identity / legacy_bridge admission proofs below are
-  # unchanged; only the timeout widens. Overridable for tests.
+  # unchanged; only the timeout widens. Overridable for tests; a malformed
+  # override (empty, non-numeric, leading-zero octal, zero, or oversized) falls
+  # back to 300 rather than aborting the arithmetic under `set -u` or making the
+  # gate fail immediately, and a valid-but-huge value is clamped to 1800s (30
+  # min, well beyond any legitimate cold model load) so a fat-fingered override
+  # cannot hang a failing install for days.
   coordinator_ready_timeout="${MACPROVIDER_COORDINATOR_READY_TIMEOUT_SECONDS:-300}"
+  case "$coordinator_ready_timeout" in
+    ''|*[!0-9]*) coordinator_ready_timeout=300 ;;
+    *)
+      if [ "${#coordinator_ready_timeout}" -gt 6 ]; then
+        coordinator_ready_timeout=300
+      else
+        coordinator_ready_timeout=$((10#$coordinator_ready_timeout))
+        [ "$coordinator_ready_timeout" -ge 1 ] || coordinator_ready_timeout=300
+        [ "$coordinator_ready_timeout" -le 1800 ] || coordinator_ready_timeout=1800
+      fi
+      ;;
+  esac
   deadline=$(( $(date +%s) + coordinator_ready_timeout ))
   while [ "$(date +%s)" -lt "$deadline" ]; do
     local_status="$(curl -fsS --max-time 5 "http://127.0.0.1:${PORT}/v1/status" 2>/dev/null || true)"
@@ -13493,7 +13545,7 @@ main() {
   # exact current/previous catalog identity for normal upgrades, or exact
   # session-bound buyer-serving legacy_bridge proof for an explicit signed
   # emergency downgrade.
-  log "Waiting up to $(( ${MACPROVIDER_COORDINATOR_READY_TIMEOUT_SECONDS:-300} / 60 )) min for exact coordinator admission and buyer-serving readiness (cold model load on low-RAM Macs can take minutes)."
+  log "Waiting for exact coordinator admission and buyer-serving readiness (cold model load on low-RAM Macs can take minutes)."
   if ! wait_for_coordinator "$provider_id" "$coordinator_base"; then
     if [ "${REPAIR_EXISTING_INSTALL:-0}" -eq 1 ]; then
       log "Coordinator did not admit the repaired provider yet; committing local repair and leaving coordinator rejoin as telemetry."

--- a/phase3-binary/dist/install.sh
+++ b/phase3-binary/dist/install.sh
@@ -3239,6 +3239,51 @@ recovery_launchctl() {
   fi
 }
 
+# F6 (#1364): `launchctl bootstrap` can transiently return "Input/output error"
+# on a launchd domain that is briefly refusing new services (observed 6/6 on an
+# isolated GUI domain during acceptance; it cleared only after a re-login). A
+# single failed bootstrap previously tripped `recovery_failed` -> exit 70,
+# leaving the provider down AND a preserved bundle that hard-blocked the next
+# install. Retry with a short linear backoff, booting out any half-loaded label
+# between attempts, so a transient domain I/O error clears in place instead of
+# wedging recovery. A label that is already loaded (a prior partial bootstrap)
+# is treated as success; the caller still verifies the launchd identity.
+recovery_bootstrap_service() {
+  bootstrap_domain="$1"
+  bootstrap_plist_path="$2"
+  bootstrap_label="$3"
+  bootstrap_attempt=0
+  bootstrap_max_attempts="${MACPROVIDER_RECOVERY_BOOTSTRAP_ATTEMPTS:-5}"
+  bootstrap_backoff_unit="${MACPROVIDER_RECOVERY_BOOTSTRAP_BACKOFF_SECONDS:-2}"
+  while :; do
+    bootstrap_attempt=$((bootstrap_attempt + 1))
+    if recovery_launchctl bootstrap "$bootstrap_domain" "$bootstrap_plist_path" >/dev/null 2>&1; then
+      return 0
+    fi
+    if recovery_launchctl print "$bootstrap_domain/$bootstrap_label" >/dev/null 2>&1; then
+      return 0
+    fi
+    if [ "$bootstrap_attempt" -ge "$bootstrap_max_attempts" ]; then
+      return 1
+    fi
+    recovery_log "launchctl bootstrap of $bootstrap_label was refused (attempt ${bootstrap_attempt}/${bootstrap_max_attempts}); booting out any partial load and retrying."
+    recovery_launchctl bootout "$bootstrap_domain/$bootstrap_label" >/dev/null 2>&1 || true
+    sleep "$(( bootstrap_attempt * bootstrap_backoff_unit ))"
+  done
+}
+
+# Same failure as recovery_failed but with the concrete, non-folklore
+# remediation for a launchd domain that keeps refusing a (re)start: the
+# previous provider files are restored on disk, only the service is not
+# running, and a re-login / reboot recreates the domain so the preserved
+# recover.sh can finish.
+recovery_bootstrap_failed() {
+  recovery_log "$1"
+  recovery_log "The previous provider files are restored on disk, but launchd refused to (re)start the service after retries — usually a transient launchd domain I/O error."
+  recovery_log "Log out and back in (or reboot) to recreate the launchd session, then retry exactly: bash '$RECOVERY_DIR/recover.sh'"
+  exit 70
+}
+
 validate_recovery_launchdaemon_plist() {
   managed_path="$1"
   bootstrap_path="$2"
@@ -6017,8 +6062,8 @@ if [ ! -e "$RECOVERY_DIR/cutover-started" ] && [ ! -L "$RECOVERY_DIR/cutover-sta
         || recovery_failed "the prior provider service disappeared before cutover and no launchd plist was preserved"
       paths_match "$RECOVERY_DIR/provider.plist" "$REC_PLIST_PATH" file \
         || recovery_failed "the pre-cutover provider plist changed after the recovery snapshot"
-      recovery_launchctl bootstrap "$REC_LAUNCHD_DOMAIN" "$REC_PLIST_BOOTSTRAP_PATH" >/dev/null 2>&1 \
-        || recovery_failed "could not restore the unexpectedly inactive pre-cutover provider service"
+      recovery_bootstrap_service "$REC_LAUNCHD_DOMAIN" "$REC_PLIST_BOOTSTRAP_PATH" "$REC_PROVIDER_LABEL" \
+        || recovery_bootstrap_failed "could not restore the unexpectedly inactive pre-cutover provider service"
       recovery_launchctl kickstart -k "$REC_LAUNCHD_DOMAIN/$REC_PROVIDER_LABEL" >/dev/null 2>&1 \
         || recovery_failed "could not start the unexpectedly inactive pre-cutover provider service"
     fi
@@ -6032,8 +6077,8 @@ if [ ! -e "$RECOVERY_DIR/cutover-started" ] && [ ! -L "$RECOVERY_DIR/cutover-sta
         || recovery_failed "the prior legacy provider service disappeared before cutover and no launchd plist was preserved"
       paths_match "$RECOVERY_DIR/legacy-provider.plist" "$REC_LEGACY_PLIST_PATH" file \
         || recovery_failed "the pre-cutover legacy provider plist changed after the recovery snapshot"
-      recovery_launchctl bootstrap "$REC_LAUNCHD_DOMAIN" "$REC_LEGACY_PLIST_BOOTSTRAP_PATH" >/dev/null 2>&1 \
-        || recovery_failed "could not restore the unexpectedly inactive pre-cutover legacy provider service"
+      recovery_bootstrap_service "$REC_LAUNCHD_DOMAIN" "$REC_LEGACY_PLIST_BOOTSTRAP_PATH" "$REC_LEGACY_PROVIDER_LABEL" \
+        || recovery_bootstrap_failed "could not restore the unexpectedly inactive pre-cutover legacy provider service"
       recovery_launchctl kickstart -k "$REC_LAUNCHD_DOMAIN/$REC_LEGACY_PROVIDER_LABEL" >/dev/null 2>&1 \
         || recovery_failed "could not start the unexpectedly inactive pre-cutover legacy provider service"
     fi
@@ -6047,8 +6092,8 @@ if [ ! -e "$RECOVERY_DIR/cutover-started" ] && [ ! -L "$RECOVERY_DIR/cutover-sta
         || recovery_failed "the prior watchdog was active but no launchd plist was preserved"
       paths_match "$RECOVERY_DIR/watchdog.plist" "$REC_WATCHDOG_PLIST_PATH" file \
         || recovery_failed "the pre-cutover watchdog plist changed after the recovery snapshot"
-      recovery_launchctl bootstrap "$REC_LAUNCHD_DOMAIN" "$REC_WATCHDOG_PLIST_BOOTSTRAP_PATH" >/dev/null 2>&1 \
-        || recovery_failed "could not restore the pre-cutover watchdog service"
+      recovery_bootstrap_service "$REC_LAUNCHD_DOMAIN" "$REC_WATCHDOG_PLIST_BOOTSTRAP_PATH" "$REC_WATCHDOG_LABEL" \
+        || recovery_bootstrap_failed "could not restore the pre-cutover watchdog service"
     fi
     recovery_launchctl kickstart -k "$REC_LAUNCHD_DOMAIN/$REC_WATCHDOG_LABEL" >/dev/null 2>&1 \
       || recovery_failed "could not start the pre-cutover watchdog service"
@@ -6062,8 +6107,8 @@ if [ ! -e "$RECOVERY_DIR/cutover-started" ] && [ ! -L "$RECOVERY_DIR/cutover-sta
         || recovery_failed "the prior legacy watchdog was active but no launchd plist was preserved"
       paths_match "$RECOVERY_DIR/legacy-watchdog.plist" "$REC_LEGACY_WATCHDOG_PLIST_PATH" file \
         || recovery_failed "the pre-cutover legacy watchdog plist changed after the recovery snapshot"
-      recovery_launchctl bootstrap "$REC_LAUNCHD_DOMAIN" "$REC_LEGACY_WATCHDOG_PLIST_BOOTSTRAP_PATH" >/dev/null 2>&1 \
-        || recovery_failed "could not restore the pre-cutover legacy watchdog service"
+      recovery_bootstrap_service "$REC_LAUNCHD_DOMAIN" "$REC_LEGACY_WATCHDOG_PLIST_BOOTSTRAP_PATH" "$REC_LEGACY_WATCHDOG_LABEL" \
+        || recovery_bootstrap_failed "could not restore the pre-cutover legacy watchdog service"
     fi
     recovery_launchctl kickstart -k "$REC_LAUNCHD_DOMAIN/$REC_LEGACY_WATCHDOG_LABEL" >/dev/null 2>&1 \
       || recovery_failed "could not start the pre-cutover legacy watchdog service"
@@ -6437,14 +6482,14 @@ else
 fi
 if [ "$REC_SERVICE_WAS_ACTIVE" -eq 1 ]; then
   [ "$REC_HAD_PLIST" -eq 1 ] || recovery_failed "previous service was active but no previous plist was preserved"
-  recovery_launchctl bootstrap "$REC_LAUNCHD_DOMAIN" "$REC_PLIST_BOOTSTRAP_PATH" >/dev/null 2>&1 || recovery_failed "could not bootstrap the previous provider service"
+  recovery_bootstrap_service "$REC_LAUNCHD_DOMAIN" "$REC_PLIST_BOOTSTRAP_PATH" "$REC_PROVIDER_LABEL" || recovery_bootstrap_failed "could not bootstrap the previous provider service"
   recovery_launchctl kickstart -k "$REC_LAUNCHD_DOMAIN/$REC_PROVIDER_LABEL" >/dev/null 2>&1 || recovery_failed "could not kickstart the previous provider service"
   service_identity_matches "$REC_PROVIDER_LABEL" "$REC_PLIST_BOOTSTRAP_PATH" \
     "$REC_INSTALL_DIR/macprovider-cli" "$REC_BINARY_PATH" "$REC_HEADLESS_REPAIR_INCUMBENT_BINARY" \
     || recovery_failed "previous provider service has an unexpected identity"
 elif [ "$REC_LEGACY_SERVICE_WAS_ACTIVE" -eq 1 ]; then
   [ "$REC_HAD_LEGACY_PLIST" -eq 1 ] || recovery_failed "previous legacy service was active but no previous plist was preserved"
-  recovery_launchctl bootstrap "$REC_LAUNCHD_DOMAIN" "$REC_LEGACY_PLIST_BOOTSTRAP_PATH" >/dev/null 2>&1 || recovery_failed "could not bootstrap the previous legacy provider service"
+  recovery_bootstrap_service "$REC_LAUNCHD_DOMAIN" "$REC_LEGACY_PLIST_BOOTSTRAP_PATH" "$REC_LEGACY_PROVIDER_LABEL" || recovery_bootstrap_failed "could not bootstrap the previous legacy provider service"
   recovery_launchctl kickstart -k "$REC_LAUNCHD_DOMAIN/$REC_LEGACY_PROVIDER_LABEL" >/dev/null 2>&1 || recovery_failed "could not kickstart the previous legacy provider service"
   service_identity_matches "$REC_LEGACY_PROVIDER_LABEL" "$REC_LEGACY_PLIST_BOOTSTRAP_PATH" \
     "$REC_INSTALL_DIR/macprovider-cli" "$REC_BINARY_PATH" \
@@ -6465,14 +6510,14 @@ else
 fi
 if [ "$REC_WATCHDOG_WAS_ACTIVE" -eq 1 ]; then
   [ "$REC_HAD_WATCHDOG_PLIST" -eq 1 ] || recovery_failed "previous watchdog was active but no previous plist was preserved"
-  recovery_launchctl bootstrap "$REC_LAUNCHD_DOMAIN" "$REC_WATCHDOG_PLIST_BOOTSTRAP_PATH" >/dev/null 2>&1 || recovery_failed "could not bootstrap the previous watchdog service"
+  recovery_bootstrap_service "$REC_LAUNCHD_DOMAIN" "$REC_WATCHDOG_PLIST_BOOTSTRAP_PATH" "$REC_WATCHDOG_LABEL" || recovery_bootstrap_failed "could not bootstrap the previous watchdog service"
   recovery_launchctl kickstart -k "$REC_LAUNCHD_DOMAIN/$REC_WATCHDOG_LABEL" >/dev/null 2>&1 || recovery_failed "could not kickstart the previous watchdog service"
   service_identity_matches "$REC_WATCHDOG_LABEL" "$REC_WATCHDOG_PLIST_BOOTSTRAP_PATH" \
     "/Library/Application Support/macprovider/macprovider-health-monitor" "$REC_WATCHDOG_DIR/macprovider-health-monitor" "$REC_WATCHDOG_DIR/watchdog.sh" \
     || recovery_failed "previous watchdog service has an unexpected identity"
 elif [ "$REC_LEGACY_WATCHDOG_WAS_ACTIVE" -eq 1 ]; then
   [ "$REC_HAD_LEGACY_WATCHDOG_PLIST" -eq 1 ] || recovery_failed "previous legacy watchdog was active but no previous plist was preserved"
-  recovery_launchctl bootstrap "$REC_LAUNCHD_DOMAIN" "$REC_LEGACY_WATCHDOG_PLIST_BOOTSTRAP_PATH" >/dev/null 2>&1 || recovery_failed "could not bootstrap the previous legacy watchdog service"
+  recovery_bootstrap_service "$REC_LAUNCHD_DOMAIN" "$REC_LEGACY_WATCHDOG_PLIST_BOOTSTRAP_PATH" "$REC_LEGACY_WATCHDOG_LABEL" || recovery_bootstrap_failed "could not bootstrap the previous legacy watchdog service"
   recovery_launchctl kickstart -k "$REC_LAUNCHD_DOMAIN/$REC_LEGACY_WATCHDOG_LABEL" >/dev/null 2>&1 || recovery_failed "could not kickstart the previous legacy watchdog service"
   service_identity_matches "$REC_LEGACY_WATCHDOG_LABEL" "$REC_LEGACY_WATCHDOG_PLIST_BOOTSTRAP_PATH" \
     "/Library/Application Support/macprovider/macprovider-health-monitor" "$REC_WATCHDOG_DIR/macprovider-health-monitor" "$REC_WATCHDOG_DIR/watchdog.sh" \
@@ -12130,7 +12175,15 @@ print_local_self_test_diagnostics() {
 wait_for_coordinator() {
   provider_id="$1"
   coordinator_base="$2"
-  deadline=$(( $(date +%s) + 30 ))
+  # F5 (#1365): a cold model load on a low-RAM Mac can push first
+  # buyer-serving readiness well past 30s (observed 97s/114s/296s on an 8GB
+  # Tier C M2). A flat 30s gate rolled back installs that had genuinely reached
+  # buyer_serving. Give coordinator admission a generous deadline aligned with
+  # the model-load reality (the local /v1/models waits above use 300s/1200s).
+  # The exact catalog-identity / legacy_bridge admission proofs below are
+  # unchanged; only the timeout widens. Overridable for tests.
+  coordinator_ready_timeout="${MACPROVIDER_COORDINATOR_READY_TIMEOUT_SECONDS:-300}"
+  deadline=$(( $(date +%s) + coordinator_ready_timeout ))
   while [ "$(date +%s)" -lt "$deadline" ]; do
     local_status="$(curl -fsS --max-time 5 "http://127.0.0.1:${PORT}/v1/status" 2>/dev/null || true)"
     assigned_id="$(python3 - "$provider_id" "$local_status" <<'PY' 2>/dev/null || true
@@ -13440,7 +13493,7 @@ main() {
   # exact current/previous catalog identity for normal upgrades, or exact
   # session-bound buyer-serving legacy_bridge proof for an explicit signed
   # emergency downgrade.
-  log "Waiting up to 30s for exact coordinator admission and buyer-serving readiness."
+  log "Waiting up to $(( ${MACPROVIDER_COORDINATOR_READY_TIMEOUT_SECONDS:-300} / 60 )) min for exact coordinator admission and buyer-serving readiness (cold model load on low-RAM Macs can take minutes)."
   if ! wait_for_coordinator "$provider_id" "$coordinator_base"; then
     if [ "${REPAIR_EXISTING_INSTALL:-0}" -eq 1 ]; then
       log "Coordinator did not admit the repaired provider yet; committing local repair and leaving coordinator rejoin as telemetry."

--- a/phase3-binary/dist/test/install_coordinator_admission.test.sh
+++ b/phase3-binary/dist/test/install_coordinator_admission.test.sh
@@ -313,3 +313,55 @@ disarm = commit_body.index("disarm_install_recovery_agent")
 if not retire < mark < disarm:
     raise SystemExit("recovery observer is disarmed before the atomic no-rollback boundary")
 PY
+
+# F5 (#1365): the coordinator-admission deadline must be generous (a cold model
+# load on a low-RAM Mac can take minutes) and driven by
+# MACPROVIDER_COORDINATOR_READY_TIMEOUT_SECONDS, not a flat 30s. A healthy
+# install that reaches buyer_serving inside the window must never be rolled back.
+python3 - "$TMP/function.sh" <<'PY'
+import re
+import sys
+
+body = open(sys.argv[1], encoding="utf-8").read()
+if ":-300" not in body:
+    raise SystemExit("wait_for_coordinator no longer defaults the readiness timeout to 300s")
+if re.search(r"date \+%s\)\s*\)?\s*\+\s*30\s*\)\)", body):
+    raise SystemExit("wait_for_coordinator still hardcodes a 30s readiness deadline")
+if "MACPROVIDER_COORDINATOR_READY_TIMEOUT_SECONDS" not in body:
+    raise SystemExit("wait_for_coordinator ignores the readiness timeout override")
+PY
+
+# The readiness loop length must scale with the configured timeout: a
+# coordinator that stays connected but never admits should iterate more under a
+# larger deadline. The mock date increments 10 per call, so deadline is
+# start(100) + timeout, and each iteration emits one details=readiness curl.
+run_wait_timeout() {
+  timeout_seconds="$1"
+  coordinator_response="$2"
+  printf '100\n' > "$TMP/date-state"
+  : > "$TMP/curl.log"
+  PATH="$TMP/bin:/usr/bin:/bin" DATE_STATE="$TMP/date-state" CURL_LOG="$TMP/curl.log" \
+    LOCAL_RESPONSE="$TMP/local.json" COORDINATOR_RESPONSE="$coordinator_response" \
+    EMERGENCY_ROLLBACK=0 MACPROVIDER_COORDINATOR_READY_TIMEOUT_SECONDS="$timeout_seconds" \
+    FUNCTION_PATH="$TMP/function.sh" INSTALL_ROOT="$TMP/install" bash -c '
+      set -euo pipefail
+      PORT=18080
+      INSTALL_DIR="$INSTALL_ROOT"
+      urlencode() { printf "%s" "$1"; }
+      source "$FUNCTION_PATH"
+      wait_for_coordinator provider-test https://coordinator.example || true
+    '
+  grep -Fc 'details=readiness' "$TMP/curl.log" || printf 0
+}
+
+short_iterations="$(run_wait_timeout 20 "$TMP/mismatch.json")"
+long_iterations="$(run_wait_timeout 300 "$TMP/mismatch.json")"
+if [ "$long_iterations" -le "$short_iterations" ]; then
+  echo "readiness deadline did not scale with the configured timeout ($short_iterations vs $long_iterations)" >&2
+  exit 1
+fi
+
+# A coordinator that admits buyer-serving traffic is accepted (not rolled back)
+# even though several poll iterations elapse first — the healthy-install case
+# from F5 where the model was still finishing its cold load.
+run_wait "$TMP/coordinator.json"

--- a/phase3-binary/dist/test/install_recovery_bootstrap_retry.test.sh
+++ b/phase3-binary/dist/test/install_recovery_bootstrap_retry.test.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# F6 (#1364): launchctl bootstrap can transiently return "Input/output error"
+# on a launchd domain that is briefly refusing new services. A single failed
+# bootstrap used to trip recovery_failed -> exit 70, leaving the provider down
+# and a preserved bundle that hard-blocked the next install. recovery_bootstrap_service
+# must retry with backoff, boot out any partial load between attempts, treat an
+# already-loaded label as success, and only give up (non-zero, no hang) after a
+# bounded number of attempts.
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+INSTALL_SH="$REPO_ROOT/phase3-binary/dist/install.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+python3 - "$INSTALL_SH" > "$TMP/function.sh" <<'PY'
+import sys
+
+name = "recovery_bootstrap_service"
+lines = open(sys.argv[1], encoding="utf-8").read().splitlines()
+for index, line in enumerate(lines):
+    if not line.startswith(name + "()"):
+        continue
+    depth = 0
+    for body_line in lines[index:]:
+        print(body_line)
+        depth += body_line.count("{") - body_line.count("}")
+        if depth == 0:
+            raise SystemExit(0)
+raise SystemExit("recovery_bootstrap_service not found")
+PY
+
+[ -s "$TMP/function.sh" ] || { echo "failed to extract recovery_bootstrap_service" >&2; exit 1; }
+
+# Harness: a mock recovery_launchctl whose behavior is scripted per-verb through
+# files, plus a call log. bootstrap consumes one line of BOOTSTRAP_PLAN each
+# call ("ok" -> exit 0, anything else -> exit 5, the launchd I/O error code);
+# print returns PRINT_RC; bootout is always recorded and succeeds.
+run_bootstrap() {
+  bootstrap_plan="$1"
+  print_rc="$2"
+  max_attempts="$3"
+  : > "$TMP/calls.log"
+  printf '%s\n' "$bootstrap_plan" > "$TMP/bootstrap-plan"
+  PATH="/usr/bin:/bin" \
+  CALLS_LOG="$TMP/calls.log" BOOTSTRAP_PLAN_FILE="$TMP/bootstrap-plan" PRINT_RC="$print_rc" \
+  FUNCTION_PATH="$TMP/function.sh" MAX_ATTEMPTS="$max_attempts" bash -c '
+    set -uo pipefail
+    recovery_log() { :; }
+    recovery_launchctl() {
+      verb="$1"
+      printf "%s\n" "$verb" >> "$CALLS_LOG"
+      case "$verb" in
+        bootstrap)
+          plan_line="$(sed -n "1p" "$BOOTSTRAP_PLAN_FILE")"
+          sed -i.bak "1d" "$BOOTSTRAP_PLAN_FILE" 2>/dev/null || true
+          [ "$plan_line" = "ok" ] && return 0
+          return 5
+          ;;
+        print) return "$PRINT_RC" ;;
+        bootout) return 0 ;;
+        *) return 0 ;;
+      esac
+    }
+    MACPROVIDER_RECOVERY_BOOTSTRAP_ATTEMPTS="$MAX_ATTEMPTS"
+    MACPROVIDER_RECOVERY_BOOTSTRAP_BACKOFF_SECONDS=0
+    source "$FUNCTION_PATH"
+    recovery_bootstrap_service system /Library/LaunchDaemons/live.malibu.provider.plist live.malibu.provider
+  '
+}
+
+# 1. Transient I/O error clears on retry: bootstrap fails twice, succeeds third.
+if ! run_bootstrap "$(printf 'fail\nfail\nok')" 1 5; then
+  echo "recovery_bootstrap_service did not recover a transient bootstrap I/O error" >&2
+  exit 1
+fi
+# It must have booted out the partial load between the failed attempts.
+if ! grep -qx bootout "$TMP/calls.log"; then
+  echo "recovery_bootstrap_service did not bootout a partial load between retries" >&2
+  exit 1
+fi
+bootstrap_calls="$(grep -cx bootstrap "$TMP/calls.log")"
+if [ "$bootstrap_calls" -ne 3 ]; then
+  echo "expected 3 bootstrap attempts before success, saw $bootstrap_calls" >&2
+  exit 1
+fi
+
+# 2. Already-loaded label (print succeeds) is treated as success without needing
+#    a further bootstrap to report ok.
+if ! run_bootstrap "$(printf 'fail')" 0 5; then
+  echo "recovery_bootstrap_service failed even though the label was already loaded" >&2
+  exit 1
+fi
+
+# 3. Persistent failure gives up cleanly (non-zero) after the bounded attempts
+#    and does not hang. print never succeeds either.
+if run_bootstrap "$(printf 'fail\nfail\nfail')" 1 3; then
+  echo "recovery_bootstrap_service reported success despite a persistent bootstrap failure" >&2
+  exit 1
+fi
+give_up_calls="$(grep -cx bootstrap "$TMP/calls.log")"
+if [ "$give_up_calls" -ne 3 ]; then
+  echo "expected exactly 3 bootstrap attempts before giving up, saw $give_up_calls" >&2
+  exit 1
+fi
+
+# The main rollback bootstrap sites route through recovery_bootstrap_service and
+# degrade via recovery_bootstrap_failed (which preserves recover.sh + gives the
+# re-login/reboot remediation), never a bare recovery_launchctl bootstrap.
+python3 - "$INSTALL_SH" <<'PY'
+import re
+import sys
+
+text = open(sys.argv[1], encoding="utf-8").read()
+for label in (
+    "could not bootstrap the previous provider service",
+    "could not bootstrap the previous legacy provider service",
+    "could not bootstrap the previous watchdog service",
+    "could not bootstrap the previous legacy watchdog service",
+):
+    idx = text.index(label)
+    line_start = text.rfind("\n", 0, idx) + 1
+    line = text[line_start:text.index("\n", idx)]
+    if "recovery_bootstrap_service" not in line or "recovery_bootstrap_failed" not in line:
+        raise SystemExit(f"rollback bootstrap site not routed through retry helper: {label}")
+if "Log out and back in (or reboot)" not in text:
+    raise SystemExit("recovery_bootstrap_failed lost its re-login/reboot remediation")
+PY
+
+echo "install_recovery_bootstrap_retry.test.sh: PASS"

--- a/phase3-binary/dist/test/install_recovery_bootstrap_retry.test.sh
+++ b/phase3-binary/dist/test/install_recovery_bootstrap_retry.test.sh
@@ -5,9 +5,13 @@ set -euo pipefail
 # on a launchd domain that is briefly refusing new services. A single failed
 # bootstrap used to trip recovery_failed -> exit 70, leaving the provider down
 # and a preserved bundle that hard-blocked the next install. recovery_bootstrap_service
-# must retry with backoff, boot out any partial load between attempts, treat an
-# already-loaded label as success, and only give up (non-zero, no hang) after a
-# bounded number of attempts.
+# must retry with backoff, boot out any partial load between attempts, and only
+# give up (non-zero, no hang) after a bounded number of attempts.
+#
+# It must NOT accept an already-loaded label as success (a same-user process
+# could have bootstrapped a foreign plist under it, and the caller kickstarts
+# before verifying identity — audit security MEDIUM), and a malformed attempts
+# override must not cause an unbounded loop (audit code MEDIUM).
 
 REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 INSTALL_SH="$REPO_ROOT/phase3-binary/dist/install.sh"
@@ -17,35 +21,41 @@ trap 'rm -rf "$TMP"' EXIT
 python3 - "$INSTALL_SH" > "$TMP/function.sh" <<'PY'
 import sys
 
-name = "recovery_bootstrap_service"
+names = ["recovery_positive_int", "recovery_bootstrap_service"]
 lines = open(sys.argv[1], encoding="utf-8").read().splitlines()
-for index, line in enumerate(lines):
-    if not line.startswith(name + "()"):
-        continue
-    depth = 0
-    for body_line in lines[index:]:
-        print(body_line)
-        depth += body_line.count("{") - body_line.count("}")
-        if depth == 0:
-            raise SystemExit(0)
-raise SystemExit("recovery_bootstrap_service not found")
+for name in names:
+    found = False
+    for index, line in enumerate(lines):
+        if not line.startswith(name + "()"):
+            continue
+        found = True
+        depth = 0
+        for body_line in lines[index:]:
+            print(body_line)
+            depth += body_line.count("{") - body_line.count("}")
+            if depth == 0:
+                break
+        break
+    if not found:
+        raise SystemExit(f"{name} not found")
 PY
 
-[ -s "$TMP/function.sh" ] || { echo "failed to extract recovery_bootstrap_service" >&2; exit 1; }
+[ -s "$TMP/function.sh" ] || { echo "failed to extract recovery helpers" >&2; exit 1; }
 
-# Harness: a mock recovery_launchctl whose behavior is scripted per-verb through
-# files, plus a call log. bootstrap consumes one line of BOOTSTRAP_PLAN each
-# call ("ok" -> exit 0, anything else -> exit 5, the launchd I/O error code);
-# print returns PRINT_RC; bootout is always recorded and succeeds.
+# Harness: a mock recovery_launchctl whose bootstrap behavior is scripted
+# per-call through BOOTSTRAP_PLAN ("ok" -> exit 0, anything else -> exit 5, the
+# launchd I/O error code), plus a call log. print returns PRINT_RC; bootout is
+# recorded and succeeds. A hard ceiling of 20 bootstrap calls converts a
+# regressed infinite loop into a clean, assertable failure instead of a hang.
 run_bootstrap() {
   bootstrap_plan="$1"
   print_rc="$2"
-  max_attempts="$3"
+  attempts_override="$3"
   : > "$TMP/calls.log"
   printf '%s\n' "$bootstrap_plan" > "$TMP/bootstrap-plan"
   PATH="/usr/bin:/bin" \
   CALLS_LOG="$TMP/calls.log" BOOTSTRAP_PLAN_FILE="$TMP/bootstrap-plan" PRINT_RC="$print_rc" \
-  FUNCTION_PATH="$TMP/function.sh" MAX_ATTEMPTS="$max_attempts" bash -c '
+  FUNCTION_PATH="$TMP/function.sh" ATTEMPTS_OVERRIDE="$attempts_override" bash -c '
     set -uo pipefail
     recovery_log() { :; }
     recovery_launchctl() {
@@ -53,6 +63,7 @@ run_bootstrap() {
       printf "%s\n" "$verb" >> "$CALLS_LOG"
       case "$verb" in
         bootstrap)
+          if [ "$(grep -cx bootstrap "$CALLS_LOG")" -gt 20 ]; then exit 99; fi
           plan_line="$(sed -n "1p" "$BOOTSTRAP_PLAN_FILE")"
           sed -i.bak "1d" "$BOOTSTRAP_PLAN_FILE" 2>/dev/null || true
           [ "$plan_line" = "ok" ] && return 0
@@ -63,53 +74,109 @@ run_bootstrap() {
         *) return 0 ;;
       esac
     }
-    MACPROVIDER_RECOVERY_BOOTSTRAP_ATTEMPTS="$MAX_ATTEMPTS"
+    MACPROVIDER_RECOVERY_BOOTSTRAP_ATTEMPTS="$ATTEMPTS_OVERRIDE"
     MACPROVIDER_RECOVERY_BOOTSTRAP_BACKOFF_SECONDS=0
     source "$FUNCTION_PATH"
     recovery_bootstrap_service system /Library/LaunchDaemons/live.malibu.provider.plist live.malibu.provider
   '
 }
 
+bootstrap_count() { grep -cx bootstrap "$TMP/calls.log"; }
+
 # 1. Transient I/O error clears on retry: bootstrap fails twice, succeeds third.
 if ! run_bootstrap "$(printf 'fail\nfail\nok')" 1 5; then
   echo "recovery_bootstrap_service did not recover a transient bootstrap I/O error" >&2
   exit 1
 fi
-# It must have booted out the partial load between the failed attempts.
 if ! grep -qx bootout "$TMP/calls.log"; then
   echo "recovery_bootstrap_service did not bootout a partial load between retries" >&2
   exit 1
 fi
-bootstrap_calls="$(grep -cx bootstrap "$TMP/calls.log")"
-if [ "$bootstrap_calls" -ne 3 ]; then
-  echo "expected 3 bootstrap attempts before success, saw $bootstrap_calls" >&2
+if [ "$(bootstrap_count)" -ne 3 ]; then
+  echo "expected 3 bootstrap attempts before success, saw $(bootstrap_count)" >&2
   exit 1
 fi
 
-# 2. Already-loaded label (print succeeds) is treated as success without needing
-#    a further bootstrap to report ok.
-if ! run_bootstrap "$(printf 'fail')" 0 5; then
-  echo "recovery_bootstrap_service failed even though the label was already loaded" >&2
+# 2. Security: an already-loaded label (print would succeed) must NOT be treated
+#    as success. bootstrap never returns ok, so the helper must give up rather
+#    than accept whatever foreign plist happens to be loaded under the label.
+if run_bootstrap "$(printf 'fail\nfail\nfail')" 0 3; then
+  echo "recovery_bootstrap_service accepted an already-loaded label without a successful bootstrap of the expected plist" >&2
+  exit 1
+fi
+if [ "$(bootstrap_count)" -ne 3 ]; then
+  echo "expected exactly 3 bootstrap attempts (already-loaded path), saw $(bootstrap_count)" >&2
   exit 1
 fi
 
 # 3. Persistent failure gives up cleanly (non-zero) after the bounded attempts
-#    and does not hang. print never succeeds either.
-if run_bootstrap "$(printf 'fail\nfail\nfail')" 1 3; then
+#    with print never consulted for success.
+if run_bootstrap "$(printf 'fail\nfail\nfail\nfail')" 1 4; then
   echo "recovery_bootstrap_service reported success despite a persistent bootstrap failure" >&2
   exit 1
 fi
-give_up_calls="$(grep -cx bootstrap "$TMP/calls.log")"
-if [ "$give_up_calls" -ne 3 ]; then
-  echo "expected exactly 3 bootstrap attempts before giving up, saw $give_up_calls" >&2
+if [ "$(bootstrap_count)" -ne 4 ]; then
+  echo "expected exactly 4 bootstrap attempts before giving up, saw $(bootstrap_count)" >&2
   exit 1
 fi
+
+# 4. Code: a malformed attempts override must not spin forever — it falls back
+#    to the default (5) and gives up. The 20-call ceiling would surface a
+#    regressed unbounded loop as a count far above 5.
+for bad in abc "" 0 -3; do
+  if run_bootstrap "$(printf 'fail')" 1 "$bad"; then
+    echo "recovery_bootstrap_service reported success with attempts override '$bad'" >&2
+    exit 1
+  fi
+  if [ "$(bootstrap_count)" -ne 5 ]; then
+    echo "malformed attempts override '$bad' did not fall back to 5 bounded attempts (saw $(bootstrap_count))" >&2
+    exit 1
+  fi
+done
+
+# A leading-zero value is decoded as decimal (08 -> 8), not treated as octal and
+# not rejected: it must produce exactly 8 bounded attempts.
+if run_bootstrap "$(printf 'fail')" 1 08; then
+  echo "recovery_bootstrap_service reported success with attempts override '08'" >&2
+  exit 1
+fi
+if [ "$(bootstrap_count)" -ne 8 ]; then
+  echo "attempts override '08' did not decode to 8 bounded attempts (saw $(bootstrap_count))" >&2
+  exit 1
+fi
+
+# A valid-but-huge attempts override is clamped to the sane maximum (20), not
+# run literally — a fat-fingered value must not schedule a near-infinite loop.
+if run_bootstrap "$(printf 'fail')" 1 999999; then
+  echo "recovery_bootstrap_service reported success with a huge attempts override" >&2
+  exit 1
+fi
+if [ "$(bootstrap_count)" -ne 20 ]; then
+  echo "attempts override 999999 was not clamped to 20 (saw $(bootstrap_count))" >&2
+  exit 1
+fi
+
+# recovery_positive_int itself: fallbacks and clamps.
+positive_int_check() {
+  PATH="/usr/bin:/bin" FUNCTION_PATH="$TMP/function.sh" bash -c '
+    set -uo pipefail
+    source "$FUNCTION_PATH"
+    recovery_positive_int "$1" "$2" "${3:-}" "${4:-}"
+  ' _ "$1" "$2" "${3:-}" "${4:-}"
+}
+[ "$(positive_int_check abc 5)" = "5" ] || { echo "positive_int abc did not fall back" >&2; exit 1; }
+[ "$(positive_int_check 08 5)" = "8" ] || { echo "positive_int 08 not decoded as decimal 8" >&2; exit 1; }
+[ "$(positive_int_check 0 5)" = "5" ] || { echo "positive_int 0 not rejected without allow_zero" >&2; exit 1; }
+[ "$(positive_int_check 0 2 allow_zero)" = "0" ] || { echo "positive_int 0 not allowed with allow_zero" >&2; exit 1; }
+[ "$(positive_int_check 12345678901 5)" = "5" ] || { echo "positive_int over-length not rejected" >&2; exit 1; }
+[ "$(positive_int_check 42 5)" = "42" ] || { echo "positive_int passthrough failed" >&2; exit 1; }
+[ "$(positive_int_check 999 5 '' 20)" = "20" ] || { echo "positive_int not clamped to maximum" >&2; exit 1; }
+[ "$(positive_int_check 15 5 '' 20)" = "15" ] || { echo "positive_int under-max value altered" >&2; exit 1; }
 
 # The main rollback bootstrap sites route through recovery_bootstrap_service and
 # degrade via recovery_bootstrap_failed (which preserves recover.sh + gives the
 # re-login/reboot remediation), never a bare recovery_launchctl bootstrap.
 python3 - "$INSTALL_SH" <<'PY'
-import re
 import sys
 
 text = open(sys.argv[1], encoding="utf-8").read()


### PR DESCRIPTION
## Installer / updater recovery net (gates 1.8.119 broadcast promotion)

Physical acceptance of the signed 1.8.119 provider candidate (@SmtTheSE, #1358)
passed on the candidate itself — the fleet's real path (auto-update 117→119) is
clean and every truthfulness surface stayed honest. What it surfaced is a broken
**recovery net around the installer/updater**: pre-existing fragilities already
live in the fleet (not 1.8.119 regressions) that mean if 119 misbehaves we
currently cannot reliably get a provider back. These gate broadcast promotion.

This PR fixes all four recovery-net findings, plus the F1 doc mandate. It does
**not** touch the 1.8.119 candidate, its version bump (#1359), or E2E.

### Findings fixed (one reviewable commit each)

- **F3 (#1363) — real blocker.** A failed self-update wedged the provider with
  no in-CLI escape: `pending.json` stuck in `restoring_previous` plus an
  updater-owned `rollback_in_progress` lifecycle record fenced both `serve`
  (`operationFenced` on the `starting_provider` transition — launchd respawns
  forever) and `update` (`transactionPending`), and the only resolver ran inside
  the coordinator-session path, which cannot run because serve cannot start.
  New `WedgedUpdateRecovery` recovers the expired marker (`recoverOrphanedMarker`)
  and translates the dead updater-owned record into an installer-owned one that
  serve may leave — exactly as install.sh's `restore_lifecycle_state` already
  does. Driven by a first-class `macprovider-cli recover-update` subcommand
  (runs from a fresh CLI while serve is down) **and** by serve-startup self-heal
  (catch the fence, recover, retry once — the launchd respawn loop self-heals).
  Safety preserved: a genuinely in-progress update/rollback (future
  `marker_deadline`, or a live installer/updater owner) is never un-fenced.

- **F6 (#1364) — real blocker.** `launchctl bootstrap` returned `Input/output
  error` 6/6 on a transiently-refusing launchd domain, leaving the provider down
  and an unrecoverable recovery bundle that hard-blocked the next install (only
  a re-login cleared it). New `recovery_bootstrap_service` retries with backoff
  and bootout-between-attempts, and gives up cleanly (never hangs). Only a
  successful bootstrap of the expected plist counts as success — an already-loaded
  label is never trusted (audit) — and the caller still verifies identity. All
  rollback/pre-cutover bootstrap sites route through it; `recovery_bootstrap_failed`
  gives the concrete re-login/reboot remediation instead of folklore.

- **F5 (#1365).** `wait_for_coordinator()`'s flat 30s admission gate rolled back
  installs that had genuinely reached `buyer_serving` on slow/low-RAM Macs (cold
  6 GB load: 97s/114s/296s). Deadline default 30s → 300s (aligned with the
  file's 300s/1200s model-load waits), overridable via
  `MACPROVIDER_COORDINATOR_READY_TIMEOUT_SECONDS`. The exact catalog-identity /
  legacy_bridge admission proofs are unchanged.

- **F2 (#1366).** `MACPROVIDER_COORDINATOR_HOST=host:port` was rejected by the
  updater trusted-root check (`installed_watchdog_plist_invalid`), bricking
  self-update for any non-default-port coordinator. Host validation now accepts
  an optional `:port` (host keeps its charset/length guard; port must be
  1..65535). Production uses a portless host, so the live fleet was unaffected.

- **F1 (#1358) — docs only.** Because `malibuAppCandidates()` targets the global
  `/Applications/Malibu.app` first, an acceptance run on a machine with a live
  earner targets the earner's app regardless of user; only Standard-account
  POSIX perms saved it. The provider hardware-test runbook now mandates a
  dedicated spare Mac (never a second login) for Tier-C acceptance.
  `malibuAppCandidates()` behavior is unchanged.

### Tests

- `WedgedUpdateRecoveryTests` (5): un-fences an abandoned updater rollback (with
  and without an expired marker), refuses a live owner, refuses a future-deadline
  (in-progress) transaction, no-ops a non-updater state; proves `serve` can start
  after recovery and is fenced before it.
- `CoordinatorHostValidationTests` (4): portless, host:port, invalid port,
  invalid host / bare IPv6 / over-length.
- `install_coordinator_admission.test.sh`: default 300, honors the override,
  poll loop scales with the timeout, buyer_serving install admitted.
- `install_recovery_bootstrap_retry.test.sh` (new, wired into `make test-dist`):
  transient-recover, already-loaded, bounded give-up, and that rollback sites
  route through the retry helper.
- Full `AutoUpdateTests` + `SelfUpdateTests` (159) and the lifecycle suites
  (`ProviderLifecycleStateTests`, `ProviderLifecycleShellConformanceTests`) pass
  unchanged; `swift build` clean.

Findings filed as #1363/#1364/#1365/#1366, all referencing #1358.

Audit: full combined fix diff (`origin/main..HEAD`) run through three codex
lanes (code / security / architecture). Findings addressed across rounds — an
insecure already-loaded bootstrap shortcut, unvalidated/unbounded integer env
overrides (all in the new install.sh code), and a stale branch base that made
the diff appear to revert #1367's SwiftPM lock gate (fixed by rebasing onto
current `main`). Final re-audit is **0 CRITICAL / 0 HIGH / 0 MEDIUM** across all
three lanes on the rebased diff (10 files, no ci.yml/Package.resolved/scripts
reversion). Local audit evidence retained under
`audits/2026-09-04-installer-recovery-net/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "issue": "https://github.com/Augustas11/macprovider/issues/1358",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020", "SPEC-003"],
  "requirements": ["SPEC-020-R003", "SPEC-020-R004"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "phase3-binary/Tests/macprovider-cliTests/WedgedUpdateRecoveryTests.swift:testUnfencesAbandonedUpdaterRollbackWithNoMarker",
    "phase3-binary/Tests/macprovider-cliTests/CoordinatorHostValidationTests.swift:testAcceptsHostPort",
    "phase3-binary/dist/test/install_recovery_bootstrap_retry.test.sh",
    "phase3-binary/dist/test/install_coordinator_admission.test.sh"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END
