### PR TITLE
Add coordinator archive-rotate ops scaffolding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,8 @@ test-dist:
 	bash phase4-coordinator/dist/test/coordinator_release_tag_guard.test.sh
 	bash phase4-coordinator/dist/test/check_deploy_static_feed_access.test.sh
 	bash phase4-coordinator/dist/test/coordinator_deploy_recovery.test.sh
+	bash phase4-coordinator/dist/test/coordinator_archive_rotate.test.sh
+	bash phase4-coordinator/dist/test/coordinator_sqlite_relief.test.sh
 	bash phase4-coordinator/dist/test/coord_deploy_smoke_probe.test.sh
 	bash phase4-coordinator/dist/test/coord_deploy_drift_redact.test.sh
 	bash phase4-coordinator/dist/test/coord_deploy_tier2_migration_gate.test.sh

--- a/phase4-coordinator/dist/coordinator-archive-restore.sh
+++ b/phase4-coordinator/dist/coordinator-archive-restore.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# coordinator-archive-restore.sh — forensic restore for coordinator DB archives (#1226).
+#
+# Restores archives produced by coordinator-archive-rotate.sh to a separate
+# target. Replacing the live coordinator DB is refused; promote restored files
+# manually only after operator review.
+
+set -euo pipefail
+
+COORDINATOR_DB_PATH="${COORDINATOR_DB_PATH:-/var/lib/macprovider/coordinator.db}"
+COORDINATOR_AUDIT_DB_PATH="${COORDINATOR_AUDIT_DB_PATH:-}"
+SKIP_CHECKSUM="${SKIP_CHECKSUM:-0}"
+ALLOW_UNPAIRED_AUDIT_RESTORE="${ALLOW_UNPAIRED_AUDIT_RESTORE:-0}"
+
+log() { printf '[coordinator-archive-restore] %s\n' "$*" >&2; }
+fail() { log "ERROR: $*"; exit 1; }
+refuse() { log "REFUSING: $*"; exit 4; }
+
+need_tool() {
+  command -v "$1" >/dev/null 2>&1 || fail "missing required tool: $1"
+}
+
+TO_LIVE=0
+if [ "${1:-}" = "--to-live" ]; then
+  TO_LIVE=1
+  shift
+fi
+
+ARCHIVE_PATH="${1:-}"
+if [ -z "$ARCHIVE_PATH" ]; then
+  echo "usage: coordinator-archive-restore.sh [--to-live] <archive-path> [target-path]" >&2
+  exit 2
+fi
+[ -f "$ARCHIVE_PATH" ] || fail "archive not found"
+
+if [ "$TO_LIVE" = "1" ]; then
+  refuse "live restore is not implemented in Phase 3; restore to a separate target and promote manually after verification"
+fi
+TARGET_PATH="${2:-$(mktemp -t coordinator-restored.XXXXXX).db}"
+
+archive_base=$(basename "$ARCHIVE_PATH")
+case "$archive_base" in
+  coordinator-audit-*) refuse "audit archive cannot be restored as the primary archive; pass the matching coordinator-*.db.gz archive instead" ;;
+esac
+
+default_audit_db_path_for() {
+  local primary_path="$1"
+  local primary_dir
+  primary_dir=$(dirname "$primary_path")
+  if [ "$primary_dir" = "." ] || [ -z "$primary_dir" ]; then
+    printf 'coordinator-audit.db\n'
+  else
+    printf '%s/coordinator-audit.db\n' "$primary_dir"
+  fi
+}
+
+canonical_path() {
+  local path="$1"
+  local dir base
+  dir=$(dirname "$path")
+  base=$(basename "$path")
+  if [ -d "$dir" ]; then
+    ( cd "$dir" && printf '%s/%s\n' "$(pwd -P)" "$base" )
+  else
+    printf '%s\n' "$path"
+  fi
+}
+
+resolved_path() {
+  local path="$1"
+  if [ -e "$path" ] || [ -L "$path" ]; then
+    if command -v realpath >/dev/null 2>&1; then
+      realpath "$path"
+      return
+    fi
+    python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$path"
+    return
+  fi
+  canonical_path "$path"
+}
+
+refuse_restore_target() {
+  local label="$1"
+  local target="$2"
+  local live="$3"
+  local target_canon live_canon
+  [ -d "$target" ] && refuse "$label restore target is a directory; restore to a regular non-live file path"
+  [ -L "$target" ] && refuse "$label restore target is a symlink; restore to a regular non-live path"
+  if [ -e "$target" ] && [ -e "$live" ] && [ "$target" -ef "$live" ]; then
+    refuse "$label restore target is the same file as the configured live coordinator DB path; live restore is not implemented"
+  fi
+  if [ -e "${target}-wal" ] || [ -L "${target}-wal" ]; then
+    refuse "$label restore target has existing SQLite WAL sidecar ${target}-wal; restore to an empty non-live path"
+  fi
+  if [ -e "${target}-shm" ] || [ -L "${target}-shm" ]; then
+    refuse "$label restore target has existing SQLite SHM sidecar ${target}-shm; restore to an empty non-live path"
+  fi
+  target_canon=$(resolved_path "$target")
+  live_canon=$(resolved_path "$live")
+  if [ "$target_canon" = "$live_canon" ]; then
+    refuse "$label restore target resolves to the configured live coordinator DB path; live restore is not implemented"
+  fi
+}
+
+LIVE_AUDIT_DB_PATH="${COORDINATOR_AUDIT_DB_PATH:-$(default_audit_db_path_for "$COORDINATOR_DB_PATH")}"
+if [ -z "$COORDINATOR_AUDIT_DB_PATH" ]; then
+  COORDINATOR_AUDIT_DB_PATH=$(default_audit_db_path_for "$TARGET_PATH")
+fi
+refuse_restore_target "primary" "$TARGET_PATH" "$COORDINATOR_DB_PATH"
+
+need_tool sqlite3
+need_tool gzip
+if command -v sha256sum >/dev/null 2>&1; then
+  CHECKSUM_CMD="sha256sum"
+elif command -v shasum >/dev/null 2>&1; then
+  CHECKSUM_CMD="shasum -a 256"
+else
+  fail "neither sha256sum nor shasum found"
+fi
+
+check_archive_checksum() {
+  local archive_path="$1"
+  [ "$SKIP_CHECKSUM" = "1" ] && return 0
+
+  CHECKSUM_FILE="${archive_path}.sha256"
+  [ -f "$CHECKSUM_FILE" ] || fail "checksum sidecar missing"
+  archive_base=$(basename "$archive_path")
+  sidecar_base=$(awk '{print $NF}' "$CHECKSUM_FILE" | head -1)
+  if [ "$sidecar_base" != "$archive_base" ]; then
+    log "ERROR: checksum sidecar filename does not match archive"
+    exit 5
+  fi
+  archive_dir=$(dirname "$archive_path")
+  ( cd "$archive_dir" && $CHECKSUM_CMD -c "$(basename "$CHECKSUM_FILE")" >/dev/null ) || {
+    log "ERROR: checksum mismatch"
+    exit 5
+  }
+}
+
+paired_audit_archive_for() {
+  local archive_path="$1"
+  local archive_dir archive_base suffix candidate
+  archive_dir=$(dirname "$archive_path")
+  archive_base=$(basename "$archive_path")
+  case "$archive_base" in
+    coordinator-audit-*) return 0 ;;
+    coordinator-*.db.gz)
+      suffix=${archive_base#coordinator-}
+      candidate="$archive_dir/coordinator-audit-$suffix"
+      [ -f "$candidate" ] && printf '%s\n' "$candidate"
+      return 0
+      ;;
+  esac
+}
+
+TMP_DIR=$(mktemp -d -t coordinator-restore.XXXXXX)
+cleanup() { rm -rf "$TMP_DIR"; }
+trap cleanup EXIT
+
+restore_archive_to_temp() {
+  local archive_path="$1"
+  local tmp_db="$2"
+
+  check_archive_checksum "$archive_path"
+
+  case "$archive_path" in
+    *.gz) gzip -dc "$archive_path" >"$tmp_db" || fail "gzip decompress failed" ;;
+    *.db) cp "$archive_path" "$tmp_db" || fail "copy failed" ;;
+    *) fail "unknown archive extension; expected .gz or .db" ;;
+  esac
+
+  integrity=$(sqlite3 "$tmp_db" "PRAGMA integrity_check;" || echo "fail")
+  [ "$integrity" = "ok" ] || fail "restored DB integrity_check failed"
+  fk=$(sqlite3 "$tmp_db" "PRAGMA foreign_key_check;" || echo "fail")
+  [ -z "$fk" ] || fail "restored DB foreign_key_check failed"
+}
+
+AUDIT_ARCHIVE_PATH=$(paired_audit_archive_for "$ARCHIVE_PATH")
+if [ -z "$AUDIT_ARCHIVE_PATH" ] && [ "$ALLOW_UNPAIRED_AUDIT_RESTORE" != "1" ]; then
+  refuse "paired coordinator-audit archive missing; set ALLOW_UNPAIRED_AUDIT_RESTORE=1 only for legacy primary-only forensic restores"
+fi
+PRIMARY_TMP="$TMP_DIR/coordinator.db"
+AUDIT_TMP="$TMP_DIR/coordinator-audit.db"
+if [ -n "$AUDIT_ARCHIVE_PATH" ]; then
+  refuse_restore_target "audit" "$COORDINATOR_AUDIT_DB_PATH" "$LIVE_AUDIT_DB_PATH"
+  primary_canon=$(resolved_path "$TARGET_PATH")
+  audit_canon=$(resolved_path "$COORDINATOR_AUDIT_DB_PATH")
+  if [ "$primary_canon" = "$audit_canon" ]; then
+    refuse "audit restore target collides with primary restore target"
+  fi
+  if [ -e "$TARGET_PATH" ] && [ -e "$COORDINATOR_AUDIT_DB_PATH" ] && [ "$TARGET_PATH" -ef "$COORDINATOR_AUDIT_DB_PATH" ]; then
+    refuse "audit restore target collides with primary restore target"
+  fi
+fi
+restore_archive_to_temp "$ARCHIVE_PATH" "$PRIMARY_TMP"
+if [ -n "$AUDIT_ARCHIVE_PATH" ]; then
+  restore_archive_to_temp "$AUDIT_ARCHIVE_PATH" "$AUDIT_TMP"
+fi
+
+install -m 0600 "$PRIMARY_TMP" "$TARGET_PATH" || fail "install failed"
+if [ -n "$AUDIT_ARCHIVE_PATH" ]; then
+  install -m 0600 "$AUDIT_TMP" "$COORDINATOR_AUDIT_DB_PATH" || fail "audit install failed"
+fi
+
+log "DONE restored coordinator archive"

