### PR TITLE
BYOM slice-2: model discovery CLI foundation (supersedes #1260)

### DIFF
--- a/phase3-binary/Package.resolved
+++ b/phase3-binary/Package.resolved
@@ -1,15 +1,6 @@
 {
   "pins" : [
     {
-      "identity" : "async-http-client",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swift-server/async-http-client.git",
-      "state" : {
-        "revision" : "f95c908967e98c68c5ce3fd61a7974e7e869e303",
-        "version" : "1.36.1"
-      }
-    },
-    {
       "identity" : "eventsource",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattt/EventSource.git",
@@ -37,15 +28,6 @@
       }
     },
     {
-      "identity" : "swift-algorithms",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-algorithms.git",
-      "state" : {
-        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
-        "version" : "1.2.1"
-      }
-    },
-    {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
@@ -64,30 +46,12 @@
       }
     },
     {
-      "identity" : "swift-async-algorithms",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-async-algorithms.git",
-      "state" : {
-        "revision" : "3da39bbc4e687d4192af7c9cf4eab805745a0b9c",
-        "version" : "1.1.5"
-      }
-    },
-    {
       "identity" : "swift-atomics",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
         "revision" : "0442cb5a3f98ab802acb777929fdb446bda11a34",
         "version" : "1.3.1"
-      }
-    },
-    {
-      "identity" : "swift-certificates",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-certificates.git",
-      "state" : {
-        "revision" : "c8aece90ea05f9866bd392a5bf13b5cae56c0e03",
-        "version" : "1.20.0"
       }
     },
     {
@@ -109,33 +73,6 @@
       }
     },
     {
-      "identity" : "swift-distributed-tracing",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-distributed-tracing.git",
-      "state" : {
-        "revision" : "dc4030184203ffafbb2ec614352487235d747fe0",
-        "version" : "1.4.1"
-      }
-    },
-    {
-      "identity" : "swift-http-structured-headers",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-http-structured-headers.git",
-      "state" : {
-        "revision" : "933538faa42c432d385f02e07df0ace7c5ecfc47",
-        "version" : "1.7.0"
-      }
-    },
-    {
-      "identity" : "swift-http-types",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-http-types.git",
-      "state" : {
-        "revision" : "db774a277f60063a32d854f2980299caf06da041",
-        "version" : "1.6.0"
-      }
-    },
-    {
       "identity" : "swift-huggingface",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-huggingface.git",
@@ -154,15 +91,6 @@
       }
     },
     {
-      "identity" : "swift-log",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-log.git",
-      "state" : {
-        "revision" : "3ffafb9722d5d918c614feb496c8789a3b59d222",
-        "version" : "1.15.0"
-      }
-    },
-    {
       "identity" : "swift-nio",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
@@ -172,66 +100,12 @@
       }
     },
     {
-      "identity" : "swift-nio-extras",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-extras.git",
-      "state" : {
-        "revision" : "3078359149adac3dd1255621a041e361e3f0edd1",
-        "version" : "1.35.0"
-      }
-    },
-    {
-      "identity" : "swift-nio-http2",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-http2.git",
-      "state" : {
-        "revision" : "0f3e54e29c944c2e835ad52159da7d9e1c94ac69",
-        "version" : "1.46.0"
-      }
-    },
-    {
-      "identity" : "swift-nio-ssl",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-ssl.git",
-      "state" : {
-        "revision" : "03827c1a9fdb2b6b00a4e93ede8861520263af8c",
-        "version" : "2.37.4"
-      }
-    },
-    {
-      "identity" : "swift-nio-transport-services",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-transport-services.git",
-      "state" : {
-        "revision" : "67787bb645a5e67d2edcdfbe48a216cc549222d5",
-        "version" : "1.28.0"
-      }
-    },
-    {
       "identity" : "swift-numerics",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-numerics",
       "state" : {
         "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
         "version" : "1.1.1"
-      }
-    },
-    {
-      "identity" : "swift-service-context",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-service-context.git",
-      "state" : {
-        "revision" : "d0997351b0c7779017f88e7a93bc30a1878d7f29",
-        "version" : "1.3.0"
-      }
-    },
-    {
-      "identity" : "swift-service-lifecycle",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
-      "state" : {
-        "revision" : "7f9326b0326ff86e3646295ea6e891f68c471c5e",
-        "version" : "2.12.0"
       }
     },
     {
@@ -259,15 +133,6 @@
       "state" : {
         "revision" : "2fa33e1f5e7131a7fc64c28e6d161dcec0d24820",
         "version" : "1.3.3"
-      }
-    },
-    {
-      "identity" : "swift-xet",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-xet.git",
-      "state" : {
-        "revision" : "341bfd4172f6a57119bfd49bafa11cf5d21fab75",
-        "version" : "0.2.3"
       }
     },
     {

--- a/phase3-binary/Package.resolved
+++ b/phase3-binary/Package.resolved
@@ -1,6 +1,15 @@
 {
   "pins" : [
     {
+      "identity" : "async-http-client",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/async-http-client.git",
+      "state" : {
+        "revision" : "f95c908967e98c68c5ce3fd61a7974e7e869e303",
+        "version" : "1.36.1"
+      }
+    },
+    {
       "identity" : "eventsource",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattt/EventSource.git",
@@ -28,6 +37,15 @@
       }
     },
     {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms.git",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
+      }
+    },
+    {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
@@ -46,12 +64,30 @@
       }
     },
     {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms.git",
+      "state" : {
+        "revision" : "3da39bbc4e687d4192af7c9cf4eab805745a0b9c",
+        "version" : "1.1.5"
+      }
+    },
+    {
       "identity" : "swift-atomics",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
         "revision" : "0442cb5a3f98ab802acb777929fdb446bda11a34",
         "version" : "1.3.1"
+      }
+    },
+    {
+      "identity" : "swift-certificates",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-certificates.git",
+      "state" : {
+        "revision" : "c8aece90ea05f9866bd392a5bf13b5cae56c0e03",
+        "version" : "1.20.0"
       }
     },
     {
@@ -73,6 +109,33 @@
       }
     },
     {
+      "identity" : "swift-distributed-tracing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-distributed-tracing.git",
+      "state" : {
+        "revision" : "dc4030184203ffafbb2ec614352487235d747fe0",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-http-structured-headers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-structured-headers.git",
+      "state" : {
+        "revision" : "933538faa42c432d385f02e07df0ace7c5ecfc47",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types.git",
+      "state" : {
+        "revision" : "db774a277f60063a32d854f2980299caf06da041",
+        "version" : "1.6.0"
+      }
+    },
+    {
       "identity" : "swift-huggingface",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-huggingface.git",
@@ -91,6 +154,15 @@
       }
     },
     {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "3ffafb9722d5d918c614feb496c8789a3b59d222",
+        "version" : "1.15.0"
+      }
+    },
+    {
       "identity" : "swift-nio",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
@@ -100,12 +172,66 @@
       }
     },
     {
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras.git",
+      "state" : {
+        "revision" : "3078359149adac3dd1255621a041e361e3f0edd1",
+        "version" : "1.35.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "0f3e54e29c944c2e835ad52159da7d9e1c94ac69",
+        "version" : "1.46.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "03827c1a9fdb2b6b00a4e93ede8861520263af8c",
+        "version" : "2.37.4"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "67787bb645a5e67d2edcdfbe48a216cc549222d5",
+        "version" : "1.28.0"
+      }
+    },
+    {
       "identity" : "swift-numerics",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-numerics",
       "state" : {
         "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
         "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-service-context",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-service-context.git",
+      "state" : {
+        "revision" : "d0997351b0c7779017f88e7a93bc30a1878d7f29",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-service-lifecycle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
+      "state" : {
+        "revision" : "7f9326b0326ff86e3646295ea6e891f68c471c5e",
+        "version" : "2.12.0"
       }
     },
     {
@@ -133,6 +259,15 @@
       "state" : {
         "revision" : "2fa33e1f5e7131a7fc64c28e6d161dcec0d24820",
         "version" : "1.3.3"
+      }
+    },
+    {
+      "identity" : "swift-xet",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-xet.git",
+      "state" : {
+        "revision" : "341bfd4172f6a57119bfd49bafa11cf5d21fab75",
+        "version" : "0.2.3"
       }
     },
     {

--- a/phase3-binary/Sources/macprovider-cli/BYOMDiscovery.swift
+++ b/phase3-binary/Sources/macprovider-cli/BYOMDiscovery.swift
@@ -1160,40 +1160,33 @@ enum BYOMDiscoveryPrivacy {
     private static func looksLikeEndpoint(_ value: String) -> Bool {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         let lower = trimmed.lowercased()
-        if lower == "localhost" || lower == "[::1]" || lower == "::1" {
+        // Loopback names and ANY IPv6 form — `localhost` and the `::` / bracket
+        // notations never appear in a legitimate model reference, so match them
+        // anywhere in the string (embedded, with a port, etc.).
+        if lower.contains("localhost") || trimmed.contains("::") {
             return true
         }
-        if trimmed.range(of: #"^[0-9]{1,3}(\.[0-9]{1,3}){3}$"#, options: .regularExpression) != nil {
+        if trimmed.range(of: #"\[[0-9A-Fa-f:]+\]"#, options: .regularExpression) != nil {
             return true
         }
-        if trimmed.range(of: #"^\[[0-9A-Fa-f:]+\]$"#, options: .regularExpression) != nil {
+        // Uncompressed IPv6 (>=4 colon-separated hex groups).
+        if trimmed.range(of: #"(^|[^0-9A-Za-z:])([0-9A-Fa-f]{1,4}:){3,}[0-9A-Fa-f]{1,4}"#, options: .regularExpression) != nil {
             return true
         }
-        if trimmed.range(of: #"^[0-9A-Fa-f]{0,4}(:[0-9A-Fa-f]{0,4}){2,}$"#, options: .regularExpression) != nil {
-            return true
-        }
-        // IPv4-mapped / IPv4-embedded IPv6 (e.g. ::ffff:127.0.0.1, ::127.0.0.1)
-        // that the bracketless-IPv6 pattern above misses because of the dots.
-        if lower.contains("::ffff:") {
-            return true
-        }
-        if trimmed.contains("::"),
-           trimmed.range(of: #"[0-9]{1,3}(\.[0-9]{1,3}){3}"#, options: .regularExpression) != nil {
-            return true
-        }
-        // Encoded dotted IPv4 forms the plain dotted-quad above misses: octal
-        // (0177.0.0.1) and hex (0x7f.0.0.1) octets.
+        // Dotted IPv4 (four octets: decimal, octal 0177, or hex 0x7f), matched
+        // when embedded or carrying a :port — not just as the whole value.
         if trimmed.range(
-            of: #"^(0?[0-9]{1,4}|0[xX][0-9A-Fa-f]{1,4})(\.(0?[0-9]{1,4}|0[xX][0-9A-Fa-f]{1,4})){1,3}$"#,
+            of: #"(^|[^0-9A-Za-z])(0?[0-9]{1,3}|0[xX][0-9A-Fa-f]{1,2})(\.(0?[0-9]{1,4}|0[xX][0-9A-Fa-f]{1,4})){3}($|[^0-9A-Za-z.])"#,
             options: .regularExpression
         ) != nil {
             return true
         }
-        // One-piece encoded IPv4: a hex dword (0x7f000001) or a bare 32-bit decimal.
-        if trimmed.range(of: #"^0[xX][0-9A-Fa-f]{5,8}$"#, options: .regularExpression) != nil {
+        // One-piece encoded IPv4: a hex dword (0x7f000001) or a bare 32-bit
+        // decimal (2130706433), boundary-delimited so a :port suffix is caught.
+        if trimmed.range(of: #"(^|[^0-9A-Za-z])0[xX][0-9A-Fa-f]{5,8}($|[^0-9A-Za-z])"#, options: .regularExpression) != nil {
             return true
         }
-        if trimmed.range(of: #"^[0-9]{8,10}$"#, options: .regularExpression) != nil {
+        if trimmed.range(of: #"(^|[^0-9A-Za-z])[0-9]{8,10}($|[^0-9A-Za-z])"#, options: .regularExpression) != nil {
             return true
         }
         // Any DNS hostname: one or more dotted labels ending in an alphabetic
@@ -1201,14 +1194,8 @@ enum BYOMDiscoveryPrivacy {
         // with or without a port or scheme/path). Legitimate model refs put only
         // numeric version tokens after a dot (e.g. `llama3.2`, `mistral-7b-v0.2`),
         // so their final label is never a bare alpha TLD and they are unaffected.
-        if trimmed.range(
-            of: #"(^|[^A-Za-z0-9_-])([A-Za-z0-9-]+\.)+[A-Za-z]{2,}\.?($|[^A-Za-z0-9-])"#,
-            options: .regularExpression
-        ) != nil {
-            return true
-        }
         return trimmed.range(
-            of: #"(^|[^A-Za-z0-9._-])(localhost|[0-9]{1,3}(\.[0-9]{1,3}){3}|\[[0-9A-Fa-f:]+\]):[0-9]{1,5}($|[^A-Za-z0-9._-])"#,
+            of: #"(^|[^A-Za-z0-9_-])([A-Za-z0-9-]+\.)+[A-Za-z]{2,}\.?($|[^A-Za-z0-9-])"#,
             options: .regularExpression
         ) != nil
     }

--- a/phase3-binary/Sources/macprovider-cli/BYOMDiscovery.swift
+++ b/phase3-binary/Sources/macprovider-cli/BYOMDiscovery.swift
@@ -1,0 +1,1223 @@
+import CryptoKit
+import Foundation
+import MacProviderCore
+import Security
+
+enum BYOMDiscoveryWarning: String, Codable, Sendable {
+    case candidateIDUnstable = "candidate_id_unstable"
+    case adapterUnavailable = "adapter_unavailable"
+    case adapterTimeout = "adapter_timeout"
+    case adapterRejectedNonLoopback = "adapter_rejected_non_loopback"
+    case adapterMalformedResponse = "adapter_malformed_response"
+    case adapterResponseTruncated = "adapter_response_truncated"
+    case catalogMatchUnverified = "catalog_match_unverified"
+    case capabilityUnevaluated = "capability_unevaluated"
+    case evaluationRequired = "evaluation_required"
+    case requiresPreparation = "requires_preparation"
+    case namespacePermissionInvalid = "namespace_permission_invalid"
+}
+
+struct BYOMDiscoveryWire: Codable, Equatable, Sendable {
+    struct Adapter: Codable, Equatable, Sendable {
+        let runtimeSource: String
+        let status: String
+        let originClass: String?
+        let warningCodes: [String]
+
+        enum CodingKeys: String, CodingKey {
+            case runtimeSource = "runtime_source"
+            case status
+            case originClass = "origin_class"
+            case warningCodes = "warning_codes"
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(runtimeSource, forKey: .runtimeSource)
+            try container.encode(status, forKey: .status)
+            if let originClass {
+                try container.encode(originClass, forKey: .originClass)
+            } else {
+                try container.encodeNil(forKey: .originClass)
+            }
+            try container.encode(warningCodes, forKey: .warningCodes)
+        }
+    }
+
+    struct Capabilities: Codable, Equatable, Sendable {
+        let chatCompletions: Bool?
+        let streaming: Bool?
+        let toolCallPassthrough: Bool?
+        let structuredOutputPassthrough: Bool?
+        let jsonMode: Bool?
+        let usageReporting: Bool?
+        let maxContextTokens: Int?
+        let quantization: String?
+        let family: String?
+        let runtimeVersion: String?
+
+        enum CodingKeys: String, CodingKey {
+            case chatCompletions = "chat_completions"
+            case streaming
+            case toolCallPassthrough = "tool_call_passthrough"
+            case structuredOutputPassthrough = "structured_output_passthrough"
+            case jsonMode = "json_mode"
+            case usageReporting = "usage_reporting"
+            case maxContextTokens = "max_context_tokens"
+            case quantization
+            case family
+            case runtimeVersion = "runtime_version"
+        }
+
+        static let unknown = Capabilities(
+            chatCompletions: nil,
+            streaming: nil,
+            toolCallPassthrough: nil,
+            structuredOutputPassthrough: nil,
+            jsonMode: nil,
+            usageReporting: nil,
+            maxContextTokens: nil,
+            quantization: nil,
+            family: nil,
+            runtimeVersion: nil
+        )
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try encodeNullable(chatCompletions, forKey: .chatCompletions, into: &container)
+            try encodeNullable(streaming, forKey: .streaming, into: &container)
+            try encodeNullable(toolCallPassthrough, forKey: .toolCallPassthrough, into: &container)
+            try encodeNullable(structuredOutputPassthrough, forKey: .structuredOutputPassthrough, into: &container)
+            try encodeNullable(jsonMode, forKey: .jsonMode, into: &container)
+            try encodeNullable(usageReporting, forKey: .usageReporting, into: &container)
+            try encodeNullable(maxContextTokens, forKey: .maxContextTokens, into: &container)
+            try encodeNullable(quantization, forKey: .quantization, into: &container)
+            try encodeNullable(family, forKey: .family, into: &container)
+            try encodeNullable(runtimeVersion, forKey: .runtimeVersion, into: &container)
+        }
+
+        private func encodeNullable<T: Encodable>(
+            _ value: T?,
+            forKey key: CodingKeys,
+            into container: inout KeyedEncodingContainer<CodingKeys>
+        ) throws {
+            if let value {
+                try container.encode(value, forKey: key)
+            } else {
+                try container.encodeNil(forKey: key)
+            }
+        }
+    }
+
+    struct Guidance: Codable, Equatable, Sendable {
+        let stateLabelKey: String
+        let stateMeaningKey: String
+        let nextAction: String
+        let transitionReasonCode: String?
+        let earningPathClass: String
+
+        enum CodingKeys: String, CodingKey {
+            case stateLabelKey = "state_label_key"
+            case stateMeaningKey = "state_meaning_key"
+            case nextAction = "next_action"
+            case transitionReasonCode = "transition_reason_code"
+            case earningPathClass = "earning_path_class"
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(stateLabelKey, forKey: .stateLabelKey)
+            try container.encode(stateMeaningKey, forKey: .stateMeaningKey)
+            try container.encode(nextAction, forKey: .nextAction)
+            if let transitionReasonCode {
+                try container.encode(transitionReasonCode, forKey: .transitionReasonCode)
+            } else {
+                try container.encodeNil(forKey: .transitionReasonCode)
+            }
+            try container.encode(earningPathClass, forKey: .earningPathClass)
+        }
+    }
+
+    struct Candidate: Codable, Equatable, Sendable {
+        let candidateID: String
+        let runtimeSource: String
+        let displayName: String
+        let servedModelRef: String
+        let catalogModelKey: String?
+        let identityState: String
+        let locality: String
+        let estimatedGB: Double?
+        let contextWindowTokens: Int?
+        let capabilities: Capabilities
+        let readinessState: String
+        let fitState: String
+        let evaluationState: String
+        let admissionState: String
+        let admissionStateSource: String
+        let providerGuidance: Guidance
+        let warningCodes: [String]
+
+        enum CodingKeys: String, CodingKey {
+            case candidateID = "candidate_id"
+            case runtimeSource = "runtime_source"
+            case displayName = "display_name"
+            case servedModelRef = "served_model_ref"
+            case catalogModelKey = "catalog_model_key"
+            case identityState = "identity_state"
+            case locality
+            case estimatedGB = "estimated_gb"
+            case contextWindowTokens = "context_window_tokens"
+            case capabilities
+            case readinessState = "readiness_state"
+            case fitState = "fit_state"
+            case evaluationState = "evaluation_state"
+            case admissionState = "admission_state"
+            case admissionStateSource = "admission_state_source"
+            case providerGuidance = "provider_guidance"
+            case warningCodes = "warning_codes"
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(candidateID, forKey: .candidateID)
+            try container.encode(runtimeSource, forKey: .runtimeSource)
+            try container.encode(displayName, forKey: .displayName)
+            try container.encode(servedModelRef, forKey: .servedModelRef)
+            if let catalogModelKey {
+                try container.encode(catalogModelKey, forKey: .catalogModelKey)
+            } else {
+                try container.encodeNil(forKey: .catalogModelKey)
+            }
+            try container.encode(identityState, forKey: .identityState)
+            try container.encode(locality, forKey: .locality)
+            if let estimatedGB {
+                try container.encode(estimatedGB, forKey: .estimatedGB)
+            } else {
+                try container.encodeNil(forKey: .estimatedGB)
+            }
+            if let contextWindowTokens {
+                try container.encode(contextWindowTokens, forKey: .contextWindowTokens)
+            } else {
+                try container.encodeNil(forKey: .contextWindowTokens)
+            }
+            try container.encode(capabilities, forKey: .capabilities)
+            try container.encode(readinessState, forKey: .readinessState)
+            try container.encode(fitState, forKey: .fitState)
+            try container.encode(evaluationState, forKey: .evaluationState)
+            try container.encode(admissionState, forKey: .admissionState)
+            try container.encode(admissionStateSource, forKey: .admissionStateSource)
+            try container.encode(providerGuidance, forKey: .providerGuidance)
+            try container.encode(warningCodes, forKey: .warningCodes)
+        }
+    }
+
+    let schema: String
+    let generatedAt: String
+    let cliVersion: String
+    let projectionSequence: Int
+    let adapters: [Adapter]
+    let candidates: [Candidate]
+    let warnings: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case schema
+        case generatedAt = "generated_at"
+        case cliVersion = "cli_version"
+        case projectionSequence = "projection_sequence"
+        case adapters
+        case candidates
+        case warnings
+    }
+
+    init(
+        generatedAt: String = ModelSwitchingWireCodec.timestamp(),
+        cliVersion: String = CoordinatorClient.binaryVersion,
+        projectionSequence: Int = 1,
+        adapters: [Adapter],
+        candidates: [Candidate],
+        warnings: [String]
+    ) {
+        schema = "provider_byom_discovery.v1"
+        self.generatedAt = generatedAt
+        self.cliVersion = cliVersion
+        self.projectionSequence = projectionSequence
+        self.adapters = adapters
+        self.candidates = candidates
+        self.warnings = warnings
+    }
+}
+
+struct BYOMDiscoveryEnvironment: Sendable {
+    let namespaceURL: URL
+    let mlxCacheRoot: URL
+    let ollamaOrigin: String?
+
+    static func production(
+        namespacePath: String?,
+        mlxCacheDir: String?,
+        ollamaOrigin: String?,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) -> BYOMDiscoveryEnvironment {
+        BYOMDiscoveryEnvironment(
+            namespaceURL: namespacePath.map(URL.init(fileURLWithPath:)) ?? defaultNamespaceURL(homeDirectory: homeDirectory),
+            mlxCacheRoot: mlxCacheDir.map(URL.init(fileURLWithPath:)) ?? defaultMLXCacheRoot(environment: environment, homeDirectory: homeDirectory),
+            ollamaOrigin: ollamaOrigin
+        )
+    }
+
+    static func defaultNamespaceURL(homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser) -> URL {
+        homeDirectory
+            .appendingPathComponent(".config/macprovider", isDirectory: true)
+            .appendingPathComponent("local_discovery_namespace")
+    }
+
+    static func defaultMLXCacheRoot(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) -> URL {
+        if let cache = environment["HF_HUB_CACHE"], !cache.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return URL(fileURLWithPath: cache)
+        }
+        if let hfHome = environment["HF_HOME"], !hfHome.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return URL(fileURLWithPath: hfHome).appendingPathComponent("hub", isDirectory: true)
+        }
+        return homeDirectory
+            .appendingPathComponent(".cache/huggingface/hub", isDirectory: true)
+    }
+}
+
+struct BYOMHTTPResponse: Sendable {
+    let statusCode: Int
+    let headers: [(String, String)]
+    let body: Data
+}
+
+protocol BYOMDiscoveryHTTPClient: Sendable {
+    func get(_ url: URL, maxHeaderBytes: Int, maxBodyBytes: Int) async throws -> BYOMHTTPResponse
+}
+
+final class BYOMURLSessionHTTPClient: BYOMDiscoveryHTTPClient, @unchecked Sendable {
+    func get(_ url: URL, maxHeaderBytes: Int, maxBodyBytes: Int) async throws -> BYOMHTTPResponse {
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+        let session = Self.directLoopbackSession()
+        defer { session.invalidateAndCancel() }
+        let (bytes, response) = try await session.bytes(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw BYOMDiscoveryAdapterError.malformed
+        }
+        let headers = http.allHeaderFields.compactMap { key, value -> (String, String)? in
+            guard let key = key as? String else { return nil }
+            return (key, String(describing: value))
+        }
+        guard BYOMDiscoveryHTTPBounds.headerBytes(headers) <= maxHeaderBytes else {
+            throw BYOMDiscoveryAdapterError.truncated
+        }
+        var body = Data()
+        body.reserveCapacity(min(maxBodyBytes, 64 * 1024))
+        for try await byte in bytes {
+            guard body.count < maxBodyBytes else {
+                throw BYOMDiscoveryAdapterError.truncated
+            }
+            body.append(byte)
+        }
+        return BYOMHTTPResponse(statusCode: http.statusCode, headers: headers, body: body)
+    }
+
+    static func directLoopbackConfiguration() -> URLSessionConfiguration {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.timeoutIntervalForRequest = 1.5
+        configuration.timeoutIntervalForResource = 2.0
+        configuration.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+        configuration.urlCache = nil
+        configuration.httpCookieStorage = nil
+        configuration.httpCookieAcceptPolicy = .never
+        configuration.httpAdditionalHeaders = nil
+        configuration.connectionProxyDictionary = [:]
+        configuration.waitsForConnectivity = false
+        return configuration
+    }
+
+    private static func directLoopbackSession() -> URLSession {
+        URLSession(configuration: directLoopbackConfiguration(), delegate: NoRedirectURLSessionDelegate(), delegateQueue: nil)
+    }
+}
+
+enum BYOMDiscoveryAdapterError: Error {
+    case rejectedNonLoopback
+    case malformed
+    case truncated
+}
+
+struct BYOMDiscoveryRunner {
+    private let environment: BYOMDiscoveryEnvironment
+    private let fileManager: FileManager
+    private let httpClient: any BYOMDiscoveryHTTPClient
+
+    init(
+        environment: BYOMDiscoveryEnvironment,
+        fileManager: FileManager = .default,
+        httpClient: any BYOMDiscoveryHTTPClient = BYOMURLSessionHTTPClient()
+    ) {
+        self.environment = environment
+        self.fileManager = fileManager
+        self.httpClient = httpClient
+    }
+
+    func discover() async -> BYOMDiscoveryWire {
+        let namespace = BYOMDiscoveryNamespaceStore(fileManager: fileManager)
+            .readOrCreateNamespace(at: environment.namespaceURL)
+        let catalog = BYOMCatalogMatcher()
+        var adapters: [BYOMDiscoveryWire.Adapter] = []
+        var candidates: [BYOMDiscoveryWire.Candidate] = []
+        var warnings = Set(namespace.warnings.map(\.rawValue))
+
+        let mlx = BYOMMLXCacheDiscovery(
+            cacheRoot: environment.mlxCacheRoot,
+            namespace: namespace.bytes,
+            namespaceWarnings: namespace.warnings,
+            catalogMatcher: catalog,
+            fileManager: fileManager
+        ).discover()
+        adapters.append(mlx.adapter)
+        candidates.append(contentsOf: mlx.candidates)
+        warnings.formUnion(mlx.adapter.warningCodes)
+        for candidate in mlx.candidates {
+            warnings.formUnion(candidate.warningCodes)
+        }
+
+        if let ollamaOrigin = environment.ollamaOrigin,
+           !ollamaOrigin.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            let ollama = await BYOMOllamaDiscovery(
+                origin: ollamaOrigin,
+                namespace: namespace.bytes,
+                namespaceWarnings: namespace.warnings,
+                catalogMatcher: catalog,
+                httpClient: httpClient
+            ).discover()
+            adapters.append(ollama.adapter)
+            candidates.append(contentsOf: ollama.candidates)
+            warnings.formUnion(ollama.adapter.warningCodes)
+            for candidate in ollama.candidates {
+                warnings.formUnion(candidate.warningCodes)
+            }
+        }
+
+        candidates.sort {
+            if $0.runtimeSource == $1.runtimeSource {
+                return $0.servedModelRef < $1.servedModelRef
+            }
+            return $0.runtimeSource < $1.runtimeSource
+        }
+        adapters.sort { $0.runtimeSource < $1.runtimeSource }
+
+        return BYOMDiscoveryWire(
+            adapters: adapters,
+            candidates: candidates,
+            warnings: Array(warnings).sorted()
+        )
+    }
+}
+
+struct BYOMDiscoveryNamespaceStore {
+    struct Result: Sendable {
+        let bytes: Data?
+        let warnings: [BYOMDiscoveryWarning]
+    }
+
+    private let fileManager: FileManager
+
+    init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+    }
+
+    func readOrCreateNamespace(at url: URL) -> Result {
+        do {
+            let parent = url.deletingLastPathComponent()
+            if fileManager.fileExists(atPath: url.path) {
+                guard namespaceDirectoryPermissionsArePrivate(parent), namespaceFilePermissionsArePrivate(url) else {
+                    return Result(bytes: nil, warnings: [.namespacePermissionInvalid, .candidateIDUnstable])
+                }
+                let data = try Data(contentsOf: url)
+                guard data.count == 32 else {
+                    return Result(bytes: nil, warnings: [.namespacePermissionInvalid, .candidateIDUnstable])
+                }
+                return Result(bytes: data, warnings: [])
+            }
+
+            try fileManager.createDirectory(
+                at: parent,
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700]
+            )
+            try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: parent.path)
+            let data = try secureRandomBytes(count: 32)
+            guard fileManager.createFile(atPath: url.path, contents: data, attributes: [.posixPermissions: 0o600]) else {
+                return Result(bytes: nil, warnings: [.candidateIDUnstable])
+            }
+            try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+            return Result(bytes: data, warnings: [])
+        } catch {
+            return Result(bytes: nil, warnings: [.candidateIDUnstable])
+        }
+    }
+
+    private func namespaceDirectoryPermissionsArePrivate(_ url: URL) -> Bool {
+        guard let attrs = try? fileManager.attributesOfItem(atPath: url.path),
+              let type = attrs[.type] as? FileAttributeType,
+              type == .typeDirectory,
+              let permissions = attrs[.posixPermissions] as? NSNumber else {
+            return false
+        }
+        return permissions.intValue & 0o077 == 0
+    }
+
+    private func namespaceFilePermissionsArePrivate(_ url: URL) -> Bool {
+        guard let attrs = try? fileManager.attributesOfItem(atPath: url.path),
+              let type = attrs[.type] as? FileAttributeType,
+              type == .typeRegular,
+              let permissions = attrs[.posixPermissions] as? NSNumber else {
+            return false
+        }
+        return permissions.intValue & 0o077 == 0
+    }
+
+    private func secureRandomBytes(count: Int) throws -> Data {
+        var bytes = [UInt8](repeating: 0, count: count)
+        let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        guard status == errSecSuccess else {
+            throw BYOMDiscoveryAdapterError.malformed
+        }
+        return Data(bytes)
+    }
+}
+
+struct BYOMCandidateIdentity: Sendable {
+    static func candidateID(namespace: Data?, runtimeSource: String, servedModelRef: String) -> (String, [BYOMDiscoveryWarning]) {
+        let normalized = normalizedServedModelRef(servedModelRef)
+        let framed = Data(runtimeSource.utf8) + Data([0]) + Data(normalized.utf8)
+        guard let namespace, namespace.count == 32 else {
+            let digest = SHA256.hash(data: framed)
+            return ("byom_unstable_\(base32URLNoPadding(Data(digest)))", [.candidateIDUnstable])
+        }
+        let mac = HMAC<SHA256>.authenticationCode(for: framed, using: SymmetricKey(data: namespace))
+        return ("byom_\(base32URLNoPadding(Data(mac)))", [])
+    }
+
+    static func normalizedServedModelRef(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(with: nil)
+    }
+
+    static func base32URLNoPadding(_ data: Data) -> String {
+        let alphabet = Array("abcdefghijklmnopqrstuvwxyz234567")
+        var output = ""
+        var buffer = 0
+        var bitsLeft = 0
+        for byte in data {
+            buffer = (buffer << 8) | Int(byte)
+            bitsLeft += 8
+            while bitsLeft >= 5 {
+                let index = (buffer >> (bitsLeft - 5)) & 0x1f
+                output.append(alphabet[index])
+                bitsLeft -= 5
+            }
+        }
+        if bitsLeft > 0 {
+            let index = (buffer << (5 - bitsLeft)) & 0x1f
+            output.append(alphabet[index])
+        }
+        return output
+    }
+}
+
+struct BYOMCatalogMatcher: Sendable {
+    private let rows: [(key: String, modelID: String)]
+
+    init() {
+        let baked = Data(AutotuneStaticInputs.bakedCandidateCatalogJSON.utf8)
+        if let catalog = try? AutotuneStaticInputs.decodeSignedStaticCandidateCatalog(baked) {
+            rows = catalog.rows.map { (key: $0.key, modelID: $0.value.modelID) }
+        } else {
+            rows = []
+        }
+    }
+
+    func catalogKey(for servedModelRef: String) -> String? {
+        let normalized = BYOMCandidateIdentity.normalizedServedModelRef(servedModelRef)
+        return rows.first { row in
+            BYOMCandidateIdentity.normalizedServedModelRef(row.key) == normalized
+                || BYOMCandidateIdentity.normalizedServedModelRef(row.modelID) == normalized
+        }?.key
+    }
+}
+
+struct BYOMMLXCacheDiscovery {
+    private let cacheRoot: URL
+    private let namespace: Data?
+    private let namespaceWarnings: [BYOMDiscoveryWarning]
+    private let catalogMatcher: BYOMCatalogMatcher
+    private let fileManager: FileManager
+
+    init(
+        cacheRoot: URL,
+        namespace: Data?,
+        namespaceWarnings: [BYOMDiscoveryWarning] = [],
+        catalogMatcher: BYOMCatalogMatcher,
+        fileManager: FileManager = .default
+    ) {
+        self.cacheRoot = cacheRoot
+        self.namespace = namespace
+        self.namespaceWarnings = namespaceWarnings
+        self.catalogMatcher = catalogMatcher
+        self.fileManager = fileManager
+    }
+
+    func discover() -> (adapter: BYOMDiscoveryWire.Adapter, candidates: [BYOMDiscoveryWire.Candidate]) {
+        guard let entries = try? fileManager.contentsOfDirectory(
+            at: cacheRoot,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return (
+                BYOMDiscoveryWire.Adapter(
+                    runtimeSource: "mlx_cache",
+                    status: "unavailable",
+                    originClass: nil,
+                    warningCodes: [BYOMDiscoveryWarning.adapterUnavailable.rawValue]
+                ),
+                []
+            )
+        }
+
+        var candidates: [BYOMDiscoveryWire.Candidate] = []
+        for entry in entries.sorted(by: { $0.lastPathComponent < $1.lastPathComponent }).prefix(200) {
+            guard (try? entry.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true,
+                  let modelID = modelID(fromHFCacheDirectoryName: entry.lastPathComponent) else {
+                continue
+            }
+            let snapshotSummary = summarizeSnapshots(repoDirectory: entry)
+            let candidate = buildCandidate(
+                servedModelRef: modelID,
+                readinessState: snapshotSummary.ready ? "ready" : "needs_weights",
+                estimatedGB: estimatedGB(modelID: modelID, snapshotBytes: snapshotSummary.weightBytes),
+                contextWindowTokens: snapshotSummary.contextWindowTokens,
+                warningCodes: snapshotSummary.ready ? [] : [.requiresPreparation]
+            )
+            candidates.append(candidate)
+        }
+
+        return (
+            BYOMDiscoveryWire.Adapter(
+                runtimeSource: "mlx_cache",
+                status: "ok",
+                originClass: nil,
+                warningCodes: []
+            ),
+            candidates
+        )
+    }
+
+    private func modelID(fromHFCacheDirectoryName name: String) -> String? {
+        guard name.hasPrefix("models--") else { return nil }
+        let modelID = String(name.dropFirst("models--".count))
+            .replacingOccurrences(of: "--", with: "/")
+        guard !modelID.isEmpty,
+              BYOMDiscoveryPrivacy.isSafeModelReference(modelID),
+              modelID.lowercased().contains("mlx") else {
+            return nil
+        }
+        return modelID
+    }
+
+    private func summarizeSnapshots(repoDirectory: URL) -> (ready: Bool, weightBytes: UInt64, contextWindowTokens: Int?) {
+        let snapshots = repoDirectory.appendingPathComponent("snapshots", isDirectory: true)
+        guard let snapshotDirs = try? fileManager.contentsOfDirectory(
+            at: snapshots,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return (false, 0, nil)
+        }
+        var sawConfig = false
+        var weightBytes: UInt64 = 0
+        var context: Int?
+        var inspected = 0
+        for snapshot in snapshotDirs.prefix(20) {
+            guard (try? snapshot.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true else { continue }
+            if let config = try? Data(contentsOf: snapshot.appendingPathComponent("config.json")),
+               config.count <= 128 * 1024 {
+                sawConfig = true
+                context = context ?? BYOMDiscoveryJSON.contextWindowTokens(from: config)
+            }
+            guard let enumerator = fileManager.enumerator(
+                at: snapshot,
+                includingPropertiesForKeys: [.isRegularFileKey, .fileSizeKey],
+                options: [.skipsHiddenFiles, .skipsPackageDescendants]
+            ) else {
+                continue
+            }
+            for case let fileURL as URL in enumerator {
+                inspected += 1
+                if inspected > 2048 { break }
+                guard BYOMMLXCacheDiscovery.isModelWeightFile(fileURL.lastPathComponent),
+                      let values = try? fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey]),
+                      values.isRegularFile == true else {
+                    continue
+                }
+                weightBytes += UInt64(values.fileSize ?? 0)
+            }
+        }
+        return (sawConfig && weightBytes > 0, weightBytes, context)
+    }
+
+    private static func isModelWeightFile(_ name: String) -> Bool {
+        let lower = name.lowercased()
+        return lower.hasSuffix(".safetensors")
+            || lower.hasSuffix(".bin")
+            || lower.hasSuffix(".gguf")
+            || lower.hasSuffix(".npz")
+    }
+
+    private func estimatedGB(modelID: String, snapshotBytes: UInt64) -> Double? {
+        if let estimate = ModelFit.estimateWeightSizeGB(modelID: modelID) {
+            return Double(estimate)
+        }
+        guard snapshotBytes > 0 else { return nil }
+        let gb = Double(snapshotBytes) / 1_073_741_824.0
+        return (gb * 100).rounded() / 100
+    }
+
+    private func buildCandidate(
+        servedModelRef: String,
+        readinessState: String,
+        estimatedGB: Double?,
+        contextWindowTokens: Int?,
+        warningCodes localWarnings: [BYOMDiscoveryWarning]
+    ) -> BYOMDiscoveryWire.Candidate {
+        let (candidateID, idWarnings) = BYOMCandidateIdentity.candidateID(
+            namespace: namespace,
+            runtimeSource: "mlx_cache",
+            servedModelRef: servedModelRef
+        )
+        let catalogKey = catalogMatcher.catalogKey(for: servedModelRef)
+        var warnings = Set((namespaceWarnings + idWarnings + localWarnings + [.capabilityUnevaluated, .evaluationRequired]).map(\.rawValue))
+        if catalogKey != nil {
+            warnings.insert(BYOMDiscoveryWarning.catalogMatchUnverified.rawValue)
+        }
+        let fit = fitState(modelID: servedModelRef)
+        let admission = localAdmissionState(
+            stableID: idWarnings.isEmpty,
+            readinessState: readinessState,
+            fitState: fit,
+            blockingWarnings: warnings
+        )
+        return BYOMDiscoveryWire.Candidate(
+            candidateID: candidateID,
+            runtimeSource: "mlx_cache",
+            displayName: BYOMDiscoveryPrivacy.displayName(from: servedModelRef),
+            servedModelRef: servedModelRef,
+            catalogModelKey: catalogKey,
+            identityState: catalogKey == nil ? "runtime_reported" : "catalog_matched",
+            locality: "local_artifact",
+            estimatedGB: estimatedGB,
+            contextWindowTokens: contextWindowTokens,
+            capabilities: BYOMDiscoveryWire.Capabilities(
+                chatCompletions: nil,
+                streaming: nil,
+                toolCallPassthrough: nil,
+                structuredOutputPassthrough: nil,
+                jsonMode: nil,
+                usageReporting: nil,
+                maxContextTokens: contextWindowTokens,
+                quantization: BYOMDiscoveryPrivacy.safeOptionalLabel(BYOMDiscoveryPrivacy.quantizationHint(from: servedModelRef)),
+                family: nil,
+                runtimeVersion: nil
+            ),
+            readinessState: readinessState,
+            fitState: fit,
+            evaluationState: "not_evaluated",
+            admissionState: admission,
+            admissionStateSource: "local_default",
+            providerGuidance: BYOMDiscoveryGuidance.guidance(forAdmissionState: admission, warnings: warnings),
+            warningCodes: Array(warnings).sorted()
+        )
+    }
+
+    private func fitState(modelID: String) -> String {
+        switch ModelFit.evaluate(modelID: modelID, ramGB: ModelFit.detectRAMGB()) {
+        case .fits, .tight:
+            return "fits"
+        case .wontFit:
+            return "does_not_fit"
+        case .unknown:
+            return "unknown"
+        }
+    }
+}
+
+struct BYOMOllamaDiscovery: Sendable {
+    private let origin: String
+    private let namespace: Data?
+    private let namespaceWarnings: [BYOMDiscoveryWarning]
+    private let catalogMatcher: BYOMCatalogMatcher
+    private let httpClient: any BYOMDiscoveryHTTPClient
+
+    init(
+        origin: String,
+        namespace: Data?,
+        namespaceWarnings: [BYOMDiscoveryWarning] = [],
+        catalogMatcher: BYOMCatalogMatcher,
+        httpClient: any BYOMDiscoveryHTTPClient
+    ) {
+        self.origin = origin
+        self.namespace = namespace
+        self.namespaceWarnings = namespaceWarnings
+        self.catalogMatcher = catalogMatcher
+        self.httpClient = httpClient
+    }
+
+    func discover() async -> (adapter: BYOMDiscoveryWire.Adapter, candidates: [BYOMDiscoveryWire.Candidate]) {
+        guard let baseURL = BYOMLoopbackOriginValidator.validatedHTTPOrigin(origin) else {
+            return (
+                BYOMDiscoveryWire.Adapter(
+                    runtimeSource: "ollama_loopback",
+                    status: "rejected",
+                    originClass: "rejected",
+                    warningCodes: [BYOMDiscoveryWarning.adapterRejectedNonLoopback.rawValue]
+                ),
+                []
+            )
+        }
+
+        do {
+            let response = try await httpClient.get(
+                baseURL.appendingPathComponent("api/tags"),
+                maxHeaderBytes: BYOMDiscoveryHTTPBounds.maxHeaderBytes,
+                maxBodyBytes: BYOMDiscoveryHTTPBounds.maxBodyBytes
+            )
+            guard response.statusCode == 200 else {
+                return adapterFailure(.adapterUnavailable, status: "unavailable")
+            }
+            guard BYOMDiscoveryHTTPBounds.headerBytes(response.headers) <= BYOMDiscoveryHTTPBounds.maxHeaderBytes else {
+                return adapterFailure(.adapterResponseTruncated, status: "truncated")
+            }
+            guard response.body.count <= BYOMDiscoveryHTTPBounds.maxBodyBytes else {
+                return adapterFailure(.adapterResponseTruncated, status: "truncated")
+            }
+            let models = try BYOMDiscoveryJSON.parseOllamaTags(response.body)
+            return (
+                BYOMDiscoveryWire.Adapter(
+                    runtimeSource: "ollama_loopback",
+                    status: "ok",
+                    originClass: "loopback_http",
+                    warningCodes: []
+                ),
+                models.map(buildCandidate)
+            )
+        } catch is CancellationError {
+            return adapterFailure(.adapterTimeout, status: "timeout")
+        } catch let error as URLError where error.code == .timedOut {
+            return adapterFailure(.adapterTimeout, status: "timeout")
+        } catch let error as BYOMDiscoveryAdapterError {
+            switch error {
+            case .malformed:
+                return adapterFailure(.adapterMalformedResponse, status: "malformed")
+            case .truncated:
+                return adapterFailure(.adapterResponseTruncated, status: "truncated")
+            case .rejectedNonLoopback:
+                return adapterFailure(.adapterRejectedNonLoopback, status: "rejected")
+            }
+        } catch {
+            return adapterFailure(.adapterUnavailable, status: "unavailable")
+        }
+    }
+
+    private func adapterFailure(
+        _ warning: BYOMDiscoveryWarning,
+        status: String
+    ) -> (adapter: BYOMDiscoveryWire.Adapter, candidates: [BYOMDiscoveryWire.Candidate]) {
+        (
+            BYOMDiscoveryWire.Adapter(
+                runtimeSource: "ollama_loopback",
+                status: status,
+                originClass: "loopback_http",
+                warningCodes: [warning.rawValue]
+            ),
+            []
+        )
+    }
+
+    private func buildCandidate(_ model: BYOMDiscoveryJSON.OllamaModel) -> BYOMDiscoveryWire.Candidate {
+        let servedModelRef = "ollama:\(model.name)"
+        let (candidateID, idWarnings) = BYOMCandidateIdentity.candidateID(
+            namespace: namespace,
+            runtimeSource: "ollama_loopback",
+            servedModelRef: servedModelRef
+        )
+        let catalogKey = catalogMatcher.catalogKey(for: model.name)
+        var warnings = Set((namespaceWarnings + idWarnings + [.capabilityUnevaluated, .evaluationRequired]).map(\.rawValue))
+        if catalogKey != nil {
+            warnings.insert(BYOMDiscoveryWarning.catalogMatchUnverified.rawValue)
+        }
+        let fit = fitState(modelID: model.name)
+        let admission = localAdmissionState(
+            stableID: idWarnings.isEmpty,
+            readinessState: "ready",
+            fitState: fit,
+            blockingWarnings: warnings
+        )
+        return BYOMDiscoveryWire.Candidate(
+            candidateID: candidateID,
+            runtimeSource: "ollama_loopback",
+            displayName: BYOMDiscoveryPrivacy.displayName(from: model.name),
+            servedModelRef: servedModelRef,
+            catalogModelKey: catalogKey,
+            identityState: catalogKey == nil ? "runtime_reported" : "catalog_matched",
+            locality: "loopback_runtime",
+            estimatedGB: ModelFit.estimateWeightSizeGB(modelID: model.name).map(Double.init),
+            contextWindowTokens: nil,
+            capabilities: BYOMDiscoveryWire.Capabilities(
+                chatCompletions: true,
+                streaming: nil,
+                toolCallPassthrough: nil,
+                structuredOutputPassthrough: nil,
+                jsonMode: nil,
+                usageReporting: nil,
+                maxContextTokens: nil,
+                quantization: BYOMDiscoveryPrivacy.safeOptionalLabel(model.quantization),
+                family: BYOMDiscoveryPrivacy.safeOptionalLabel(model.family),
+                runtimeVersion: nil
+            ),
+            readinessState: "ready",
+            fitState: fit,
+            evaluationState: "not_evaluated",
+            admissionState: admission,
+            admissionStateSource: "local_default",
+            providerGuidance: BYOMDiscoveryGuidance.guidance(forAdmissionState: admission, warnings: warnings),
+            warningCodes: Array(warnings).sorted()
+        )
+    }
+
+    private func fitState(modelID: String) -> String {
+        switch ModelFit.evaluate(modelID: modelID, ramGB: ModelFit.detectRAMGB()) {
+        case .fits, .tight:
+            return "fits"
+        case .wontFit:
+            return "does_not_fit"
+        case .unknown:
+            return "unknown"
+        }
+    }
+}
+
+enum BYOMLoopbackOriginValidator {
+    static func validatedHTTPOrigin(_ raw: String) -> URL? {
+        guard var components = URLComponents(string: raw.trimmingCharacters(in: .whitespacesAndNewlines)),
+              components.scheme == "http",
+              components.user == nil,
+              components.password == nil,
+              components.query == nil,
+              components.fragment == nil,
+              let host = components.host,
+              isLoopbackLiteral(host),
+              components.port.map({ (1...65535).contains($0) }) ?? false else {
+            return nil
+        }
+        guard components.path.isEmpty || components.path == "/" else {
+            return nil
+        }
+        components.path = ""
+        return components.url
+    }
+
+    static func isLoopbackLiteral(_ host: String) -> Bool {
+        let normalized = host.trimmingCharacters(in: CharacterSet(charactersIn: "[]")).lowercased()
+        if normalized == "::1" { return true }
+        let parts = normalized.split(separator: ".", omittingEmptySubsequences: false)
+        return parts.count == 4
+            && UInt8(parts[0]) == 127
+            && parts.dropFirst().allSatisfy { UInt8($0) != nil }
+    }
+}
+
+enum BYOMDiscoveryHTTPBounds {
+    static let maxHeaderBytes = 64 * 1024
+    static let maxBodyBytes = 256 * 1024
+
+    static func headerBytes(_ headers: [(String, String)]) -> Int {
+        headers.reduce(0) { total, header in
+            total + header.0.utf8.count + header.1.utf8.count
+        }
+    }
+}
+
+enum BYOMDiscoveryJSON {
+    struct OllamaModel: Equatable {
+        let name: String
+        let family: String?
+        let quantization: String?
+    }
+
+    static func parseOllamaTags(_ data: Data) throws -> [OllamaModel] {
+        guard let text = String(data: data, encoding: .utf8),
+              case .object(let root) = try? StrictJSONParser.parse(text),
+              case .array(let rawModels)? = root["models"] else {
+            throw BYOMDiscoveryAdapterError.malformed
+        }
+        return rawModels.prefix(100).compactMap { value in
+            guard case .object(let object) = value,
+                  case .string(let name)? = object["name"],
+                  BYOMDiscoveryPrivacy.isSafeRuntimeModelReference(name) else {
+                return nil
+            }
+            let details: [String: JSONValue]
+            if case .object(let detailObject)? = object["details"] {
+                details = detailObject
+            } else {
+                details = [:]
+            }
+            return OllamaModel(
+                name: name,
+                family: stringField("family", in: details),
+                quantization: stringField("quantization_level", in: details)
+            )
+        }
+    }
+
+    static func contextWindowTokens(from data: Data) -> Int? {
+        guard let text = String(data: data, encoding: .utf8),
+              case .object(let root) = try? StrictJSONParser.parse(text) else {
+            return nil
+        }
+        for key in ["max_position_embeddings", "model_max_length", "max_sequence_length", "n_ctx"] {
+            if let value = intField(key, in: root), value > 0 {
+                return value
+            }
+        }
+        return nil
+    }
+
+    private static func stringField(_ key: String, in object: [String: JSONValue]) -> String? {
+        guard case .string(let value)? = object[key] else { return nil }
+        return value
+    }
+
+    private static func intField(_ key: String, in object: [String: JSONValue]) -> Int? {
+        switch object[key] {
+        case .int(let value)?:
+            return value
+        case .double(let value)? where value.rounded(.towardZero) == value:
+            return Int(value)
+        default:
+            return nil
+        }
+    }
+}
+
+enum BYOMDiscoveryPrivacy {
+    static func isSafeModelReference(_ value: String) -> Bool {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, trimmed.utf8.count <= 256 else { return false }
+        let lower = trimmed.lowercased()
+        guard !trimmed.contains(".."),
+              !trimmed.hasPrefix("/"),
+              !trimmed.contains("\\"),
+              !trimmed.contains("@"),
+              !trimmed.contains("="),
+              !trimmed.contains("?"),
+              !trimmed.contains("#"),
+              !trimmed.contains("&"),
+              !lower.contains("://"),
+              !lower.hasPrefix("http:"),
+              !lower.hasPrefix("https:"),
+              !lower.hasPrefix("file:"),
+              !lower.hasPrefix("unix:"),
+              !lower.hasPrefix("ws:"),
+              !lower.hasPrefix("wss:"),
+              !lower.contains("token="),
+              !lower.contains("api_key="),
+              !lower.contains("apikey="),
+              !lower.contains("secret="),
+              !lower.contains("authorization="),
+              !lower.contains("password="),
+              !lower.contains("bearer ") else {
+            return false
+        }
+        guard !looksLikeEndpoint(trimmed), !looksLikeCredential(trimmed) else { return false }
+        return trimmed.unicodeScalars.allSatisfy { scalar in
+            scalar.value >= 0x21 && scalar.value <= 0x7e
+                && scalar != "<"
+                && scalar != ">"
+                && scalar != "\""
+                && scalar != "'"
+                && scalar != ";"
+        }
+    }
+
+    static func isSafeRuntimeModelReference(_ value: String) -> Bool {
+        guard isSafeModelReference(value) else { return false }
+        return !value.contains("/")
+    }
+
+    static func displayName(from value: String) -> String {
+        let safe = value.unicodeScalars.map { scalar -> Character in
+            if scalar.value >= 0x20 && scalar.value <= 0x7e,
+               scalar != "<",
+               scalar != ">",
+               scalar != "\"",
+               scalar != "'" {
+                return Character(scalar)
+            }
+            return "?"
+        }
+        let string = String(safe).trimmingCharacters(in: .whitespacesAndNewlines)
+        return String(string.prefix(128))
+    }
+
+    static func safeOptionalLabel(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              trimmed.utf8.count <= 64,
+              !looksSensitive(trimmed),
+              trimmed.unicodeScalars.allSatisfy({ scalar in
+                  scalar.value >= 0x21 && scalar.value <= 0x7e
+                      && (scalar.properties.isAlphabetic
+                          || scalar.properties.isMath
+                          || CharacterSet.decimalDigits.contains(scalar)
+                          || scalar == "_"
+                          || scalar == "-"
+                          || scalar == "."
+                          || scalar == "+")
+              }) else {
+            return nil
+        }
+        return trimmed
+    }
+
+    private static func looksSensitive(_ value: String) -> Bool {
+        let lower = value.lowercased()
+        return value.contains("/")
+            || value.contains("\\")
+            || value.contains("=")
+            || value.contains("?")
+            || value.contains("#")
+            || value.contains("&")
+            || value.contains("@")
+            || lower.contains("://")
+            || lower.hasPrefix("http:")
+            || lower.hasPrefix("https:")
+            || lower.hasPrefix("file:")
+            || lower.hasPrefix("unix:")
+            || lower.contains("token")
+            || lower.contains("api_key")
+            || lower.contains("apikey")
+            || lower.contains("secret")
+            || lower.contains("authorization")
+            || lower.contains("password")
+            || lower.contains("bearer ")
+            || looksLikeEndpoint(value)
+            || looksLikeCredential(value)
+    }
+
+    private static func looksLikeEndpoint(_ value: String) -> Bool {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        let lower = trimmed.lowercased()
+        if lower == "localhost" || lower == "[::1]" || lower == "::1" {
+            return true
+        }
+        if trimmed.range(of: #"^[0-9]{1,3}(\.[0-9]{1,3}){3}$"#, options: .regularExpression) != nil {
+            return true
+        }
+        if trimmed.range(of: #"^\[[0-9A-Fa-f:]+\]$"#, options: .regularExpression) != nil {
+            return true
+        }
+        if trimmed.range(of: #"^[0-9A-Fa-f]{0,4}(:[0-9A-Fa-f]{0,4}){2,}$"#, options: .regularExpression) != nil {
+            return true
+        }
+        return trimmed.range(
+            of: #"(^|[^A-Za-z0-9._-])(localhost|[0-9]{1,3}(\.[0-9]{1,3}){3}|\[[0-9A-Fa-f:]+\]):[0-9]{1,5}($|[^A-Za-z0-9._-])"#,
+            options: .regularExpression
+        ) != nil
+    }
+
+    private static func looksLikeCredential(_ value: String) -> Bool {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        let lower = trimmed.lowercased()
+        if lower.hasPrefix("sk-") || lower.hasPrefix("ghp_") || lower.hasPrefix("github_pat_") {
+            return true
+        }
+        if lower.hasPrefix("xoxb-") || lower.hasPrefix("xoxp-") || lower.hasPrefix("xoxa-") || lower.hasPrefix("xoxr-") {
+            return true
+        }
+        if trimmed.range(of: #"^eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}$"#, options: .regularExpression) != nil {
+            return true
+        }
+        return trimmed.range(of: #"^[A-Za-z0-9_-]{40,}$"#, options: .regularExpression) != nil
+    }
+
+    static func quantizationHint(from value: String) -> String? {
+        let lower = value.lowercased()
+        if lower.contains("4bit") || lower.contains("-q4") || lower.contains("_q4") {
+            return "q4"
+        }
+        if lower.contains("8bit") || lower.contains("-q8") || lower.contains("_q8") {
+            return "q8"
+        }
+        if lower.contains("bf16") {
+            return "bf16"
+        }
+        if lower.contains("fp16") || lower.contains("-f16") {
+            return "fp16"
+        }
+        return nil
+    }
+}
+
+enum BYOMDiscoveryGuidance {
+    static func guidance(forAdmissionState state: String, warnings: Set<String>) -> BYOMDiscoveryWire.Guidance {
+        switch state {
+        case "offerable":
+            return BYOMDiscoveryWire.Guidance(
+                stateLabelKey: "byom.local.offerable",
+                stateMeaningKey: "byom.local.offerable_not_earning",
+                nextAction: warnings.contains(BYOMDiscoveryWarning.evaluationRequired.rawValue) ? "evaluate" : "offer_dry_run",
+                transitionReasonCode: nil,
+                earningPathClass: "local_inventory_only"
+            )
+        default:
+            return BYOMDiscoveryWire.Guidance(
+                stateLabelKey: "byom.local.local_only",
+                stateMeaningKey: "byom.local.local_only_not_earning",
+                nextAction: "fix_local_blocker",
+                transitionReasonCode: warnings.sorted().first,
+                earningPathClass: "local_inventory_only"
+            )
+        }
+    }
+}
+
+private func localAdmissionState(
+    stableID: Bool,
+    readinessState: String,
+    fitState: String,
+    blockingWarnings: Set<String>
+) -> String {
+    let blockingWarningCodes = Set([
+        BYOMDiscoveryWarning.candidateIDUnstable.rawValue,
+        BYOMDiscoveryWarning.namespacePermissionInvalid.rawValue,
+        BYOMDiscoveryWarning.adapterRejectedNonLoopback.rawValue,
+        BYOMDiscoveryWarning.adapterMalformedResponse.rawValue,
+        BYOMDiscoveryWarning.adapterResponseTruncated.rawValue,
+        BYOMDiscoveryWarning.requiresPreparation.rawValue,
+    ])
+    guard stableID,
+          readinessState == "ready",
+          fitState != "does_not_fit",
+          blockingWarnings.isDisjoint(with: blockingWarningCodes) else {
+        return "local_only"
+    }
+    return "offerable"
+}

--- a/phase3-binary/Sources/macprovider-cli/BYOMDiscovery.swift
+++ b/phase3-binary/Sources/macprovider-cli/BYOMDiscovery.swift
@@ -368,7 +368,7 @@ struct BYOMDiscoveryRunner {
 
     func discover() async -> BYOMDiscoveryWire {
         let namespace = BYOMDiscoveryNamespaceStore(fileManager: fileManager)
-            .readOrCreateNamespace(at: environment.namespaceURL)
+            .readNamespace(at: environment.namespaceURL)
         let catalog = BYOMCatalogMatcher()
         var adapters: [BYOMDiscoveryWire.Adapter] = []
         var candidates: [BYOMDiscoveryWire.Candidate] = []
@@ -433,35 +433,22 @@ struct BYOMDiscoveryNamespaceStore {
         self.fileManager = fileManager
     }
 
-    func readOrCreateNamespace(at url: URL) -> Result {
-        do {
-            let parent = url.deletingLastPathComponent()
-            if fileManager.fileExists(atPath: url.path) {
-                guard namespaceDirectoryPermissionsArePrivate(parent), namespaceFilePermissionsArePrivate(url) else {
-                    return Result(bytes: nil, warnings: [.namespacePermissionInvalid, .candidateIDUnstable])
-                }
-                let data = try Data(contentsOf: url)
-                guard data.count == 32 else {
-                    return Result(bytes: nil, warnings: [.namespacePermissionInvalid, .candidateIDUnstable])
-                }
-                return Result(bytes: data, warnings: [])
-            }
-
-            try fileManager.createDirectory(
-                at: parent,
-                withIntermediateDirectories: true,
-                attributes: [.posixPermissions: 0o700]
-            )
-            try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: parent.path)
-            let data = try secureRandomBytes(count: 32)
-            guard fileManager.createFile(atPath: url.path, contents: data, attributes: [.posixPermissions: 0o600]) else {
-                return Result(bytes: nil, warnings: [.candidateIDUnstable])
-            }
-            try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
-            return Result(bytes: data, warnings: [])
-        } catch {
+    /// Read-only namespace lookup. `models discover` MUST NOT mutate local state
+    /// (SPEC-046-R001), so an absent salt yields unstable candidate IDs rather
+    /// than provisioning the salt here; salt creation belongs to a later
+    /// mutating command (e.g. offer), never to discovery.
+    func readNamespace(at url: URL) -> Result {
+        let parent = url.deletingLastPathComponent()
+        guard fileManager.fileExists(atPath: url.path) else {
             return Result(bytes: nil, warnings: [.candidateIDUnstable])
         }
+        guard namespaceDirectoryPermissionsArePrivate(parent), namespaceFilePermissionsArePrivate(url) else {
+            return Result(bytes: nil, warnings: [.namespacePermissionInvalid, .candidateIDUnstable])
+        }
+        guard let data = try? Data(contentsOf: url), data.count == 32 else {
+            return Result(bytes: nil, warnings: [.namespacePermissionInvalid, .candidateIDUnstable])
+        }
+        return Result(bytes: data, warnings: [])
     }
 
     private func namespaceDirectoryPermissionsArePrivate(_ url: URL) -> Bool {
@@ -482,15 +469,6 @@ struct BYOMDiscoveryNamespaceStore {
             return false
         }
         return permissions.intValue & 0o077 == 0
-    }
-
-    private func secureRandomBytes(count: Int) throws -> Data {
-        var bytes = [UInt8](repeating: 0, count: count)
-        let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
-        guard status == errSecSuccess else {
-            throw BYOMDiscoveryAdapterError.malformed
-        }
-        return Data(bytes)
     }
 }
 
@@ -574,12 +552,62 @@ struct BYOMMLXCacheDiscovery {
         self.fileManager = fileManager
     }
 
-    func discover() -> (adapter: BYOMDiscoveryWire.Adapter, candidates: [BYOMDiscoveryWire.Candidate]) {
-        guard let entries = try? fileManager.contentsOfDirectory(
-            at: cacheRoot,
+    /// Enumerate at most `cap` immediate children of `root`, then sort by name.
+    /// Uses a streaming enumerator with an early cutoff so a cache root holding
+    /// millions of entries cannot exhaust memory/time before the caller's
+    /// `.prefix(...)` cap applies (bulk `contentsOfDirectory` materializes the
+    /// whole listing first). `cap` is set well above the caller's prefix so
+    /// normal caches enumerate fully and deterministically.
+    private func boundedDirectoryEntries(at root: URL, cap: Int) -> [URL]? {
+        // Treat a missing or non-directory path as unreadable (nil), matching
+        // the throwing `contentsOfDirectory` this replaced — an `enumerator`
+        // over a missing path yields an empty, non-nil sequence otherwise.
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: root.path, isDirectory: &isDirectory), isDirectory.boolValue else {
+            return nil
+        }
+        guard let enumerator = fileManager.enumerator(
+            at: root,
             includingPropertiesForKeys: [.isDirectoryKey],
-            options: [.skipsHiddenFiles]
+            options: [.skipsHiddenFiles, .skipsSubdirectoryDescendants, .skipsPackageDescendants]
         ) else {
+            return nil
+        }
+        var collected: [URL] = []
+        collected.reserveCapacity(min(cap, 1024))
+        for case let url as URL in enumerator {
+            collected.append(url)
+            if collected.count >= cap { break }
+        }
+        return collected.sorted(by: { $0.lastPathComponent < $1.lastPathComponent })
+    }
+
+    /// True when `url`, after symlink resolution, is `root` itself or lives
+    /// under it — used to reject symlinks that escape the cache root.
+    private func pathIsContained(_ url: URL, in root: URL) -> Bool {
+        let target = url.resolvingSymlinksInPath().standardizedFileURL.path
+        let base = root.resolvingSymlinksInPath().standardizedFileURL.path
+        if target == base { return true }
+        return target.hasPrefix(base.hasSuffix("/") ? base : base + "/")
+    }
+
+    /// Read a file only after confirming (via the resolved target's stat) that
+    /// it is a regular file inside `root` and no larger than `maxBytes`. The
+    /// size gate runs BEFORE any bytes are read, so a multi-GB or symlinked
+    /// file cannot force an unbounded `Data(contentsOf:)` allocation.
+    private func boundedFileContents(at url: URL, within root: URL, maxBytes: Int) -> Data? {
+        let resolved = url.resolvingSymlinksInPath()
+        guard pathIsContained(resolved, in: root),
+              let values = try? resolved.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey]),
+              values.isRegularFile == true,
+              let size = values.fileSize, size >= 0, size <= maxBytes else {
+            return nil
+        }
+        return try? Data(contentsOf: resolved)
+    }
+
+    func discover() -> (adapter: BYOMDiscoveryWire.Adapter, candidates: [BYOMDiscoveryWire.Candidate]) {
+        guard let entries = boundedDirectoryEntries(at: cacheRoot, cap: 4096) else {
             return (
                 BYOMDiscoveryWire.Adapter(
                     runtimeSource: "mlx_cache",
@@ -592,7 +620,7 @@ struct BYOMMLXCacheDiscovery {
         }
 
         var candidates: [BYOMDiscoveryWire.Candidate] = []
-        for entry in entries.sorted(by: { $0.lastPathComponent < $1.lastPathComponent }).prefix(200) {
+        for entry in entries.prefix(200) {
             guard (try? entry.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true,
                   let modelID = modelID(fromHFCacheDirectoryName: entry.lastPathComponent) else {
                 continue
@@ -633,11 +661,7 @@ struct BYOMMLXCacheDiscovery {
 
     private func summarizeSnapshots(repoDirectory: URL) -> (ready: Bool, weightBytes: UInt64, contextWindowTokens: Int?) {
         let snapshots = repoDirectory.appendingPathComponent("snapshots", isDirectory: true)
-        guard let snapshotDirs = try? fileManager.contentsOfDirectory(
-            at: snapshots,
-            includingPropertiesForKeys: [.isDirectoryKey],
-            options: [.skipsHiddenFiles]
-        ) else {
+        guard let snapshotDirs = boundedDirectoryEntries(at: snapshots, cap: 256) else {
             return (false, 0, nil)
         }
         var sawConfig = false
@@ -646,8 +670,11 @@ struct BYOMMLXCacheDiscovery {
         var inspected = 0
         for snapshot in snapshotDirs.prefix(20) {
             guard (try? snapshot.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true else { continue }
-            if let config = try? Data(contentsOf: snapshot.appendingPathComponent("config.json")),
-               config.count <= 128 * 1024 {
+            if let config = boundedFileContents(
+                at: snapshot.appendingPathComponent("config.json"),
+                within: cacheRoot,
+                maxBytes: 128 * 1024
+            ) {
                 sawConfig = true
                 context = context ?? BYOMDiscoveryJSON.contextWindowTokens(from: config)
             }
@@ -661,8 +688,16 @@ struct BYOMMLXCacheDiscovery {
             for case let fileURL as URL in enumerator {
                 inspected += 1
                 if inspected > 2048 { break }
-                guard BYOMMLXCacheDiscovery.isModelWeightFile(fileURL.lastPathComponent),
-                      let values = try? fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey]),
+                guard BYOMMLXCacheDiscovery.isModelWeightFile(fileURL.lastPathComponent) else {
+                    continue
+                }
+                // HF snapshots store weights as symlinks into the sibling
+                // `blobs/` dir, so resolve the target (an unresolved symlink is
+                // not `isRegularFile` and would be miscounted as missing) and
+                // require it to stay under the cache root to block symlink escape.
+                let resolved = fileURL.resolvingSymlinksInPath()
+                guard pathIsContained(resolved, in: cacheRoot),
+                      let values = try? resolved.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey]),
                       values.isRegularFile == true else {
                     continue
                 }
@@ -1135,6 +1170,34 @@ enum BYOMDiscoveryPrivacy {
             return true
         }
         if trimmed.range(of: #"^[0-9A-Fa-f]{0,4}(:[0-9A-Fa-f]{0,4}){2,}$"#, options: .regularExpression) != nil {
+            return true
+        }
+        // IPv4-mapped / IPv4-embedded IPv6 (e.g. ::ffff:127.0.0.1, ::127.0.0.1)
+        // that the bracketless-IPv6 pattern above misses because of the dots.
+        if lower.contains("::ffff:") {
+            return true
+        }
+        if trimmed.contains("::"),
+           trimmed.range(of: #"[0-9]{1,3}(\.[0-9]{1,3}){3}"#, options: .regularExpression) != nil {
+            return true
+        }
+        // Hex/octal-encoded IPv4 octets (e.g. 0x7f.0.0.1, 0177.0.0.1).
+        if trimmed.range(
+            of: #"(^|[^A-Za-z0-9._-])(0[xX][0-9A-Fa-f]+)(\.[0-9A-Fa-fxX]+){1,3}($|[^A-Za-z0-9._-])"#,
+            options: .regularExpression
+        ) != nil {
+            return true
+        }
+        // mDNS / private-network bare hostnames.
+        for suffix in [".local", ".internal", ".lan", ".home", ".corp", ".localdomain", ".intranet"] where lower.hasSuffix(suffix) {
+            return true
+        }
+        // DNS hostname with an explicit numeric port. A legitimate runtime
+        // model tag (e.g. `llama3.2:3b`) is not `:<digits>`, so it is unaffected.
+        if trimmed.range(
+            of: #"(^|[^A-Za-z0-9._-])([A-Za-z0-9-]+\.)+[A-Za-z0-9-]+:[0-9]{1,5}($|[^A-Za-z0-9._-])"#,
+            options: .regularExpression
+        ) != nil {
             return true
         }
         return trimmed.range(

--- a/phase3-binary/Sources/macprovider-cli/BYOMDiscovery.swift
+++ b/phase3-binary/Sources/macprovider-cli/BYOMDiscovery.swift
@@ -1043,8 +1043,11 @@ enum BYOMDiscoveryJSON {
         switch object[key] {
         case .int(let value)?:
             return value
-        case .double(let value)? where value.rounded(.towardZero) == value:
-            return Int(value)
+        case .double(let value)?:
+            // Int(exactly:) rejects non-integral, out-of-range, NaN and infinite
+            // values (e.g. a hostile config.json with 1e20), where Int(_:) would
+            // trap and abort discovery.
+            return Int(exactly: value)
         default:
             return nil
         }

--- a/phase3-binary/Sources/macprovider-cli/BYOMDiscovery.swift
+++ b/phase3-binary/Sources/macprovider-cli/BYOMDiscovery.swift
@@ -1181,21 +1181,28 @@ enum BYOMDiscoveryPrivacy {
            trimmed.range(of: #"[0-9]{1,3}(\.[0-9]{1,3}){3}"#, options: .regularExpression) != nil {
             return true
         }
-        // Hex/octal-encoded IPv4 octets (e.g. 0x7f.0.0.1, 0177.0.0.1).
+        // Encoded dotted IPv4 forms the plain dotted-quad above misses: octal
+        // (0177.0.0.1) and hex (0x7f.0.0.1) octets.
         if trimmed.range(
-            of: #"(^|[^A-Za-z0-9._-])(0[xX][0-9A-Fa-f]+)(\.[0-9A-Fa-fxX]+){1,3}($|[^A-Za-z0-9._-])"#,
+            of: #"^(0?[0-9]{1,4}|0[xX][0-9A-Fa-f]{1,4})(\.(0?[0-9]{1,4}|0[xX][0-9A-Fa-f]{1,4})){1,3}$"#,
             options: .regularExpression
         ) != nil {
             return true
         }
-        // mDNS / private-network bare hostnames.
-        for suffix in [".local", ".internal", ".lan", ".home", ".corp", ".localdomain", ".intranet"] where lower.hasSuffix(suffix) {
+        // One-piece encoded IPv4: a hex dword (0x7f000001) or a bare 32-bit decimal.
+        if trimmed.range(of: #"^0[xX][0-9A-Fa-f]{5,8}$"#, options: .regularExpression) != nil {
             return true
         }
-        // DNS hostname with an explicit numeric port. A legitimate runtime
-        // model tag (e.g. `llama3.2:3b`) is not `:<digits>`, so it is unaffected.
+        if trimmed.range(of: #"^[0-9]{8,10}$"#, options: .regularExpression) != nil {
+            return true
+        }
+        // Any DNS hostname: one or more dotted labels ending in an alphabetic
+        // TLD (public OR private like .local/.internal, optional trailing dot,
+        // with or without a port or scheme/path). Legitimate model refs put only
+        // numeric version tokens after a dot (e.g. `llama3.2`, `mistral-7b-v0.2`),
+        // so their final label is never a bare alpha TLD and they are unaffected.
         if trimmed.range(
-            of: #"(^|[^A-Za-z0-9._-])([A-Za-z0-9-]+\.)+[A-Za-z0-9-]+:[0-9]{1,5}($|[^A-Za-z0-9._-])"#,
+            of: #"(^|[^A-Za-z0-9_-])([A-Za-z0-9-]+\.)+[A-Za-z]{2,}\.?($|[^A-Za-z0-9-])"#,
             options: .regularExpression
         ) != nil {
             return true

--- a/phase3-binary/Sources/macprovider-cli/BYOMDiscovery.swift
+++ b/phase3-binary/Sources/macprovider-cli/BYOMDiscovery.swift
@@ -1092,8 +1092,24 @@ enum BYOMDiscoveryPrivacy {
     }
 
     static func isSafeRuntimeModelReference(_ value: String) -> Bool {
-        guard isSafeModelReference(value) else { return false }
-        return !value.contains("/")
+        guard isSafeModelReference(value), !value.contains("/") else { return false }
+        // Structural IP guard: reject when the authority (the part before an
+        // optional `:<tag>`/`:<port>`) is an all-numeric or 0x-hex dotted
+        // address. This closes every IPv4 shorthand at once — 127.1, 127.0.1,
+        // 0177.1, 0x7f.1, 017700000001, 2130706433, 0x7f000001 — where an
+        // encoding-by-encoding blocklist cannot. A legitimate model name's
+        // pre-tag part always carries a non-hex letter or hyphen, so it is
+        // unaffected (llama3.2:3b, qwen2.5-coder:7b, mistral-7b-instruct-v0.2).
+        let authority = value.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
+            .first.map(String.init)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? value
+        if authority.range(
+            of: #"^(0[xX][0-9A-Fa-f]+|[0-9]+)(\.(0[xX][0-9A-Fa-f]+|[0-9]+))*$"#,
+            options: .regularExpression
+        ) != nil {
+            return false
+        }
+        return true
     }
 
     static func displayName(from value: String) -> String {

--- a/phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift
@@ -9,12 +9,52 @@ struct ModelsCommand: AsyncParsableCommand {
         abstract: "Inspect or switch the provider warm model.",
         subcommands: [
             ModelsListCommand.self,
+            ModelsDiscoverCommand.self,
             ModelsSwitchCommand.self,
             ModelsStatusCommand.self,
             ModelsBrowseCommand.self,
             ModelsAdoptRecommendationCommand.self,
         ]
     )
+}
+
+struct ModelsDiscoverCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "discover",
+        abstract: "Discover provider-local BYOM candidates."
+    )
+
+    @Flag(name: .customLong("json"), help: "Emit the strict provider_byom_discovery.v1 JSON contract.")
+    var emitJSON = false
+
+    @Option(help: ArgumentHelp("CLI-owned local discovery namespace path.", visibility: .hidden))
+    var localDiscoveryNamespacePath: String?
+
+    @Option(help: "HuggingFace cache root to inspect read-only. Defaults to HF_HUB_CACHE, HF_HOME/hub, or ~/.cache/huggingface/hub.")
+    var mlxCacheDir: String?
+
+    @Option(help: "Ollama-compatible loopback origin to query. Must be http://127.0.0.0/8:<port> or http://[::1]:<port>.")
+    var ollamaOrigin: String = "http://127.0.0.1:11434"
+
+    @Flag(help: "Skip the Ollama-compatible loopback adapter.")
+    var skipOllama = false
+
+    func run() async throws {
+        guard emitJSON else {
+            writeStderr("models discover is JSON-only in this release; pass --json")
+            throw ExitCode(2)
+        }
+        let environment = BYOMDiscoveryEnvironment.production(
+            namespacePath: localDiscoveryNamespacePath,
+            mlxCacheDir: mlxCacheDir,
+            ollamaOrigin: skipOllama ? nil : ollamaOrigin
+        )
+        let document = await BYOMDiscoveryRunner(environment: environment).discover()
+        for warning in document.warnings.sorted() {
+            writeStderr("models discover warning: \(warning)")
+        }
+        try ModelSwitchingWireCodec.printJSON(document)
+    }
 }
 
 struct ModelsListCommand: AsyncParsableCommand {

--- a/phase3-binary/Tests/macprovider-cliTests/BYOMDiscoveryTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/BYOMDiscoveryTests.swift
@@ -119,18 +119,34 @@ final class BYOMDiscoveryTests: XCTestCase {
     func testRuntimeModelReferenceRejectsHostnameAndHostPortShapes() {
         for leak in [
             "coordinator.malibu.tech:443",
-            "prod.internal:11434",
+            "coordinator.malibu.tech",       // bare public hostname, no port
+            "coordinator.malibu.tech.",      // trailing-dot hostname
             "example.com:8080",
+            "host.io",
+            "hf.co/library/x",
+            "prod.internal:11434",
+            "prod.internal",
             "macbook.local",
             "gateway.corp",
             "::ffff:127.0.0.1",
+            "127.0.0.1",
             "0x7f.0.0.1",
+            "0177.0.0.1",                    // octal dotted IPv4
+            "0x7f000001",                    // one-piece hex IPv4
+            "2130706433",                    // one-piece decimal IPv4
         ] {
             XCTAssertFalse(BYOMDiscoveryPrivacy.isSafeRuntimeModelReference(leak), "must reject \(leak)")
         }
-        for ok in ["llama3.2:3b", "mistral:latest", "qwen2.5:7b", "gemma2:9b", "deepseek-r1:14b"] {
+        for ok in [
+            "llama3.2:3b", "mistral:latest", "qwen2.5:7b", "qwen2.5-coder:7b",
+            "gemma2:9b", "deepseek-r1:14b", "phi-3.5-mini", "mistral-7b-instruct-v0.2",
+        ] {
             XCTAssertTrue(BYOMDiscoveryPrivacy.isSafeRuntimeModelReference(ok), "must allow \(ok)")
         }
+        // The slash-bearing HF cache id form is a valid model reference (the
+        // runtime-ref gate additionally bans "/", but the shared sanitizer must
+        // not reject a legitimate cache id on hostname/TLD grounds).
+        XCTAssertTrue(BYOMDiscoveryPrivacy.isSafeModelReference("mlx-community/Llama-3.2-3B-Instruct-4bit"))
     }
 
     func testDiscoverCommandMirrorsWarningsToStderrInJSONMode() async throws {

--- a/phase3-binary/Tests/macprovider-cliTests/BYOMDiscoveryTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/BYOMDiscoveryTests.swift
@@ -134,6 +134,14 @@ final class BYOMDiscoveryTests: XCTestCase {
             "0177.0.0.1",                    // octal dotted IPv4
             "0x7f000001",                    // one-piece hex IPv4
             "2130706433",                    // one-piece decimal IPv4
+            "127.0.0.1:11434",               // encoded/plain IPv4 with :port
+            "0x7f000001:11434",
+            "2130706433:11434",
+            "0177.0.0.1:11434",
+            "model-127.0.0.1",               // IP literal embedded in a name
+            "model-0x7f000001",
+            "model-::1",
+            "2001:db8:85a3:0:0:8a2e:370:7334",  // uncompressed IPv6
         ] {
             XCTAssertFalse(BYOMDiscoveryPrivacy.isSafeRuntimeModelReference(leak), "must reject \(leak)")
         }

--- a/phase3-binary/Tests/macprovider-cliTests/BYOMDiscoveryTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/BYOMDiscoveryTests.swift
@@ -8,7 +8,13 @@ final class BYOMDiscoveryTests: XCTestCase {
     func testDiscoverCommandEmitsClosedSchemaWithNullableAdvisoryFields() async throws {
         let root = try temporaryDirectory("byom-schema")
         let cache = root.appendingPathComponent("hf", isDirectory: true)
-        let namespace = root.appendingPathComponent("ns")
+        let namespaceDir = root.appendingPathComponent("nsdir", isDirectory: true)
+        try FileManager.default.createDirectory(at: namespaceDir, withIntermediateDirectories: true)
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: namespaceDir.path)
+        let namespace = namespaceDir.appendingPathComponent("ns")
+        try Data(repeating: 0x37, count: 32).write(to: namespace)
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: namespace.path)
+        let namespaceBefore = try Data(contentsOf: namespace)
         try createMLXSnapshot(
             cacheRoot: cache,
             modelID: "mlx-community/Tiny-1B-4bit",
@@ -50,7 +56,81 @@ final class BYOMDiscoveryTests: XCTestCase {
         XCTAssertEqual(capabilities["max_context_tokens"] as? Int, 4096)
         let guidance = try XCTUnwrap(candidate["provider_guidance"] as? [String: Any])
         XCTAssertEqual(guidance["earning_path_class"] as? String, "local_inventory_only")
-        XCTAssertNotNil(try? Data(contentsOf: namespace))
+        // Discovery is read-only: a pre-existing salt is read, never rewritten.
+        XCTAssertEqual(try Data(contentsOf: namespace), namespaceBefore)
+    }
+
+    func testDiscoverIsReadOnlyWhenNamespaceMissing() async throws {
+        let root = try temporaryDirectory("byom-readonly")
+        let cache = root.appendingPathComponent("hf", isDirectory: true)
+        let namespace = root.appendingPathComponent("missing-ns")
+        try createMLXSnapshot(cacheRoot: cache, modelID: "mlx-community/Tiny-1B-4bit")
+
+        let document = await BYOMDiscoveryRunner(
+            environment: BYOMDiscoveryEnvironment(namespaceURL: namespace, mlxCacheRoot: cache, ollamaOrigin: nil)
+        ).discover()
+
+        // SPEC-046-R001: discovery MUST NOT provision the salt (no write).
+        XCTAssertFalse(FileManager.default.fileExists(atPath: namespace.path))
+        let candidate = try XCTUnwrap(document.candidates.first)
+        XCTAssertTrue(candidate.candidateID.hasPrefix("byom_unstable_"))
+        XCTAssertEqual(candidate.admissionState, "local_only")
+        XCTAssertTrue(candidate.warningCodes.contains("candidate_id_unstable"))
+    }
+
+    func testMLXWeightSymlinkIntoBlobsIsResolvedAndCounted() async throws {
+        let root = try temporaryDirectory("byom-symlink")
+        let cache = root.appendingPathComponent("hf", isDirectory: true)
+        // Mimic a real HF cache: weights live in blobs/ and the snapshot holds
+        // relative symlinks into them (the shape H1 must handle).
+        let repo = cache.appendingPathComponent("models--mlx-community--Tiny-1B-4bit", isDirectory: true)
+        let blobs = repo.appendingPathComponent("blobs", isDirectory: true)
+        let snapshot = repo.appendingPathComponent("snapshots", isDirectory: true)
+            .appendingPathComponent("0123456789abcdef0123456789abcdef01234567", isDirectory: true)
+        try FileManager.default.createDirectory(at: blobs, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: snapshot, withIntermediateDirectories: true)
+        try Data(#"{"max_position_embeddings":4096}"#.utf8).write(to: blobs.appendingPathComponent("config-blob"))
+        try Data(repeating: 0x7a, count: 4096).write(to: blobs.appendingPathComponent("weights-blob"))
+        // Use the path/string API so the destination stays a genuine RELATIVE
+        // symlink (the URL API would resolve it against the cwd).
+        try FileManager.default.createSymbolicLink(
+            atPath: snapshot.appendingPathComponent("config.json").path,
+            withDestinationPath: "../../blobs/config-blob"
+        )
+        try FileManager.default.createSymbolicLink(
+            atPath: snapshot.appendingPathComponent("model.safetensors").path,
+            withDestinationPath: "../../blobs/weights-blob"
+        )
+        // An escaping symlink must be ignored, never followed out of the cache.
+        try FileManager.default.createSymbolicLink(
+            atPath: snapshot.appendingPathComponent("escape.safetensors").path,
+            withDestinationPath: "/etc/hosts"
+        )
+
+        let document = await BYOMDiscoveryRunner(
+            environment: BYOMDiscoveryEnvironment(namespaceURL: root.appendingPathComponent("ns"), mlxCacheRoot: cache, ollamaOrigin: nil)
+        ).discover()
+
+        let candidate = try XCTUnwrap(document.candidates.first)
+        // Symlinked config + weights are resolved, so the model reads as ready.
+        XCTAssertEqual(candidate.readinessState, "ready")
+    }
+
+    func testRuntimeModelReferenceRejectsHostnameAndHostPortShapes() {
+        for leak in [
+            "coordinator.malibu.tech:443",
+            "prod.internal:11434",
+            "example.com:8080",
+            "macbook.local",
+            "gateway.corp",
+            "::ffff:127.0.0.1",
+            "0x7f.0.0.1",
+        ] {
+            XCTAssertFalse(BYOMDiscoveryPrivacy.isSafeRuntimeModelReference(leak), "must reject \(leak)")
+        }
+        for ok in ["llama3.2:3b", "mistral:latest", "qwen2.5:7b", "gemma2:9b", "deepseek-r1:14b"] {
+            XCTAssertTrue(BYOMDiscoveryPrivacy.isSafeRuntimeModelReference(ok), "must allow \(ok)")
+        }
     }
 
     func testDiscoverCommandMirrorsWarningsToStderrInJSONMode() async throws {

--- a/phase3-binary/Tests/macprovider-cliTests/BYOMDiscoveryTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/BYOMDiscoveryTests.swift
@@ -142,6 +142,11 @@ final class BYOMDiscoveryTests: XCTestCase {
             "model-0x7f000001",
             "model-::1",
             "2001:db8:85a3:0:0:8a2e:370:7334",  // uncompressed IPv6
+            "127.1",                         // legacy IPv4 shorthand (authority)
+            "127.0.1:11434",
+            "0177.1:11434",                  // octal shorthand + port
+            "0x7f.1:11434",                  // hex shorthand + port
+            "017700000001:11434",            // one-piece octal + port
         ] {
             XCTAssertFalse(BYOMDiscoveryPrivacy.isSafeRuntimeModelReference(leak), "must reject \(leak)")
         }

--- a/phase3-binary/Tests/macprovider-cliTests/BYOMDiscoveryTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/BYOMDiscoveryTests.swift
@@ -162,6 +162,14 @@ final class BYOMDiscoveryTests: XCTestCase {
         XCTAssertTrue(BYOMDiscoveryPrivacy.isSafeModelReference("mlx-community/Llama-3.2-3B-Instruct-4bit"))
     }
 
+    func testContextWindowParsingRejectsOutOfRangeNumberWithoutCrashing() {
+        // A hostile config.json must degrade to nil, never trap the process.
+        XCTAssertNil(BYOMDiscoveryJSON.contextWindowTokens(from: Data(#"{"max_position_embeddings":1e20}"#.utf8)))
+        XCTAssertNil(BYOMDiscoveryJSON.contextWindowTokens(from: Data(#"{"max_position_embeddings":-1e20}"#.utf8)))
+        XCTAssertNil(BYOMDiscoveryJSON.contextWindowTokens(from: Data(#"{"max_position_embeddings":1.5}"#.utf8)))
+        XCTAssertEqual(BYOMDiscoveryJSON.contextWindowTokens(from: Data(#"{"max_position_embeddings":4096}"#.utf8)), 4096)
+    }
+
     func testDiscoverCommandMirrorsWarningsToStderrInJSONMode() async throws {
         let root = try temporaryDirectory("byom-stderr")
         let command = try ModelsDiscoverCommand.parse([

--- a/phase3-binary/Tests/macprovider-cliTests/BYOMDiscoveryTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/BYOMDiscoveryTests.swift
@@ -1,0 +1,610 @@
+import ArgumentParser
+import Darwin
+import Foundation
+import XCTest
+@testable import macprovider_cli
+
+final class BYOMDiscoveryTests: XCTestCase {
+    func testDiscoverCommandEmitsClosedSchemaWithNullableAdvisoryFields() async throws {
+        let root = try temporaryDirectory("byom-schema")
+        let cache = root.appendingPathComponent("hf", isDirectory: true)
+        let namespace = root.appendingPathComponent("ns")
+        try createMLXSnapshot(
+            cacheRoot: cache,
+            modelID: "mlx-community/Tiny-1B-4bit",
+            configJSON: #"{"max_position_embeddings":4096}"#
+        )
+
+        let command = try ModelsDiscoverCommand.parse([
+            "--json",
+            "--local-discovery-namespace-path", namespace.path,
+            "--mlx-cache-dir", cache.path,
+            "--skip-ollama",
+        ])
+        let capture = await captureBYOMOutput {
+            try await command.run()
+        }
+
+        XCTAssertNil(capture.error)
+        let object = try jsonObject(capture.stdout)
+        XCTAssertEqual(object["schema"] as? String, "provider_byom_discovery.v1")
+        XCTAssertEqual(object["projection_sequence"] as? Int, 1)
+        XCTAssertEqual(object["cli_version"] as? String, CoordinatorClient.binaryVersion)
+        let adapters = try XCTUnwrap(object["adapters"] as? [[String: Any]])
+        XCTAssertEqual(adapters.first?["runtime_source"] as? String, "mlx_cache")
+        let candidates = try XCTUnwrap(object["candidates"] as? [[String: Any]])
+        let candidate = try XCTUnwrap(candidates.first)
+        XCTAssertEqual(candidate["runtime_source"] as? String, "mlx_cache")
+        XCTAssertEqual(candidate["served_model_ref"] as? String, "mlx-community/Tiny-1B-4bit")
+        XCTAssertTrue((candidate["candidate_id"] as? String)?.hasPrefix("byom_") == true)
+        XCTAssertEqual(candidate["locality"] as? String, "local_artifact")
+        XCTAssertEqual(candidate["readiness_state"] as? String, "ready")
+        XCTAssertEqual(candidate["evaluation_state"] as? String, "not_evaluated")
+        XCTAssertEqual(candidate["admission_state_source"] as? String, "local_default")
+        XCTAssertEqual(candidate["admission_state"] as? String, "offerable")
+        XCTAssertEqual(candidate["context_window_tokens"] as? Int, 4096)
+        XCTAssertTrue(candidate.keys.contains("catalog_model_key"))
+        let capabilities = try XCTUnwrap(candidate["capabilities"] as? [String: Any])
+        XCTAssertTrue(capabilities.keys.contains("tool_call_passthrough"))
+        XCTAssertTrue(capabilities["tool_call_passthrough"] is NSNull)
+        XCTAssertEqual(capabilities["max_context_tokens"] as? Int, 4096)
+        let guidance = try XCTUnwrap(candidate["provider_guidance"] as? [String: Any])
+        XCTAssertEqual(guidance["earning_path_class"] as? String, "local_inventory_only")
+        XCTAssertNotNil(try? Data(contentsOf: namespace))
+    }
+
+    func testDiscoverCommandMirrorsWarningsToStderrInJSONMode() async throws {
+        let root = try temporaryDirectory("byom-stderr")
+        let command = try ModelsDiscoverCommand.parse([
+            "--json",
+            "--local-discovery-namespace-path", root.appendingPathComponent("ns").path,
+            "--mlx-cache-dir", root.appendingPathComponent("missing-cache", isDirectory: true).path,
+            "--skip-ollama",
+        ])
+        let capture = await captureBYOMOutput {
+            try await command.run()
+        }
+
+        XCTAssertNil(capture.error)
+        XCTAssertNoThrow(try jsonObject(capture.stdout))
+        XCTAssertTrue(capture.stderr.contains("models discover warning: adapter_unavailable"))
+        XCTAssertFalse(capture.stderr.contains(root.path))
+    }
+
+    func testDiscoverCommandRequiresJSONFlag() async throws {
+        let command = try ModelsDiscoverCommand.parse(["--skip-ollama"])
+        let capture = await captureBYOMOutput {
+            try await command.run()
+        }
+
+        XCTAssertTrue(capture.stdout.isEmpty)
+        XCTAssertTrue(capture.stderr.contains("JSON-only"))
+        XCTAssertEqual((capture.error as? ExitCode), ExitCode(2))
+    }
+
+    func testCandidateIDIsStableWithinNamespaceAndScopedByRuntimeSource() {
+        let namespace = Data(repeating: 0x42, count: 32)
+        let first = BYOMCandidateIdentity.candidateID(
+            namespace: namespace,
+            runtimeSource: "mlx_cache",
+            servedModelRef: "MLX-Community/Tiny-1B"
+        )
+        let second = BYOMCandidateIdentity.candidateID(
+            namespace: namespace,
+            runtimeSource: "mlx_cache",
+            servedModelRef: "mlx-community/tiny-1b"
+        )
+        let otherRuntime = BYOMCandidateIdentity.candidateID(
+            namespace: namespace,
+            runtimeSource: "ollama_loopback",
+            servedModelRef: "mlx-community/tiny-1b"
+        )
+
+        XCTAssertEqual(first.0, second.0)
+        XCTAssertNotEqual(first.0, otherRuntime.0)
+        XCTAssertEqual(first.1.map(\.rawValue), [])
+        XCTAssertTrue(first.0.range(of: #"^byom_[a-z2-7]+$"#, options: .regularExpression) != nil)
+    }
+
+    func testInvalidNamespacePermissionsKeepCandidateLocalOnly() async throws {
+        let root = try temporaryDirectory("byom-ns")
+        let cache = root.appendingPathComponent("hf", isDirectory: true)
+        let namespace = root.appendingPathComponent("ns")
+        try Data(repeating: 0x11, count: 32).write(to: namespace)
+        try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: namespace.path)
+        try createMLXSnapshot(cacheRoot: cache, modelID: "mlx-community/Tiny-1B-4bit")
+
+        let document = await BYOMDiscoveryRunner(
+            environment: BYOMDiscoveryEnvironment(namespaceURL: namespace, mlxCacheRoot: cache, ollamaOrigin: nil)
+        ).discover()
+
+        XCTAssertTrue(document.warnings.contains("namespace_permission_invalid"))
+        let candidate = try XCTUnwrap(document.candidates.first)
+        XCTAssertTrue(candidate.candidateID.hasPrefix("byom_unstable_"))
+        XCTAssertEqual(candidate.admissionState, "local_only")
+        XCTAssertTrue(candidate.warningCodes.contains("candidate_id_unstable"))
+        XCTAssertTrue(candidate.warningCodes.contains("namespace_permission_invalid"))
+    }
+
+    func testInsecureNamespaceDirectoryKeepsCandidateLocalOnly() async throws {
+        let root = try temporaryDirectory("byom-ns-dir")
+        let insecureDir = root.appendingPathComponent("insecure", isDirectory: true)
+        let cache = root.appendingPathComponent("hf", isDirectory: true)
+        let namespace = insecureDir.appendingPathComponent("ns")
+        try FileManager.default.createDirectory(at: insecureDir, withIntermediateDirectories: true)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: insecureDir.path)
+        try Data(repeating: 0x11, count: 32).write(to: namespace)
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: namespace.path)
+        try createMLXSnapshot(cacheRoot: cache, modelID: "mlx-community/Tiny-1B-4bit")
+
+        let document = await BYOMDiscoveryRunner(
+            environment: BYOMDiscoveryEnvironment(namespaceURL: namespace, mlxCacheRoot: cache, ollamaOrigin: nil)
+        ).discover()
+
+        let candidate = try XCTUnwrap(document.candidates.first)
+        XCTAssertTrue(document.warnings.contains("namespace_permission_invalid"))
+        XCTAssertEqual(candidate.admissionState, "local_only")
+        XCTAssertTrue(candidate.warningCodes.contains("namespace_permission_invalid"))
+    }
+
+    func testLoopbackOriginValidatorAcceptsOnlyLiteralLoopbackHTTPOrigins() {
+        XCTAssertNotNil(BYOMLoopbackOriginValidator.validatedHTTPOrigin("http://127.0.0.1:11434"))
+        XCTAssertNotNil(BYOMLoopbackOriginValidator.validatedHTTPOrigin("http://127.9.8.7:11434"))
+        XCTAssertNotNil(BYOMLoopbackOriginValidator.validatedHTTPOrigin("http://[::1]:11434"))
+
+        XCTAssertNil(BYOMLoopbackOriginValidator.validatedHTTPOrigin("https://127.0.0.1:11434"))
+        XCTAssertNil(BYOMLoopbackOriginValidator.validatedHTTPOrigin("http://localhost:11434"))
+        XCTAssertNil(BYOMLoopbackOriginValidator.validatedHTTPOrigin("http://LOCALHOST:11434"))
+        XCTAssertNil(BYOMLoopbackOriginValidator.validatedHTTPOrigin("http://127.0.0.1.example.com:11434"))
+        XCTAssertNil(BYOMLoopbackOriginValidator.validatedHTTPOrigin("http://0.0.0.0:11434"))
+        XCTAssertNil(BYOMLoopbackOriginValidator.validatedHTTPOrigin("http://192.168.1.10:11434"))
+        XCTAssertNil(BYOMLoopbackOriginValidator.validatedHTTPOrigin("http://127.0.0.1"))
+        XCTAssertNil(BYOMLoopbackOriginValidator.validatedHTTPOrigin("http://user:pass@127.0.0.1:11434"))
+        XCTAssertNil(BYOMLoopbackOriginValidator.validatedHTTPOrigin("unix:///tmp/ollama.sock"))
+    }
+
+    func testOllamaDiscoveryUsesHermeticLoopbackResponseAndRedactsUnsafeFields() async throws {
+        let root = try temporaryDirectory("byom-ollama")
+        let namespace = root.appendingPathComponent("ns")
+        let cache = root.appendingPathComponent("hf", isDirectory: true)
+        let leakedEndpoint = "http://127.0.0.1:11434"
+        let secret = "sk-local-secret"
+        let body = """
+        {"models":[
+          {"name":"Tiny-Ollama-1B-Q4","details":{"family":"llama","quantization_level":"Q4_0"}},
+          {"name":"/Users/augstar/\(secret)<script>","details":{"family":"bad"}},
+          {"name":"http://127.0.0.1:11434/\(secret)?api_key=hidden","details":{"family":"bad"}},
+          {"name":"127.0.0.1:11434","details":{"family":"bad"}},
+          {"name":"127.0.0.1","details":{"family":"bad"}},
+          {"name":"localhost","details":{"family":"bad"}},
+          {"name":"[::1]","details":{"family":"bad"}},
+          {"name":"sk-local-secret","details":{"family":"bad"}},
+          {"name":"ghp_abcdefghijklmnopqrstuvwxyz0123456789","details":{"family":"bad"}},
+          {"name":"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.signature000","details":{"family":"bad"}},
+          {"name":"safe-name","details":{"family":"http://127.0.0.1:11434/\(secret)","quantization_level":"api_key=hidden"}}
+        ]}
+        """
+        let client = StubBYOMHTTPClient(response: BYOMHTTPResponse(
+            statusCode: 200,
+            headers: [("content-type", "application/json")],
+            body: Data(body.utf8)
+        ))
+        let document = await BYOMDiscoveryRunner(
+            environment: BYOMDiscoveryEnvironment(
+                namespaceURL: namespace,
+                mlxCacheRoot: cache,
+                ollamaOrigin: leakedEndpoint
+            ),
+            httpClient: client
+        ).discover()
+        let encoded = try ModelSwitchingWireCodec.encode(document)
+
+        XCTAssertEqual(document.candidates.count, 2)
+        let candidate = try XCTUnwrap(document.candidates.first { $0.servedModelRef == "ollama:Tiny-Ollama-1B-Q4" })
+        XCTAssertEqual(candidate.runtimeSource, "ollama_loopback")
+        XCTAssertEqual(candidate.servedModelRef, "ollama:Tiny-Ollama-1B-Q4")
+        XCTAssertEqual(candidate.capabilities.chatCompletions, true)
+        XCTAssertEqual(candidate.capabilities.family, "llama")
+        XCTAssertEqual(candidate.capabilities.quantization, "Q4_0")
+        let safeNameCandidate = try XCTUnwrap(document.candidates.first { $0.servedModelRef == "ollama:safe-name" })
+        XCTAssertNil(safeNameCandidate.capabilities.family)
+        XCTAssertNil(safeNameCandidate.capabilities.quantization)
+        XCTAssertFalse(encoded.contains(leakedEndpoint))
+        XCTAssertFalse(encoded.contains(secret))
+        XCTAssertFalse(encoded.contains("/Users/augstar"))
+        XCTAssertFalse(encoded.contains("api_key"))
+        XCTAssertFalse(encoded.contains("ghp_"))
+        XCTAssertFalse(encoded.contains("eyJhbGci"))
+        XCTAssertFalse(encoded.lowercased().contains("<script>"))
+    }
+
+    func testRejectedAdapterOriginIsReportedWithoutEndpointLeak() async throws {
+        let root = try temporaryDirectory("byom-rejected-origin")
+        let origin = "http://localhost:11434"
+        let document = await BYOMDiscoveryRunner(
+            environment: BYOMDiscoveryEnvironment(
+                namespaceURL: root.appendingPathComponent("ns"),
+                mlxCacheRoot: root.appendingPathComponent("hf", isDirectory: true),
+                ollamaOrigin: origin
+            ),
+            httpClient: StubBYOMHTTPClient(response: BYOMHTTPResponse(statusCode: 200, headers: [], body: Data()))
+        ).discover()
+        let encoded = try ModelSwitchingWireCodec.encode(document)
+
+        XCTAssertTrue(document.warnings.contains("adapter_rejected_non_loopback"))
+        XCTAssertEqual(document.adapters.first { $0.runtimeSource == "ollama_loopback" }?.status, "rejected")
+        XCTAssertFalse(encoded.contains(origin))
+    }
+
+    func testOversizedOllamaResponseIsTruncatedNotParsed() async throws {
+        let root = try temporaryDirectory("byom-oversized")
+        let body = Data(repeating: UInt8(ascii: "{"), count: BYOMDiscoveryHTTPBounds.maxBodyBytes + 1)
+        let client = StubBYOMHTTPClient(response: BYOMHTTPResponse(statusCode: 200, headers: [], body: body))
+        let document = await BYOMDiscoveryRunner(
+            environment: BYOMDiscoveryEnvironment(
+                namespaceURL: root.appendingPathComponent("ns"),
+                mlxCacheRoot: root.appendingPathComponent("hf", isDirectory: true),
+                ollamaOrigin: "http://127.0.0.1:11434"
+            ),
+            httpClient: client
+        ).discover()
+
+        XCTAssertTrue(document.warnings.contains("adapter_response_truncated"))
+        XCTAssertTrue(document.candidates.isEmpty)
+        XCTAssertEqual(document.adapters.first { $0.runtimeSource == "ollama_loopback" }?.status, "truncated")
+    }
+
+    func testURLSessionClientStopsReadingOversizedLoopbackBody() async throws {
+        let bodySize = 16 * 1024
+        let server = try OneShotHTTPServer(
+            body: Data(repeating: UInt8(ascii: "x"), count: bodySize),
+            chunkSize: 256,
+            chunkDelayMicroseconds: 2_000
+        )
+
+        do {
+            _ = try await BYOMURLSessionHTTPClient().get(
+                server.url,
+                maxHeaderBytes: BYOMDiscoveryHTTPBounds.maxHeaderBytes,
+                maxBodyBytes: 1024
+            )
+            XCTFail("expected oversized streaming response to truncate")
+        } catch BYOMDiscoveryAdapterError.truncated {
+            try await Task.sleep(nanoseconds: 50_000_000)
+            XCTAssertTrue(server.bytesAttempted >= 1024)
+            XCTAssertLessThan(server.bytesAttempted, bodySize)
+        }
+    }
+
+    func testURLSessionClientRejectsOversizedLoopbackHeaders() async throws {
+        let server = try OneShotHTTPServer(
+            headers: [("X-Too-Large", String(repeating: "a", count: BYOMDiscoveryHTTPBounds.maxHeaderBytes + 1))],
+            body: Data(#"{"models":[]}"#.utf8)
+        )
+
+        do {
+            _ = try await BYOMURLSessionHTTPClient().get(
+                server.url,
+                maxHeaderBytes: BYOMDiscoveryHTTPBounds.maxHeaderBytes,
+                maxBodyBytes: BYOMDiscoveryHTTPBounds.maxBodyBytes
+            )
+            XCTFail("expected oversized response headers to truncate")
+        } catch BYOMDiscoveryAdapterError.truncated {
+            XCTAssertEqual(server.requestCount, 1)
+        }
+    }
+
+    func testURLSessionClientRefusesRedirects() async throws {
+        let server = try OneShotHTTPServer(
+            statusCode: 302,
+            headers: [("Location", "http://192.168.1.10:11434/api/tags")],
+            body: Data()
+        )
+
+        let response = try await BYOMURLSessionHTTPClient().get(
+            server.url,
+            maxHeaderBytes: BYOMDiscoveryHTTPBounds.maxHeaderBytes,
+            maxBodyBytes: BYOMDiscoveryHTTPBounds.maxBodyBytes
+        )
+
+        XCTAssertEqual(response.statusCode, 302)
+        XCTAssertEqual(server.requestCount, 1)
+    }
+
+    func testURLSessionClientUsesDirectNoProxyConfiguration() {
+        let configuration = BYOMURLSessionHTTPClient.directLoopbackConfiguration()
+
+        XCTAssertEqual(configuration.connectionProxyDictionary?.isEmpty, true)
+        XCTAssertNil(configuration.urlCache)
+        XCTAssertNil(configuration.httpCookieStorage)
+        XCTAssertEqual(configuration.httpCookieAcceptPolicy, .never)
+        XCTAssertFalse(configuration.waitsForConnectivity)
+    }
+
+    func testTransportFailureIsUnavailableNotMalformed() async throws {
+        let root = try temporaryDirectory("byom-transport")
+        let client = StubBYOMHTTPClient(error: URLError(.cannotConnectToHost))
+        let document = await BYOMDiscoveryRunner(
+            environment: BYOMDiscoveryEnvironment(
+                namespaceURL: root.appendingPathComponent("ns"),
+                mlxCacheRoot: root.appendingPathComponent("hf", isDirectory: true),
+                ollamaOrigin: "http://127.0.0.1:11434"
+            ),
+            httpClient: client
+        ).discover()
+
+        XCTAssertTrue(document.warnings.contains("adapter_unavailable"))
+        XCTAssertFalse(document.warnings.contains("adapter_malformed_response"))
+        XCTAssertEqual(document.adapters.first { $0.runtimeSource == "ollama_loopback" }?.status, "unavailable")
+    }
+
+    func testMalformedOllamaResponseEmitsWarningNotCandidate() async throws {
+        let root = try temporaryDirectory("byom-malformed")
+        let client = StubBYOMHTTPClient(response: BYOMHTTPResponse(
+            statusCode: 200,
+            headers: [("content-type", "application/json")],
+            body: Data(#"{"models":[{"name":"unterminated"}"#.utf8)
+        ))
+        let document = await BYOMDiscoveryRunner(
+            environment: BYOMDiscoveryEnvironment(
+                namespaceURL: root.appendingPathComponent("ns"),
+                mlxCacheRoot: root.appendingPathComponent("hf", isDirectory: true),
+                ollamaOrigin: "http://127.0.0.1:11434"
+            ),
+            httpClient: client
+        ).discover()
+
+        XCTAssertTrue(document.warnings.contains("adapter_malformed_response"))
+        XCTAssertTrue(document.candidates.isEmpty)
+        XCTAssertEqual(document.adapters.first { $0.runtimeSource == "ollama_loopback" }?.status, "malformed")
+    }
+
+    func testDiscoveryDoesNotMutateModelCache() async throws {
+        let root = try temporaryDirectory("byom-readonly")
+        let cache = root.appendingPathComponent("hf", isDirectory: true)
+        let namespace = root.appendingPathComponent("ns")
+        try createMLXSnapshot(cacheRoot: cache, modelID: "mlx-community/Tiny-1B-4bit")
+        let before = try recursiveRelativePaths(cache)
+
+        _ = await BYOMDiscoveryRunner(
+            environment: BYOMDiscoveryEnvironment(namespaceURL: namespace, mlxCacheRoot: cache, ollamaOrigin: nil)
+        ).discover()
+
+        let after = try recursiveRelativePaths(cache)
+        XCTAssertEqual(before, after)
+    }
+
+    private func createMLXSnapshot(
+        cacheRoot: URL,
+        modelID: String,
+        configJSON: String = #"{"max_position_embeddings":2048}"#
+    ) throws {
+        let repo = cacheRoot
+            .appendingPathComponent("models--" + modelID.replacingOccurrences(of: "/", with: "--"), isDirectory: true)
+            .appendingPathComponent("snapshots", isDirectory: true)
+            .appendingPathComponent("0123456789abcdef0123456789abcdef01234567", isDirectory: true)
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        try Data(configJSON.utf8).write(to: repo.appendingPathComponent("config.json"))
+        try Data(repeating: 0x7a, count: 128).write(to: repo.appendingPathComponent("model.safetensors"))
+    }
+
+    private func temporaryDirectory(_ name: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(name)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func jsonObject(_ stdout: String) throws -> [String: Any] {
+        let line = try XCTUnwrap(stdout.split(whereSeparator: \.isNewline).first { line in
+            line.trimmingCharacters(in: .whitespaces).hasPrefix("{")
+        })
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any])
+    }
+
+    private func recursiveRelativePaths(_ root: URL) throws -> [String] {
+        guard let enumerator = FileManager.default.enumerator(at: root, includingPropertiesForKeys: [.isRegularFileKey]) else {
+            return []
+        }
+        var result: [String] = []
+        for case let url as URL in enumerator {
+            result.append(String(url.path.dropFirst(root.path.count + 1)))
+        }
+        return result.sorted()
+    }
+}
+
+private final class StubBYOMHTTPClient: BYOMDiscoveryHTTPClient, @unchecked Sendable {
+    let response: BYOMHTTPResponse?
+    let error: Error?
+
+    init(response: BYOMHTTPResponse) {
+        self.response = response
+        self.error = nil
+    }
+
+    init(error: Error) {
+        self.response = nil
+        self.error = error
+    }
+
+    func get(_ url: URL, maxHeaderBytes: Int, maxBodyBytes: Int) async throws -> BYOMHTTPResponse {
+        if let error {
+            throw error
+        }
+        return try XCTUnwrap(response)
+    }
+}
+
+private final class OneShotHTTPServer {
+    let url: URL
+    private let socketFD: Int32
+    private let lock = NSLock()
+    private var attempted = 0
+
+    var bytesAttempted: Int {
+        lock.withLock { attempted }
+    }
+
+    private var requests = 0
+
+    var requestCount: Int {
+        lock.withLock { requests }
+    }
+
+    init(
+        statusCode: Int = 200,
+        headers: [(String, String)] = [],
+        body: Data,
+        chunkSize: Int = 512,
+        chunkDelayMicroseconds: useconds_t = 0
+    ) throws {
+        let fd = Darwin.socket(AF_INET, SOCK_STREAM, 0)
+        guard fd >= 0 else { throw POSIXError(.init(rawValue: errno) ?? .EIO) }
+        socketFD = fd
+
+        var reuse: Int32 = 1
+        setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &reuse, socklen_t(MemoryLayout<Int32>.size))
+
+        var address = sockaddr_in()
+        address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        address.sin_family = sa_family_t(AF_INET)
+        address.sin_port = in_port_t(0).bigEndian
+        address.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
+
+        let bindResult = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { rebound in
+                Darwin.bind(fd, rebound, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard bindResult == 0 else { throw POSIXError(.init(rawValue: errno) ?? .EIO) }
+        guard Darwin.listen(fd, 1) == 0 else { throw POSIXError(.init(rawValue: errno) ?? .EIO) }
+
+        var bound = sockaddr_in()
+        var boundLength = socklen_t(MemoryLayout<sockaddr_in>.size)
+        let nameResult = withUnsafeMutablePointer(to: &bound) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { rebound in
+                Darwin.getsockname(fd, rebound, &boundLength)
+            }
+        }
+        guard nameResult == 0 else { throw POSIXError(.init(rawValue: errno) ?? .EIO) }
+        url = try XCTUnwrap(URL(string: "http://127.0.0.1:\(UInt16(bigEndian: bound.sin_port))/api/tags"))
+
+        DispatchQueue.global(qos: .userInitiated).async { [fd, weak self] in
+            let client = Darwin.accept(fd, nil, nil)
+            guard client >= 0 else { return }
+            defer { Darwin.close(client) }
+
+            var noSignal: Int32 = 1
+            setsockopt(client, SOL_SOCKET, SO_NOSIGPIPE, &noSignal, socklen_t(MemoryLayout<Int32>.size))
+
+            var buffer = [UInt8](repeating: 0, count: 1024)
+            _ = Darwin.read(client, &buffer, buffer.count)
+
+            self?.recordRequest()
+
+            var responseHeaders = [
+                "HTTP/1.1 \(statusCode) \(Self.reasonPhrase(for: statusCode))",
+                "Content-Type: application/json",
+                "Content-Length: \(body.count)",
+                "Connection: close",
+            ]
+            responseHeaders.append(contentsOf: headers.map { "\($0.0): \($0.1)" })
+            let header = responseHeaders.joined(separator: "\r\n") + "\r\n\r\n"
+            guard Self.writeAll(data: Data(header.utf8), to: client) else { return }
+            var offset = 0
+            while offset < body.count {
+                let next = min(offset + chunkSize, body.count)
+                let chunk = body[offset..<next]
+                self?.recordAttempt(chunk.count)
+                guard Self.writeAll(data: Data(chunk), to: client) else { return }
+                offset = next
+                if chunkDelayMicroseconds > 0 {
+                    usleep(chunkDelayMicroseconds)
+                }
+            }
+        }
+    }
+
+    deinit {
+        Darwin.close(socketFD)
+    }
+
+    private func recordAttempt(_ count: Int) {
+        lock.withLock {
+            attempted += count
+        }
+    }
+
+    private func recordRequest() {
+        lock.withLock {
+            requests += 1
+        }
+    }
+
+    private static func reasonPhrase(for statusCode: Int) -> String {
+        switch statusCode {
+        case 200:
+            return "OK"
+        case 302:
+            return "Found"
+        default:
+            return "Status"
+        }
+    }
+
+    private static func writeAll(data: Data, to fd: Int32) -> Bool {
+        data.withUnsafeBytes { rawBuffer in
+            guard let baseAddress = rawBuffer.baseAddress else { return true }
+            var sent = 0
+            while sent < rawBuffer.count {
+                let result = Darwin.write(fd, baseAddress.advanced(by: sent), rawBuffer.count - sent)
+                if result <= 0 {
+                    return false
+                }
+                sent += result
+            }
+            return true
+        }
+    }
+}
+
+private struct BYOMCapturedOutput {
+    let stdout: String
+    let stderr: String
+    let error: Error?
+}
+
+private func captureBYOMOutput(_ body: () async throws -> Void) async -> BYOMCapturedOutput {
+    let stdoutPipe = Pipe()
+    let stderrPipe = Pipe()
+    let savedStdout = dup(STDOUT_FILENO)
+    let savedStderr = dup(STDERR_FILENO)
+    dup2(stdoutPipe.fileHandleForWriting.fileDescriptor, STDOUT_FILENO)
+    dup2(stderrPipe.fileHandleForWriting.fileDescriptor, STDERR_FILENO)
+
+    let error: Error?
+    do {
+        try await body()
+        error = nil
+    } catch let caught {
+        error = caught
+    }
+
+    fflush(stdout)
+    fflush(stderr)
+    dup2(savedStdout, STDOUT_FILENO)
+    dup2(savedStderr, STDERR_FILENO)
+    close(savedStdout)
+    close(savedStderr)
+    stdoutPipe.fileHandleForWriting.closeFile()
+    stderrPipe.fileHandleForWriting.closeFile()
+
+    let stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+    let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+    return BYOMCapturedOutput(
+        stdout: String(decoding: stdoutData, as: UTF8.self),
+        stderr: String(decoding: stderrData, as: UTF8.self),
+        error: error
+    )
+}


### PR DESCRIPTION
## Summary

BYOM slice-2: the provider-local model **discovery** CLI foundation
(`models discover`). First implementation slice of the BYOM epic (#1240); builds
directly on the merged slice-1 contract lock (#1368). Rebased onto current `main`.

Closes #1250. Advances #1240. Reworks/supersedes #1260.

`models discover --json` emits the strict closed `provider_byom_discovery.v1`
envelope (JSON-only in this release), inventorying local model candidates
**without joining the network, earning, or mutating serving state**. Adapters:
read-only MLX/HuggingFace cache scan and an Ollama-compatible **loopback-only**
adapter. Discovered candidates carry `earning_path_class: "local_inventory_only"`
with honest non-earning labels — exactly the disclosure contract slice-1 locked.

## Rework vs #1260

Stacked-rebased off the merged slice-1 base onto `main` (clean), then hardened
against a full 3-lane codex audit.

## Audit (3-lane codex, full `origin/main..HEAD` diff, bar 0 C/H/M)

Final: **all three lanes PASS (0 CRITICAL / 0 HIGH / 0 MEDIUM).** Findings fixed:

- **HIGH — symlinked HF weights ignored:** real HF snapshots store weights as
  symlinks into `blobs/`, so ready models reported `needs_weights`. Now resolve
  symlinks for config + weights and count the target, with a cache-root
  containment check that blocks symlink escape.
- **HIGH — model-ref privacy leak:** the runtime model-ref sanitizer accepted
  hostnames, host:port, encoded/embedded IPs, and IPv4 shorthands. Rewrote
  `looksLikeEndpoint` (embedded IPv4/IPv6, TLD-hostname, one-piece dwords) and
  added a **structural authority guard** to `isSafeRuntimeModelReference` that
  rejects any all-numeric/hex dotted authority — closing every IPv4 shorthand by
  construction rather than enumeration. Validated 0 false-positives on real model
  names (`llama3.2:3b`, `qwen2.5-coder:7b`, `mistral-7b-instruct-v0.2`, …).
- **MEDIUM ×4:** `models discover` is now **read-only** (no salt provisioning;
  absent → `candidate_id_unstable`, per SPEC-046-R001); config.json is size-gated
  **before** read; the cache dir is streamed via a **bounded** enumerator (with a
  missing-dir guard preserving the prior unavailable semantics); snapshot
  inspection is **sorted + bounded** (deterministic).
- **MEDIUM — crash on hostile metadata:** `Int(_:)` on an out-of-range JSON
  double (`1e20`) trapped; now `Int(exactly:)` degrades to nil.

Locking tests added for each; the discovery contract stays honest end to end.

## Money-path invariant (unchanged)

Discovery cannot mint credit, join the network, or imply earning. A discovered
non-catalog model is `local_inventory_only`. Positive credit still requires
catalog-verified identity + a settlement-capable receipt (SPEC-022).

## Tests

- `cd phase3-binary && swift build --product macprovider-cli`
- `cd phase3-binary && swift test --filter BYOMDiscovery` (21/21)

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "issue": "https://github.com/Augustas11/macprovider/issues/1250",
  "specs": ["SPEC-001", "SPEC-046", "SPEC-047"],
  "requirements": [
    "SPEC-046-R001",
    "SPEC-046-R002",
    "SPEC-046-R003",
    "SPEC-046-R004",
    "SPEC-046-R006",
    "SPEC-046-R007",
    "SPEC-046-R008"
  ],
  "authority_domains": ["provider-byom-discovery"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "cd phase3-binary && swift test --filter macprovider_cliTests.BYOMDiscoveryTests",
    "cd phase3-binary && swift test --filter macprovider_cliTests",
    "git diff --check --cached"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
