### PR TITLE
Checkpoint money SQLite WAL under load

### DIFF
--- a/phase4-coordinator/cmd/coordinator/main.go
+++ b/phase4-coordinator/cmd/coordinator/main.go
@@ -363,7 +363,7 @@ func main() {
 	shutdownCtx, stopBackground := context.WithCancel(context.Background())
 	defer stopBackground()
 	moneySQLiteActivity := newMoneySQLiteActivity(time.Now())
-	startMoneySQLiteWALCheckpointer(shutdownCtx, moneyCheckpointDB, metricsHandle, logger, moneySQLiteActivity)
+	startMoneySQLiteWALCheckpointer(shutdownCtx, moneyCheckpointDB, metricsHandle, logger, moneySQLiteActivity, cfg.Storage.DBPath)
 	// SPEC-017 v0.1.8 Step 2 — rollup runner. Reads OLTP source
 	// tables via `statsPools.Rollup`, writes the seven
 	// stats_* + stats_components_health + stats_rewards_populated
@@ -1474,9 +1474,32 @@ type settlementReceiptAuditOutboxObserver interface {
 }
 
 const (
-	moneySQLiteCheckpointIdleInterval = 30 * time.Second
-	moneySQLiteCheckpointTimeout      = time.Second
+	moneySQLiteCheckpointPollInterval   = 30 * time.Second
+	moneySQLiteCheckpointIdleInterval   = 30 * time.Second
+	moneySQLiteCheckpointMinTimeout     = 15 * time.Second
+	moneySQLiteCheckpointMaxTimeout     = 5 * time.Minute
+	moneySQLiteCheckpointBytesPerSecond = 32 << 20
 )
+
+type moneySQLiteWALCheckpointerConfig struct {
+	PollInterval   time.Duration
+	IdleInterval   time.Duration
+	MinTimeout     time.Duration
+	MaxTimeout     time.Duration
+	BytesPerSecond int64
+	DBPath         string
+}
+
+func defaultMoneySQLiteWALCheckpointerConfig(dbPath string) moneySQLiteWALCheckpointerConfig {
+	return moneySQLiteWALCheckpointerConfig{
+		PollInterval:   moneySQLiteCheckpointPollInterval,
+		IdleInterval:   moneySQLiteCheckpointIdleInterval,
+		MinTimeout:     moneySQLiteCheckpointMinTimeout,
+		MaxTimeout:     moneySQLiteCheckpointMaxTimeout,
+		BytesPerSecond: moneySQLiteCheckpointBytesPerSecond,
+		DBPath:         dbPath,
+	}
+}
 
 type moneySQLiteActivity struct {
 	lastUnixNano atomic.Int64
@@ -1520,39 +1543,109 @@ type moneySQLiteIdleTracker interface {
 	IdleFor(time.Time) time.Duration
 }
 
-func startMoneySQLiteWALCheckpointer(ctx context.Context, db *sql.DB, observer sqliteutil.WALObserver, logger zerolog.Logger, idle moneySQLiteIdleTracker) {
-	startMoneySQLiteWALCheckpointerWithConfig(ctx, db, observer, logger, idle, moneySQLiteCheckpointIdleInterval, moneySQLiteCheckpointTimeout)
+func startMoneySQLiteWALCheckpointer(ctx context.Context, db *sql.DB, observer sqliteutil.WALObserver, logger zerolog.Logger, idle moneySQLiteIdleTracker, dbPath string) {
+	startMoneySQLiteWALCheckpointerWithConfig(ctx, db, observer, logger, idle, defaultMoneySQLiteWALCheckpointerConfig(dbPath))
 }
 
-func startMoneySQLiteWALCheckpointerWithConfig(ctx context.Context, db *sql.DB, observer sqliteutil.WALObserver, logger zerolog.Logger, idle moneySQLiteIdleTracker, idleInterval, checkpointTimeout time.Duration) {
+func startMoneySQLiteWALCheckpointerWithConfig(ctx context.Context, db *sql.DB, observer sqliteutil.WALObserver, logger zerolog.Logger, idle moneySQLiteIdleTracker, cfg moneySQLiteWALCheckpointerConfig) {
 	if db == nil {
 		return
 	}
-	if idleInterval <= 0 || checkpointTimeout <= 0 {
+	if cfg.PollInterval <= 0 || cfg.IdleInterval <= 0 || cfg.MinTimeout <= 0 || cfg.MaxTimeout <= 0 || cfg.BytesPerSecond <= 0 {
 		return
 	}
-	run := func() {
-		checkpointCtx, cancel := context.WithTimeout(ctx, checkpointTimeout)
-		defer cancel()
-		if err := sqliteutil.RunWALCheckpoint(checkpointCtx, db, "wal_checkpoint", observer); err != nil {
-			logger.Warn().Err(err).Msg("money sqlite WAL checkpoint failed")
-		}
-	}
 	go func() {
-		ticker := time.NewTicker(idleInterval)
+		ticker := time.NewTicker(cfg.PollInterval)
 		defer ticker.Stop()
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				if idle != nil && idle.IdleFor(time.Now()) < idleInterval {
-					continue
-				}
-				run()
+				runMoneySQLiteWALCheckpoint(ctx, db, observer, logger, idle, cfg)
 			}
 		}
 	}()
+}
+
+func moneySQLiteCheckpointTimeout(walBytes int64, cfg moneySQLiteWALCheckpointerConfig) time.Duration {
+	minTimeout := cfg.MinTimeout
+	maxTimeout := cfg.MaxTimeout
+	if maxTimeout < minTimeout {
+		maxTimeout = minTimeout
+	}
+	if walBytes <= 0 || cfg.BytesPerSecond <= 0 {
+		return minTimeout
+	}
+	maxSeconds := int64(maxTimeout / time.Second)
+	if maxSeconds <= 0 {
+		return minTimeout
+	}
+	if walBytes/cfg.BytesPerSecond >= maxSeconds {
+		return maxTimeout
+	}
+	timeout := time.Duration(walBytes/cfg.BytesPerSecond)*time.Second +
+		time.Duration(walBytes%cfg.BytesPerSecond)*time.Second/time.Duration(cfg.BytesPerSecond)
+	if timeout < minTimeout {
+		return minTimeout
+	}
+	if timeout > maxTimeout {
+		return maxTimeout
+	}
+	return timeout
+}
+
+func moneySQLiteCheckpointDecision(idle, idleInterval time.Duration, walBytes int64, cfg moneySQLiteWALCheckpointerConfig) (sqliteutil.WALCheckpointMode, time.Duration) {
+	mode := sqliteutil.WALCheckpointPassive
+	if idleInterval > 0 && idle >= idleInterval {
+		mode = sqliteutil.WALCheckpointTruncate
+	}
+	return mode, moneySQLiteCheckpointTimeout(walBytes, cfg)
+}
+
+// moneySQLiteShouldFollowUpTruncate is the #1374 live-soak shrink path:
+// PASSIVE copies frames without waiting; busy==0 means that copy finished.
+// A timeout-bounded TRUNCATE then shrinks the sidecar file. RESTART is never
+// used. The remaining deadline is the only wait bound if a reader still holds
+// the WAL. Idle tracking stays the existing buyer-HTTP activity signal from
+// #1211; expanding it is out of this slice.
+func moneySQLiteShouldFollowUpTruncate(mode sqliteutil.WALCheckpointMode, busy int64, remaining time.Duration) bool {
+	return mode == sqliteutil.WALCheckpointPassive && busy == 0 && remaining > 0
+}
+
+func runMoneySQLiteWALCheckpoint(ctx context.Context, db *sql.DB, observer sqliteutil.WALObserver, logger zerolog.Logger, idle moneySQLiteIdleTracker, cfg moneySQLiteWALCheckpointerConfig) {
+	idleFor := time.Duration(0)
+	if idle != nil {
+		idleFor = idle.IdleFor(time.Now())
+	}
+	walBytes := sqliteutil.WALFileSize(cfg.DBPath)
+	mode, timeout := moneySQLiteCheckpointDecision(idleFor, cfg.IdleInterval, walBytes, cfg)
+	if timeout <= 0 {
+		return
+	}
+	if err := sqliteutil.SetBusyTimeout(ctx, db, timeout); err != nil {
+		logger.Warn().Err(err).Int64("wal_bytes", walBytes).Msg("money sqlite WAL busy_timeout failed")
+	}
+	deadline := time.Now().Add(timeout)
+	checkpointCtx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
+	result, err := sqliteutil.RunWALCheckpointMode(checkpointCtx, db, "wal_checkpoint", observer, mode)
+	if err != nil {
+		logger.Warn().Err(err).Str("mode", string(mode)).Int64("wal_bytes", walBytes).Msg("money sqlite WAL checkpoint failed")
+		return
+	}
+	remaining := time.Until(deadline)
+	if !moneySQLiteShouldFollowUpTruncate(mode, result.Busy, remaining) {
+		return
+	}
+	if err := sqliteutil.SetBusyTimeout(ctx, db, remaining); err != nil {
+		logger.Warn().Err(err).Int64("wal_bytes", walBytes).Msg("money sqlite WAL busy_timeout failed")
+	}
+	truncateCtx, truncateCancel := context.WithTimeout(ctx, remaining)
+	defer truncateCancel()
+	if _, err := sqliteutil.RunWALCheckpointMode(truncateCtx, db, "wal_checkpoint", observer, sqliteutil.WALCheckpointTruncate); err != nil {
+		logger.Warn().Err(err).Str("mode", string(sqliteutil.WALCheckpointTruncate)).Int64("wal_bytes", walBytes).Msg("money sqlite WAL checkpoint failed")
+	}
 }
 
 func startSettlementStartupScan(ctx context.Context, scanner settlementStartupScanner, settlement config.SettlementConfig, now time.Time, logger zerolog.Logger) {

--- a/phase4-coordinator/cmd/coordinator/main_test.go
+++ b/phase4-coordinator/cmd/coordinator/main_test.go
@@ -210,8 +210,9 @@ func TestRetentionPrunersDefaultToStartupDelete(t *testing.T) {
 	assertImmediatePrune(t, auditPruner.called, "audit_log")
 }
 
-func TestMoneySQLiteWALCheckpointerWaitsForIdle(t *testing.T) {
-	db, err := sql.Open("sqlite", sqliteutil.WithPragmas(filepath.Join(t.TempDir(), "checkpoint.db")))
+func TestMoneySQLiteWALCheckpointerRunsWhileBusy(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "checkpoint.db")
+	db, err := sql.Open("sqlite", sqliteutil.WithPragmas(dbPath))
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
@@ -225,18 +226,22 @@ func TestMoneySQLiteWALCheckpointerWaitsForIdle(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	observer := &walObserverStub{called: make(chan string, 3)}
-	startMoneySQLiteWALCheckpointerWithConfig(ctx, db, observer, zerolog.Nop(), fixedIdleTracker{idleFor: 0}, 10*time.Millisecond, time.Second)
+	observer := &walObserverStub{called: make(chan string, 16), durations: make(chan struct{}, 4)}
+	startMoneySQLiteWALCheckpointerWithConfig(ctx, db, observer, zerolog.Nop(), fixedIdleTracker{idleFor: 0}, moneySQLiteWALCheckpointerConfig{
+		PollInterval:   10 * time.Millisecond,
+		IdleInterval:   time.Hour,
+		MinTimeout:     time.Second,
+		MaxTimeout:     time.Second,
+		BytesPerSecond: moneySQLiteCheckpointBytesPerSecond,
+		DBPath:         dbPath,
+	})
 
-	select {
-	case pageClass := <-observer.called:
-		t.Fatalf("checkpoint ran while buyer activity was not idle: %s", pageClass)
-	case <-time.After(50 * time.Millisecond):
-	}
+	assertWALCheckpointObservations(t, observer)
 }
 
 func TestMoneySQLiteWALCheckpointerRunsAfterIdle(t *testing.T) {
-	db, err := sql.Open("sqlite", sqliteutil.WithPragmas(filepath.Join(t.TempDir(), "checkpoint.db")))
+	dbPath := filepath.Join(t.TempDir(), "checkpoint.db")
+	db, err := sql.Open("sqlite", sqliteutil.WithPragmas(dbPath))
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
@@ -250,9 +255,76 @@ func TestMoneySQLiteWALCheckpointerRunsAfterIdle(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	observer := &walObserverStub{called: make(chan string, 3), durations: make(chan struct{}, 1)}
-	startMoneySQLiteWALCheckpointerWithConfig(ctx, db, observer, zerolog.Nop(), fixedIdleTracker{idleFor: time.Hour}, 10*time.Millisecond, time.Second)
+	observer := &walObserverStub{called: make(chan string, 16), durations: make(chan struct{}, 4)}
+	startMoneySQLiteWALCheckpointerWithConfig(ctx, db, observer, zerolog.Nop(), fixedIdleTracker{idleFor: time.Hour}, moneySQLiteWALCheckpointerConfig{
+		PollInterval:   10 * time.Millisecond,
+		IdleInterval:   10 * time.Millisecond,
+		MinTimeout:     time.Second,
+		MaxTimeout:     time.Second,
+		BytesPerSecond: moneySQLiteCheckpointBytesPerSecond,
+		DBPath:         dbPath,
+	})
 
+	assertWALCheckpointObservations(t, observer)
+}
+
+func TestMoneySQLiteCheckpointTimeoutScalesWithWALSize(t *testing.T) {
+	cfg := defaultMoneySQLiteWALCheckpointerConfig("")
+	if got := moneySQLiteCheckpointTimeout(0, cfg); got != cfg.MinTimeout {
+		t.Fatalf("0-byte timeout=%s want min %s", got, cfg.MinTimeout)
+	}
+	if got := moneySQLiteCheckpointTimeout(1<<62, cfg); got != cfg.MaxTimeout {
+		t.Fatalf("huge WAL timeout=%s want max %s", got, cfg.MaxTimeout)
+	}
+	midBytes := int64(1 << 30) // 1 GiB at 32 MiB/s = 32s
+	got := moneySQLiteCheckpointTimeout(midBytes, cfg)
+	if got <= cfg.MinTimeout || got >= cfg.MaxTimeout {
+		t.Fatalf("1GiB timeout=%s want between min=%s and max=%s", got, cfg.MinTimeout, cfg.MaxTimeout)
+	}
+	wantMid := time.Duration(midBytes) * time.Second / time.Duration(cfg.BytesPerSecond)
+	if got != wantMid {
+		t.Fatalf("1GiB timeout=%s want %s", got, wantMid)
+	}
+}
+
+func TestMoneySQLiteCheckpointDecision(t *testing.T) {
+	cfg := defaultMoneySQLiteWALCheckpointerConfig("")
+	mode, timeout := moneySQLiteCheckpointDecision(time.Hour, moneySQLiteCheckpointIdleInterval, 0, cfg)
+	if mode != sqliteutil.WALCheckpointTruncate {
+		t.Fatalf("idle mode=%s want TRUNCATE", mode)
+	}
+	if timeout != cfg.MinTimeout {
+		t.Fatalf("idle 0-byte timeout=%s want min %s", timeout, cfg.MinTimeout)
+	}
+	mode, timeout = moneySQLiteCheckpointDecision(0, moneySQLiteCheckpointIdleInterval, 0, cfg)
+	if mode != sqliteutil.WALCheckpointPassive {
+		t.Fatalf("busy mode=%s want PASSIVE", mode)
+	}
+	if timeout != cfg.MinTimeout {
+		t.Fatalf("busy 0-byte timeout=%s want min %s", timeout, cfg.MinTimeout)
+	}
+}
+
+func TestMoneySQLiteShouldFollowUpTruncate(t *testing.T) {
+	if !moneySQLiteShouldFollowUpTruncate(sqliteutil.WALCheckpointPassive, 0, time.Second) {
+		t.Fatal("PASSIVE busy=0 with remaining budget should follow up TRUNCATE")
+	}
+	if moneySQLiteShouldFollowUpTruncate(sqliteutil.WALCheckpointPassive, 1, time.Second) {
+		t.Fatal("PASSIVE busy!=0 must not follow up TRUNCATE")
+	}
+	if moneySQLiteShouldFollowUpTruncate(sqliteutil.WALCheckpointPassive, 0, 0) {
+		t.Fatal("PASSIVE with no remaining budget must not follow up TRUNCATE")
+	}
+	if moneySQLiteShouldFollowUpTruncate(sqliteutil.WALCheckpointTruncate, 0, time.Second) {
+		t.Fatal("idle TRUNCATE must not follow up with another TRUNCATE")
+	}
+	if moneySQLiteShouldFollowUpTruncate(sqliteutil.WALCheckpointMode("RESTART"), 0, time.Second) {
+		t.Fatal("unsupported RESTART must not follow up")
+	}
+}
+
+func assertWALCheckpointObservations(t *testing.T, observer *walObserverStub) {
+	t.Helper()
 	seen := map[string]bool{}
 	deadline := time.After(time.Second)
 	for len(seen) < 3 {
@@ -382,7 +454,10 @@ type walObserverStub struct {
 
 func (s *walObserverStub) ObserveSQLiteWALCheckpoint(component, pageClass, outcome string, _ int64) {
 	if component == "wal_checkpoint" && outcome == "success" {
-		s.called <- pageClass
+		select {
+		case s.called <- pageClass:
+		default:
+		}
 	}
 }
 

--- a/phase4-coordinator/internal/sqliteutil/wal.go
+++ b/phase4-coordinator/internal/sqliteutil/wal.go
@@ -3,8 +3,30 @@ package sqliteutil
 import (
 	"context"
 	"database/sql"
+	"fmt"
+	"os"
+	"strconv"
 	"time"
 )
+
+// WALCheckpointMode is a closed set of SQLite wal_checkpoint modes used by
+// the money checkpointer. SQL is selected by switch, never by interpolating
+// caller strings. RESTART is intentionally omitted: it waits on readers and
+// is forbidden on the live soak path.
+type WALCheckpointMode string
+
+const (
+	WALCheckpointPassive  WALCheckpointMode = "PASSIVE"
+	WALCheckpointTruncate WALCheckpointMode = "TRUNCATE"
+)
+
+// WALCheckpointResult is the busy/log/checkpointed triple from
+// PRAGMA wal_checkpoint.
+type WALCheckpointResult struct {
+	Busy              int64
+	LogPages          int64
+	CheckpointedPages int64
+}
 
 // WALObserver receives closed-set WAL checkpoint page observations.
 type WALObserver interface {
@@ -12,19 +34,71 @@ type WALObserver interface {
 	ObserveSQLiteWALCheckpointDuration(component, outcome string, duration time.Duration)
 }
 
-// RunWALCheckpoint runs a bounded TRUNCATE checkpoint on the supplied SQLite
-// handle and observes the busy/log/checkpointed page counts. Callers should
-// provide an off-hot-path *sql.DB so disabling wal_autocheckpoint does not
-// move checkpoint work onto request or billing pools.
-func RunWALCheckpoint(ctx context.Context, db *sql.DB, component string, observer WALObserver) error {
-	var busy, logPages, checkpointedPages int64
+func walCheckpointSQL(mode WALCheckpointMode) (string, error) {
+	switch mode {
+	case WALCheckpointPassive:
+		return `PRAGMA wal_checkpoint(PASSIVE)`, nil
+	case WALCheckpointTruncate:
+		return `PRAGMA wal_checkpoint(TRUNCATE)`, nil
+	default:
+		return "", fmt.Errorf("sqliteutil: unsupported wal checkpoint mode %q", mode)
+	}
+}
+
+// RunWALCheckpointMode runs a bounded checkpoint in a closed-set mode and
+// observes the busy/log/checkpointed page counts. Callers should provide an
+// off-hot-path *sql.DB so disabling wal_autocheckpoint does not move
+// checkpoint work onto request or billing pools.
+func RunWALCheckpointMode(ctx context.Context, db *sql.DB, component string, observer WALObserver, mode WALCheckpointMode) (WALCheckpointResult, error) {
+	query, err := walCheckpointSQL(mode)
+	if err != nil {
+		return WALCheckpointResult{}, err
+	}
+	var result WALCheckpointResult
 	started := time.Now()
-	err := db.QueryRowContext(ctx, `PRAGMA wal_checkpoint(TRUNCATE)`).Scan(&busy, &logPages, &checkpointedPages)
+	err = db.QueryRowContext(ctx, query).Scan(&result.Busy, &result.LogPages, &result.CheckpointedPages)
 	outcome := sqliteOutcome(err)
 	observeWALCheckpointDuration(observer, component, outcome, time.Since(started))
-	observeWALCheckpoint(observer, component, "busy", outcome, busy)
-	observeWALCheckpoint(observer, component, "log", outcome, logPages)
-	observeWALCheckpoint(observer, component, "checkpointed", outcome, checkpointedPages)
+	observeWALCheckpoint(observer, component, "busy", outcome, result.Busy)
+	observeWALCheckpoint(observer, component, "log", outcome, result.LogPages)
+	observeWALCheckpoint(observer, component, "checkpointed", outcome, result.CheckpointedPages)
+	return result, err
+}
+
+// RunWALCheckpoint runs a bounded TRUNCATE checkpoint on the supplied SQLite
+// handle and observes the busy/log/checkpointed page counts.
+func RunWALCheckpoint(ctx context.Context, db *sql.DB, component string, observer WALObserver) error {
+	_, err := RunWALCheckpointMode(ctx, db, component, observer, WALCheckpointTruncate)
+	return err
+}
+
+// WALFileSize returns the size of dbPath's sidecar WAL file, or 0 if the
+// file is missing or unreadable.
+func WALFileSize(dbPath string) int64 {
+	info, err := os.Stat(dbPath + "-wal")
+	if err != nil {
+		return 0
+	}
+	return info.Size()
+}
+
+const maxBusyTimeout = 5 * time.Minute
+
+// SetBusyTimeout sets PRAGMA busy_timeout on db to timeout, clamped to
+// [1ms, 5m]. The duration is converted to a decimal integer; it is not
+// interpolated as a SQL keyword or identifier.
+func SetBusyTimeout(ctx context.Context, db *sql.DB, timeout time.Duration) error {
+	if db == nil {
+		return fmt.Errorf("sqliteutil: nil db")
+	}
+	if timeout > maxBusyTimeout {
+		timeout = maxBusyTimeout
+	}
+	ms := timeout.Milliseconds()
+	if ms < 1 {
+		ms = 1
+	}
+	_, err := db.ExecContext(ctx, "PRAGMA busy_timeout = "+strconv.FormatInt(ms, 10))
 	return err
 }
 

--- a/phase4-coordinator/internal/sqliteutil/wal_test.go
+++ b/phase4-coordinator/internal/sqliteutil/wal_test.go
@@ -1,0 +1,158 @@
+package sqliteutil
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func openManualCheckpointDB(t *testing.T) (dbPath string, db *sql.DB) {
+	t.Helper()
+	dbPath = filepath.Join(t.TempDir(), "checkpoint.db")
+	db, err := sql.Open("sqlite", WithManualWALCheckpointPragmas(dbPath))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	if _, err := db.Exec(`CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO t (v) VALUES ('a'), ('b'), ('c')`); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	return dbPath, db
+}
+
+func TestRunWALCheckpointModeTruncateShrinksWAL(t *testing.T) {
+	dbPath, db := openManualCheckpointDB(t)
+	if size := WALFileSize(dbPath); size == 0 {
+		t.Fatal("WAL size before TRUNCATE = 0, want growth from inserts")
+	}
+
+	observer := &testObserver{}
+	result, err := RunWALCheckpointMode(context.Background(), db, "wal_checkpoint", observer, WALCheckpointTruncate)
+	if err != nil {
+		t.Fatalf("TRUNCATE checkpoint: %v", err)
+	}
+	if result.Busy != 0 {
+		t.Fatalf("TRUNCATE busy=%d want 0", result.Busy)
+	}
+	assertWALObservations(t, observer)
+	if size := WALFileSize(dbPath); size != 0 {
+		t.Fatalf("WAL size after TRUNCATE=%d want 0", size)
+	}
+}
+
+func TestRunWALCheckpointModePassiveIsValid(t *testing.T) {
+	dbPath, db := openManualCheckpointDB(t)
+	observer := &testObserver{}
+	result, err := RunWALCheckpointMode(context.Background(), db, "wal_checkpoint", observer, WALCheckpointPassive)
+	if err != nil {
+		t.Fatalf("PASSIVE checkpoint: %v", err)
+	}
+	if result.LogPages < 0 || result.CheckpointedPages < 0 {
+		t.Fatalf("PASSIVE result = %+v, want non-negative pages", result)
+	}
+	assertWALObservations(t, observer)
+	if _, err := os.Stat(dbPath); err != nil {
+		t.Fatalf("db missing after PASSIVE: %v", err)
+	}
+}
+
+func TestRunWALCheckpointModeRejectsInvalidMode(t *testing.T) {
+	_, db := openManualCheckpointDB(t)
+	for _, mode := range []WALCheckpointMode{
+		"RESTART",
+		"TRUNCATE); DROP TABLE t; --",
+	} {
+		observer := &testObserver{}
+		result, err := RunWALCheckpointMode(context.Background(), db, "wal_checkpoint", observer, mode)
+		if err == nil {
+			t.Fatalf("mode %q returned nil error", mode)
+		}
+		if !strings.Contains(err.Error(), "unsupported wal checkpoint mode") {
+			t.Fatalf("mode %q error = %v, want unsupported", mode, err)
+		}
+		if result != (WALCheckpointResult{}) {
+			t.Fatalf("mode %q result = %+v, want zero value", mode, result)
+		}
+		if len(observer.events) != 0 {
+			t.Fatalf("mode %q emitted observations: %+v", mode, observer.events)
+		}
+	}
+	if _, err := db.Exec(`INSERT INTO t (v) VALUES ('still-there')`); err != nil {
+		t.Fatalf("table t should still exist after rejected mode: %v", err)
+	}
+}
+
+func TestWALFileSizeMissingIsZero(t *testing.T) {
+	if got := WALFileSize(filepath.Join(t.TempDir(), "missing.db")); got != 0 {
+		t.Fatalf("WALFileSize(missing)=%d want 0", got)
+	}
+}
+
+func TestSetBusyTimeout(t *testing.T) {
+	_, db := openManualCheckpointDB(t)
+	if err := SetBusyTimeout(context.Background(), db, 15*time.Second); err != nil {
+		t.Fatalf("SetBusyTimeout: %v", err)
+	}
+	var ms int64
+	if err := db.QueryRow(`PRAGMA busy_timeout`).Scan(&ms); err != nil {
+		t.Fatalf("PRAGMA busy_timeout: %v", err)
+	}
+	if ms != 15000 {
+		t.Fatalf("busy_timeout=%d want 15000", ms)
+	}
+}
+
+func TestSetBusyTimeoutBoundsTruncateWaitAgainstReader(t *testing.T) {
+	dbPath, db := openManualCheckpointDB(t)
+	reader, err := sql.Open("sqlite", WithPragmas(dbPath))
+	if err != nil {
+		t.Fatalf("open reader: %v", err)
+	}
+	t.Cleanup(func() { _ = reader.Close() })
+	tx, err := reader.Begin()
+	if err != nil {
+		t.Fatalf("begin reader tx: %v", err)
+	}
+	t.Cleanup(func() { _ = tx.Rollback() })
+	rows, err := tx.Query(`SELECT v FROM t`)
+	if err != nil {
+		t.Fatalf("reader select: %v", err)
+	}
+	t.Cleanup(func() { _ = rows.Close() })
+	if !rows.Next() {
+		t.Fatal("reader select returned no rows")
+	}
+
+	if err := SetBusyTimeout(context.Background(), db, 50*time.Millisecond); err != nil {
+		t.Fatalf("SetBusyTimeout: %v", err)
+	}
+	started := time.Now()
+	result, err := RunWALCheckpointMode(context.Background(), db, "wal_checkpoint", nil, WALCheckpointTruncate)
+	elapsed := time.Since(started)
+	if err != nil {
+		t.Fatalf("TRUNCATE with held reader: %v", err)
+	}
+	if result.Busy == 0 {
+		t.Fatal("TRUNCATE busy=0 with held reader, want busy!=0")
+	}
+	if elapsed > time.Second {
+		t.Fatalf("TRUNCATE waited %s, want ~50ms busy_timeout not the 5s DSN default", elapsed)
+	}
+}
+
+func assertWALObservations(t *testing.T, observer *testObserver) {
+	t.Helper()
+	assertObserved(t, observer.events, observedEvent{kind: "wal:busy", component: "wal_checkpoint", outcome: "success"})
+	assertObserved(t, observer.events, observedEvent{kind: "wal:log", component: "wal_checkpoint", outcome: "success"})
+	assertObserved(t, observer.events, observedEvent{kind: "wal:checkpointed", component: "wal_checkpoint", outcome: "success"})
+	assertObserved(t, observer.events, observedEvent{kind: "wal_duration", component: "wal_checkpoint", outcome: "success"})
+}


### PR DESCRIPTION
## Summary

Coordinator money SQLite WAL checkpointer no longer waits for 30s buyer idle before running. House soak never idles, so #1211 skipped TRUNCATE while `coordinator.db-wal` grew to multiple GB.

- Keep `wal_autocheckpoint(0)` on money writers.
- Every poll tick checkpoints on the dedicated off-hot-path handle.
- Idle ≥ 30s → `TRUNCATE`; otherwise `PASSIVE`, with optional follow-up `TRUNCATE` when `busy==0` and budget remains.
- Timeout scales with WAL size (`walBytes / 32 MiB/s`, clamp 15s–5m) and is applied as `PRAGMA busy_timeout` on the checkpoint connection only.
- Closed-set SQL: `PASSIVE` and `TRUNCATE` only (`RESTART` rejected). Closes #1374.

Layer 2 / #1226 ops scripts are out of scope.

## Test plan

- [x] `cd phase4-coordinator && go test ./internal/sqliteutil ./cmd/coordinator -count=1`
- [x] TRUNCATE shrinks WAL; PASSIVE is valid; invalid modes (including RESTART and interpolated SQL) error without executing
- [x] Non-idle loop runs PASSIVE observations; idle loop still TRUNCATEs
- [x] Timeout scaling: 0 bytes → min; huge WAL → max; 1 GiB in between
- [x] Decision unit tests; follow-up TRUNCATE predicate; busy_timeout 15s readback; held-reader TRUNCATE bounded by 50ms busy_timeout
- [ ] CI `spec-index` / `check` green before merge

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "issue": "https://github.com/Augustas11/macprovider/issues/1374",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-005", "SPEC-022"],
  "requirements": ["SPEC-005-R002", "SPEC-022-R001"],
  "authority_domains": ["billing-settlement-formula", "verified-model-settlement"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "phase4-coordinator/internal/sqliteutil",
    "phase4-coordinator/cmd/coordinator"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END

Made with [Cursor](https://cursor.com)