--- a/phase4-coordinator/dist/coordinator-archive-rotate.sh
+++ b/phase4-coordinator/dist/coordinator-archive-rotate.sh
@@ -1,0 +1,379 @@
+#!/usr/bin/env bash
+# coordinator-archive-rotate.sh — coordinator.db archive-rotate scaffold (#1226).
+#
+# Manual ops capacity ceiling for the 1-writer money DB: dry-run-first sizing
+# and snapshot scaffolding only (VACUUM INTO + gzip + sha256). Same fail-closed
+# shape as gateway archive-rotate, without live row DELETE. It reports
+# coordinator hot table counts and candidate terminal settlement bundles, but
+# refuses live prune by default.
+# Do not weaken settlement/audit compliance here:
+#   - settlement chains are never age-only deleted;
+#   - audit_log is never considered below the existing 90-day floor;
+#   - live prune requires a later, reviewed delete plan.
+#
+# Environment:
+#   COORDINATOR_DB_PATH                  default: /var/lib/macprovider/coordinator.db
+#   COORDINATOR_AUDIT_DB_PATH            default: sibling coordinator-audit.db
+#   COORDINATOR_ARCHIVE_DIR             default: /var/lib/macprovider-coordinator-archive
+#   COORDINATOR_ARCHIVE_TERMINAL_DAYS   default: 180
+#   COORDINATOR_ARCHIVE_AUDIT_DAYS      default: 90; values below 90 are refused
+#   COORDINATOR_ARCHIVE_SNAPSHOT_ONLY   default: 0; set 1 to take a verified archive
+#   COORDINATOR_ARCHIVE_ASSUME_QUIESCED default: 0; required for snapshot/live paths
+#   FORCE_ROTATE                        default: 0; required for snapshot/live paths
+#   LIVE_PRUNE                          default: 0; live prune still refuses in Phase 3
+#   DRY_RUN                             default: 1; report only, no state changes
+#
+# Exit codes:
+#   0  dry-run report or snapshot success
+#   1  generic error
+#   2  usage / malformed environment
+#   4  live/snapshot safety gate refused
+
+set -euo pipefail
+
+COORDINATOR_DB_PATH="${COORDINATOR_DB_PATH:-/var/lib/macprovider/coordinator.db}"
+COORDINATOR_AUDIT_DB_PATH="${COORDINATOR_AUDIT_DB_PATH:-}"
+COORDINATOR_ARCHIVE_DIR="${COORDINATOR_ARCHIVE_DIR:-/var/lib/macprovider-coordinator-archive}"
+COORDINATOR_ARCHIVE_TERMINAL_DAYS="${COORDINATOR_ARCHIVE_TERMINAL_DAYS:-180}"
+COORDINATOR_ARCHIVE_AUDIT_DAYS="${COORDINATOR_ARCHIVE_AUDIT_DAYS:-90}"
+COORDINATOR_ARCHIVE_SNAPSHOT_ONLY="${COORDINATOR_ARCHIVE_SNAPSHOT_ONLY:-0}"
+COORDINATOR_ARCHIVE_ASSUME_QUIESCED="${COORDINATOR_ARCHIVE_ASSUME_QUIESCED:-0}"
+FORCE_ROTATE="${FORCE_ROTATE:-0}"
+LIVE_PRUNE="${LIVE_PRUNE:-0}"
+DRY_RUN="${DRY_RUN:-1}"
+
+log() { printf '[coordinator-archive-rotate] %s\n' "$*" >&2; }
+fail() { log "ERROR: $*"; exit 1; }
+refuse() { log "REFUSING: $*"; exit 4; }
+
+need_tool() {
+  command -v "$1" >/dev/null 2>&1 || fail "missing required tool: $1"
+}
+
+need_tool sqlite3
+need_tool stat
+need_tool date
+need_tool awk
+need_tool gzip
+
+if command -v sha256sum >/dev/null 2>&1; then
+  CHECKSUM_CMD="sha256sum"
+elif command -v shasum >/dev/null 2>&1; then
+  CHECKSUM_CMD="shasum -a 256"
+else
+  fail "neither sha256sum nor shasum found"
+fi
+SQLITE_ERROR_FILE=$(mktemp -t coordinator-archive-sqlite-error.XXXXXX)
+rm -f "$SQLITE_ERROR_FILE"
+cleanup_sqlite_error_file() { rm -f "$SQLITE_ERROR_FILE"; }
+trap cleanup_sqlite_error_file EXIT
+
+for v in COORDINATOR_ARCHIVE_TERMINAL_DAYS COORDINATOR_ARCHIVE_AUDIT_DAYS; do
+  case "${!v}" in
+    ''|*[!0-9]*) log "ERROR: $v must be a non-negative integer"; exit 2 ;;
+  esac
+done
+
+case "$COORDINATOR_DB_PATH" in
+  *$'\n'*|*'$'*|*'`'*|*';'*|*'&'*|*'|'*|*'>'*|*'<'*|*'*'*|*'?'*) log "ERROR: unsafe coordinator DB path"; exit 2 ;;
+esac
+if [ -z "$COORDINATOR_AUDIT_DB_PATH" ]; then
+  coordinator_db_dir=$(dirname "$COORDINATOR_DB_PATH")
+  if [ "$coordinator_db_dir" = "." ] || [ -z "$coordinator_db_dir" ]; then
+    COORDINATOR_AUDIT_DB_PATH="coordinator-audit.db"
+  else
+    COORDINATOR_AUDIT_DB_PATH="$coordinator_db_dir/coordinator-audit.db"
+  fi
+fi
+case "$COORDINATOR_AUDIT_DB_PATH" in
+  *$'\n'*|*'$'*|*'`'*|*';'*|*'&'*|*'|'*|*'>'*|*'<'*|*'*'*|*'?'*) log "ERROR: unsafe coordinator audit DB path"; exit 2 ;;
+esac
+case "$COORDINATOR_ARCHIVE_DIR" in
+  *$'\n'*|*'$'*|*'`'*|*';'*|*'&'*|*'|'*|*'>'*|*'<'*|*'*'*|*'?'*) log "ERROR: unsafe archive directory path"; exit 2 ;;
+esac
+
+[ -f "$COORDINATOR_DB_PATH" ] || fail "coordinator SQLite DB not found"
+
+if [ "$COORDINATOR_ARCHIVE_AUDIT_DAYS" -lt 90 ]; then
+  refuse "COORDINATOR_ARCHIVE_AUDIT_DAYS cannot be below the 90-day audit_log floor"
+fi
+if [ "$LIVE_PRUNE" = "1" ]; then
+  refuse "live prune is not implemented in Phase 3; use DRY_RUN=1 or COORDINATOR_ARCHIVE_SNAPSHOT_ONLY=1"
+fi
+
+stat_size() {
+  if stat -c %s "$1" >/dev/null 2>&1; then
+    stat -c %s "$1"
+  else
+    stat -f %z "$1"
+  fi
+}
+
+utc_ts() { date -u +%Y%m%dT%H%M%SZ; }
+now_epoch() { date -u +%s; }
+
+sqlite_scalar() {
+  local sql="$1"
+  local out
+  if ! out=$(sqlite3 -batch -noheader "$COORDINATOR_DB_PATH" "$sql" 2>&1); then
+    log "ERROR: sqlite query failed for coordinator DB: $out"
+    : >"$SQLITE_ERROR_FILE"
+    printf '0\n'
+    return 0
+  fi
+  printf '%s\n' "$out"
+}
+
+sqlite_scalar_db() {
+  local db_path="$1"
+  local sql="$2"
+  local out
+  if ! out=$(sqlite3 -batch -noheader "$db_path" "$sql" 2>&1); then
+    log "ERROR: sqlite query failed for $db_path: $out"
+    : >"$SQLITE_ERROR_FILE"
+    printf '0\n'
+    return 0
+  fi
+  printf '%s\n' "$out"
+}
+
+abort_on_sqlite_error() {
+  [ ! -f "$SQLITE_ERROR_FILE" ] || fail "one or more SQLite reads failed; refusing to continue with partial archive sizing"
+}
+
+table_exists() {
+  local table="$1"
+  local n
+  n=$(sqlite_scalar "SELECT COUNT(*) FROM sqlite_schema WHERE type='table' AND name='$table';")
+  [ "$n" = "1" ]
+}
+
+table_exists_db() {
+  local db_path="$1"
+  local table="$2"
+  local n
+  n=$(sqlite_scalar_db "$db_path" "SELECT COUNT(*) FROM sqlite_schema WHERE type='table' AND name='$table';")
+  [ "$n" = "1" ]
+}
+
+table_count() {
+  local table="$1"
+  if table_exists "$table"; then
+    sqlite_scalar "SELECT COUNT(*) FROM $table;"
+  else
+    printf '0\n'
+  fi
+}
+
+dbstat_bytes() {
+  local table="$1"
+  if ! table_exists "$table"; then
+    printf '0\n'
+    return 0
+  fi
+  sqlite_scalar "SELECT COALESCE(SUM(pgsize), 0) FROM dbstat WHERE name='$table';"
+}
+
+report_table() {
+  local table="$1"
+  local rows bytes
+  rows=$(table_count "$table")
+  abort_on_sqlite_error
+  bytes=$(dbstat_bytes "$table")
+  abort_on_sqlite_error
+  log "table=$table rows=$rows approx_bytes=$bytes"
+}
+
+report_audit_sibling() {
+  if [ ! -f "$COORDINATOR_AUDIT_DB_PATH" ]; then
+    log "sibling_audit_db=absent"
+    return 0
+  fi
+  local size rows
+  size=$(stat_size "$COORDINATOR_AUDIT_DB_PATH")
+  if table_exists_db "$COORDINATOR_AUDIT_DB_PATH" "audit_log"; then
+    rows=$(sqlite_scalar_db "$COORDINATOR_AUDIT_DB_PATH" "SELECT COUNT(*) FROM audit_log;")
+    abort_on_sqlite_error
+  else
+    abort_on_sqlite_error
+    rows=0
+  fi
+  log "sibling_audit_db=present size=${size}B audit_log_rows=$rows"
+}
+
+terminal_cutoff_ms() {
+  local cutoff_epoch
+  cutoff_epoch=$(( $(now_epoch) - COORDINATOR_ARCHIVE_TERMINAL_DAYS * 86400 ))
+  printf '%s000\n' "$cutoff_epoch"
+}
+
+audit_cutoff_text() {
+  local cutoff_epoch
+  cutoff_epoch=$(( $(now_epoch) - COORDINATOR_ARCHIVE_AUDIT_DAYS * 86400 ))
+  date -u -r "$cutoff_epoch" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+    || date -u -d "@$cutoff_epoch" +%Y-%m-%dT%H:%M:%SZ
+}
+
+settlement_terminal_where() {
+  local cutoff_ms="$1"
+  cat <<SQL
+closed = 1
+AND settlement_outcome IN ('verified','quarantined','zero_settled')
+AND idempotency_status IN ('first_terminal','terminal_after_pending','terminal_noop')
+AND received_at_unix_ms < $cutoff_ms
+SQL
+}
+
+candidate_terminal_bundle_count() {
+  if ! table_exists "settlement_receipt_verdicts"; then
+    printf '0\n'
+    return 0
+  fi
+  local cutoff_ms where
+  cutoff_ms=$(terminal_cutoff_ms)
+  where=$(settlement_terminal_where "$cutoff_ms")
+  sqlite_scalar "SELECT COUNT(*) FROM (SELECT account_scope_hash, request_id, attempt_n, provider_id FROM settlement_receipt_verdicts WHERE $where GROUP BY account_scope_hash, request_id, attempt_n, provider_id);"
+}
+
+candidate_terminal_row_count() {
+  if ! table_exists "settlement_receipt_verdicts"; then
+    printf '0\n'
+    return 0
+  fi
+  local cutoff_ms where
+  cutoff_ms=$(terminal_cutoff_ms)
+  where=$(settlement_terminal_where "$cutoff_ms")
+  sqlite_scalar "SELECT COUNT(*) FROM settlement_receipt_verdicts WHERE $where;"
+}
+
+audit_floor_row_count() {
+  if ! table_exists "audit_log"; then
+    printf '0\n'
+    return 0
+  fi
+  local cutoff
+  cutoff=$(audit_cutoff_text)
+  sqlite_scalar "SELECT COUNT(*) FROM audit_log WHERE julianday(ts_utc) < julianday('$cutoff');"
+}
+
+predicted_reclaim_bytes() {
+  local candidates total bytes
+  candidates=$(candidate_terminal_row_count)
+  total=$(table_count "settlement_receipt_verdicts")
+  bytes=$(dbstat_bytes "settlement_receipt_verdicts")
+  if [ "$total" -le 0 ] || [ "$bytes" -le 0 ]; then
+    printf '0\n'
+    return 0
+  fi
+  awk -v e="$candidates" -v t="$total" -v b="$bytes" 'BEGIN { printf "%.0f\n", (e / t) * b }'
+}
+
+run_dry_report() {
+  local size bundles rows reclaim audit_rows
+  size=$(stat_size "$COORDINATOR_DB_PATH")
+  log "DRY_RUN=1 coordinator.db size=${size}B"
+  log "candidate terminal settlement bundle reporting requires closed terminal receipt verdicts older than ${COORDINATOR_ARCHIVE_TERMINAL_DAYS}d"
+  log "audit_log reporting floor=${COORDINATOR_ARCHIVE_AUDIT_DAYS}d (minimum 90d)"
+
+  for table in \
+    request_log audit_log \
+    ledger_request_credits ledger_provider_earnings ledger_operator_credits ledger_payout_ready \
+    ledger_provider_identity_snapshots ledger_config_audit_events ledger_quarantine_resolutions \
+    settlement_route_snapshots settlement_compute_integrity_captures settlement_attempt_outputs \
+    settlement_receipt_verdicts settlement_receipt_audit_outbox; do
+    report_table "$table"
+  done
+  report_audit_sibling
+
+  bundles=$(candidate_terminal_bundle_count)
+  abort_on_sqlite_error
+  rows=$(candidate_terminal_row_count)
+  abort_on_sqlite_error
+  reclaim=$(predicted_reclaim_bytes)
+  abort_on_sqlite_error
+  audit_rows=$(audit_floor_row_count)
+  abort_on_sqlite_error
+  log "candidate_terminal_settlement_bundles=$bundles candidate_receipt_verdict_rows=$rows predicted_reclaim_bytes_approx=$reclaim"
+  log "audit_log_rows_older_than_floor=$audit_rows (reported only; this script does not delete audit_log)"
+  log "DRY_RUN complete: no DB changes, no snapshots, no deletes, no VACUUM"
+}
+
+refuse_existing_archive() {
+  local stem="$1"
+  local ts="$2"
+  local snapshot archive checksum
+  snapshot="$COORDINATOR_ARCHIVE_DIR/${stem}-${ts}.db"
+  archive="${snapshot}.gz"
+  checksum="${archive}.sha256"
+  if [ -e "$snapshot" ] || [ -e "$archive" ] || [ -e "$checksum" ]; then
+    fail "$stem archive already exists; refusing overwrite of $archive"
+  fi
+}
+
+snapshot_one() {
+  local db_path="$1"
+  local stem="$2"
+  local ts="$3"
+  local snapshot archive checksum esc_snapshot integrity fk
+  snapshot="$COORDINATOR_ARCHIVE_DIR/${stem}-${ts}.db"
+  archive="${snapshot}.gz"
+  checksum="${archive}.sha256"
+  esc_snapshot="${snapshot//\'/\'\'}"
+  refuse_existing_archive "$stem" "$ts"
+
+  log "pre-snapshot integrity_check db=$stem"
+  integrity=$(sqlite3 "$db_path" "PRAGMA integrity_check;" || echo "fail")
+  [ "$integrity" = "ok" ] || fail "$stem integrity_check failed before snapshot"
+  fk=$(sqlite3 "$db_path" "PRAGMA foreign_key_check;" || echo "fail")
+  [ -z "$fk" ] || fail "$stem foreign_key_check failed before snapshot"
+
+  log "snapshot via sqlite3 VACUUM INTO db=$stem"
+  sqlite3 "$db_path" "VACUUM INTO '$esc_snapshot';" || fail "$stem VACUUM INTO failed"
+  chmod 0600 "$snapshot"
+
+  log "snapshot integrity_check db=$stem"
+  integrity=$(sqlite3 "$snapshot" "PRAGMA integrity_check;" || echo "fail")
+  [ "$integrity" = "ok" ] || fail "$stem snapshot integrity_check failed"
+  fk=$(sqlite3 "$snapshot" "PRAGMA foreign_key_check;" || echo "fail")
+  [ -z "$fk" ] || fail "$stem snapshot foreign_key_check failed"
+
+  gzip -9 <"$snapshot" >"$archive" || fail "$stem gzip archive failed"
+  chmod 0600 "$archive"
+  ( cd "$COORDINATOR_ARCHIVE_DIR" && $CHECKSUM_CMD "$(basename "$archive")" >"$checksum" )
+  chmod 0600 "$checksum"
+  rm -f "$snapshot"
+  log "DONE snapshot_archive=$(basename "$archive") checksum=$(basename "$checksum")"
+}
+
+snapshot_archive() {
+  [ "$FORCE_ROTATE" = "1" ] || refuse "snapshot requires FORCE_ROTATE=1"
+  [ "$COORDINATOR_ARCHIVE_ASSUME_QUIESCED" = "1" ] || refuse "snapshot requires COORDINATOR_ARCHIVE_ASSUME_QUIESCED=1 after stopping coordinator writers"
+
+  mkdir -p "$COORDINATOR_ARCHIVE_DIR"
+  chmod 0700 "$COORDINATOR_ARCHIVE_DIR" 2>/dev/null || true
+
+  local ts
+  ts=$(utc_ts)
+  refuse_existing_archive "coordinator" "$ts"
+  if [ -f "$COORDINATOR_AUDIT_DB_PATH" ]; then
+    refuse_existing_archive "coordinator-audit" "$ts"
+  fi
+  snapshot_one "$COORDINATOR_DB_PATH" "coordinator" "$ts"
+  if [ -f "$COORDINATOR_AUDIT_DB_PATH" ]; then
+    snapshot_one "$COORDINATOR_AUDIT_DB_PATH" "coordinator-audit" "$ts"
+  else
+    log "sibling coordinator-audit DB absent; no paired audit snapshot created"
+  fi
+}
+
+if [ "$DRY_RUN" = "1" ]; then
+  run_dry_report
+  exit 0
+fi
+
+if [ "$COORDINATOR_ARCHIVE_SNAPSHOT_ONLY" = "1" ]; then
+  snapshot_archive
+  exit 0
+fi
+
+refuse "non-dry-run mode defaults closed; set DRY_RUN=1 for reporting or COORDINATOR_ARCHIVE_SNAPSHOT_ONLY=1 for verified snapshot scaffolding"

--- a/phase4-coordinator/dist/coordinator-sqlite-relief.sh
+++ b/phase4-coordinator/dist/coordinator-sqlite-relief.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Safe, manual SQLite hot-DB relief for coordinator operators.
+# Runs a passive WAL checkpoint and touches hot-table schema metadata without
+# changing durability pragmas or emitting credential-bearing config values.
+
+set -euo pipefail
+
+usage() {
+  echo "usage: coordinator-sqlite-relief.sh [coordinator.db]" >&2
+  echo "       or set MACPROVIDER_COORDINATOR_DB" >&2
+}
+
+DB_PATH="${1:-${MACPROVIDER_COORDINATOR_DB:-}}"
+if [ -z "$DB_PATH" ]; then
+  usage
+  exit 2
+fi
+if [ "${2:-}" != "" ]; then
+  usage
+  exit 2
+fi
+if [ ! -f "$DB_PATH" ]; then
+  echo "coordinator SQLite DB not found" >&2
+  exit 1
+fi
+
+SQLITE3="${SQLITE3:-sqlite3}"
+if ! command -v "$SQLITE3" >/dev/null 2>&1; then
+  echo "sqlite3 not found" >&2
+  exit 1
+fi
+
+"$SQLITE3" "$DB_PATH" <<'SQL'
+PRAGMA busy_timeout=5000;
+PRAGMA wal_checkpoint(PASSIVE);
+SELECT name
+  FROM sqlite_schema
+ WHERE type = 'table'
+   AND name IN (
+     'request_log',
+     'audit_log',
+     'ledger_request_credits',
+     'ledger_provider_earnings',
+     'ledger_payout_ready'
+   )
+ ORDER BY name;
+SQL

--- a/phase4-coordinator/dist/test/coordinator_archive_rotate.test.sh
+++ b/phase4-coordinator/dist/test/coordinator_archive_rotate.test.sh
@@ -1,0 +1,446 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DIST_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ROTATE="$DIST_DIR/coordinator-archive-rotate.sh"
+RESTORE="$DIST_DIR/coordinator-archive-restore.sh"
+TMP="$(umask 077 && mktemp -d -t coordinator-archive-rotate-test.XXXXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+[ -f "$ROTATE" ] || fail "missing rotate script"
+[ -f "$RESTORE" ] || fail "missing restore script"
+command -v sqlite3 >/dev/null 2>&1 || { echo "SKIP: sqlite3 not installed" >&2; exit 0; }
+
+DB="$TMP/coordinator.db"
+AUDIT_DB="$TMP/coordinator-audit.db"
+ARCHIVE_DIR="$TMP/archive"
+
+seed_db() {
+  local db="$1"
+  sqlite3 "$db" <<'SQL'
+PRAGMA foreign_keys=ON;
+CREATE TABLE request_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts_utc TEXT NOT NULL,
+    request_id TEXT NOT NULL
+);
+CREATE TABLE audit_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts_utc TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    provider_id TEXT NOT NULL,
+    payload_json TEXT NOT NULL
+);
+CREATE TABLE ledger_request_credits (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    request_id TEXT NOT NULL,
+    attempt_n INTEGER NOT NULL,
+    provider_id TEXT NOT NULL,
+    ts_utc TEXT NOT NULL,
+    settled INTEGER NOT NULL,
+    settlement_id INTEGER NULL,
+    created_at_utc TEXT NOT NULL
+);
+CREATE TABLE settlement_receipt_verdicts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    account_scope_hash TEXT NOT NULL,
+    request_id TEXT NOT NULL,
+    attempt_n INTEGER NOT NULL,
+    provider_id TEXT NOT NULL,
+    receipt_present INTEGER NOT NULL,
+    receipt_version TEXT NOT NULL,
+    receipt_result TEXT NOT NULL,
+    settlement_outcome TEXT NOT NULL,
+    reason TEXT NOT NULL,
+    idempotency_status TEXT NOT NULL,
+    closed INTEGER NOT NULL,
+    terminal_state TEXT NOT NULL,
+    terminal_state_ts_unix_ms INTEGER NOT NULL,
+    pending_deadline_unix_ms INTEGER NOT NULL,
+    received_at_unix_ms INTEGER NOT NULL,
+    created_at_utc TEXT NOT NULL
+);
+CREATE TABLE settlement_attempt_outputs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    account_scope TEXT NOT NULL,
+    request_id TEXT NOT NULL,
+    attempt_n INTEGER NOT NULL,
+    provider_id TEXT NOT NULL,
+    terminal_state TEXT NOT NULL,
+    terminal_state_ts_unix_ms INTEGER NOT NULL,
+    created_at_utc TEXT NOT NULL
+);
+CREATE TABLE settlement_route_snapshots (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    account_scope TEXT NOT NULL,
+    request_id TEXT NOT NULL,
+    attempt_n INTEGER NOT NULL,
+    provider_id TEXT NOT NULL,
+    created_at_utc TEXT NOT NULL
+);
+CREATE TABLE settlement_compute_integrity_captures (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    account_scope TEXT NOT NULL,
+    request_id TEXT NOT NULL,
+    attempt_n INTEGER NOT NULL,
+    provider_id TEXT NOT NULL,
+    created_at_utc TEXT NOT NULL
+);
+CREATE TABLE settlement_receipt_audit_outbox (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    settlement_receipt_verdict_id INTEGER NOT NULL REFERENCES settlement_receipt_verdicts(id),
+    event_type TEXT NOT NULL,
+    created_at_utc TEXT NOT NULL
+);
+
+INSERT INTO request_log(ts_utc, request_id) VALUES('2025-01-01T00:00:00Z', 'req-old');
+INSERT INTO audit_log(ts_utc, event_type, provider_id, payload_json) VALUES('2025-01-01T00:00:00Z', 'settlement_receipt_verdict', 'provider-1', '{}');
+INSERT INTO ledger_request_credits(request_id, attempt_n, provider_id, ts_utc, settled, settlement_id, created_at_utc)
+VALUES('req-old', 0, 'provider-1', '2025-01-01T00:00:00Z', 1, 7, '2025-01-01T00:00:00Z');
+INSERT INTO settlement_receipt_verdicts(
+    account_scope_hash, request_id, attempt_n, provider_id, receipt_present, receipt_version,
+    receipt_result, settlement_outcome, reason, idempotency_status, closed, terminal_state,
+    terminal_state_ts_unix_ms, pending_deadline_unix_ms, received_at_unix_ms, created_at_utc
+) VALUES
+('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'req-old', 0, 'provider-1', 1, 'v0.4',
+ 'valid', 'verified', 'verified_settlement', 'first_terminal', 1, 'normal_done',
+ 1735689600000, 1735689600000, 1735689600000, '2025-01-01T00:00:00Z'),
+('bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', 'req-pending', 0, 'provider-1', 0, 'v0.4',
+ 'missing', 'pending', 'pending', 'pending', 0, 'normal_done',
+ 1735689600000, 1735689600000, 1735689600000, '2025-01-01T00:00:00Z');
+INSERT INTO settlement_attempt_outputs(account_scope, request_id, attempt_n, provider_id, terminal_state, terminal_state_ts_unix_ms, created_at_utc)
+VALUES('acct', 'req-old', 0, 'provider-1', 'normal_done', 1735689600000, '2025-01-01T00:00:00Z');
+INSERT INTO settlement_route_snapshots(account_scope, request_id, attempt_n, provider_id, created_at_utc)
+VALUES('acct', 'req-old', 0, 'provider-1', '2025-01-01T00:00:00Z');
+INSERT INTO settlement_compute_integrity_captures(account_scope, request_id, attempt_n, provider_id, created_at_utc)
+VALUES('acct', 'req-old', 0, 'provider-1', '2025-01-01T00:00:00Z');
+INSERT INTO settlement_receipt_audit_outbox(settlement_receipt_verdict_id, event_type, created_at_utc)
+VALUES(1, 'settlement_receipt_verdict', '2025-01-01T00:00:00Z');
+SQL
+}
+
+seed_db "$DB"
+sqlite3 "$AUDIT_DB" <<'SQL'
+CREATE TABLE audit_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts_utc TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    provider_id TEXT NOT NULL,
+    payload_json TEXT NOT NULL
+);
+INSERT INTO audit_log(ts_utc, event_type, provider_id, payload_json)
+VALUES('2025-01-01T00:00:00Z', 'settlement_receipt_verdict', 'provider-1', '{"sibling":true}');
+SQL
+
+DRY_RUN=1 \
+  COORDINATOR_DB_PATH="$DB" \
+  COORDINATOR_AUDIT_DB_PATH="$AUDIT_DB" \
+  COORDINATOR_ARCHIVE_DIR="$ARCHIVE_DIR" \
+  COORDINATOR_ARCHIVE_TERMINAL_DAYS=1 \
+  "$ROTATE" >"$TMP/dry.out" 2>"$TMP/dry.err"
+
+grep -q "DRY_RUN=1 coordinator.db size=" "$TMP/dry.err" || fail "dry-run size report missing"
+grep -q "table=request_log rows=1" "$TMP/dry.err" || fail "request_log count missing"
+grep -q "table=audit_log rows=1" "$TMP/dry.err" || fail "audit_log count missing"
+grep -q "candidate_terminal_settlement_bundles=1" "$TMP/dry.err" || fail "terminal bundle candidate count missing"
+grep -q "candidate_receipt_verdict_rows=1" "$TMP/dry.err" || fail "terminal row candidate count missing"
+grep -q "audit_log_rows_older_than_floor=1" "$TMP/dry.err" || fail "audit floor report missing"
+grep -q "sibling_audit_db=present" "$TMP/dry.err" || fail "sibling audit DB report missing"
+grep -q "no DB changes" "$TMP/dry.err" || fail "dry-run no-change statement missing"
+
+[ "$(sqlite3 "$DB" "SELECT COUNT(*) FROM settlement_receipt_verdicts;")" = "2" ] || fail "dry-run changed settlement verdict rows"
+[ "$(sqlite3 "$DB" "SELECT COUNT(*) FROM audit_log;")" = "1" ] || fail "dry-run changed audit_log rows"
+if find "$ARCHIVE_DIR" -type f 2>/dev/null | grep -q .; then
+  fail "dry-run created archive files"
+fi
+
+set +e
+DRY_RUN=1 \
+  COORDINATOR_DB_PATH="$DB" \
+  COORDINATOR_ARCHIVE_AUDIT_DAYS=89 \
+  "$ROTATE" >"$TMP/floor.out" 2>"$TMP/floor.err"
+floor_rc=$?
+set -e
+[ "$floor_rc" = "4" ] || fail "audit floor should refuse with exit 4"
+grep -q "90-day audit_log floor" "$TMP/floor.err" || fail "audit floor refusal text missing"
+
+printf 'not sqlite' >"$TMP/corrupt.db"
+set +e
+DRY_RUN=1 \
+  COORDINATOR_DB_PATH="$TMP/corrupt.db" \
+  "$ROTATE" >"$TMP/corrupt.out" 2>"$TMP/corrupt.err"
+corrupt_rc=$?
+set -e
+[ "$corrupt_rc" = "1" ] || fail "corrupt DB dry-run should fail with exit 1"
+grep -q "sqlite query failed" "$TMP/corrupt.err" || fail "corrupt DB failure text missing"
+
+set +e
+DRY_RUN=0 \
+  COORDINATOR_DB_PATH="$DB" \
+  COORDINATOR_ARCHIVE_DIR="$ARCHIVE_DIR" \
+  "$ROTATE" >"$TMP/refuse.out" 2>"$TMP/refuse.err"
+refuse_rc=$?
+set -e
+[ "$refuse_rc" = "4" ] || fail "non-dry-run default should refuse with exit 4"
+grep -q "non-dry-run mode defaults closed" "$TMP/refuse.err" || fail "default refusal text missing"
+
+set +e
+DRY_RUN=0 \
+  LIVE_PRUNE=1 \
+  FORCE_ROTATE=1 \
+  COORDINATOR_ARCHIVE_ASSUME_QUIESCED=1 \
+  COORDINATOR_DB_PATH="$DB" \
+  COORDINATOR_AUDIT_DB_PATH="$AUDIT_DB" \
+  COORDINATOR_ARCHIVE_DIR="$ARCHIVE_DIR" \
+  "$ROTATE" >"$TMP/live.out" 2>"$TMP/live.err"
+live_rc=$?
+set -e
+[ "$live_rc" = "4" ] || fail "live prune should refuse with exit 4"
+grep -q "live prune is not implemented in Phase 3" "$TMP/live.err" || fail "live prune refusal text missing"
+[ "$(sqlite3 "$DB" "SELECT COUNT(*) FROM settlement_receipt_verdicts;")" = "2" ] || fail "live refusal changed DB rows"
+
+set +e
+LIVE_PRUNE=1 \
+  COORDINATOR_DB_PATH="$DB" \
+  COORDINATOR_AUDIT_DB_PATH="$AUDIT_DB" \
+  COORDINATOR_ARCHIVE_DIR="$ARCHIVE_DIR" \
+  "$ROTATE" >"$TMP/live-dry.out" 2>"$TMP/live-dry.err"
+live_dry_rc=$?
+set -e
+[ "$live_dry_rc" = "4" ] || fail "LIVE_PRUNE=1 with default DRY_RUN should refuse with exit 4"
+grep -q "live prune is not implemented in Phase 3" "$TMP/live-dry.err" || fail "LIVE_PRUNE default dry-run refusal text missing"
+
+set +e
+DRY_RUN=0 \
+  LIVE_PRUNE=1 \
+  COORDINATOR_ARCHIVE_SNAPSHOT_ONLY=1 \
+  FORCE_ROTATE=1 \
+  COORDINATOR_ARCHIVE_ASSUME_QUIESCED=1 \
+  COORDINATOR_DB_PATH="$DB" \
+  COORDINATOR_AUDIT_DB_PATH="$AUDIT_DB" \
+  COORDINATOR_ARCHIVE_DIR="$TMP/snapshot-blocked" \
+  "$ROTATE" >"$TMP/live-snap.out" 2>"$TMP/live-snap.err"
+live_snap_rc=$?
+set -e
+[ "$live_snap_rc" = "4" ] || fail "LIVE_PRUNE=1 with snapshot-only should refuse with exit 4"
+if find "$TMP/snapshot-blocked" -type f 2>/dev/null | grep -q .; then
+  fail "LIVE_PRUNE snapshot-only refusal created archive files"
+fi
+
+DRY_RUN=0 \
+  COORDINATOR_ARCHIVE_SNAPSHOT_ONLY=1 \
+  FORCE_ROTATE=1 \
+  COORDINATOR_ARCHIVE_ASSUME_QUIESCED=1 \
+  COORDINATOR_DB_PATH="$DB" \
+  COORDINATOR_AUDIT_DB_PATH="$AUDIT_DB" \
+  COORDINATOR_ARCHIVE_DIR="$ARCHIVE_DIR" \
+  "$ROTATE" >"$TMP/snapshot.out" 2>"$TMP/snapshot.err"
+
+archive_count=$(find "$ARCHIVE_DIR" -type f -name 'coordinator-*.db.gz' | wc -l | tr -d ' ')
+[ "$archive_count" = "2" ] || fail "paired snapshot archives not created"
+checksum_count=$(find "$ARCHIVE_DIR" -type f -name '*.sha256' | wc -l | tr -d ' ')
+[ "$checksum_count" = "2" ] || fail "paired snapshot checksums not created"
+
+DATE_BIN="$TMP/bin/date"
+mkdir -p "$TMP/bin"
+cat >"$DATE_BIN" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = "-u" ] && [ "${2:-}" = "+%Y%m%dT%H%M%SZ" ]; then
+  printf '20260101T000000Z\n'
+  exit 0
+fi
+exec /bin/date "$@"
+SH
+chmod +x "$DATE_BIN"
+FIXED_ARCHIVE_DIR="$TMP/fixed-ts-archive"
+PATH="$TMP/bin:$PATH" \
+  DRY_RUN=0 \
+  COORDINATOR_ARCHIVE_SNAPSHOT_ONLY=1 \
+  FORCE_ROTATE=1 \
+  COORDINATOR_ARCHIVE_ASSUME_QUIESCED=1 \
+  COORDINATOR_DB_PATH="$DB" \
+  COORDINATOR_AUDIT_DB_PATH="$AUDIT_DB" \
+  COORDINATOR_ARCHIVE_DIR="$FIXED_ARCHIVE_DIR" \
+  "$ROTATE" >"$TMP/fixed-ts-1.out" 2>"$TMP/fixed-ts-1.err"
+[ -f "$FIXED_ARCHIVE_DIR/coordinator-20260101T000000Z.db.gz" ] || fail "fixed-timestamp snapshot missing"
+set +e
+PATH="$TMP/bin:$PATH" \
+  DRY_RUN=0 \
+  COORDINATOR_ARCHIVE_SNAPSHOT_ONLY=1 \
+  FORCE_ROTATE=1 \
+  COORDINATOR_ARCHIVE_ASSUME_QUIESCED=1 \
+  COORDINATOR_DB_PATH="$DB" \
+  COORDINATOR_AUDIT_DB_PATH="$AUDIT_DB" \
+  COORDINATOR_ARCHIVE_DIR="$FIXED_ARCHIVE_DIR" \
+  "$ROTATE" >"$TMP/fixed-ts-2.out" 2>"$TMP/fixed-ts-2.err"
+fixed_ts_rc=$?
+set -e
+[ "$fixed_ts_rc" = "1" ] || fail "same-timestamp snapshot rerun should fail with exit 1"
+grep -q "archive already exists; refusing overwrite" "$TMP/fixed-ts-2.err" || fail "same-timestamp overwrite refusal text missing"
+[ "$(find "$FIXED_ARCHIVE_DIR" -type f -name 'coordinator-20260101T000000Z.db.gz' | wc -l | tr -d ' ')" = "1" ] || fail "same-timestamp rerun created extra archives"
+
+AUDIT_ONLY_COLLIDE_DIR="$TMP/audit-only-collide-archive"
+mkdir -p "$AUDIT_ONLY_COLLIDE_DIR"
+printf 'preexisting-audit-archive\n' >"$AUDIT_ONLY_COLLIDE_DIR/coordinator-audit-20260101T000000Z.db.gz"
+printf 'preexisting-audit-checksum\n' >"$AUDIT_ONLY_COLLIDE_DIR/coordinator-audit-20260101T000000Z.db.gz.sha256"
+set +e
+PATH="$TMP/bin:$PATH" \
+  DRY_RUN=0 \
+  COORDINATOR_ARCHIVE_SNAPSHOT_ONLY=1 \
+  FORCE_ROTATE=1 \
+  COORDINATOR_ARCHIVE_ASSUME_QUIESCED=1 \
+  COORDINATOR_DB_PATH="$DB" \
+  COORDINATOR_AUDIT_DB_PATH="$AUDIT_DB" \
+  COORDINATOR_ARCHIVE_DIR="$AUDIT_ONLY_COLLIDE_DIR" \
+  "$ROTATE" >"$TMP/audit-only-collide.out" 2>"$TMP/audit-only-collide.err"
+audit_only_collide_rc=$?
+set -e
+[ "$audit_only_collide_rc" = "1" ] || fail "audit-only timestamp collision should fail with exit 1"
+grep -q "archive already exists; refusing overwrite" "$TMP/audit-only-collide.err" || fail "audit-only collision refusal text missing"
+[ ! -e "$AUDIT_ONLY_COLLIDE_DIR/coordinator-20260101T000000Z.db" ] || fail "audit-only collision created primary snapshot"
+[ ! -e "$AUDIT_ONLY_COLLIDE_DIR/coordinator-20260101T000000Z.db.gz" ] || fail "audit-only collision created primary archive"
+[ ! -e "$AUDIT_ONLY_COLLIDE_DIR/coordinator-20260101T000000Z.db.gz.sha256" ] || fail "audit-only collision created primary checksum"
+[ "$(cat "$AUDIT_ONLY_COLLIDE_DIR/coordinator-audit-20260101T000000Z.db.gz")" = "preexisting-audit-archive" ] || fail "audit-only collision mutated preexisting audit archive"
+
+archive_path=$(find "$ARCHIVE_DIR" -type f -name 'coordinator-*.db.gz' ! -name 'coordinator-audit-*.db.gz' | head -1)
+set +e
+ASSUME_YES=1 \
+  SKIP_CHECKSUM=1 \
+  COORDINATOR_DB_PATH="$DB" \
+  COORDINATOR_AUDIT_DB_PATH="$AUDIT_DB" \
+  "$RESTORE" --to-live "$archive_path" >"$TMP/restore-live-skip.out" 2>"$TMP/restore-live-skip.err"
+skip_live_rc=$?
+set -e
+[ "$skip_live_rc" = "4" ] || fail "live restore should refuse with exit 4"
+grep -q "live restore is not implemented in Phase 3" "$TMP/restore-live-skip.err" || fail "live restore refusal text missing"
+
+set +e
+ASSUME_YES=1 \
+  COORDINATOR_DB_PATH="$DB" \
+  COORDINATOR_AUDIT_DB_PATH="$AUDIT_DB" \
+  "$RESTORE" --to-live "$archive_path" >"$TMP/restore-live-paired.out" 2>"$TMP/restore-live-paired.err"
+paired_live_rc=$?
+set -e
+[ "$paired_live_rc" = "4" ] || fail "paired live restore should refuse with exit 4"
+grep -q "live restore is not implemented in Phase 3" "$TMP/restore-live-paired.err" || fail "paired live restore refusal text missing"
+
+live_marker_before=$(sqlite3 "$DB" "SELECT COUNT(*) FROM settlement_receipt_verdicts;")
+set +e
+COORDINATOR_DB_PATH="$DB" \
+  COORDINATOR_AUDIT_DB_PATH="$AUDIT_DB" \
+  "$RESTORE" "$archive_path" "$DB" >"$TMP/restore-positional-live.out" 2>"$TMP/restore-positional-live.err"
+positional_live_rc=$?
+set -e
+[ "$positional_live_rc" = "4" ] || fail "positional live restore target should refuse with exit 4"
+grep -q "primary restore target is the same file as the configured live coordinator DB path" "$TMP/restore-positional-live.err" || fail "positional live restore refusal text missing"
+[ "$(sqlite3 "$DB" "SELECT COUNT(*) FROM settlement_receipt_verdicts;")" = "$live_marker_before" ] || fail "positional live restore mutated live DB"
+
+LIVE_REAL="$TMP/live-real.db"
+LIVE_LINK="$TMP/live-link.db"
+printf 'live-marker' >"$LIVE_REAL"
+ln -s "$LIVE_REAL" "$LIVE_LINK"
+set +e
+COORDINATOR_DB_PATH="$LIVE_LINK" \
+  COORDINATOR_AUDIT_DB_PATH="$AUDIT_DB" \
+  "$RESTORE" "$archive_path" "$LIVE_REAL" >"$TMP/restore-symlink-live.out" 2>"$TMP/restore-symlink-live.err"
+symlink_live_rc=$?
+set -e
+[ "$symlink_live_rc" = "4" ] || fail "symlinked live restore target should refuse with exit 4"
+grep -q "primary restore target is the same file as the configured live coordinator DB path" "$TMP/restore-symlink-live.err" || fail "symlinked live restore refusal text missing"
+[ "$(cat "$LIVE_REAL")" = "live-marker" ] || fail "symlinked live restore mutated live DB"
+
+HARDLINK_LIVE="$TMP/hardlink-live.db"
+HARDLINK_TARGET="$TMP/hardlink-target.db"
+printf 'hardlink-live-marker' >"$HARDLINK_LIVE"
+ln "$HARDLINK_LIVE" "$HARDLINK_TARGET"
+set +e
+COORDINATOR_DB_PATH="$HARDLINK_LIVE" \
+  COORDINATOR_AUDIT_DB_PATH="$AUDIT_DB" \
+  "$RESTORE" "$archive_path" "$HARDLINK_TARGET" >"$TMP/restore-hardlink-live.out" 2>"$TMP/restore-hardlink-live.err"
+hardlink_live_rc=$?
+set -e
+[ "$hardlink_live_rc" = "4" ] || fail "hardlinked live restore target should refuse with exit 4"
+grep -q "primary restore target is the same file as the configured live coordinator DB path" "$TMP/restore-hardlink-live.err" || fail "hardlinked live restore refusal text missing"
+[ "$(cat "$HARDLINK_LIVE")" = "hardlink-live-marker" ] || fail "hardlinked live restore mutated live DB"
+
+SIDECAR_RESTORE_DIR="$TMP/sidecar-restore-target"
+mkdir -p "$SIDECAR_RESTORE_DIR"
+sidecar_target="$SIDECAR_RESTORE_DIR/restored.db"
+ln -s "$TMP/missing-wal-target" "${sidecar_target}-wal"
+set +e
+"$RESTORE" "$archive_path" "$sidecar_target" >"$TMP/restore-sidecar-symlink.out" 2>"$TMP/restore-sidecar-symlink.err"
+sidecar_symlink_rc=$?
+set -e
+[ "$sidecar_symlink_rc" = "4" ] || fail "dangling WAL sidecar symlink should refuse with exit 4"
+grep -q "existing SQLite WAL sidecar" "$TMP/restore-sidecar-symlink.err" || fail "dangling WAL sidecar refusal text missing"
+[ ! -f "$sidecar_target" ] || fail "sidecar symlink refusal created restore target"
+
+audit_archive_path=$(find "$ARCHIVE_DIR" -type f -name 'coordinator-audit-*.db.gz' | head -1)
+set +e
+"$RESTORE" "$audit_archive_path" "$TMP/audit-as-primary.db" >"$TMP/audit-as-primary.out" 2>"$TMP/audit-as-primary.err"
+audit_primary_rc=$?
+set -e
+[ "$audit_primary_rc" = "4" ] || fail "audit archive as primary should refuse with exit 4"
+grep -q "audit archive cannot be restored as the primary archive" "$TMP/audit-as-primary.err" || fail "audit archive primary refusal text missing"
+
+UNPAIRED_DIR="$TMP/unpaired-archive"
+mkdir -p "$UNPAIRED_DIR"
+cp "$archive_path" "$UNPAIRED_DIR/$(basename "$archive_path")"
+cp "${archive_path}.sha256" "$UNPAIRED_DIR/$(basename "$archive_path").sha256"
+unpaired_archive="$UNPAIRED_DIR/$(basename "$archive_path")"
+set +e
+"$RESTORE" "$unpaired_archive" "$TMP/unpaired-restored.db" >"$TMP/unpaired.out" 2>"$TMP/unpaired.err"
+unpaired_rc=$?
+set -e
+[ "$unpaired_rc" = "4" ] || fail "unpaired audit restore should refuse with exit 4"
+grep -q "paired coordinator-audit archive missing" "$TMP/unpaired.err" || fail "unpaired audit restore refusal text missing"
+
+UNPAIRED_RESTORE_DIR="$TMP/unpaired-restore-target"
+mkdir -p "$UNPAIRED_RESTORE_DIR"
+ALLOW_UNPAIRED_AUDIT_RESTORE=1 \
+  "$RESTORE" "$unpaired_archive" "$UNPAIRED_RESTORE_DIR/restored.db" >"$TMP/unpaired-override.out" 2>"$TMP/unpaired-override.err"
+[ -f "$UNPAIRED_RESTORE_DIR/restored.db" ] || fail "unpaired override restore target missing"
+[ ! -f "$UNPAIRED_RESTORE_DIR/coordinator-audit.db" ] || fail "unpaired override unexpectedly restored audit DB"
+
+RESTORE_DIR="$TMP/restore-target"
+mkdir -p "$RESTORE_DIR"
+restored="$RESTORE_DIR/restored.db"
+"$RESTORE" "$archive_path" "$restored" >"$TMP/restore.out" 2>"$TMP/restore.err"
+[ -f "$restored" ] || fail "restore target missing"
+[ -f "$RESTORE_DIR/coordinator-audit.db" ] || fail "paired audit restore target missing"
+[ "$(sqlite3 "$restored" "PRAGMA integrity_check;")" = "ok" ] || fail "restored DB integrity failed"
+[ "$(sqlite3 "$RESTORE_DIR/coordinator-audit.db" "PRAGMA integrity_check;")" = "ok" ] || fail "restored audit DB integrity failed"
+[ "$(sqlite3 "$restored" "SELECT COUNT(*) FROM settlement_receipt_verdicts;")" = "2" ] || fail "restored DB missing settlement chain rows"
+[ "$(sqlite3 "$RESTORE_DIR/coordinator-audit.db" "SELECT COUNT(*) FROM audit_log WHERE event_type='settlement_receipt_verdict';")" = "1" ] || fail "restored audit DB missing settlement audit rows"
+
+LIVE_DIR="$TMP/live-parent"
+mkdir -p "$LIVE_DIR"
+printf 'live-parent-marker\n' >"$LIVE_DIR/coordinator.db"
+set +e
+COORDINATOR_DB_PATH="$LIVE_DIR/coordinator.db" \
+  COORDINATOR_AUDIT_DB_PATH="$AUDIT_DB" \
+  "$RESTORE" "$archive_path" "$LIVE_DIR" >"$TMP/restore-dir.out" 2>"$TMP/restore-dir.err"
+dir_rc=$?
+set -e
+[ "$dir_rc" = "4" ] || fail "directory restore target should refuse with exit 4"
+grep -q "primary restore target is a directory" "$TMP/restore-dir.err" || fail "directory restore refusal text missing"
+[ "$(cat "$LIVE_DIR/coordinator.db")" = "live-parent-marker" ] || fail "directory restore mutated live coordinator.db"
+
+COLLIDE_DIR="$TMP/collide-restore"
+mkdir -p "$COLLIDE_DIR"
+set +e
+COORDINATOR_DB_PATH="$DB" \
+  "$RESTORE" "$archive_path" "$COLLIDE_DIR/coordinator-audit.db" >"$TMP/restore-collide.out" 2>"$TMP/restore-collide.err"
+collide_rc=$?
+set -e
+[ "$collide_rc" = "4" ] || fail "colliding primary/audit restore targets should refuse with exit 4"
+grep -q "audit restore target collides with primary restore target" "$TMP/restore-collide.err" || fail "colliding restore target refusal text missing"
+[ ! -f "$COLLIDE_DIR/coordinator-audit.db" ] || fail "colliding restore created a target file"
+
+echo "coordinator archive rotate scaffold tests passed"

--- a/phase4-coordinator/dist/test/coordinator_sqlite_relief.test.sh
+++ b/phase4-coordinator/dist/test/coordinator_sqlite_relief.test.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+RELIEF="$SCRIPT_DIR/../coordinator-sqlite-relief.sh"
+TMP="$(umask 077 && mktemp -d -t coordinator-sqlite-relief-test.XXXXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+[ -f "$RELIEF" ] || fail "missing relief script"
+
+DB="$TMP/coordinator.db"
+SQL_CAPTURE="$TMP/sql.txt"
+touch "$DB"
+mkdir -p "$TMP/bin"
+cat >"$TMP/bin/sqlite3" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+[ "$1" = "$MACPROVIDER_TEST_DB" ] || exit 11
+cat > "$MACPROVIDER_TEST_SQL_CAPTURE"
+SH
+chmod +x "$TMP/bin/sqlite3"
+
+PATH="$TMP/bin:$PATH" \
+  MACPROVIDER_TEST_DB="$DB" \
+  MACPROVIDER_TEST_SQL_CAPTURE="$SQL_CAPTURE" \
+  "$RELIEF" "$DB"
+
+grep -q "PRAGMA busy_timeout=5000;" "$SQL_CAPTURE" || fail "busy timeout pragma missing"
+grep -q "PRAGMA wal_checkpoint(PASSIVE);" "$SQL_CAPTURE" || fail "passive checkpoint missing"
+grep -q "request_log" "$SQL_CAPTURE" || fail "hot table schema prewarm missing"
+if grep -qi "synchronous *( *NORMAL" "$SQL_CAPTURE"; then
+  fail "script weakened SQLite synchronous durability"
+fi
+
+if "$RELIEF" "$TMP/missing.db" >"$TMP/out.txt" 2>"$TMP/err.txt"; then
+  fail "missing DB unexpectedly succeeded"
+fi
+grep -q "not found" "$TMP/err.txt" || fail "missing DB error not clear"
+if grep -q "$TMP/missing.db" "$TMP/err.txt"; then
+  fail "missing DB error printed operator path"
+fi
+
+echo "coordinator sqlite relief script tests passed"


### PR DESCRIPTION
## Summary

Harvest coordinator archive-rotate ops tooling from the #1197 stack into a narrow PR. Snapshot-only, fail-closed, never live-DELETE of `audit_log` inside 90 days, SPEC-022-safe on settlement tables. Closes #1226.

- `coordinator-archive-rotate.sh`: dry-run sizing by default; snapshot via `VACUUM INTO` + gzip + sha256 behind `FORCE_ROTATE=1` and `COORDINATOR_ARCHIVE_ASSUME_QUIESCED=1`; `LIVE_PRUNE=1` refused first; paired audit snapshot with preflight of both output stems.
- `coordinator-archive-restore.sh`: forensic restore only; `--to-live`, live path, directory, symlink/hardlink, WAL sidecar, unpaired audit, and primary/audit target collision all refuse.
- `coordinator-sqlite-relief.sh`: PASSIVE WAL checkpoint plus hot-table schema probe; no secret printing.

No coordinator Go / money-path runtime changes. No timer wiring. No live prune.

## Test plan

- [x] `bash phase4-coordinator/dist/test/coordinator_archive_rotate.test.sh`
- [x] `bash phase4-coordinator/dist/test/coordinator_sqlite_relief.test.sh`
- [x] `bash -n` on the three dist scripts
- [ ] CI `test-dist` / `spec-index` / `check` green before merge

Carried LOW from three-lane Codex audit (0 CRITICAL / 0 HIGH / 0 MEDIUM): default restore `mktemp` `.db` suffix, shellcheck SC2329 on trap helpers, rotate does not refuse primary/audit source identity collision, dangling output symlink not treated as collision.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "issue": "https://github.com/Augustas11/macprovider/issues/1226",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-005", "SPEC-022"],
  "requirements": ["SPEC-005-R002", "SPEC-022-R001"],
  "authority_domains": ["billing-settlement-formula", "verified-model-settlement"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "phase4-coordinator/dist/test/coordinator_archive_rotate.test.sh",
    "phase4-coordinator/dist/test/coordinator_sqlite_relief.test.sh"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END

Made with [Cursor](https://cursor.com)