### PR TITLE
BYOM slice-8: Malibu consumption of CLI catalog economics (supersedes codex/1257)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,20 @@
 # targets below to preserve parallel jobs and failure isolation.
 
 .PHONY: test test-coordinator test-coordinator-integration test-gateway test-integration test-dist \
+        test-byom-e2e \
         vet vet-coordinator vet-gateway \
         lint-coordinator \
         build-linux check check-exceptions fmt verify-autotune-catalog
 
 test: test-coordinator test-gateway test-integration test-dist
+
+# BYOM CLI onboarding process E2E. This is MANUAL macOS release evidence, not
+# part of `make test` / required PR coverage: it builds the Swift macprovider-cli
+# and drives the provider-visible offer/status/catalog-economics/withdraw path
+# against a hermetic loopback fake coordinator. Run on macOS before promoting a
+# BYOM-affecting provider CLI/app release. See test/e2e/byom/README.md.
+test-byom-e2e:
+	test/e2e/byom/run-cli-onboarding-e2e.py
 
 verify-autotune-catalog:
 	python3 scripts/catalog-release.py verify

--- a/phase3-binary/Sources/macprovider-cli/BYOMDiscovery.swift
+++ b/phase3-binary/Sources/macprovider-cli/BYOMDiscovery.swift
@@ -1514,6 +1514,13 @@ struct BYOMModelAdmissionClient: Sendable {
         return components.url
     }
 
+    static func urlSessionConfiguration(for baseURL: URL) -> URLSessionConfiguration {
+        if baseURL.scheme == "http" {
+            return BYOMURLSessionHTTPClient.directLoopbackConfiguration()
+        }
+        return .ephemeral
+    }
+
     func submitOffer(_ package: BYOMOfferSubmissionPackage, bearerToken: String) async throws -> BYOMAdmissionStatusWire {
         var request = URLRequest(url: baseURL.appendingPathComponent("v1/provider/model-admission/offers"))
         request.httpMethod = "POST"
@@ -1573,7 +1580,11 @@ struct BYOMModelAdmissionClient: Sendable {
         if let session {
             (data, response) = try await session.data(for: request)
         } else {
-            let ephemeral = URLSession(configuration: .ephemeral, delegate: NoRedirectURLSessionDelegate(), delegateQueue: nil)
+            let ephemeral = URLSession(
+                configuration: Self.urlSessionConfiguration(for: baseURL),
+                delegate: NoRedirectURLSessionDelegate(),
+                delegateQueue: nil
+            )
             defer { ephemeral.finishTasksAndInvalidate() }
             (data, response) = try await ephemeral.data(for: request)
         }
@@ -1607,7 +1618,11 @@ struct BYOMModelAdmissionClient: Sendable {
         if let session {
             (data, response) = try await session.data(for: request)
         } else {
-            let ephemeral = URLSession(configuration: .ephemeral, delegate: NoRedirectURLSessionDelegate(), delegateQueue: nil)
+            let ephemeral = URLSession(
+                configuration: Self.urlSessionConfiguration(for: baseURL),
+                delegate: NoRedirectURLSessionDelegate(),
+                delegateQueue: nil
+            )
             defer { ephemeral.finishTasksAndInvalidate() }
             (data, response) = try await ephemeral.data(for: request)
         }

--- a/phase3-binary/Sources/macprovider-cli/BYOMDiscovery.swift
+++ b/phase3-binary/Sources/macprovider-cli/BYOMDiscovery.swift
@@ -1452,6 +1452,8 @@ struct BYOMWithdrawalBuilder {
 }
 
 struct BYOMModelAdmissionClient: Sendable {
+    private static let allowInsecureLoopbackCoordinatorEnvironmentKey =
+        "MACPROVIDER_BYOM_ALLOW_INSECURE_LOOPBACK_COORDINATOR"
     private static let maxStatusResponseBytes = 64 * 1024
 
     let baseURL: URL
@@ -1471,6 +1473,18 @@ struct BYOMModelAdmissionClient: Sendable {
     }
 
     static func httpBaseURL(from coordinatorURL: String?) -> URL? {
+        httpBaseURL(
+            from: coordinatorURL,
+            allowInsecureLoopbackHTTP: ProcessInfo.processInfo.environment[
+                allowInsecureLoopbackCoordinatorEnvironmentKey
+            ] == "1"
+        )
+    }
+
+    static func httpBaseURL(
+        from coordinatorURL: String?,
+        allowInsecureLoopbackHTTP: Bool
+    ) -> URL? {
         guard let coordinatorURL,
               var components = URLComponents(string: coordinatorURL.trimmingCharacters(in: .whitespacesAndNewlines)) else {
             return nil
@@ -1485,6 +1499,12 @@ struct BYOMModelAdmissionClient: Sendable {
             components.scheme = "https"
         case "https":
             break
+        case "http":
+            guard allowInsecureLoopbackHTTP,
+                  let loopbackURL = BYOMLoopbackOriginValidator.validatedHTTPOrigin(coordinatorURL) else {
+                return nil
+            }
+            return loopbackURL
         default:
             return nil
         }

--- a/phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift
@@ -181,7 +181,12 @@ struct ModelsOfferCommand: AsyncParsableCommand {
                 providerID: providerID
             )
             let client = try BYOMModelAdmissionClient(coordinatorURL: resolved.coordinatorURL)
-            let runtime = BYOMModelAdmissionRuntime(environment: environment, client: client)
+            let runtime = BYOMModelAdmissionRuntime(
+                environment: environment,
+                credentialStore: ProviderCredentialStoreFactory.providerStore(for: resolved.config),
+                identityStore: ProviderCredentialStoreFactory.receiptKeyStore(for: resolved.config),
+                client: client
+            )
             let status = try await runtime.submitOffer(
                 providerID: resolved.providerID,
                 target: candidate,
@@ -257,7 +262,12 @@ struct ModelsAdmissionStatusCommand: AsyncParsableCommand {
                 ollamaOrigin: skipOllama ? nil : ollamaOrigin
             )
             let client = try BYOMModelAdmissionClient(coordinatorURL: resolved.coordinatorURL)
-            let runtime = BYOMModelAdmissionRuntime(environment: environment, client: client)
+            let runtime = BYOMModelAdmissionRuntime(
+                environment: environment,
+                credentialStore: ProviderCredentialStoreFactory.providerStore(for: resolved.config),
+                identityStore: ProviderCredentialStoreFactory.receiptKeyStore(for: resolved.config),
+                client: client
+            )
             let status = try await runtime.status(providerID: resolved.providerID, target: candidate)
             try ModelSwitchingWireCodec.printJSON(status)
         } catch let error as BYOMModelAdmissionError {
@@ -327,7 +337,12 @@ struct ModelsAdmissionWithdrawCommand: AsyncParsableCommand {
                 ollamaOrigin: skipOllama ? nil : ollamaOrigin
             )
             let client = try BYOMModelAdmissionClient(coordinatorURL: resolved.coordinatorURL)
-            let runtime = BYOMModelAdmissionRuntime(environment: environment, client: client)
+            let runtime = BYOMModelAdmissionRuntime(
+                environment: environment,
+                credentialStore: ProviderCredentialStoreFactory.providerStore(for: resolved.config),
+                identityStore: ProviderCredentialStoreFactory.receiptKeyStore(for: resolved.config),
+                client: client
+            )
             let withdrawal = try await runtime.withdraw(
                 providerID: resolved.providerID,
                 target: candidate,
@@ -434,16 +449,14 @@ struct ModelsCatalogEconomicsCommand: AsyncParsableCommand {
         discovery: BYOMDiscoveryWire
     ) async -> [String: BYOMAdmissionStatusWire] {
         guard !skipCoordinatorStatus,
-              let resolved = try? loadModelAdmissionConfig(
-                  config: config,
-                  coordinatorURL: coordinatorURL,
-                  providerID: providerID
-              ),
+              let resolved = try? loadModelAdmissionRuntimeConfig(),
               let client = try? BYOMModelAdmissionClient(coordinatorURL: resolved.coordinatorURL)
         else {
             return [:]
         }
-        guard let bearer = try? KeychainProviderCredentialStore().load(providerID: resolved.providerID) else {
+        guard let bearer = try? ProviderCredentialStoreFactory
+            .providerStore(for: resolved.config)
+            .load(providerID: resolved.providerID) else {
             return [:]
         }
         var statuses: [String: BYOMAdmissionStatusWire] = [:]
@@ -459,14 +472,37 @@ struct ModelsCatalogEconomicsCommand: AsyncParsableCommand {
         }
         return statuses
     }
+
+    private func loadModelAdmissionRuntimeConfig() throws -> (
+        config: AppConfig,
+        coordinatorURL: String,
+        providerID: String
+    ) {
+        var resolved = try ConfigLoader.load(cli: CLIOverrides(
+            coordinatorURL: coordinatorURL,
+            providerID: providerID,
+            configPath: config
+        ))
+        guard let providerID = resolved.providerID?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !providerID.isEmpty else {
+            throw BYOMModelAdmissionError.missingProviderID
+        }
+        guard let coordinatorURL = resolved.coordinatorURL?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !coordinatorURL.isEmpty else {
+            throw BYOMModelAdmissionError.missingCoordinatorURL
+        }
+        resolved.providerID = providerID
+        resolved.coordinatorURL = coordinatorURL
+        return (resolved, coordinatorURL, providerID)
+    }
 }
 
 private func loadModelAdmissionConfig(
     config: String?,
     coordinatorURL: String?,
     providerID: String?
-) throws -> (coordinatorURL: String, providerID: String) {
-    let resolved = try ConfigLoader.load(cli: CLIOverrides(
+) throws -> (config: AppConfig, coordinatorURL: String, providerID: String) {
+    var resolved = try ConfigLoader.load(cli: CLIOverrides(
         coordinatorURL: coordinatorURL,
         providerID: providerID,
         configPath: config
@@ -479,7 +515,9 @@ private func loadModelAdmissionConfig(
           !coordinatorURL.isEmpty else {
         throw BYOMModelAdmissionError.missingCoordinatorURL
     }
-    return (coordinatorURL, providerID)
+    resolved.providerID = providerID
+    resolved.coordinatorURL = coordinatorURL
+    return (resolved, coordinatorURL, providerID)
 }
 
 struct ModelsListCommand: AsyncParsableCommand {

--- a/phase3-binary/Tests/macprovider-cliTests/BYOMDiscoveryTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/BYOMDiscoveryTests.swift
@@ -311,6 +311,20 @@ final class BYOMDiscoveryTests: XCTestCase {
         ))
     }
 
+    func testAdmissionClientUsesDirectNoProxyConfigurationForInsecureLoopbackTesting() throws {
+        let baseURL = try XCTUnwrap(BYOMModelAdmissionClient.httpBaseURL(
+            from: "http://127.0.0.1:11434",
+            allowInsecureLoopbackHTTP: true
+        ))
+        let configuration = BYOMModelAdmissionClient.urlSessionConfiguration(for: baseURL)
+
+        XCTAssertEqual(configuration.connectionProxyDictionary?.isEmpty, true)
+        XCTAssertNil(configuration.urlCache)
+        XCTAssertNil(configuration.httpCookieStorage)
+        XCTAssertEqual(configuration.httpCookieAcceptPolicy, .never)
+        XCTAssertFalse(configuration.waitsForConnectivity)
+    }
+
     func testOllamaDiscoveryUsesHermeticLoopbackResponseAndRedactsUnsafeFields() async throws {
         let root = try temporaryDirectory("byom-ollama")
         let namespace = root.appendingPathComponent("ns")

--- a/phase3-binary/Tests/macprovider-cliTests/BYOMDiscoveryTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/BYOMDiscoveryTests.swift
@@ -280,6 +280,37 @@ final class BYOMDiscoveryTests: XCTestCase {
         XCTAssertNil(BYOMLoopbackOriginValidator.validatedHTTPOrigin("unix:///tmp/ollama.sock"))
     }
 
+    func testAdmissionClientAllowsInsecureHTTPOnlyForExplicitLoopbackTesting() {
+        XCTAssertNil(BYOMModelAdmissionClient.httpBaseURL(
+            from: "http://127.0.0.1:11434",
+            allowInsecureLoopbackHTTP: false
+        ))
+        XCTAssertEqual(
+            BYOMModelAdmissionClient.httpBaseURL(
+                from: "http://127.0.0.1:11434",
+                allowInsecureLoopbackHTTP: true
+            )?.absoluteString,
+            "http://127.0.0.1:11434"
+        )
+
+        XCTAssertNil(BYOMModelAdmissionClient.httpBaseURL(
+            from: "http://localhost:11434",
+            allowInsecureLoopbackHTTP: true
+        ))
+        XCTAssertNil(BYOMModelAdmissionClient.httpBaseURL(
+            from: "http://192.168.1.10:11434",
+            allowInsecureLoopbackHTTP: true
+        ))
+        XCTAssertNil(BYOMModelAdmissionClient.httpBaseURL(
+            from: "http://user:pass@127.0.0.1:11434",
+            allowInsecureLoopbackHTTP: true
+        ))
+        XCTAssertNil(BYOMModelAdmissionClient.httpBaseURL(
+            from: "http://127.0.0.1:11434/ws/provider",
+            allowInsecureLoopbackHTTP: true
+        ))
+    }
+
     func testOllamaDiscoveryUsesHermeticLoopbackResponseAndRedactsUnsafeFields() async throws {
         let root = try temporaryDirectory("byom-ollama")
         let namespace = root.appendingPathComponent("ns")

--- a/phase3-binary/app/Sources/Malibu/ModelManagement/MalibuJSONDuplicateKeyScanner.swift
+++ b/phase3-binary/app/Sources/Malibu/ModelManagement/MalibuJSONDuplicateKeyScanner.swift
@@ -1,0 +1,138 @@
+import Foundation
+
+/// Rejects JSON input that contains duplicate object keys. `JSONDecoder` (and
+/// `JSONSerialization`) silently keep one value for a duplicated key, so an
+/// ambiguous/malformed catalog-economics projection — e.g. first
+/// `"economics_state":"trusted"` then a later conflicting value for the same key
+/// — could otherwise reach trusted-row rendering. The closed-schema decoder
+/// rejects unknown keys but not duplicate known keys, so this preflight runs
+/// before decoding. Ported from the CLI's AutotuneStrictJSON duplicate-key
+/// scanner to keep memory/CLI parity without adding a cross-package dependency.
+enum MalibuStrictJSON {
+    static func rejectDuplicateKeys(_ data: Data) throws {
+        var scanner = JSONDuplicateKeyScanner(data: data)
+        try scanner.validate()
+    }
+}
+
+private struct JSONDuplicateKeyScanner {
+    private let bytes: [UInt8]
+    private var index = 0
+
+    init(data: Data) {
+        bytes = Array(data)
+    }
+
+    mutating func validate() throws {
+        skipWhitespace()
+        try parseValue()
+        skipWhitespace()
+        guard index == bytes.count else { throw invalid("trailing bytes") }
+    }
+
+    private mutating func parseValue() throws {
+        guard index < bytes.count else { throw invalid("unexpected end") }
+        switch bytes[index] {
+        case 0x7B: try parseObject()
+        case 0x5B: try parseArray()
+        case 0x22: _ = try parseString()
+        case 0x74: try consumeLiteral("true")
+        case 0x66: try consumeLiteral("false")
+        case 0x6E: try consumeLiteral("null")
+        default: try parseNumber()
+        }
+    }
+
+    private mutating func parseObject() throws {
+        index += 1
+        skipWhitespace()
+        var keys = Set<String>()
+        if consume(0x7D) { return }
+        while true {
+            guard index < bytes.count, bytes[index] == 0x22 else { throw invalid("object key") }
+            let key = try parseString()
+            guard keys.insert(key).inserted else { throw invalid("duplicate object key \(key)") }
+            skipWhitespace()
+            guard consume(0x3A) else { throw invalid("object colon") }
+            skipWhitespace()
+            try parseValue()
+            skipWhitespace()
+            if consume(0x7D) { return }
+            guard consume(0x2C) else { throw invalid("object separator") }
+            skipWhitespace()
+        }
+    }
+
+    private mutating func parseArray() throws {
+        index += 1
+        skipWhitespace()
+        if consume(0x5D) { return }
+        while true {
+            try parseValue()
+            skipWhitespace()
+            if consume(0x5D) { return }
+            guard consume(0x2C) else { throw invalid("array separator") }
+            skipWhitespace()
+        }
+    }
+
+    private mutating func parseString() throws -> String {
+        let start = index
+        index += 1
+        var escaped = false
+        while index < bytes.count {
+            let byte = bytes[index]
+            index += 1
+            if escaped {
+                escaped = false
+                continue
+            }
+            if byte == 0x5C {
+                escaped = true
+            } else if byte == 0x22 {
+                let token = Data(bytes[start ..< index])
+                guard let decoded = try? JSONDecoder().decode(String.self, from: token) else {
+                    throw invalid("string")
+                }
+                return decoded
+            } else if byte < 0x20 {
+                throw invalid("control character")
+            }
+        }
+        throw invalid("unterminated string")
+    }
+
+    private mutating func parseNumber() throws {
+        let start = index
+        while index < bytes.count, ![0x20, 0x09, 0x0A, 0x0D, 0x2C, 0x5D, 0x7D].contains(bytes[index]) {
+            index += 1
+        }
+        guard index > start else { throw invalid("number") }
+        let token = Data(bytes[start ..< index])
+        guard (try? JSONSerialization.jsonObject(with: token, options: [.fragmentsAllowed])) is NSNumber else {
+            throw invalid("number")
+        }
+    }
+
+    private mutating func consumeLiteral(_ literal: String) throws {
+        let expected = Array(literal.utf8)
+        guard index + expected.count <= bytes.count,
+              Array(bytes[index ..< index + expected.count]) == expected
+        else { throw invalid("literal") }
+        index += expected.count
+    }
+
+    private mutating func skipWhitespace() {
+        while index < bytes.count, [0x20, 0x09, 0x0A, 0x0D].contains(bytes[index]) { index += 1 }
+    }
+
+    private mutating func consume(_ byte: UInt8) -> Bool {
+        guard index < bytes.count, bytes[index] == byte else { return false }
+        index += 1
+        return true
+    }
+
+    private func invalid(_ reason: String) -> ModelManagementError {
+        .invalidCatalog
+    }
+}

--- a/phase3-binary/app/Sources/Malibu/ModelManagement/ModelManagement.swift
+++ b/phase3-binary/app/Sources/Malibu/ModelManagement/ModelManagement.swift
@@ -513,24 +513,11 @@ struct MalibuModelCatalogEconomicsDocument: Decodable, Equatable, Sendable {
         }
     }
 
-    private struct DecodedRow: Decodable {
-        let row: Row?
-
-        init(from decoder: Decoder) throws {
-            do {
-                row = try Row(from: decoder)
-            } catch {
-                row = nil
-            }
-        }
-    }
-
     let schema: String
     let generatedAt: String
     let projectionSequence: UInt64
     let source: Source
     let rows: [Row]
-    let invalidRowCount: Int
     let warnings: [String]
 
     enum CodingKeys: String, CodingKey, CaseIterable {
@@ -549,9 +536,11 @@ struct MalibuModelCatalogEconomicsDocument: Decodable, Equatable, Sendable {
         generatedAt = try container.decode(String.self, forKey: .generatedAt)
         projectionSequence = try container.decode(UInt64.self, forKey: .projectionSequence)
         source = try container.decode(Source.self, forKey: .source)
-        let decodedRows = try container.decode([DecodedRow].self, forKey: .rows)
-        rows = decodedRows.compactMap(\.row)
-        invalidRowCount = decodedRows.count - rows.count
+        // Strict, closed-schema decode: any malformed / unknown-field row fails
+        // the WHOLE projection (fail-closed) rather than being quarantined and the
+        // rest of the trusted rows still rendered. A malformed row can indicate a
+        // tampered or incompatible projection, so none of it is trustworthy.
+        rows = try container.decode([Row].self, forKey: .rows)
         warnings = try container.decode([String].self, forKey: .warnings)
     }
 
@@ -588,6 +577,10 @@ struct MalibuModelCatalogEconomicsDocument: Decodable, Equatable, Sendable {
                 currentModelID: currentModelID
             )
         }
+    }
+
+    var generatedAtDate: Date? {
+        Self.date(from: generatedAt)
     }
 
     var freshnessDeadline: Date? {
@@ -644,6 +637,23 @@ struct MalibuModelCatalogEconomicsDocument: Decodable, Equatable, Sendable {
                   row.providerPromptPayoutUSDPerMillionTokens != nil,
                   row.providerCompletionPayoutUSDPerMillionTokens != nil else {
                 throw ModelManagementError.invalidCatalog
+            }
+            // A trusted-economics row that is NOT settlement_capable (e.g.
+            // catalog_priced) may display signed catalog rates, but the provider
+            // is not earning yet. It MUST carry the non-earning disclosure warning
+            // so Malibu always shows "No provider credit yet" alongside the rates.
+            // Reject a projection that shows catalog economics for a
+            // non-settlement row without it — the disclosure must not depend on a
+            // possibly-omitted warning, and a settlement_capable row must not
+            // carry it.
+            if row.admission.settlementCapable {
+                guard !row.warningCodes.contains("admission_state_not_settlement_capable") else {
+                    throw ModelManagementError.invalidCatalog
+                }
+            } else {
+                guard row.warningCodes.contains("admission_state_not_settlement_capable") else {
+                    throw ModelManagementError.invalidCatalog
+                }
             }
         }
         if row.switchAction.available {
@@ -776,7 +786,9 @@ struct MalibuModelCatalogEconomicsDocument: Decodable, Equatable, Sendable {
                   let timeout = action.actionTimeoutSeconds,
                   Self.closedTransactionKinds.contains(kind),
                   UUID(uuidString: transactionID) != nil,
-                  (1...1_800).contains(timeout) else {
+                  (1...1_800).contains(timeout),
+                  // An available action must not carry an unavailable reason.
+                  action.unavailableReason == nil else {
                 throw ModelManagementError.invalidCatalog
             }
             if ["switch_model", "switch_model_deferred", "prepare_model", "cleanup_staging", "adopt_recommendation"].contains(kind)
@@ -786,7 +798,14 @@ struct MalibuModelCatalogEconomicsDocument: Decodable, Equatable, Sendable {
         } else {
             guard action.transactionKind == nil,
                   action.transactionID == nil,
-                  action.actionTimeoutSeconds == nil else {
+                  action.actionTimeoutSeconds == nil,
+                  // An unavailable action must carry a non-empty reason so the UI
+                  // never renders a disabled action with no explanation. The reason
+                  // is mapped to localized copy through a closed switch at display
+                  // time, so unknown values degrade safely rather than showing raw
+                  // text.
+                  let reason = action.unavailableReason,
+                  !reason.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
                 throw ModelManagementError.invalidCatalog
             }
         }
@@ -1526,6 +1545,7 @@ final class ModelManagementStore: ObservableObject {
     private var backgroundCheckSafetyCancelled = false
     private var catalogProjectionProcessLaunchID: String?
     private var catalogProjectionSequence: UInt64?
+    private var catalogProjectionAcceptedGeneratedAt: Date?
     private var catalogProjectionExpiryTask: Task<Void, Never>?
 
     init(
@@ -1819,6 +1839,7 @@ final class ModelManagementStore: ObservableObject {
         catalogProjectionExpiryTask = nil
         catalogProjectionProcessLaunchID = nil
         catalogProjectionSequence = nil
+        catalogProjectionAcceptedGeneratedAt = nil
     }
 
     private func refreshCatalogEconomics(configuredModel: String?) async {
@@ -1850,17 +1871,11 @@ final class ModelManagementStore: ObservableObject {
             self.listState = rows.contains(where: { $0.action == .switchModel }) ? .ready : .viewOnly
             self.operation = .idle
             if rows.isEmpty {
-                self.statusLine = document.invalidRowCount > 0
-                    ? String(localized: "Network catalog loaded, but unsupported rows were hidden. Local BYOM discovery remains CLI-only in this release.", comment: "Catalog economics unsupported rows")
-                    : String(localized: "Network catalog has no admitted economics rows yet. Local BYOM discovery remains CLI-only in this release.", comment: "Catalog economics empty")
+                self.statusLine = String(localized: "Network catalog has no admitted economics rows yet. Local BYOM discovery remains CLI-only in this release.", comment: "Catalog economics empty")
             } else if rows.contains(where: { $0.providerCompletionPayoutUSDPerMillionTokens != nil }) {
-                self.statusLine = document.invalidRowCount > 0
-                    ? String(localized: "Network catalog rates loaded from the provider CLI projection. Unsupported rows were hidden.", comment: "Catalog economics loaded with unsupported rows")
-                    : String(localized: "Network catalog rates loaded from the provider CLI projection.", comment: "Catalog economics loaded")
+                self.statusLine = String(localized: "Network catalog rates loaded from the provider CLI projection.", comment: "Catalog economics loaded")
             } else {
-                self.statusLine = document.invalidRowCount > 0
-                    ? String(localized: "Network catalog loaded with no trusted rate rows available. Unsupported rows were hidden.", comment: "Catalog economics no trusted rates with unsupported rows")
-                    : String(localized: "Network catalog loaded with no trusted rate rows available.", comment: "Catalog economics no trusted rates")
+                self.statusLine = String(localized: "Network catalog loaded with no trusted rate rows available.", comment: "Catalog economics no trusted rates")
             }
             scheduleCatalogProjectionExpiry(document)
         } catch {
@@ -1873,14 +1888,25 @@ final class ModelManagementStore: ObservableObject {
     }
 
     private func acceptCatalogProjection(_ document: MalibuModelCatalogEconomicsDocument) -> Bool {
-        guard catalogProjectionProcessLaunchID == document.source.processLaunchID,
-              let previousSequence = catalogProjectionSequence else {
-            catalogProjectionProcessLaunchID = document.source.processLaunchID
-            catalogProjectionSequence = document.projectionSequence
-            return true
+        guard let incomingGeneratedAt = document.generatedAtDate else {
+            return false
         }
-        guard document.projectionSequence > previousSequence else { return false }
+        // Never accept a projection older than the one currently displayed, even
+        // when it carries a different process_launch_id. A slow reply from an
+        // OLDER CLI process (before a restart) must not overwrite newer accepted
+        // state and reintroduce stale rates/actions. Cross-process ordering is by
+        // generated_at; within a process, projection_sequence is the tiebreaker.
+        if let acceptedGeneratedAt = catalogProjectionAcceptedGeneratedAt,
+           incomingGeneratedAt < acceptedGeneratedAt {
+            return false
+        }
+        if catalogProjectionProcessLaunchID == document.source.processLaunchID,
+           let previousSequence = catalogProjectionSequence {
+            guard document.projectionSequence > previousSequence else { return false }
+        }
+        catalogProjectionProcessLaunchID = document.source.processLaunchID
         catalogProjectionSequence = document.projectionSequence
+        catalogProjectionAcceptedGeneratedAt = incomingGeneratedAt
         return true
     }
 
@@ -2394,6 +2420,11 @@ final class ModelManagementStore: ObservableObject {
               let data = lines[0].data(using: .utf8) else {
             throw ModelManagementError.invalidCatalog
         }
+        // Reject ambiguous input with duplicate object keys before decoding: the
+        // closed-schema decoder rejects unknown keys but Foundation silently keeps
+        // one value for a duplicated known key, which could smuggle conflicting
+        // trusted-economics values into a rendered row.
+        try MalibuStrictJSON.rejectDuplicateKeys(data)
         return try JSONDecoder().decode(MalibuModelCatalogEconomicsDocument.self, from: data)
     }
 
@@ -2515,6 +2546,19 @@ struct MalibuModelRow: Identifiable, Equatable, Sendable {
 
     let id: String
     let displayID: String
+    // The coordinator-verified catalog identity (catalog model key) for a
+    // trusted-economics network-catalog row. displayID is the provider-REPORTED
+    // name and must never be presented as catalog-verified; when this is set the
+    // UI shows it as the authoritative catalog identity so provider-reported text
+    // cannot masquerade as verified. nil for rows without trusted catalog
+    // economics.
+    let catalogVerifiedModelKey: String?
+    // Non-blocking "no provider credit yet" disclosure for a trusted-economics
+    // row that is not settlement_capable (e.g. catalog_priced). It is rendered
+    // beside the rates regardless of whether the row is switchable / actionable,
+    // so a switchable catalog_priced row can never show rates without the
+    // non-earning caveat. nil for settlement_capable and non-economics rows.
+    let nonEarningDisclosure: String?
     var category: Category
     let state: String
     let weightsPresentLocally: Bool
@@ -2532,6 +2576,8 @@ struct MalibuModelRow: Identifiable, Equatable, Sendable {
     init(row: MalibuModelsListDocument.Row, currentModelID: String?, warmSwapAvailable: Bool) {
         id = row.actionModelID
         displayID = row.displayID
+        catalogVerifiedModelKey = nil
+        nonEarningDisclosure = nil
         state = row.state
         weightsPresentLocally = row.weightsPresentLocally
         fit = row.fit ?? "unknown"
@@ -2578,6 +2624,12 @@ struct MalibuModelRow: Identifiable, Equatable, Sendable {
         let projectedID = row.actionModelID ?? row.modelKey
         id = projectedID
         displayID = row.displayModelID
+        catalogVerifiedModelKey = (row.economicsState == "trusted" && row.admission.catalogEconomicsPermitted)
+            ? row.modelKey
+            : nil
+        nonEarningDisclosure = (row.economicsState == "trusted" && !row.admission.settlementCapable)
+            ? String(localized: "No provider credit yet; catalog and receipt checks are still required.", comment: "Non-earning disclosure beside catalog rates for a non-settlement row")
+            : nil
         state = row.runtimeState
         weightsPresentLocally = row.weightsPresentLocally
         fit = Self.displayFit(row.fit)
@@ -2647,6 +2699,8 @@ struct MalibuModelRow: Identifiable, Equatable, Sendable {
 
         id = projectedID
         displayID = row.displayModelID
+        catalogVerifiedModelKey = nil
+        nonEarningDisclosure = nil
         state = row.runtimeState
         weightsPresentLocally = row.weightsPresentLocally
         fit = Self.displayFit(row.fit)

--- a/phase3-binary/app/Sources/Malibu/ModelManagement/ModelManagement.swift
+++ b/phase3-binary/app/Sources/Malibu/ModelManagement/ModelManagement.swift
@@ -303,6 +303,589 @@ struct MalibuModelsListDocument: Decodable, Equatable, Sendable {
     }
 }
 
+struct MalibuModelCatalogEconomicsDocument: Decodable, Equatable, Sendable {
+    struct Source: Decodable, Equatable, Sendable {
+        let cliVersion: String
+        let cliBuildCommit: String
+        let processLaunchID: String
+        let processStartedAt: String
+        let projectionProtocolVersion: String
+        let rateCardSource: String
+        let rateCardDigest: String?
+        let rateCardSignatureDigest: String?
+        let demandFeedDigest: String?
+        let candidateFeedDigest: String?
+        let rateCardMaxAgeSeconds: Int
+
+        enum CodingKeys: String, CodingKey, CaseIterable {
+            case cliVersion = "cli_version"
+            case cliBuildCommit = "cli_build_commit"
+            case processLaunchID = "process_launch_id"
+            case processStartedAt = "process_started_at"
+            case projectionProtocolVersion = "projection_protocol_version"
+            case rateCardSource = "rate_card_source"
+            case rateCardDigest = "rate_card_digest"
+            case rateCardSignatureDigest = "rate_card_signature_digest"
+            case demandFeedDigest = "demand_feed_digest"
+            case candidateFeedDigest = "candidate_feed_digest"
+            case rateCardMaxAgeSeconds = "rate_card_max_age_seconds"
+        }
+
+        init(from decoder: Decoder) throws {
+            try rejectUnknownKeys(decoder, allowed: CodingKeys.allCases.map(\.stringValue))
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            cliVersion = try container.decode(String.self, forKey: .cliVersion)
+            cliBuildCommit = try container.decode(String.self, forKey: .cliBuildCommit)
+            processLaunchID = try container.decode(String.self, forKey: .processLaunchID)
+            processStartedAt = try container.decode(String.self, forKey: .processStartedAt)
+            projectionProtocolVersion = try container.decode(String.self, forKey: .projectionProtocolVersion)
+            rateCardSource = try container.decode(String.self, forKey: .rateCardSource)
+            rateCardDigest = try decodeExplicitNullableString(container, .rateCardDigest)
+            rateCardSignatureDigest = try decodeExplicitNullableString(container, .rateCardSignatureDigest)
+            demandFeedDigest = try decodeExplicitNullableString(container, .demandFeedDigest)
+            candidateFeedDigest = try decodeExplicitNullableString(container, .candidateFeedDigest)
+            rateCardMaxAgeSeconds = try container.decode(Int.self, forKey: .rateCardMaxAgeSeconds)
+        }
+    }
+
+    struct Admission: Decodable, Equatable, Sendable {
+        let state: String
+        let source: String
+        let coordinatorEventID: String?
+        let stateObservedAt: String?
+        let catalogEconomicsPermitted: Bool
+        let settlementCapable: Bool
+
+        enum CodingKeys: String, CodingKey, CaseIterable {
+            case state
+            case source
+            case coordinatorEventID = "coordinator_event_id"
+            case stateObservedAt = "state_observed_at"
+            case catalogEconomicsPermitted = "catalog_economics_permitted"
+            case settlementCapable = "settlement_capable"
+        }
+
+        init(from decoder: Decoder) throws {
+            try rejectUnknownKeys(decoder, allowed: CodingKeys.allCases.map(\.stringValue))
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            state = try container.decode(String.self, forKey: .state)
+            source = try container.decode(String.self, forKey: .source)
+            coordinatorEventID = try decodeExplicitNullableString(container, .coordinatorEventID)
+            stateObservedAt = try decodeExplicitNullableString(container, .stateObservedAt)
+            catalogEconomicsPermitted = try container.decode(Bool.self, forKey: .catalogEconomicsPermitted)
+            settlementCapable = try container.decode(Bool.self, forKey: .settlementCapable)
+        }
+    }
+
+    struct Action: Decodable, Equatable, Sendable {
+        let available: Bool
+        let requiresConfirmation: Bool
+        let transactionKind: String?
+        let transactionID: String?
+        let actionTimeoutSeconds: Int?
+        let estimatedBytes: Int64?
+        let unavailableReason: String?
+
+        enum CodingKeys: String, CodingKey, CaseIterable {
+            case available
+            case requiresConfirmation = "requires_confirmation"
+            case transactionKind = "transaction_kind"
+            case transactionID = "transaction_id"
+            case actionTimeoutSeconds = "action_timeout_seconds"
+            case estimatedBytes = "estimated_bytes"
+            case unavailableReason = "unavailable_reason"
+        }
+
+        init(from decoder: Decoder) throws {
+            try rejectUnknownKeys(decoder, allowed: CodingKeys.allCases.map(\.stringValue))
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            available = try container.decode(Bool.self, forKey: .available)
+            requiresConfirmation = try container.decode(Bool.self, forKey: .requiresConfirmation)
+            transactionKind = try decodeExplicitNullableString(container, .transactionKind)
+            transactionID = try decodeExplicitNullableString(container, .transactionID)
+            actionTimeoutSeconds = try decodeExplicitNullableInt(container, .actionTimeoutSeconds)
+            estimatedBytes = try decodeExplicitNullableInt64(container, .estimatedBytes)
+            unavailableReason = try decodeExplicitNullableString(container, .unavailableReason)
+        }
+    }
+
+    struct Row: Decodable, Equatable, Sendable {
+        let modelKey: String
+        let servedModelID: String
+        let displayModelID: String
+        let actionModelID: String?
+        let isCurrent: Bool
+        let weightsPresentLocally: Bool
+        let runtimeState: String
+        let estimatedGB: Double?
+        let fit: String
+        let disabledReason: String?
+        let warningCodes: [String]
+        let admission: Admission
+        let rateCardVersion: String?
+        let rateCardGeneratedAt: String?
+        let rateCardKey: String?
+        let rateSource: String
+        let promptRateUSDPerMillionTokens: Double?
+        let completionRateUSDPerMillionTokens: Double?
+        let providerShareBPS: Int?
+        let providerPromptPayoutUSDPerMillionTokens: Double?
+        let providerCompletionPayoutUSDPerMillionTokens: Double?
+        let economicsState: String
+        let demandRank: Int?
+        let demandWeight: Double?
+        let readyProviderCount: Int?
+        let supplyDeficitScore: Double?
+        let switchAction: Action
+        let prepareAction: Action
+        let evaluateAction: Action
+        let adoptRecommendationAction: Action
+        let cleanupStagingAction: Action
+
+        enum CodingKeys: String, CodingKey, CaseIterable {
+            case modelKey = "model_key"
+            case servedModelID = "served_model_id"
+            case displayModelID = "display_model_id"
+            case actionModelID = "action_model_id"
+            case isCurrent = "is_current"
+            case weightsPresentLocally = "weights_present_locally"
+            case runtimeState = "runtime_state"
+            case estimatedGB = "estimated_gb"
+            case fit
+            case disabledReason = "disabled_reason"
+            case warningCodes = "warning_codes"
+            case admission
+            case rateCardVersion = "rate_card_version"
+            case rateCardGeneratedAt = "rate_card_generated_at"
+            case rateCardKey = "rate_card_key"
+            case rateSource = "rate_source"
+            case promptRateUSDPerMillionTokens = "prompt_rate_usd_per_million_tokens"
+            case completionRateUSDPerMillionTokens = "completion_rate_usd_per_million_tokens"
+            case providerShareBPS = "provider_share_bps"
+            case providerPromptPayoutUSDPerMillionTokens = "provider_prompt_payout_usd_per_million_tokens"
+            case providerCompletionPayoutUSDPerMillionTokens = "provider_completion_payout_usd_per_million_tokens"
+            case economicsState = "economics_state"
+            case demandRank = "demand_rank"
+            case demandWeight = "demand_weight"
+            case readyProviderCount = "ready_provider_count"
+            case supplyDeficitScore = "supply_deficit_score"
+            case switchAction = "switch"
+            case prepareAction = "prepare"
+            case evaluateAction = "evaluate"
+            case adoptRecommendationAction = "adopt_recommendation"
+            case cleanupStagingAction = "cleanup_staging"
+        }
+
+        init(from decoder: Decoder) throws {
+            try rejectUnknownKeys(decoder, allowed: CodingKeys.allCases.map(\.stringValue))
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            modelKey = try container.decode(String.self, forKey: .modelKey)
+            servedModelID = try container.decode(String.self, forKey: .servedModelID)
+            displayModelID = try container.decode(String.self, forKey: .displayModelID)
+            actionModelID = try decodeExplicitNullableString(container, .actionModelID)
+            isCurrent = try container.decode(Bool.self, forKey: .isCurrent)
+            weightsPresentLocally = try container.decode(Bool.self, forKey: .weightsPresentLocally)
+            runtimeState = try container.decode(String.self, forKey: .runtimeState)
+            estimatedGB = try decodeExplicitNullableDouble(container, .estimatedGB)
+            fit = try container.decode(String.self, forKey: .fit)
+            disabledReason = try decodeExplicitNullableString(container, .disabledReason)
+            warningCodes = try container.decode([String].self, forKey: .warningCodes)
+            admission = try container.decode(Admission.self, forKey: .admission)
+            rateCardVersion = try decodeExplicitNullableString(container, .rateCardVersion)
+            rateCardGeneratedAt = try decodeExplicitNullableString(container, .rateCardGeneratedAt)
+            rateCardKey = try decodeExplicitNullableString(container, .rateCardKey)
+            rateSource = try container.decode(String.self, forKey: .rateSource)
+            promptRateUSDPerMillionTokens = try decodeExplicitNullableDouble(container, .promptRateUSDPerMillionTokens)
+            completionRateUSDPerMillionTokens = try decodeExplicitNullableDouble(container, .completionRateUSDPerMillionTokens)
+            providerShareBPS = try decodeExplicitNullableInt(container, .providerShareBPS)
+            providerPromptPayoutUSDPerMillionTokens = try decodeExplicitNullableDouble(container, .providerPromptPayoutUSDPerMillionTokens)
+            providerCompletionPayoutUSDPerMillionTokens = try decodeExplicitNullableDouble(container, .providerCompletionPayoutUSDPerMillionTokens)
+            economicsState = try container.decode(String.self, forKey: .economicsState)
+            demandRank = try decodeExplicitNullableInt(container, .demandRank)
+            demandWeight = try decodeExplicitNullableDouble(container, .demandWeight)
+            readyProviderCount = try decodeExplicitNullableInt(container, .readyProviderCount)
+            supplyDeficitScore = try decodeExplicitNullableDouble(container, .supplyDeficitScore)
+            switchAction = try container.decode(Action.self, forKey: .switchAction)
+            prepareAction = try container.decode(Action.self, forKey: .prepareAction)
+            evaluateAction = try container.decode(Action.self, forKey: .evaluateAction)
+            adoptRecommendationAction = try container.decode(Action.self, forKey: .adoptRecommendationAction)
+            cleanupStagingAction = try container.decode(Action.self, forKey: .cleanupStagingAction)
+        }
+    }
+
+    private struct DecodedRow: Decodable {
+        let row: Row?
+
+        init(from decoder: Decoder) throws {
+            do {
+                row = try Row(from: decoder)
+            } catch {
+                row = nil
+            }
+        }
+    }
+
+    let schema: String
+    let generatedAt: String
+    let projectionSequence: UInt64
+    let source: Source
+    let rows: [Row]
+    let invalidRowCount: Int
+    let warnings: [String]
+
+    enum CodingKeys: String, CodingKey, CaseIterable {
+        case schema
+        case generatedAt = "generated_at"
+        case projectionSequence = "projection_sequence"
+        case source
+        case rows
+        case warnings
+    }
+
+    init(from decoder: Decoder) throws {
+        try rejectUnknownKeys(decoder, allowed: CodingKeys.allCases.map(\.stringValue))
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        schema = try container.decode(String.self, forKey: .schema)
+        generatedAt = try container.decode(String.self, forKey: .generatedAt)
+        projectionSequence = try container.decode(UInt64.self, forKey: .projectionSequence)
+        source = try container.decode(Source.self, forKey: .source)
+        let decodedRows = try container.decode([DecodedRow].self, forKey: .rows)
+        rows = decodedRows.compactMap(\.row)
+        invalidRowCount = decodedRows.count - rows.count
+        warnings = try container.decode([String].self, forKey: .warnings)
+    }
+
+    func validated(now: Date = Date()) throws -> MalibuModelCatalogEconomicsDocument {
+        guard schema == "model_catalog_economics.v1",
+              Self.isValidGeneratedAt(generatedAt),
+              Self.isValidGeneratedAt(source.processStartedAt),
+              UUID(uuidString: source.processLaunchID) != nil,
+              source.processLaunchID == source.processLaunchID.lowercased(with: nil),
+              source.projectionProtocolVersion == "1",
+              ["live_signed", "static_signed", "none"].contains(source.rateCardSource),
+              (300...604_800).contains(source.rateCardMaxAgeSeconds),
+              generatedAtIsCurrent(now: now) else {
+            throw ModelManagementError.invalidCatalog
+        }
+        for warning in warnings {
+            guard Self.closedWarnings.contains(warning) else { throw ModelManagementError.invalidCatalog }
+        }
+        return self
+    }
+
+    func rowsForMalibu(currentModelID: String?, warmSwapAvailable: Bool) -> [MalibuModelRow] {
+        rows.compactMap { row in
+            if Self.shouldHideLocalDefaultBYOM(row) { return nil }
+            if (try? validate(row: row)) != nil {
+                return MalibuModelRow(
+                    economics: row,
+                    currentModelID: currentModelID,
+                    warmSwapAvailable: warmSwapAvailable
+                )
+            }
+            return MalibuModelRow(
+                unsupportedEconomics: row,
+                currentModelID: currentModelID
+            )
+        }
+    }
+
+    var freshnessDeadline: Date? {
+        guard let generated = Self.date(from: generatedAt) else { return nil }
+        let maxAge = min(300, source.rateCardMaxAgeSeconds)
+        return generated.addingTimeInterval(TimeInterval(maxAge))
+    }
+
+    private func generatedAtIsCurrent(now: Date) -> Bool {
+        guard let generated = Self.date(from: generatedAt),
+              let deadline = freshnessDeadline else { return false }
+        return generated <= now.addingTimeInterval(30)
+            && deadline >= now
+    }
+
+    private func validate(row: Row) throws {
+        guard isSafeModelID(row.modelKey),
+              isSafeModelID(row.servedModelID),
+              isSafeDisplayID(row.displayModelID),
+              row.actionModelID == nil || isSafeModelID(row.actionModelID),
+              ["current", "ready", "catalog", "needs_preparation", "blocked"].contains(row.runtimeState),
+              ["fits", "does_not_fit", "unknown"].contains(row.fit),
+              ["live_signed", "static_signed", "none"].contains(row.rateSource),
+              rowRateSourceIsNoLessConservativeThanProjection(row.rateSource),
+              ["trusted", "fallback", "stale", "blocked", "unavailable"].contains(row.economicsState),
+              row.warningCodes.allSatisfy(Self.closedWarnings.contains),
+              admissionIsValid(row.admission),
+              row.estimatedGB == nil || row.estimatedGB! >= 0,
+              row.providerShareBPS == nil || (0...10_000).contains(row.providerShareBPS!),
+              nonNegative(row.promptRateUSDPerMillionTokens),
+              nonNegative(row.completionRateUSDPerMillionTokens),
+              nonNegative(row.providerPromptPayoutUSDPerMillionTokens),
+              nonNegative(row.providerCompletionPayoutUSDPerMillionTokens),
+              nonNegative(row.demandWeight),
+              nonNegative(row.supplyDeficitScore),
+              row.readyProviderCount == nil || row.readyProviderCount! >= 0,
+              row.demandRank == nil || row.demandRank! >= 0 else {
+            throw ModelManagementError.invalidCatalog
+        }
+        if row.economicsState == "trusted" {
+            guard row.admission.catalogEconomicsPermitted,
+                  source.rateCardSource == "live_signed",
+                  row.rateSource == "live_signed",
+                  Set(warnings).isDisjoint(with: Self.trustedEconomicsBlockingWarnings),
+                  Set(row.warningCodes).isDisjoint(with: Self.trustedEconomicsBlockingWarnings),
+                  row.rateCardVersion != nil,
+                  row.rateCardGeneratedAt != nil,
+                  trustedRateTimestampIsCurrent(row.rateCardGeneratedAt),
+                  admissionStateObservationIsCurrent(row.admission.stateObservedAt),
+                  row.rateCardKey != nil,
+                  row.promptRateUSDPerMillionTokens != nil,
+                  row.completionRateUSDPerMillionTokens != nil,
+                  row.providerShareBPS != nil,
+                  row.providerPromptPayoutUSDPerMillionTokens != nil,
+                  row.providerCompletionPayoutUSDPerMillionTokens != nil else {
+                throw ModelManagementError.invalidCatalog
+            }
+        }
+        if row.switchAction.available {
+            guard ["ready", "catalog"].contains(row.runtimeState),
+                  row.disabledReason == nil,
+                  row.weightsPresentLocally,
+                  row.fit == "fits",
+                  row.actionModelID != nil,
+                  Set(warnings).isDisjoint(with: Self.switchActionBlockingWarnings),
+                  Set(row.warningCodes).isDisjoint(with: Self.switchActionBlockingWarnings) else {
+                throw ModelManagementError.invalidCatalog
+            }
+        }
+        if let stateObservedAt = row.admission.stateObservedAt,
+           Self.date(from: stateObservedAt) == nil {
+            throw ModelManagementError.invalidCatalog
+        }
+        if row.rateSource == "none" || row.economicsState == "unavailable" {
+            guard row.rateCardVersion == nil,
+                  row.rateCardGeneratedAt == nil,
+                  row.rateCardKey == nil,
+                  row.promptRateUSDPerMillionTokens == nil,
+                  row.completionRateUSDPerMillionTokens == nil,
+                  row.providerShareBPS == nil,
+                  row.providerPromptPayoutUSDPerMillionTokens == nil,
+                  row.providerCompletionPayoutUSDPerMillionTokens == nil else {
+                throw ModelManagementError.invalidCatalog
+            }
+        }
+        if row.economicsState != "trusted" {
+            guard !row.switchAction.available,
+                  !row.prepareAction.available,
+                  !row.adoptRecommendationAction.available,
+                  !row.cleanupStagingAction.available else {
+                throw ModelManagementError.invalidCatalog
+            }
+            if row.evaluateAction.available {
+                guard row.evaluateAction.transactionKind == "evaluate_model",
+                      row.evaluateAction.estimatedBytes == nil,
+                      (row.evaluateAction.actionTimeoutSeconds ?? 1_801) <= 10 else {
+                    throw ModelManagementError.invalidCatalog
+                }
+            }
+        }
+        if let disabledReason = row.disabledReason,
+           !Self.closedDisabledReasons.contains(disabledReason) {
+            throw ModelManagementError.invalidCatalog
+        }
+        try [
+            row.switchAction,
+            row.prepareAction,
+            row.evaluateAction,
+            row.adoptRecommendationAction,
+            row.cleanupStagingAction,
+        ].forEach(validate(action:))
+    }
+
+    private func admissionIsValid(_ admission: Admission) -> Bool {
+        switch admission.source {
+        case "local_default":
+            return ["local_only", "not_offered", "offerable"].contains(admission.state)
+                && !admission.catalogEconomicsPermitted
+                && !admission.settlementCapable
+        case "coordinator":
+            let states = [
+                "not_offered",
+                "offer_submitted",
+                "offer_rejected",
+                "sandbox_probe_only",
+                "network_visible_unpriced",
+                "network_admitted_unsettled",
+                "catalog_priced",
+                "settlement_capable",
+                "withdrawn",
+                "revoked",
+            ]
+            guard states.contains(admission.state) else { return false }
+            guard !admission.catalogEconomicsPermitted || ["catalog_priced", "settlement_capable"].contains(admission.state) else { return false }
+            guard !admission.settlementCapable || admission.state == "settlement_capable" else { return false }
+            return true
+        default:
+            return false
+        }
+    }
+
+    private func trustedRateTimestampIsCurrent(_ value: String?) -> Bool {
+        guard let value,
+              let rateGeneratedAt = Self.date(from: value),
+              let projectionGeneratedAt = Self.date(from: generatedAt) else { return false }
+        return rateGeneratedAt <= projectionGeneratedAt.addingTimeInterval(30)
+            && rateGeneratedAt.addingTimeInterval(TimeInterval(source.rateCardMaxAgeSeconds)) >= projectionGeneratedAt
+    }
+
+    private func admissionStateObservationIsCurrent(_ value: String?) -> Bool {
+        guard let value,
+              let observedAt = Self.date(from: value),
+              let projectionGeneratedAt = Self.date(from: generatedAt) else { return false }
+        let maxAge = min(300, source.rateCardMaxAgeSeconds)
+        return observedAt <= projectionGeneratedAt.addingTimeInterval(30)
+            && observedAt.addingTimeInterval(TimeInterval(maxAge)) >= projectionGeneratedAt
+    }
+
+    private func rowRateSourceIsNoLessConservativeThanProjection(_ rowRateSource: String) -> Bool {
+        guard let rowRank = Self.rateSourceTrustRank(rowRateSource),
+              let projectionRank = Self.rateSourceTrustRank(source.rateCardSource) else {
+            return false
+        }
+        return rowRank <= projectionRank
+    }
+
+    private static func rateSourceTrustRank(_ value: String) -> Int? {
+        switch value {
+        case "none": return 0
+        case "static_signed": return 1
+        case "live_signed": return 2
+        default: return nil
+        }
+    }
+
+    private static func shouldHideLocalDefaultBYOM(_ row: Row) -> Bool {
+        row.admission.source == "local_default"
+            && row.admission.catalogEconomicsPermitted == false
+            && row.economicsState != "trusted"
+    }
+
+    private func validate(action: Action) throws {
+        if action.available {
+            guard let kind = action.transactionKind,
+                  let transactionID = action.transactionID,
+                  let timeout = action.actionTimeoutSeconds,
+                  Self.closedTransactionKinds.contains(kind),
+                  UUID(uuidString: transactionID) != nil,
+                  (1...1_800).contains(timeout) else {
+                throw ModelManagementError.invalidCatalog
+            }
+            if ["switch_model", "switch_model_deferred", "prepare_model", "cleanup_staging", "adopt_recommendation"].contains(kind)
+                || kind == "evaluate_model" && ((action.estimatedBytes ?? 0) > 0 || timeout > 10) {
+                guard action.requiresConfirmation else { throw ModelManagementError.invalidCatalog }
+            }
+        } else {
+            guard action.transactionKind == nil,
+                  action.transactionID == nil,
+                  action.actionTimeoutSeconds == nil else {
+                throw ModelManagementError.invalidCatalog
+            }
+        }
+        if let estimatedBytes = action.estimatedBytes, estimatedBytes < 0 {
+            throw ModelManagementError.invalidCatalog
+        }
+    }
+
+    private func nonNegative(_ value: Double?) -> Bool {
+        guard let value else { return true }
+        return value.isFinite && value >= 0
+    }
+
+    private static func isValidGeneratedAt(_ value: String) -> Bool {
+        date(from: value) != nil
+    }
+
+    private static func date(from value: String) -> Date? {
+        let formatter = ISO8601DateFormatter()
+        if let date = formatter.date(from: value) { return date }
+        formatter.formatOptions.insert(.withFractionalSeconds)
+        return formatter.date(from: value)
+    }
+
+    private static let closedWarnings: Set<String> = [
+        "feed_fallback",
+        "feed_stale",
+        "feed_signature_invalid",
+        "feed_generation_mismatch",
+        "rate_multiplier_unknown",
+        "model_not_local",
+        "model_not_supported",
+        "hardware_fit_unknown",
+        "hardware_does_not_fit",
+        "admission_state_missing",
+        "admission_state_not_settlement_capable",
+        "warm_swap_unavailable",
+        "action_unavailable",
+        "old_cli_fallback",
+        "projection_unavailable",
+        "projection_timeout",
+        "staging_cleanup_required",
+    ]
+
+    private static let closedDisabledReasons: Set<String> = [
+        "action_unavailable",
+        "local_inventory_only",
+        "model_not_local",
+        "model_not_supported",
+        "hardware_fit_unknown",
+        "hardware_does_not_fit",
+        "catalog_rate_unavailable",
+        "admission_state_missing",
+        "admission_state_not_settlement_capable",
+        "projection_unsupported",
+        "staging_cleanup_required",
+    ]
+
+    private static let trustedEconomicsBlockingWarnings: Set<String> = [
+        "feed_fallback",
+        "feed_stale",
+        "feed_signature_invalid",
+        "feed_generation_mismatch",
+        "rate_multiplier_unknown",
+        "admission_state_missing",
+        "old_cli_fallback",
+        "projection_unavailable",
+        "projection_timeout",
+    ]
+
+    private static let switchActionBlockingWarnings: Set<String> = [
+        "feed_fallback",
+        "feed_stale",
+        "feed_signature_invalid",
+        "feed_generation_mismatch",
+        "rate_multiplier_unknown",
+        "model_not_local",
+        "model_not_supported",
+        "hardware_fit_unknown",
+        "hardware_does_not_fit",
+        "admission_state_missing",
+        "warm_swap_unavailable",
+        "action_unavailable",
+        "old_cli_fallback",
+        "projection_unavailable",
+        "projection_timeout",
+        "staging_cleanup_required",
+    ]
+
+    private static let closedTransactionKinds: Set<String> = [
+        "switch_model",
+        "switch_model_deferred",
+        "prepare_model",
+        "evaluate_model",
+        "adopt_recommendation",
+        "cleanup_staging",
+    ]
+}
+
 struct MalibuModelSwitchEvent: Decodable, Equatable, Sendable {
     let schemaVersion: String
     let type: String
@@ -331,16 +914,140 @@ struct MalibuModelSwitchEvent: Decodable, Equatable, Sendable {
 
 private func isSafeModelID(_ value: String?) -> Bool {
     guard let value, !value.isEmpty, value.utf8.count <= 256 else { return false }
-    return value.unicodeScalars.allSatisfy { scalar in
-        scalar.value >= 0x20 && scalar.value != 0x7F && !(0x80...0x9F).contains(scalar.value)
-    }
+    return isSafeProviderVisibleText(value)
 }
 
 private func isSafeDisplayID(_ value: String) -> Bool {
     guard !value.isEmpty, value.utf8.count <= 256 else { return false }
+    return isSafeProviderVisibleText(value)
+}
+
+private func isSafeProviderVisibleText(_ value: String) -> Bool {
+    guard !looksLikeLocalPathOrURL(value),
+          !containsProhibitedMoneyClaim(value) else { return false }
     return value.unicodeScalars.allSatisfy { scalar in
         scalar.value >= 0x20 && scalar.value != 0x7F && !(0x80...0x9F).contains(scalar.value)
+            && scalar.properties.generalCategory != .format
     }
+}
+
+private func looksLikeLocalPathOrURL(_ value: String) -> Bool {
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(with: nil)
+    return trimmed.hasPrefix("/")
+        || trimmed.hasPrefix("~/")
+        || trimmed.hasPrefix("file:")
+        || trimmed.contains("://")
+        || trimmed.contains("/private/")
+        || trimmed.contains("/users/")
+        || trimmed.contains("\\")
+}
+
+private func containsProhibitedMoneyClaim(_ value: String) -> Bool {
+    let lowercased = value.lowercased(with: nil)
+    let prohibited = [
+        "guaranteed",
+        "will pay",
+        "daily revenue",
+        "hourly pay",
+        "estimated daily",
+        "up to",
+        "up to $",
+        "earns",
+        "earn $",
+        "pays daily",
+        "potential earnings",
+        "average payout",
+        "projected return",
+        "higher-paying",
+        "higher paying",
+    ]
+    if prohibited.contains(where: { lowercased.contains($0) }) {
+        return true
+    }
+    if lowercased.contains("$")
+        || lowercased.contains("usd")
+        || lowercased.contains("dollar") {
+        return true
+    }
+    return false
+}
+
+private struct DynamicCodingKey: CodingKey {
+    let stringValue: String
+    let intValue: Int?
+
+    init?(stringValue: String) {
+        self.stringValue = stringValue
+        intValue = nil
+    }
+
+    init?(intValue: Int) {
+        stringValue = "\(intValue)"
+        self.intValue = intValue
+    }
+}
+
+private func rejectUnknownKeys(_ decoder: Decoder, allowed: [String]) throws {
+    let container = try decoder.container(keyedBy: DynamicCodingKey.self)
+    let allowed = Set(allowed)
+    if let extra = container.allKeys.first(where: { !allowed.contains($0.stringValue) }) {
+        throw DecodingError.dataCorrupted(DecodingError.Context(
+            codingPath: decoder.codingPath + [extra],
+            debugDescription: "unsupported key \(extra.stringValue)"
+        ))
+    }
+}
+
+private func decodeExplicitNullableString<Key: CodingKey>(
+    _ container: KeyedDecodingContainer<Key>,
+    _ key: Key
+) throws -> String? {
+    guard container.contains(key) else {
+        throw DecodingError.keyNotFound(key, DecodingError.Context(
+            codingPath: container.codingPath,
+            debugDescription: "required nullable field missing"
+        ))
+    }
+    return try container.decodeIfPresent(String.self, forKey: key)
+}
+
+private func decodeExplicitNullableInt<Key: CodingKey>(
+    _ container: KeyedDecodingContainer<Key>,
+    _ key: Key
+) throws -> Int? {
+    guard container.contains(key) else {
+        throw DecodingError.keyNotFound(key, DecodingError.Context(
+            codingPath: container.codingPath,
+            debugDescription: "required nullable field missing"
+        ))
+    }
+    return try container.decodeIfPresent(Int.self, forKey: key)
+}
+
+private func decodeExplicitNullableInt64<Key: CodingKey>(
+    _ container: KeyedDecodingContainer<Key>,
+    _ key: Key
+) throws -> Int64? {
+    guard container.contains(key) else {
+        throw DecodingError.keyNotFound(key, DecodingError.Context(
+            codingPath: container.codingPath,
+            debugDescription: "required nullable field missing"
+        ))
+    }
+    return try container.decodeIfPresent(Int64.self, forKey: key)
+}
+
+private func decodeExplicitNullableDouble<Key: CodingKey>(
+    _ container: KeyedDecodingContainer<Key>,
+    _ key: Key
+) throws -> Double? {
+    guard container.contains(key) else {
+        throw DecodingError.keyNotFound(key, DecodingError.Context(
+            codingPath: container.codingPath,
+            debugDescription: "required nullable field missing"
+        ))
+    }
+    return try container.decodeIfPresent(Double.self, forKey: key)
 }
 
 // MARK: - Managed CLI invocation
@@ -778,6 +1485,7 @@ final class ModelManagementStore: ObservableObject {
                 return false
             }
         }
+
     }
 
     private struct PendingSwitch: Equatable {
@@ -816,6 +1524,9 @@ final class ModelManagementStore: ObservableObject {
     private var recommendationSchedule = MalibuRecommendationSchedule()
     private var recommendationJSON: Data?
     private var backgroundCheckSafetyCancelled = false
+    private var catalogProjectionProcessLaunchID: String?
+    private var catalogProjectionSequence: UInt64?
+    private var catalogProjectionExpiryTask: Task<Void, Never>?
 
     init(
         cli: any MalibuModelCLIRunning = MalibuModelCLI.shared,
@@ -959,6 +1670,17 @@ final class ModelManagementStore: ObservableObject {
         )
     }
 
+    var catalogEconomicsCapabilityAvailable: Bool {
+        MalibuModelCapabilityManifest.checkedIn.supports(
+            MalibuModelCapabilityManifest.catalogEconomics,
+            peer: peerEvidence
+        )
+    }
+
+    var catalogProjectionRetryAvailable: Bool {
+        listState == .unavailable && catalogEconomicsCapabilityAvailable
+    }
+
     var canPerformModelAction: Bool {
         guard readySwitchCapabilityAvailable, peerObservationFresh, peerEvidence.isFresh() else { return false }
         if let cooldownUntil { return cooldownUntil <= Date() }
@@ -1050,11 +1772,13 @@ final class ModelManagementStore: ObservableObject {
         }
         let configuredModel = currentModelID ?? ProviderConfig.readModel(paths: paths)
         self.currentModelID = configuredModel
-        guard readySwitchCapabilityAvailable,
-              MalibuModelCapabilityManifest.checkedIn.supports(
-                MalibuModelCapabilityManifest.catalogJSON,
-                peer: peer
-              ) else {
+        let supportsLegacyList = readySwitchCapabilityAvailable
+        if catalogEconomicsCapabilityAvailable {
+            await refreshCatalogEconomics(configuredModel: configuredModel)
+            return
+        }
+        clearCatalogProjectionTracking()
+        guard supportsLegacyList else {
             listState = .viewOnly
             operation = .idle
             statusLine = configuredModel == nil
@@ -1087,6 +1811,107 @@ final class ModelManagementStore: ObservableObject {
             self.listState = .unavailable
             self.operation = .failed(error.localizedDescription)
             self.statusLine = String(localized: "Model controls unavailable. The current model remains visible from provider status.", comment: "Model activity status")
+        }
+    }
+
+    private func clearCatalogProjectionTracking() {
+        catalogProjectionExpiryTask?.cancel()
+        catalogProjectionExpiryTask = nil
+        catalogProjectionProcessLaunchID = nil
+        catalogProjectionSequence = nil
+    }
+
+    private func refreshCatalogEconomics(configuredModel: String?) async {
+        let previousListState = listState
+        listState = .checking
+        operation = .loadingList
+        do {
+            let result = try await cli.run(
+                arguments: [
+                    "models", "catalog-economics", "--json",
+                    "--config", paths.configFile.path,
+                    "--ctl-socket-path", paths.controlSocket.path,
+                ],
+                peer: peerEvidence,
+                onLine: { _ in }
+            )
+            guard result.exitCode == 0 else { throw ModelManagementError.invalidCatalog }
+            let document = try decodeCatalogEconomics(result.stdout).validated()
+            guard acceptCatalogProjection(document) else {
+                self.listState = previousListState
+                self.operation = .idle
+                return
+            }
+            self.rows = document.rowsForMalibu(
+                currentModelID: configuredModel,
+                warmSwapAvailable: readySwitchCapabilityAvailable
+            ).sortedForDisplay()
+            self.currentModelID = configuredModel ?? rows.first(where: { $0.category == .current })?.id
+            self.listState = rows.contains(where: { $0.action == .switchModel }) ? .ready : .viewOnly
+            self.operation = .idle
+            if rows.isEmpty {
+                self.statusLine = document.invalidRowCount > 0
+                    ? String(localized: "Network catalog loaded, but unsupported rows were hidden. Local BYOM discovery remains CLI-only in this release.", comment: "Catalog economics unsupported rows")
+                    : String(localized: "Network catalog has no admitted economics rows yet. Local BYOM discovery remains CLI-only in this release.", comment: "Catalog economics empty")
+            } else if rows.contains(where: { $0.providerCompletionPayoutUSDPerMillionTokens != nil }) {
+                self.statusLine = document.invalidRowCount > 0
+                    ? String(localized: "Network catalog rates loaded from the provider CLI projection. Unsupported rows were hidden.", comment: "Catalog economics loaded with unsupported rows")
+                    : String(localized: "Network catalog rates loaded from the provider CLI projection.", comment: "Catalog economics loaded")
+            } else {
+                self.statusLine = document.invalidRowCount > 0
+                    ? String(localized: "Network catalog loaded with no trusted rate rows available. Unsupported rows were hidden.", comment: "Catalog economics no trusted rates with unsupported rows")
+                    : String(localized: "Network catalog loaded with no trusted rate rows available.", comment: "Catalog economics no trusted rates")
+            }
+            scheduleCatalogProjectionExpiry(document)
+        } catch {
+            self.rows = []
+            self.listState = .unavailable
+            self.operation = .failed("projection_unavailable")
+            catalogProjectionExpiryTask?.cancel()
+            self.statusLine = String(localized: "Model catalog unavailable. Warning: projection_unavailable. The current model remains visible from provider status.", comment: "Catalog economics unavailable")
+        }
+    }
+
+    private func acceptCatalogProjection(_ document: MalibuModelCatalogEconomicsDocument) -> Bool {
+        guard catalogProjectionProcessLaunchID == document.source.processLaunchID,
+              let previousSequence = catalogProjectionSequence else {
+            catalogProjectionProcessLaunchID = document.source.processLaunchID
+            catalogProjectionSequence = document.projectionSequence
+            return true
+        }
+        guard document.projectionSequence > previousSequence else { return false }
+        catalogProjectionSequence = document.projectionSequence
+        return true
+    }
+
+    private func scheduleCatalogProjectionExpiry(_ document: MalibuModelCatalogEconomicsDocument) {
+        catalogProjectionExpiryTask?.cancel()
+        guard let deadline = document.freshnessDeadline else { return }
+        scheduleCatalogProjectionExpiryCheck(
+            processLaunchID: document.source.processLaunchID,
+            sequence: document.projectionSequence,
+            delay: max(0, deadline.timeIntervalSinceNow)
+        )
+    }
+
+    private func scheduleCatalogProjectionExpiryCheck(processLaunchID: String, sequence: UInt64, delay: TimeInterval) {
+        catalogProjectionExpiryTask?.cancel()
+        catalogProjectionExpiryTask = Task { @MainActor [weak self] in
+            do {
+                try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            } catch {
+                return
+            }
+            guard let self,
+                  self.catalogProjectionProcessLaunchID == processLaunchID,
+                  self.catalogProjectionSequence == sequence else { return }
+            self.catalogProjectionExpiryTask = nil
+            self.rows = []
+            self.listState = .unavailable
+            if !self.operation.blocksRefresh {
+                self.operation = .failed("projection_unavailable")
+            }
+            self.statusLine = String(localized: "Model catalog unavailable. Warning: projection_unavailable. The current model remains visible from provider status.", comment: "Catalog economics unavailable")
         }
     }
 
@@ -1563,6 +2388,15 @@ final class ModelManagementStore: ObservableObject {
         return try JSONDecoder().decode(MalibuModelsListDocument.self, from: data)
     }
 
+    private func decodeCatalogEconomics(_ stdout: String) throws -> MalibuModelCatalogEconomicsDocument {
+        let lines = stdout.split(whereSeparator: \.isNewline).filter { !$0.isEmpty }
+        guard lines.count == 1,
+              let data = lines[0].data(using: .utf8) else {
+            throw ModelManagementError.invalidCatalog
+        }
+        return try JSONDecoder().decode(MalibuModelCatalogEconomicsDocument.self, from: data)
+    }
+
     private func operationFailureReason(from result: ModelCLIResult) -> String {
         if let lastSwitchEventReason, !lastSwitchEventReason.isEmpty {
             return localizedSwitchReason(lastSwitchEventReason)
@@ -1668,6 +2502,7 @@ struct MalibuModelRow: Identifiable, Equatable, Sendable {
     enum Category: String, Sendable {
         case current
         case ready
+        case networkCatalog
         case needsPreparation
         case blocked
     }
@@ -1685,6 +2520,12 @@ struct MalibuModelRow: Identifiable, Equatable, Sendable {
     let weightsPresentLocally: Bool
     let fit: String
     let estimatedGB: Double?
+    let economicsState: String?
+    let admissionState: String?
+    let providerPromptPayoutUSDPerMillionTokens: Double?
+    let providerCompletionPayoutUSDPerMillionTokens: Double?
+    let demandRank: Int?
+    let warningCodes: [String]
     var action: Action
     var blockReason: String?
 
@@ -1695,6 +2536,12 @@ struct MalibuModelRow: Identifiable, Equatable, Sendable {
         weightsPresentLocally = row.weightsPresentLocally
         fit = row.fit ?? "unknown"
         estimatedGB = row.estimatedGB
+        economicsState = nil
+        admissionState = nil
+        providerPromptPayoutUSDPerMillionTokens = nil
+        providerCompletionPayoutUSDPerMillionTokens = nil
+        demandRank = nil
+        warningCodes = []
         if row.modelID == currentModelID || row.state == "warm" {
             category = .current
             action = .none
@@ -1718,16 +2565,122 @@ struct MalibuModelRow: Identifiable, Equatable, Sendable {
         }
     }
 
+    init?(
+        economics row: MalibuModelCatalogEconomicsDocument.Row,
+        currentModelID: String?,
+        warmSwapAvailable: Bool
+    ) {
+        let hidesLocalDefaultBYOM = row.admission.source == "local_default"
+            && row.admission.catalogEconomicsPermitted == false
+            && row.economicsState != "trusted"
+        guard !hidesLocalDefaultBYOM else { return nil }
+
+        let projectedID = row.actionModelID ?? row.modelKey
+        id = projectedID
+        displayID = row.displayModelID
+        state = row.runtimeState
+        weightsPresentLocally = row.weightsPresentLocally
+        fit = Self.displayFit(row.fit)
+        estimatedGB = row.estimatedGB
+        economicsState = row.economicsState
+        admissionState = row.admission.state
+        warningCodes = row.warningCodes
+        demandRank = row.economicsState == "trusted" ? row.demandRank : nil
+        providerPromptPayoutUSDPerMillionTokens = row.economicsState == "trusted"
+            ? row.providerPromptPayoutUSDPerMillionTokens
+            : nil
+        providerCompletionPayoutUSDPerMillionTokens = row.economicsState == "trusted"
+            ? row.providerCompletionPayoutUSDPerMillionTokens
+            : nil
+
+        let hasTrustedEconomics = row.economicsState == "trusted" && row.admission.catalogEconomicsPermitted
+        let switchAvailable = hasTrustedEconomics && Self.actionIsAvailable(
+            row.switchAction,
+            kind: "switch_model",
+            actionModelID: row.actionModelID
+        )
+        let evaluateAvailable = Self.actionIsAvailable(
+            row.evaluateAction,
+            kind: "evaluate_model",
+            actionModelID: row.actionModelID
+        )
+        let isCurrent = row.isCurrent || currentModelID.map { modelIdentityKey($0) == modelIdentityKey(projectedID) } == true
+
+        if isCurrent || row.runtimeState == "current" {
+            category = .current
+            action = .none
+            blockReason = nil
+        } else if switchAvailable, warmSwapAvailable, row.weightsPresentLocally, row.fit == "fits" {
+            category = .ready
+            action = .switchModel
+            blockReason = nil
+        } else if row.runtimeState == "needs_preparation" || !row.weightsPresentLocally {
+            category = .needsPreparation
+            action = evaluateAvailable ? .evaluate : .none
+            blockReason = Self.rowReason(row) ?? String(localized: "Needs preparation through the provider CLI before it can be used here.", comment: "Model row guard")
+        } else if hasTrustedEconomics, row.fit != "does_not_fit" {
+            category = .networkCatalog
+            action = .none
+            blockReason = row.admission.settlementCapable
+                ? nil
+                : String(localized: "Catalog rate only. Final provider credit still requires settlement-capable route and receipt checks.", comment: "Catalog row settlement guard")
+        } else {
+            category = .blocked
+            action = evaluateAvailable ? .evaluate : .none
+            blockReason = Self.rowReason(row) ?? String(localized: "Network catalog rate unavailable for this row.", comment: "Catalog row unavailable")
+        }
+    }
+
+    fileprivate init?(
+        unsupportedEconomics row: MalibuModelCatalogEconomicsDocument.Row,
+        currentModelID: String?
+    ) {
+        let hidesLocalDefaultBYOM = row.admission.source == "local_default"
+            && row.admission.catalogEconomicsPermitted == false
+            && row.economicsState != "trusted"
+        guard !hidesLocalDefaultBYOM else { return nil }
+        let projectedID = row.actionModelID.flatMap { isSafeModelID($0) ? $0 : nil } ?? row.modelKey
+        guard isSafeModelID(row.modelKey),
+              isSafeModelID(row.servedModelID),
+              isSafeModelID(projectedID),
+              isSafeDisplayID(row.displayModelID) else { return nil }
+
+        id = projectedID
+        displayID = row.displayModelID
+        state = row.runtimeState
+        weightsPresentLocally = row.weightsPresentLocally
+        fit = Self.displayFit(row.fit)
+        estimatedGB = row.estimatedGB
+        economicsState = "blocked"
+        admissionState = row.admission.state
+        providerPromptPayoutUSDPerMillionTokens = nil
+        providerCompletionPayoutUSDPerMillionTokens = nil
+        demandRank = nil
+        warningCodes = ["projection_unsupported"]
+        action = .none
+        if currentModelID.map({ modelIdentityKey($0) == modelIdentityKey(projectedID) }) == true || row.isCurrent {
+            category = .current
+            blockReason = String(localized: "Current model details are using a newer catalog contract than this Malibu release understands.", comment: "Unsupported current catalog row")
+        } else {
+            category = .blocked
+            blockReason = String(localized: "Model catalog row unavailable because the provider CLI returned an unsupported catalog contract.", comment: "Unsupported catalog row")
+        }
+    }
+
     var categoryLabel: String {
         switch category {
         case .current: return String(localized: "Current", comment: "Model category")
         case .ready: return String(localized: "Ready to switch", comment: "Model category")
+        case .networkCatalog: return String(localized: "Network catalog", comment: "Model category")
         case .needsPreparation: return String(localized: "Needs preparation", comment: "Model category")
         case .blocked: return String(localized: "Blocked", comment: "Model category")
         }
     }
 
     func reclassified(currentModelID: String?, warmSwapAvailable: Bool) -> MalibuModelRow {
+        if isCatalogEconomicsProjectionRow {
+            return catalogActionSuspendedAfterSwitch(currentModelID: currentModelID)
+        }
         var copy = self
         if currentModelID.map({ modelIdentityKey(id) == modelIdentityKey($0) }) == true {
             copy.category = .current
@@ -1751,5 +2704,122 @@ struct MalibuModelRow: Identifiable, Equatable, Sendable {
             copy.blockReason = String(localized: "This model does not pass the current memory fit check.", comment: "Model row guard")
         }
         return copy
+    }
+
+    private var isCatalogEconomicsProjectionRow: Bool {
+        economicsState != nil
+            || admissionState != nil
+            || providerPromptPayoutUSDPerMillionTokens != nil
+            || providerCompletionPayoutUSDPerMillionTokens != nil
+            || demandRank != nil
+            || !warningCodes.isEmpty
+    }
+
+    private func catalogActionSuspendedAfterSwitch(currentModelID: String?) -> MalibuModelRow {
+        var copy = self
+        copy.action = .none
+        if currentModelID.map({ modelIdentityKey(id) == modelIdentityKey($0) }) == true {
+            copy.category = .current
+            copy.blockReason = nil
+        } else if category == .ready {
+            copy.category = .blocked
+            copy.blockReason = String(localized: "Refresh the model catalog before starting another model action.", comment: "Catalog action refresh guard")
+        }
+        return copy
+    }
+
+    private static func displayFit(_ value: String) -> String {
+        switch value {
+        case "fits": return "fits"
+        case "does_not_fit": return "wont_fit"
+        default: return "unknown"
+        }
+    }
+
+    private static func actionIsAvailable(
+        _ action: MalibuModelCatalogEconomicsDocument.Action,
+        kind: String,
+        actionModelID: String?
+    ) -> Bool {
+        action.available
+            && action.transactionKind == kind
+            && action.transactionID != nil
+            && action.actionTimeoutSeconds != nil
+            && actionModelID != nil
+    }
+
+    private static func rowReason(_ row: MalibuModelCatalogEconomicsDocument.Row) -> String? {
+        if row.warningCodes.contains("feed_stale") {
+            return String(localized: "Network catalog rate unavailable because the signed rate feed is stale.", comment: "Catalog row stale")
+        }
+        if row.warningCodes.contains("feed_fallback") {
+            return String(localized: "Network catalog rate unavailable because only fallback feed data is available.", comment: "Catalog row fallback")
+        }
+        if row.warningCodes.contains("feed_signature_invalid") {
+            return String(localized: "Network catalog rate unavailable because feed trust could not be verified.", comment: "Catalog row feed trust")
+        }
+        if row.warningCodes.contains("model_not_supported") {
+            return String(localized: "Model cannot be served by this provider release.", comment: "Catalog row unsupported")
+        }
+        if row.warningCodes.contains("model_not_local") {
+            return String(localized: "Model needs preparation before local use.", comment: "Catalog row preparation")
+        }
+        if row.warningCodes.contains("admission_state_not_settlement_capable") {
+            return String(localized: "No provider credit yet; catalog and receipt checks are still required.", comment: "Catalog row non-settlement")
+        }
+        return disabledReasonCopy(row.disabledReason)
+    }
+
+    private static func disabledReasonCopy(_ reason: String?) -> String? {
+        guard let reason else { return nil }
+        switch reason {
+        case "local_inventory_only":
+            return String(localized: "Local BYOM inventory remains CLI-only in this release.", comment: "Catalog row local inventory")
+        case "model_not_local":
+            return String(localized: "Model needs preparation before local use.", comment: "Catalog row preparation")
+        case "model_not_supported":
+            return String(localized: "Model cannot be served by this provider release.", comment: "Catalog row unsupported")
+        case "hardware_fit_unknown":
+            return String(localized: "Hardware fit is not known for this model.", comment: "Catalog row unknown fit")
+        case "hardware_does_not_fit":
+            return String(localized: "Model does not pass the current memory fit check.", comment: "Catalog row blocked fit")
+        case "admission_state_missing":
+            return String(localized: "Network admission state is not available for this row.", comment: "Catalog row admission missing")
+        case "admission_state_not_settlement_capable":
+            return String(localized: "No provider credit yet; catalog and receipt checks are still required.", comment: "Catalog row non-settlement")
+        case "staging_cleanup_required":
+            return String(localized: "Model staging cleanup is required through the provider CLI.", comment: "Catalog row cleanup")
+        case "action_unavailable", "catalog_rate_unavailable", "projection_unsupported":
+            return String(localized: "Network catalog rate unavailable for this row.", comment: "Catalog row unavailable")
+        default:
+            return nil
+        }
+    }
+}
+
+private extension Array where Element == MalibuModelRow {
+    func sortedForDisplay() -> [MalibuModelRow] {
+        sorted { lhs, rhs in
+            let leftCategory = categoryRank(lhs.category)
+            let rightCategory = categoryRank(rhs.category)
+            if leftCategory != rightCategory { return leftCategory < rightCategory }
+            let leftRate = lhs.providerCompletionPayoutUSDPerMillionTokens ?? -1
+            let rightRate = rhs.providerCompletionPayoutUSDPerMillionTokens ?? -1
+            if leftRate != rightRate { return leftRate > rightRate }
+            let leftDemand = lhs.demandRank ?? Int.max
+            let rightDemand = rhs.demandRank ?? Int.max
+            if leftDemand != rightDemand { return leftDemand < rightDemand }
+            return lhs.displayID.localizedStandardCompare(rhs.displayID) == .orderedAscending
+        }
+    }
+
+    private func categoryRank(_ category: MalibuModelRow.Category) -> Int {
+        switch category {
+        case .current: return 0
+        case .ready: return 1
+        case .networkCatalog: return 2
+        case .needsPreparation: return 3
+        case .blocked: return 4
+        }
     }
 }

--- a/phase3-binary/app/Sources/Malibu/ModelManagement/ModelManagementViews.swift
+++ b/phase3-binary/app/Sources/Malibu/ModelManagement/ModelManagementViews.swift
@@ -8,10 +8,12 @@ private enum ModelFeatureUI {
     static let currentModel = String(localized: "Current model", comment: "Model feature header")
     static let current = String(localized: "Current", comment: "Model feature section")
     static let ready = String(localized: "Ready to switch", comment: "Model feature section")
+    static let networkCatalog = String(localized: "Network catalog", comment: "Model feature section")
     static let needsPreparation = String(localized: "Needs preparation", comment: "Model feature section")
     static let blocked = String(localized: "Blocked", comment: "Model feature section")
     static let history = String(localized: "Model activity", comment: "Model feature section")
     static let close = String(localized: "Close", comment: "Model feature dismiss button")
+    static let retry = String(localized: "Retry", comment: "Model feature retry button")
     static let switchModel = String(localized: "Switch", comment: "Model feature action")
     static let evaluate = String(localized: "Evaluate this model", comment: "Model feature action")
     static let revert = String(localized: "Revert", comment: "Model feature action")
@@ -82,17 +84,35 @@ struct ModelSwitcherSheet: View {
             if store.listState == .checking {
                 ProgressView(ModelFeatureUI.checking)
                     .accessibilityLabel(Text(ModelFeatureUI.checking))
+            } else if store.catalogProjectionRetryAvailable {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(String(localized: "Model catalog unavailable. Warning: projection_unavailable.", comment: "Catalog projection unavailable"))
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Button(ModelFeatureUI.retry) {
+                        Task { await refreshFromSnapshot() }
+                    }
+                    .accessibilityLabel(Text(String(localized: "Retry model catalog refresh", comment: "Catalog retry accessibility label")))
+                }
             } else if store.rows.isEmpty {
                 Text(String(localized: "No supported models were returned by the provider.", comment: "Empty model catalog"))
                     .foregroundStyle(.secondary)
             } else {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 16) {
+                        if store.rows.contains(where: { $0.providerCompletionPayoutUSDPerMillionTokens != nil }) {
+                            Text(String(localized: "Catalog rates are informational. Final provider credit depends on eligible demand, uptime, accepted requests, trust state, routing, token mix, settlement, and active policy status.", comment: "Catalog economics disclosure"))
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .fixedSize(horizontal: false, vertical: true)
+                                .accessibilityLabel(Text(String(localized: "Catalog rate disclosure", comment: "Catalog economics disclosure accessibility label")))
+                        }
                         section(ModelFeatureUI.current, category: .current)
                         section(ModelFeatureUI.ready, category: .ready)
+                        section(ModelFeatureUI.networkCatalog, category: .networkCatalog)
                         section(ModelFeatureUI.needsPreparation, category: .needsPreparation)
                         section(ModelFeatureUI.blocked, category: .blocked)
-                    if let previous = store.previousModelID {
+                        if let previous = store.previousModelID {
                             VStack(alignment: .leading, spacing: 6) {
                                 Text(String(localized: "Previous confirmed model", comment: "Revert section"))
                                     .font(.headline)
@@ -143,16 +163,20 @@ struct ModelSwitcherSheet: View {
             Text(confirmationMessage(for: pendingSwitch))
         }
         .task(id: "\(agent.snapshot.localProviderID ?? "unknown"):\(agent.snapshot.statusObservationID ?? "unknown")") {
-            await store.refresh(
-                currentModelID: agent.snapshot.currentModelID,
-                peer: MalibuModelPeerEvidence(snapshot: agent.snapshot)
-            )
-            await store.startBackgroundCheckIfEligible(thermalState: agent.snapshot.thermalState)
+            await refreshFromSnapshot()
         }
     }
 
     private var canAct: Bool {
         store.canPerformModelAction
+    }
+
+    private func refreshFromSnapshot() async {
+        await store.refresh(
+            currentModelID: agent.snapshot.currentModelID,
+            peer: MalibuModelPeerEvidence(snapshot: agent.snapshot)
+        )
+        await store.startBackgroundCheckIfEligible(thermalState: agent.snapshot.thermalState)
     }
 
     private func recommendationCallout(_ recommendation: MalibuRecommendationDocument) -> some View {
@@ -286,14 +310,31 @@ private struct ModelRowView: View {
                     .textSelection(.enabled)
                 HStack(spacing: 8) {
                     Text(row.categoryLabel)
-                        Text(String(localized: "Fit: \(fitLabel(row.fit))", comment: "Model fit status"))
+                    Text(String(localized: "Fit: \(fitLabel(row.fit))", comment: "Model fit status"))
                     if let estimatedGB = row.estimatedGB {
                         let formattedSize = estimatedGB.formatted(.number.precision(.fractionLength(1)))
                         Text(String(localized: "Approximately \(formattedSize) GB", comment: "Model size"))
                     }
+                    if let demandRank = row.demandRank {
+                        Text(String(localized: "Network demand signal: rank \(demandRank)", comment: "Network demand signal"))
+                    }
                 }
                 .font(.caption)
                 .foregroundStyle(.secondary)
+                if let completion = row.providerCompletionPayoutUSDPerMillionTokens {
+                    let formattedCompletion = completion.formatted(.number.precision(.significantDigits(2...4)))
+                    Text(String(localized: "Provider share rate: completion $\(formattedCompletion) per 1M tokens.", comment: "Provider completion payout rate"))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                if let prompt = row.providerPromptPayoutUSDPerMillionTokens {
+                    let formattedPrompt = prompt.formatted(.number.precision(.significantDigits(2...4)))
+                    Text(String(localized: "Provider share rate: prompt $\(formattedPrompt) per 1M tokens.", comment: "Provider prompt payout rate"))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
                 if let blockReason = row.blockReason {
                     Text(blockReason)
                         .font(.caption2)

--- a/phase3-binary/app/Sources/Malibu/ModelManagement/ModelManagementViews.swift
+++ b/phase3-binary/app/Sources/Malibu/ModelManagement/ModelManagementViews.swift
@@ -105,7 +105,6 @@ struct ModelSwitcherSheet: View {
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                                 .fixedSize(horizontal: false, vertical: true)
-                                .accessibilityLabel(Text(String(localized: "Catalog rate disclosure", comment: "Catalog economics disclosure accessibility label")))
                         }
                         section(ModelFeatureUI.current, category: .current)
                         section(ModelFeatureUI.ready, category: .ready)
@@ -303,11 +302,29 @@ private struct ModelRowView: View {
     var body: some View {
         HStack(alignment: .top, spacing: 10) {
             VStack(alignment: .leading, spacing: 3) {
-                Text(row.displayID)
-                    .font(.body.monospaced())
-                    .lineLimit(2)
-                    .truncationMode(.middle)
-                    .textSelection(.enabled)
+                if let catalogVerifiedModelKey = row.catalogVerifiedModelKey {
+                    // Present the coordinator-verified catalog identity as the
+                    // authoritative name; the provider-reported display name is
+                    // shown as clearly-labelled secondary text so it can never be
+                    // mistaken for a catalog-verified identity.
+                    Text(catalogVerifiedModelKey)
+                        .font(.body.monospaced())
+                        .lineLimit(2)
+                        .truncationMode(.middle)
+                        .textSelection(.enabled)
+                    Text(String(localized: "Provider-reported: \(row.displayID)", comment: "Provider-reported model name shown under the catalog-verified identity"))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .textSelection(.enabled)
+                } else {
+                    Text(row.displayID)
+                        .font(.body.monospaced())
+                        .lineLimit(2)
+                        .truncationMode(.middle)
+                        .textSelection(.enabled)
+                }
                 HStack(spacing: 8) {
                     Text(row.categoryLabel)
                     Text(String(localized: "Fit: \(fitLabel(row.fit))", comment: "Model fit status"))
@@ -333,6 +350,15 @@ private struct ModelRowView: View {
                     Text(String(localized: "Provider share rate: prompt $\(formattedPrompt) per 1M tokens.", comment: "Provider prompt payout rate"))
                         .font(.caption)
                         .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                if let nonEarningDisclosure = row.nonEarningDisclosure {
+                    // Shown beside the rates regardless of whether the row is
+                    // switchable/actionable, so catalog_priced (non-settlement)
+                    // rates are never presented without the non-earning caveat.
+                    Text(nonEarningDisclosure)
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(.orange)
                         .fixedSize(horizontal: false, vertical: true)
                 }
                 if let blockReason = row.blockReason {

--- a/phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift
@@ -119,25 +119,151 @@ final class ModelManagementTests: XCTestCase {
         ))
     }
 
-    func testCatalogEconomicsQuarantinesMalformedRowsWithoutBlockingTrustedRows() throws {
+    func testCatalogEconomicsFailsClosedOnAnyMalformedRow() throws {
+        // A projection containing ANY malformed row must fail the WHOLE decode
+        // (fail-closed / closed-schema), never quarantine the bad row and still
+        // render trusted rates from the rest.
         let missingNullable = trustedEconomicsRowJSON()
             .replacingOccurrences(of: #","disabled_reason":null"#, with: "")
-        let unknownKey = trustedEconomicsRowJSON()
-            .replacingOccurrences(of: #""model_key":"qwen3-8b""#, with: #""model_key":"qwen3-8b","provider_secret_path":"/private/tmp/key""#)
-        let document = try JSONDecoder().decode(
+        XCTAssertThrowsError(try JSONDecoder().decode(
             MalibuModelCatalogEconomicsDocument.self,
             from: Data(catalogEconomicsJSON(rows: [
                 missingNullable,
+                trustedEconomicsRowJSON(),
+            ]).utf8)
+        ))
+
+        let unknownKey = trustedEconomicsRowJSON()
+            .replacingOccurrences(of: #""model_key":"qwen3-8b""#, with: #""model_key":"qwen3-8b","provider_secret_path":"/private/tmp/key""#)
+        XCTAssertThrowsError(try JSONDecoder().decode(
+            MalibuModelCatalogEconomicsDocument.self,
+            from: Data(catalogEconomicsJSON(rows: [
                 unknownKey,
                 trustedEconomicsRowJSON(),
             ]).utf8)
-        )
+        ))
+    }
 
-        XCTAssertEqual(document.invalidRowCount, 2)
-        let rows = try document.validated(now: ModelTestTimestamp.date)
-            .rowsForMalibu(currentModelID: "other/model", warmSwapAvailable: true)
-        XCTAssertEqual(rows.map(\.displayID), ["mlx-community/Qwen3-8B-4bit"])
-        XCTAssertEqual(rows.first?.category, .networkCatalog)
+    // A row that fails row-level validation is demoted to a non-economics
+    // (blocked) row by rowsForMalibu — no provider payout is shown — rather than
+    // rendering trusted rates. Returns the rendered provider payout for the row
+    // (nil when the row was demoted / shows no economics).
+    private func renderedProviderPayout(forRow rowJSON: String) throws -> Double? {
+        let rows = try JSONDecoder().decode(
+            MalibuModelCatalogEconomicsDocument.self,
+            from: Data(catalogEconomicsJSON(rows: [rowJSON]).utf8)
+        )
+        .rowsForMalibu(currentModelID: "other/model", warmSwapAvailable: true)
+        return rows.first?.providerCompletionPayoutUSDPerMillionTokens ?? nil
+    }
+
+    func testCatalogEconomicsRequiresNonEarningDisclosureForNonSettlementTrustedRow() throws {
+        // A catalog_priced (non-settlement) trusted row that OMITS the non-earning
+        // warning is demoted (no rates shown) — the "No provider credit yet"
+        // disclosure must not depend on a possibly-omitted CLI warning.
+        XCTAssertNil(try renderedProviderPayout(forRow: trustedEconomicsRowJSON(warningCodesJSON: "[]")))
+        // With the warning present, the non-settlement row shows economics.
+        XCTAssertNotNil(try renderedProviderPayout(forRow: trustedEconomicsRowJSON()))
+        // A settlement_capable row that CONTRADICTORILY carries the non-settlement
+        // warning is demoted; without it, it shows economics.
+        XCTAssertNil(try renderedProviderPayout(
+            forRow: trustedEconomicsRowJSON(admissionState: "settlement_capable", settlementCapable: true)
+        ))
+        XCTAssertNotNil(try renderedProviderPayout(
+            forRow: trustedEconomicsRowJSON(admissionState: "settlement_capable", settlementCapable: true, warningCodesJSON: "[]")
+        ))
+    }
+
+    func testCatalogEconomicsRejectsActionDescriptorReasonMismatch() throws {
+        // An unavailable action with no reason demotes the row (no economics).
+        let unavailableNoReason = #"{"available":false,"requires_confirmation":false,"transaction_kind":null,"transaction_id":null,"action_timeout_seconds":null,"estimated_bytes":null,"unavailable_reason":null}"#
+        XCTAssertNil(try renderedProviderPayout(forRow: trustedEconomicsRowJSON(switchAction: unavailableNoReason)))
+        // An available action carrying an unavailable reason likewise demotes it.
+        let availableWithReason = #"{"available":true,"requires_confirmation":true,"transaction_kind":"switch_model","transaction_id":"c23c5d4c-3e4f-47ac-b72d-7f8f172747a0","action_timeout_seconds":20,"estimated_bytes":null,"unavailable_reason":"action_unavailable"}"#
+        XCTAssertNil(try renderedProviderPayout(forRow: trustedEconomicsRowJSON(switchAction: availableWithReason)))
+    }
+
+    @MainActor
+    func testCatalogProjectionRejectsStaleReplyFromOlderProcess() async throws {
+        let switchAction = availableActionJSON(kind: "switch_model", timeout: 20)
+        let newer = catalogEconomicsJSON(
+            rows: [trustedEconomicsRowJSON(switchAction: switchAction)],
+            generatedAt: Self.timestamp(offset: -10)
+        )
+        // A late reply from an OLDER CLI process: different process_launch_id and
+        // an earlier generated_at, carrying no rows.
+        let olderProcess = catalogEconomicsJSON(rows: [], generatedAt: Self.timestamp(offset: -120))
+            .replacingOccurrences(
+                of: "c13c5d4c-3e4f-47ac-b72d-7f8f172747a0",
+                with: "a1111111-2222-3333-4444-555555555555"
+            )
+        let cli = FakeModelCLI(results: [
+            ModelCLIResult(exitCode: 0, stdout: newer, stderr: ""),
+            ModelCLIResult(exitCode: 0, stdout: olderProcess, stderr: ""),
+        ])
+        let store = ModelManagementStore(
+            cli: cli,
+            paths: testProviderPaths(),
+            defaults: UserDefaults(suiteName: "ModelManagementTests.staleProcess.\(UUID().uuidString)")!
+        )
+        let peer = peer(for: [
+            MalibuModelCapabilityManifest.catalogEconomics,
+            MalibuModelCapabilityManifest.readySwitch,
+        ])
+        await store.refresh(currentModelID: "other/model", peer: peer)
+        let firstRows = store.rows.map(\.id)
+        XCTAssertFalse(firstRows.isEmpty)
+
+        await store.refresh(currentModelID: "other/model", peer: peer)
+        // The older-process reply must be rejected; the newer accepted rows stay,
+        // rather than being cleared by the stale empty projection.
+        XCTAssertEqual(store.rows.map(\.id), firstRows)
+    }
+
+    func testCatalogEconomicsRejectsDuplicateJSONKeys() throws {
+        XCTAssertThrowsError(try MalibuStrictJSON.rejectDuplicateKeys(Data(#"{"a":1,"a":2}"#.utf8)))
+        XCTAssertThrowsError(try MalibuStrictJSON.rejectDuplicateKeys(Data(#"{"x":{"k":1,"k":2}}"#.utf8)))
+        XCTAssertNoThrow(try MalibuStrictJSON.rejectDuplicateKeys(Data(#"{"a":1,"b":2}"#.utf8)))
+    }
+
+    func testCatalogEconomicsRowCarriesVerifiedCatalogIdentity() throws {
+        let rows = try JSONDecoder().decode(
+            MalibuModelCatalogEconomicsDocument.self,
+            from: Data(catalogEconomicsJSON(rows: [trustedEconomicsRowJSON()]).utf8)
+        )
+        .validated(now: ModelTestTimestamp.date)
+        .rowsForMalibu(currentModelID: "other/model", warmSwapAvailable: true)
+        // The coordinator-verified catalog identity (model_key) is carried
+        // separately from the provider-reported display name.
+        XCTAssertEqual(rows.first?.catalogVerifiedModelKey, "qwen3-8b")
+        XCTAssertEqual(rows.first?.displayID, "mlx-community/Qwen3-8B-4bit")
+    }
+
+    func testSwitchableCatalogPricedRowStillShowsNonEarningDisclosure() throws {
+        // A switchable catalog_priced (non-settlement) row shows rates AND is
+        // actionable, but must ALSO carry the non-earning disclosure — the caveat
+        // cannot be dropped just because the row is .switchModel / not blocked.
+        let switchAction = availableActionJSON(kind: "switch_model", timeout: 20)
+        let switchable = try JSONDecoder().decode(
+            MalibuModelCatalogEconomicsDocument.self,
+            from: Data(catalogEconomicsJSON(rows: [trustedEconomicsRowJSON(switchAction: switchAction)]).utf8)
+        )
+        .rowsForMalibu(currentModelID: "other/model", warmSwapAvailable: true)
+        let row = try XCTUnwrap(switchable.first)
+        XCTAssertEqual(row.action, .switchModel)
+        XCTAssertNotNil(row.providerCompletionPayoutUSDPerMillionTokens)
+        XCTAssertNotNil(row.nonEarningDisclosure)
+
+        // A settlement_capable row shows rates but carries NO non-earning caveat.
+        let settlement = try JSONDecoder().decode(
+            MalibuModelCatalogEconomicsDocument.self,
+            from: Data(catalogEconomicsJSON(rows: [
+                trustedEconomicsRowJSON(admissionState: "settlement_capable", settlementCapable: true, warningCodesJSON: "[]")
+            ]).utf8)
+        )
+        .rowsForMalibu(currentModelID: "other/model", warmSwapAvailable: true)
+        XCTAssertNotNil(settlement.first?.providerCompletionPayoutUSDPerMillionTokens)
+        XCTAssertNil(settlement.first?.nonEarningDisclosure)
     }
 
     func testCatalogEconomicsDegradesUnsafeActionDescriptor() throws {

--- a/phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift
@@ -77,6 +77,659 @@ final class ModelManagementTests: XCTestCase {
         XCTAssertThrowsError(try JSONDecoder().decode(MalibuModelsListDocument.self, from: Data(json.utf8)))
     }
 
+    func testCatalogEconomicsValidationAcceptsTrustedCoordinatorRows() throws {
+        let document = try JSONDecoder().decode(
+            MalibuModelCatalogEconomicsDocument.self,
+            from: Data(catalogEconomicsJSON(rows: [trustedEconomicsRowJSON()]).utf8)
+        )
+
+        XCTAssertNoThrow(try document.validated(now: ModelTestTimestamp.date))
+        let mapped = try XCTUnwrap(MalibuModelRow(
+            economics: document.rows[0],
+            currentModelID: "other/model",
+            warmSwapAvailable: true
+        ))
+        XCTAssertEqual(mapped.category, .networkCatalog)
+        XCTAssertEqual(mapped.providerCompletionPayoutUSDPerMillionTokens, 0.36)
+        XCTAssertEqual(mapped.demandRank, 7)
+        XCTAssertEqual(mapped.action, .none)
+    }
+
+    func testCatalogEconomicsHidesLocalDefaultBYOMRowsForThisRelease() throws {
+        let document = try JSONDecoder().decode(
+            MalibuModelCatalogEconomicsDocument.self,
+            from: Data(catalogEconomicsJSON(rows: [localOnlyBYOMRowJSON()]).utf8)
+        )
+        let validated = try document.validated(now: ModelTestTimestamp.date)
+
+        XCTAssertNil(MalibuModelRow(
+            economics: validated.rows[0],
+            currentModelID: "other/model",
+            warmSwapAvailable: true
+        ))
+    }
+
+    func testCatalogEconomicsDecodeRejectsUnsupportedEnvelopeKeys() throws {
+        let json = catalogEconomicsJSON(rows: [trustedEconomicsRowJSON()])
+            .replacingOccurrences(of: #""schema":"model_catalog_economics.v1""#, with: #""schema":"model_catalog_economics.v1","provider_secret_path":"/private/tmp/key""#)
+
+        XCTAssertThrowsError(try JSONDecoder().decode(
+            MalibuModelCatalogEconomicsDocument.self,
+            from: Data(json.utf8)
+        ))
+    }
+
+    func testCatalogEconomicsQuarantinesMalformedRowsWithoutBlockingTrustedRows() throws {
+        let missingNullable = trustedEconomicsRowJSON()
+            .replacingOccurrences(of: #","disabled_reason":null"#, with: "")
+        let unknownKey = trustedEconomicsRowJSON()
+            .replacingOccurrences(of: #""model_key":"qwen3-8b""#, with: #""model_key":"qwen3-8b","provider_secret_path":"/private/tmp/key""#)
+        let document = try JSONDecoder().decode(
+            MalibuModelCatalogEconomicsDocument.self,
+            from: Data(catalogEconomicsJSON(rows: [
+                missingNullable,
+                unknownKey,
+                trustedEconomicsRowJSON(),
+            ]).utf8)
+        )
+
+        XCTAssertEqual(document.invalidRowCount, 2)
+        let rows = try document.validated(now: ModelTestTimestamp.date)
+            .rowsForMalibu(currentModelID: "other/model", warmSwapAvailable: true)
+        XCTAssertEqual(rows.map(\.displayID), ["mlx-community/Qwen3-8B-4bit"])
+        XCTAssertEqual(rows.first?.category, .networkCatalog)
+    }
+
+    func testCatalogEconomicsDegradesUnsafeActionDescriptor() throws {
+        let unsafeAction = availableActionJSON(kind: "switch_model", timeout: 20, requiresConfirmation: false)
+        let json = trustedEconomicsRowJSON(switchAction: unsafeAction)
+        let document = try JSONDecoder().decode(
+            MalibuModelCatalogEconomicsDocument.self,
+            from: Data(catalogEconomicsJSON(rows: [json]).utf8)
+        )
+
+        let row = try XCTUnwrap(document.validated(now: ModelTestTimestamp.date)
+            .rowsForMalibu(currentModelID: "other/model", warmSwapAvailable: true)
+            .first)
+        XCTAssertEqual(row.category, .blocked)
+        XCTAssertEqual(row.action, .none)
+        XCTAssertNil(row.providerCompletionPayoutUSDPerMillionTokens)
+    }
+
+    func testCatalogEconomicsDegradesRowsWithStrongerRateSourceThanProjection() throws {
+        let document = try JSONDecoder().decode(
+            MalibuModelCatalogEconomicsDocument.self,
+            from: Data(catalogEconomicsJSON(
+                rows: [trustedEconomicsRowJSON()],
+                rateCardSource: "static_signed"
+            ).utf8)
+        )
+
+        let row = try XCTUnwrap(document.validated(now: ModelTestTimestamp.date)
+            .rowsForMalibu(currentModelID: "other/model", warmSwapAvailable: true)
+            .first)
+        XCTAssertEqual(row.category, .blocked)
+        XCTAssertEqual(row.action, .none)
+        XCTAssertNil(row.providerCompletionPayoutUSDPerMillionTokens)
+    }
+
+    func testCatalogEconomicsDegradesTrustedRowsWithBlockingWarningsOrStaleAdmission() throws {
+        let staleAdmission = "2026-08-01T00:00:00Z"
+        let document = try JSONDecoder().decode(
+            MalibuModelCatalogEconomicsDocument.self,
+            from: Data(catalogEconomicsJSON(rows: [
+                trustedEconomicsRowJSON(warningCodesJSON: #"["feed_stale"]"#),
+                trustedEconomicsRowJSON(stateObservedAt: staleAdmission),
+            ]).utf8)
+        )
+
+        let rows = try document.validated(now: ModelTestTimestamp.date)
+            .rowsForMalibu(currentModelID: "other/model", warmSwapAvailable: true)
+        XCTAssertEqual(rows.count, 2)
+        XCTAssertTrue(rows.allSatisfy { $0.category == .blocked })
+        XCTAssertTrue(rows.allSatisfy { $0.action == .none })
+        XCTAssertTrue(rows.allSatisfy { $0.providerCompletionPayoutUSDPerMillionTokens == nil })
+    }
+
+    func testCatalogEconomicsDegradesProjectionLevelTrustWarnings() throws {
+        let action = availableActionJSON(kind: "switch_model", timeout: 20)
+        let json = catalogEconomicsJSON(rows: [
+            trustedEconomicsRowJSON(switchAction: action),
+        ])
+            .replacingOccurrences(of: #""warnings":[]"#, with: #""warnings":["projection_unavailable"]"#)
+        let document = try JSONDecoder().decode(
+            MalibuModelCatalogEconomicsDocument.self,
+            from: Data(json.utf8)
+        )
+
+        let row = try XCTUnwrap(document.validated(now: ModelTestTimestamp.date)
+            .rowsForMalibu(currentModelID: "other/model", warmSwapAvailable: true)
+            .first)
+        XCTAssertEqual(row.category, .blocked)
+        XCTAssertEqual(row.action, .none)
+        XCTAssertNil(row.providerCompletionPayoutUSDPerMillionTokens)
+    }
+
+    func testCatalogEconomicsDegradesContradictorySwitchableRows() throws {
+        let action = availableActionJSON(kind: "switch_model", timeout: 20)
+        let blockedRuntime = trustedEconomicsRowJSON(switchAction: action)
+            .replacingOccurrences(of: #""runtime_state":"catalog""#, with: #""runtime_state":"blocked""#)
+        let blockingWarning = trustedEconomicsRowJSON(
+            switchAction: action,
+            warningCodesJSON: #"["model_not_supported"]"#
+        )
+            .replacingOccurrences(of: "mlx-community/Qwen3-8B-4bit", with: "mlx-community/Warning-Blocked-4bit")
+            .replacingOccurrences(of: #""action_model_id":"candidate-qwen""#, with: #""action_model_id":"warning-blocked""#)
+        let disabledReason = trustedEconomicsRowJSON(switchAction: action)
+            .replacingOccurrences(of: "mlx-community/Qwen3-8B-4bit", with: "mlx-community/Disabled-Blocked-4bit")
+            .replacingOccurrences(of: #""action_model_id":"candidate-qwen""#, with: #""action_model_id":"disabled-blocked""#)
+            .replacingOccurrences(of: #""disabled_reason":null"#, with: #""disabled_reason":"model_not_supported""#)
+        let document = try JSONDecoder().decode(
+            MalibuModelCatalogEconomicsDocument.self,
+            from: Data(catalogEconomicsJSON(rows: [
+                blockedRuntime,
+                blockingWarning,
+                disabledReason,
+            ]).utf8)
+        )
+
+        let rows = try document.validated(now: ModelTestTimestamp.date)
+            .rowsForMalibu(currentModelID: "other/model", warmSwapAvailable: true)
+        XCTAssertEqual(rows.count, 3)
+        XCTAssertTrue(rows.allSatisfy { $0.category == .blocked })
+        XCTAssertTrue(rows.allSatisfy { $0.action == .none })
+        XCTAssertTrue(rows.allSatisfy { $0.providerCompletionPayoutUSDPerMillionTokens == nil })
+    }
+
+    func testCatalogEconomicsRejectsUnsafeProviderVisibleModelText() throws {
+        let pathDisplay = trustedEconomicsRowJSON()
+            .replacingOccurrences(of: #""display_model_id":"mlx-community/Qwen3-8B-4bit""#, with: #""display_model_id":"/private/tmp/will pay daily""#)
+        let bidiModel = trustedEconomicsRowJSON()
+            .replacingOccurrences(of: #""served_model_id":"mlx-community/Qwen3-8B-4bit""#, with: #""served_model_id":"mlx-community/\u202Eevil""#)
+        let formatControlDisplay = trustedEconomicsRowJSON()
+            .replacingOccurrences(of: "mlx-community/Qwen3-8B-4bit", with: "mlx-community/Hidden\\u200EText-4bit")
+            .replacingOccurrences(of: #""action_model_id":"candidate-qwen""#, with: #""action_model_id":"format-control""#)
+        let rewardClaim = trustedEconomicsRowJSON()
+            .replacingOccurrences(of: "mlx-community/Qwen3-8B-4bit", with: "mlx-community/up to higher-paying model")
+            .replacingOccurrences(of: #""action_model_id":"candidate-qwen""#, with: #""action_model_id":"reward-claim""#)
+        let monthlyPayoutClaim = trustedEconomicsRowJSON()
+            .replacingOccurrences(of: "mlx-community/Qwen3-8B-4bit", with: "mlx-community/potential earnings $20/month")
+            .replacingOccurrences(of: #""action_model_id":"candidate-qwen""#, with: #""action_model_id":"monthly-payout-claim""#)
+        let dailyPayoutClaim = trustedEconomicsRowJSON()
+            .replacingOccurrences(of: "mlx-community/Qwen3-8B-4bit", with: "mlx-community/$20/day")
+            .replacingOccurrences(of: #""action_model_id":"candidate-qwen""#, with: #""action_model_id":"daily-payout-claim""#)
+        let usdHourlyClaim = trustedEconomicsRowJSON()
+            .replacingOccurrences(of: "mlx-community/Qwen3-8B-4bit", with: "mlx-community/USD 20 per hour")
+            .replacingOccurrences(of: #""action_model_id":"candidate-qwen""#, with: #""action_model_id":"usd-hourly-claim""#)
+        let dollarsWeeklyClaim = trustedEconomicsRowJSON()
+            .replacingOccurrences(of: "mlx-community/Qwen3-8B-4bit", with: "mlx-community/earn 20 dollars every week")
+            .replacingOccurrences(of: #""action_model_id":"candidate-qwen""#, with: #""action_model_id":"dollars-weekly-claim""#)
+        let document = try JSONDecoder().decode(
+            MalibuModelCatalogEconomicsDocument.self,
+            from: Data(catalogEconomicsJSON(rows: [
+                pathDisplay,
+                bidiModel,
+                formatControlDisplay,
+                rewardClaim,
+                monthlyPayoutClaim,
+                dailyPayoutClaim,
+                usdHourlyClaim,
+                dollarsWeeklyClaim,
+            ]).utf8)
+        )
+
+        let rows = try document.validated(now: ModelTestTimestamp.date)
+            .rowsForMalibu(currentModelID: "other/model", warmSwapAvailable: true)
+        XCTAssertTrue(rows.isEmpty)
+    }
+
+    func testCatalogEconomicsSuppressesNonTrustedSwitchActionsAndRawDisabledReasons() throws {
+        let action = availableActionJSON(kind: "switch_model", timeout: 20)
+        let json = trustedEconomicsRowJSON(switchAction: action, economicsState: "fallback")
+            .replacingOccurrences(of: #""disabled_reason":null"#, with: #""disabled_reason":"/private/tmp/provider-token will pay daily""#)
+        let document = try JSONDecoder().decode(
+            MalibuModelCatalogEconomicsDocument.self,
+            from: Data(catalogEconomicsJSON(rows: [json]).utf8)
+        )
+
+        let row = try XCTUnwrap(document.validated(now: ModelTestTimestamp.date)
+            .rowsForMalibu(currentModelID: "other/model", warmSwapAvailable: true)
+            .first)
+        XCTAssertEqual(row.category, .blocked)
+        XCTAssertEqual(row.action, .none)
+        XCTAssertFalse((row.blockReason ?? "").contains("/private"))
+        XCTAssertFalse((row.blockReason ?? "").localizedCaseInsensitiveContains("will pay"))
+    }
+
+    @MainActor
+    func testRefreshUsesCatalogEconomicsProjectionWhenAdvertised() async throws {
+        let cli = FakeModelCLI(results: [
+            ModelCLIResult(
+                exitCode: 0,
+                stdout: {
+                    let timestamp = Self.recentTimestamp()
+                    return catalogEconomicsJSON(rows: [
+                        localOnlyBYOMRowJSON(),
+                        trustedEconomicsRowJSON(
+                            rateCardGeneratedAt: timestamp,
+                            stateObservedAt: timestamp
+                        ),
+                    ], generatedAt: timestamp)
+                }(),
+                stderr: ""
+            ),
+        ])
+        let store = ModelManagementStore(
+            cli: cli,
+            paths: testProviderPaths(),
+            defaults: UserDefaults(suiteName: "ModelManagementTests.catalog.\(UUID().uuidString)")!
+        )
+
+        await store.refresh(currentModelID: "other/model", peer: peer(for: MalibuModelCapabilityManifest.catalogEconomics))
+
+        XCTAssertEqual(cli.invocations.first?.prefix(3), ["models", "catalog-economics", "--json"])
+        XCTAssertEqual(store.rows.map(\.displayID), ["mlx-community/Qwen3-8B-4bit"])
+        XCTAssertEqual(store.rows.first?.category, .networkCatalog)
+        XCTAssertFalse(store.statusLine.localizedCaseInsensitiveContains("discovery failure"))
+    }
+
+    @MainActor
+    func testRefreshFallsBackToLegacyListWhenCatalogEconomicsCapabilityMissing() async throws {
+        let cli = FakeModelCLI(results: [
+            ModelCLIResult(
+                exitCode: 0,
+                stdout: """
+                {"schema_version":"models_list.v1","generated_at":"2026-08-08T00:00:00Z","source":"control_socket","warm_swap_available":true,"current_model_id":"org/current","rows":[{"model_id":"org/current","display_id":"org/current","action_model_id":"org/current","state":"warm","weights_present_locally":true,"source":"status_response","fit":"fits","estimated_gb":4.0}]}
+                """,
+                stderr: ""
+            ),
+        ])
+        let store = ModelManagementStore(
+            cli: cli,
+            paths: testProviderPaths(),
+            defaults: UserDefaults(suiteName: "ModelManagementTests.legacy.\(UUID().uuidString)")!
+        )
+
+        await store.refresh(currentModelID: "org/current", peer: peer(for: MalibuModelCapabilityManifest.readySwitch))
+
+        XCTAssertEqual(cli.invocations.first?.prefix(3), ["models", "list", "--json"])
+        XCTAssertEqual(store.rows.first?.category, .current)
+        XCTAssertEqual(store.listState, .ready)
+    }
+
+    @MainActor
+    func testLegacyFallbackCancelsPreviousCatalogProjectionExpiry() async throws {
+        let expiringAt = Self.timestamp(offset: -299.8)
+        let cli = FakeModelCLI(results: [
+            ModelCLIResult(
+                exitCode: 0,
+                stdout: catalogEconomicsJSON(
+                    rows: [trustedEconomicsRowJSON(
+                        rateCardGeneratedAt: expiringAt,
+                        stateObservedAt: expiringAt
+                    )],
+                    generatedAt: expiringAt
+                ),
+                stderr: ""
+            ),
+            ModelCLIResult(
+                exitCode: 0,
+                stdout: """
+                {"schema_version":"models_list.v1","generated_at":"2026-08-08T00:00:00Z","source":"control_socket","warm_swap_available":true,"current_model_id":"org/current","rows":[{"model_id":"org/current","display_id":"org/current","action_model_id":"org/current","state":"warm","weights_present_locally":true,"source":"status_response","fit":"fits","estimated_gb":4.0}]}
+                """,
+                stderr: ""
+            ),
+        ])
+        let store = ModelManagementStore(
+            cli: cli,
+            paths: testProviderPaths(),
+            defaults: UserDefaults(suiteName: "ModelManagementTests.expiry.\(UUID().uuidString)")!
+        )
+
+        await store.refresh(currentModelID: "other/model", peer: peer(for: MalibuModelCapabilityManifest.catalogEconomics))
+        XCTAssertFalse(store.rows.isEmpty)
+        await store.refresh(currentModelID: "org/current", peer: peer(for: MalibuModelCapabilityManifest.readySwitch))
+        try await Task.sleep(nanoseconds: 400_000_000)
+
+        XCTAssertEqual(store.rows.map(\.displayID), ["org/current"])
+        XCTAssertEqual(store.listState, .ready)
+        XCTAssertFalse(store.catalogProjectionRetryAvailable)
+    }
+
+    @MainActor
+    func testEqualCatalogProjectionSequenceIsIgnored() async throws {
+        let firstTimestamp = Self.recentTimestamp()
+        let secondTimestamp = Self.recentTimestamp()
+        let cli = FakeModelCLI(results: [
+            ModelCLIResult(
+                exitCode: 0,
+                stdout: catalogEconomicsJSON(
+                    rows: [trustedEconomicsRowJSON(
+                        rateCardGeneratedAt: firstTimestamp,
+                        stateObservedAt: firstTimestamp
+                    )],
+                    generatedAt: firstTimestamp,
+                    projectionSequence: 1
+                ),
+                stderr: ""
+            ),
+            ModelCLIResult(
+                exitCode: 0,
+                stdout: catalogEconomicsJSON(
+                    rows: [
+                        trustedEconomicsRowJSON(
+                            rateCardGeneratedAt: secondTimestamp,
+                            stateObservedAt: secondTimestamp
+                        )
+                            .replacingOccurrences(of: "mlx-community/Qwen3-8B-4bit", with: "mlx-community/Other-Trusted-4bit")
+                    ],
+                    generatedAt: secondTimestamp,
+                    projectionSequence: 1
+                ),
+                stderr: ""
+            ),
+        ])
+        let store = ModelManagementStore(
+            cli: cli,
+            paths: testProviderPaths(),
+            defaults: UserDefaults(suiteName: "ModelManagementTests.equalSequence.\(UUID().uuidString)")!
+        )
+        let peer = peer(for: MalibuModelCapabilityManifest.catalogEconomics)
+
+        await store.refresh(currentModelID: "other/model", peer: peer)
+        await store.refresh(currentModelID: "other/model", peer: peer)
+
+        XCTAssertEqual(store.rows.map(\.displayID), ["mlx-community/Qwen3-8B-4bit"])
+        XCTAssertEqual(store.listState, .viewOnly)
+    }
+
+    @MainActor
+    func testRefreshFallsBackToStaticCurrentStateWhenProjectionFails() async throws {
+        let cli = FakeModelCLI(results: [
+            ModelCLIResult(exitCode: 1, stdout: "", stderr: "boom"),
+        ])
+        let store = ModelManagementStore(
+            cli: cli,
+            paths: testProviderPaths(),
+            defaults: UserDefaults(suiteName: "ModelManagementTests.failure.\(UUID().uuidString)")!
+        )
+
+        await store.refresh(currentModelID: "org/current", peer: peer(for: MalibuModelCapabilityManifest.catalogEconomics))
+
+        XCTAssertTrue(store.rows.isEmpty)
+        XCTAssertEqual(store.currentModelID, "org/current")
+        XCTAssertEqual(store.listState, .unavailable)
+        XCTAssertTrue(store.catalogProjectionRetryAvailable)
+        XCTAssertTrue(store.statusLine.contains("projection_unavailable"))
+    }
+
+    @MainActor
+    func testCatalogProjectionExpiryClearsRowsDuringRuntimeConflict() async throws {
+        let expiringAt = Self.timestamp(offset: -299.8)
+        let action = availableActionJSON(kind: "switch_model", timeout: 20)
+        let transactionID = "c23c5d4c-3e4f-47ac-b72d-7f8f172747a0"
+        let cli = FakeModelCLI(results: [
+            ModelCLIResult(
+                exitCode: 0,
+                stdout: catalogEconomicsJSON(
+                    rows: [trustedEconomicsRowJSON(
+                        switchAction: action,
+                        rateCardGeneratedAt: expiringAt,
+                        stateObservedAt: expiringAt
+                    )],
+                    generatedAt: expiringAt
+                ),
+                stderr: ""
+            ),
+            ModelCLIResult(
+                exitCode: 0,
+                stdout: """
+                {"schema_version":"model_switch_event.v1","type":"accepted","transaction_id":"\(transactionID)","from_model_id":"other/model","target_model_id":"candidate-qwen","phase":"requested","elapsed_ms":1,"cancellable":false,"reason":null,"cooldown_seconds_remaining":null}
+                {"schema_version":"model_switch_event.v1","type":"terminal","transaction_id":"\(transactionID)","from_model_id":"other/model","target_model_id":"candidate-qwen","phase":"loaded","elapsed_ms":2,"cancellable":false,"reason":null,"cooldown_seconds_remaining":null}
+                """,
+                stderr: ""
+            ),
+        ])
+        let store = ModelManagementStore(
+            cli: cli,
+            paths: testProviderPaths(),
+            defaults: UserDefaults(suiteName: "ModelManagementTests.expiryConflict.\(UUID().uuidString)")!
+        )
+        let peer = peer(for: [
+            MalibuModelCapabilityManifest.catalogEconomics,
+            MalibuModelCapabilityManifest.readySwitch,
+        ])
+
+        await store.refresh(currentModelID: "other/model", peer: peer)
+        let row = try XCTUnwrap(store.rows.first)
+        await store.switchTo(row)
+        await store.refresh(currentModelID: "unexpected/model", peer: peer)
+        try await Task.sleep(nanoseconds: 400_000_000)
+
+        XCTAssertTrue(store.rows.isEmpty)
+        XCTAssertEqual(store.listState, .unavailable)
+        if case .runtimeConflict(expected: "candidate-qwen", observed: "unexpected/model") = store.operation {
+        } else {
+            XCTFail("Expected runtime conflict to remain after projection expiry, got \(store.operation)")
+        }
+        XCTAssertTrue(store.statusLine.contains("projection_unavailable"))
+    }
+
+    @MainActor
+    func testCatalogProjectionExpiryClearsRowsDuringReconciliation() async throws {
+        let expiringAt = Self.timestamp(offset: -299.8)
+        let action = availableActionJSON(kind: "switch_model", timeout: 20)
+        let transactionID = "d575f262-7252-449a-bfda-a16fa7f1ac7d"
+        let cli = FakeModelCLI(results: [
+            ModelCLIResult(
+                exitCode: 0,
+                stdout: catalogEconomicsJSON(
+                    rows: [trustedEconomicsRowJSON(
+                        switchAction: action,
+                        rateCardGeneratedAt: expiringAt,
+                        stateObservedAt: expiringAt
+                    )],
+                    generatedAt: expiringAt
+                ),
+                stderr: ""
+            ),
+            ModelCLIResult(
+                exitCode: 0,
+                stdout: """
+                {"schema_version":"model_switch_event.v1","type":"accepted","transaction_id":"\(transactionID)","from_model_id":"other/model","target_model_id":"candidate-qwen","phase":"requested","elapsed_ms":1,"cancellable":false,"reason":null,"cooldown_seconds_remaining":null}
+                {"schema_version":"model_switch_event.v1","type":"terminal","transaction_id":"\(transactionID)","from_model_id":"other/model","target_model_id":"candidate-qwen","phase":"loaded","elapsed_ms":2,"cancellable":false,"reason":null,"cooldown_seconds_remaining":null}
+                """,
+                stderr: ""
+            ),
+        ])
+        let store = ModelManagementStore(
+            cli: cli,
+            paths: testProviderPaths(),
+            defaults: UserDefaults(suiteName: "ModelManagementTests.expiryReconciling.\(UUID().uuidString)")!
+        )
+        let peer = peer(for: [
+            MalibuModelCapabilityManifest.catalogEconomics,
+            MalibuModelCapabilityManifest.readySwitch,
+        ])
+
+        await store.refresh(currentModelID: "other/model", peer: peer)
+        let row = try XCTUnwrap(store.rows.first)
+        XCTAssertEqual(row.action, .switchModel)
+        await store.switchTo(row)
+        try await Task.sleep(nanoseconds: 400_000_000)
+
+        XCTAssertTrue(store.rows.isEmpty)
+        XCTAssertEqual(store.listState, .unavailable)
+        if case .reconciling(target: "candidate-qwen") = store.operation {
+        } else {
+            XCTFail("Expected reconciliation to remain after projection expiry, got \(store.operation)")
+        }
+        XCTAssertTrue(store.statusLine.contains("projection_unavailable"))
+    }
+
+    @MainActor
+    func testCatalogProjectionExpiryClearsRowsDuringStalledSwitch() async throws {
+        let expiringAt = Self.timestamp(offset: -299.8)
+        let action = availableActionJSON(kind: "switch_model", timeout: 20)
+        let cli = FakeModelCLI(
+            results: [
+                ModelCLIResult(
+                    exitCode: 0,
+                    stdout: catalogEconomicsJSON(
+                        rows: [trustedEconomicsRowJSON(
+                            switchAction: action,
+                            rateCardGeneratedAt: expiringAt,
+                            stateObservedAt: expiringAt
+                        )],
+                        generatedAt: expiringAt
+                    ),
+                    stderr: ""
+                ),
+                ModelCLIResult(exitCode: 0, stdout: "", stderr: ""),
+            ],
+            returnDelaysNanoseconds: [nil, 2_000_000_000]
+        )
+        let store = ModelManagementStore(
+            cli: cli,
+            paths: testProviderPaths(),
+            defaults: UserDefaults(suiteName: "ModelManagementTests.expirySwitching.\(UUID().uuidString)")!
+        )
+        let peer = peer(for: [
+            MalibuModelCapabilityManifest.catalogEconomics,
+            MalibuModelCapabilityManifest.readySwitch,
+        ])
+
+        await store.refresh(currentModelID: "other/model", peer: peer)
+        let row = try XCTUnwrap(store.rows.first)
+        XCTAssertEqual(row.action, .switchModel)
+        let switchTask = Task { await store.switchTo(row) }
+        try await Task.sleep(nanoseconds: 400_000_000)
+
+        XCTAssertTrue(store.rows.isEmpty)
+        XCTAssertEqual(store.listState, .unavailable)
+        if case .switching(target: "candidate-qwen", phase: "requested", elapsedMS: 0) = store.operation {
+        } else {
+            XCTFail("Expected switching operation to remain after projection expiry, got \(store.operation)")
+        }
+        XCTAssertTrue(store.statusLine.contains("projection_unavailable"))
+
+        switchTask.cancel()
+        await switchTask.value
+    }
+
+    @MainActor
+    func testCatalogProjectionExpiryClearsRowsAfterOperationFailure() async throws {
+        let expiringAt = Self.timestamp(offset: -299.8)
+        let action = availableActionJSON(kind: "switch_model", timeout: 20)
+        let cli = FakeModelCLI(results: [
+            ModelCLIResult(
+                exitCode: 0,
+                stdout: catalogEconomicsJSON(
+                    rows: [trustedEconomicsRowJSON(
+                        switchAction: action,
+                        rateCardGeneratedAt: expiringAt,
+                        stateObservedAt: expiringAt
+                    )],
+                    generatedAt: expiringAt
+                ),
+                stderr: ""
+            ),
+            ModelCLIResult(exitCode: 1, stdout: "", stderr: "switch failed"),
+        ])
+        let store = ModelManagementStore(
+            cli: cli,
+            paths: testProviderPaths(),
+            defaults: UserDefaults(suiteName: "ModelManagementTests.expiryFailure.\(UUID().uuidString)")!
+        )
+        let peer = peer(for: [
+            MalibuModelCapabilityManifest.catalogEconomics,
+            MalibuModelCapabilityManifest.readySwitch,
+        ])
+
+        await store.refresh(currentModelID: "other/model", peer: peer)
+        let row = try XCTUnwrap(store.rows.first)
+        XCTAssertEqual(row.action, .switchModel)
+        await store.switchTo(row)
+        try await Task.sleep(nanoseconds: 400_000_000)
+
+        XCTAssertTrue(store.rows.isEmpty)
+        XCTAssertEqual(store.listState, .unavailable)
+        XCTAssertTrue(store.catalogProjectionRetryAvailable)
+        XCTAssertTrue(store.statusLine.contains("projection_unavailable"))
+    }
+
+    @MainActor
+    func testCatalogEconomicsSwitchReconciliationSuspendsCatalogActionsUntilRefresh() async throws {
+        let action = availableActionJSON(kind: "switch_model", timeout: 20)
+        let transactionID = "c23c5d4c-3e4f-47ac-b72d-7f8f172747a0"
+        let timestamp = Self.recentTimestamp()
+        let unsupportedRow = trustedEconomicsRowJSON(
+            rateCardGeneratedAt: timestamp,
+            stateObservedAt: timestamp
+        )
+            .replacingOccurrences(of: #""runtime_state":"catalog""#, with: #""runtime_state":"future_ready""#)
+            .replacingOccurrences(of: "mlx-community/Qwen3-8B-4bit", with: "mlx-community/Unsupported-4bit")
+            .replacingOccurrences(of: #""action_model_id":"candidate-qwen""#, with: #""action_model_id":"unsupported-candidate""#)
+        let cli = FakeModelCLI(results: [
+            ModelCLIResult(
+                exitCode: 0,
+                stdout: catalogEconomicsJSON(
+                    rows: [
+                        trustedEconomicsRowJSON(
+                            switchAction: action,
+                            rateCardGeneratedAt: timestamp,
+                            stateObservedAt: timestamp
+                        ),
+                        unsupportedRow,
+                    ],
+                    generatedAt: timestamp
+                ),
+                stderr: ""
+            ),
+            ModelCLIResult(
+                exitCode: 0,
+                stdout: """
+                {"schema_version":"model_switch_event.v1","type":"accepted","transaction_id":"\(transactionID)","from_model_id":"other/model","target_model_id":"candidate-qwen","phase":"requested","elapsed_ms":1,"cancellable":false,"reason":null,"cooldown_seconds_remaining":null}
+                {"schema_version":"model_switch_event.v1","type":"terminal","transaction_id":"\(transactionID)","from_model_id":"other/model","target_model_id":"candidate-qwen","phase":"loaded","elapsed_ms":2,"cancellable":false,"reason":null,"cooldown_seconds_remaining":null}
+                """,
+                stderr: ""
+            ),
+        ])
+        let store = ModelManagementStore(
+            cli: cli,
+            paths: testProviderPaths(),
+            defaults: UserDefaults(suiteName: "ModelManagementTests.switch.\(UUID().uuidString)")!
+        )
+        let peer = peer(for: [
+            MalibuModelCapabilityManifest.catalogEconomics,
+            MalibuModelCapabilityManifest.readySwitch,
+        ])
+
+        await store.refresh(currentModelID: "other/model", peer: peer)
+        let row = try XCTUnwrap(store.rows.first)
+        XCTAssertEqual(row.action, .switchModel)
+        await store.switchTo(row)
+        await store.refresh(currentModelID: "candidate-qwen", peer: peer)
+
+        XCTAssertEqual(store.rows.first?.category, .current)
+        XCTAssertEqual(store.rows.first?.action, MalibuModelRow.Action.none)
+        let unsupported = try XCTUnwrap(store.rows.first(where: { $0.displayID == "mlx-community/Unsupported-4bit" }))
+        XCTAssertEqual(unsupported.category, .blocked)
+        XCTAssertEqual(unsupported.action, MalibuModelRow.Action.none)
+    }
+
+    func testCatalogEconomicsDisplayCopyAvoidsForbiddenRewardClaims() {
+        let strings = [
+            "Catalog rates are informational. Final provider credit depends on eligible demand, uptime, accepted requests, trust state, routing, token mix, settlement, and active policy status.",
+            "Provider share rate: completion $0.36 per 1M tokens.",
+            "Provider share rate: prompt $0.18 per 1M tokens.",
+            "No provider credit yet; catalog and receipt checks are still required.",
+        ].joined(separator: "\n").lowercased()
+        for forbidden in ["guaranteed", "daily revenue", "hourly pay", "will pay", "estimated daily", "up to", "higher-paying"] {
+            XCTAssertFalse(strings.contains(forbidden), forbidden)
+        }
+    }
+
     func testCatalogValidationRejectsCaseVariantDuplicateActionIDs() throws {
         let document = MalibuModelsListDocument(
             schemaVersion: "models_list.v1",
@@ -970,6 +1623,119 @@ final class ModelManagementTests: XCTestCase {
         XCTAssertFalse(ModelManagementStore.Operation.idle.blocksRefresh)
     }
 
+    private func catalogEconomicsJSON(
+        rows: [String],
+        generatedAt: String = "2026-08-09T00:00:00Z",
+        rateCardSource: String = "live_signed",
+        projectionSequence: UInt64 = 1
+    ) -> String {
+        """
+        {"schema":"model_catalog_economics.v1","generated_at":"\(generatedAt)","projection_sequence":\(projectionSequence),"source":{"cli_version":"1.8.90","cli_build_commit":"test","process_launch_id":"c13c5d4c-3e4f-47ac-b72d-7f8f172747a0","process_started_at":"\(generatedAt)","projection_protocol_version":"1","rate_card_source":"\(rateCardSource)","rate_card_digest":"\(String(repeating: "a", count: 64))","rate_card_signature_digest":null,"demand_feed_digest":"\(String(repeating: "b", count: 64))","candidate_feed_digest":"\(String(repeating: "c", count: 64))","rate_card_max_age_seconds":604800},"rows":[\(rows.joined(separator: ","))],"warnings":[]}
+        """
+    }
+
+    private func trustedEconomicsRowJSON(
+        switchAction: String? = nil,
+        economicsState: String = "trusted",
+        admissionState: String = "catalog_priced",
+        settlementCapable: Bool = false,
+        rateCardGeneratedAt: String = "2026-08-09T00:00:00Z",
+        stateObservedAt: String = "2026-08-09T00:00:00Z",
+        warningCodesJSON: String = #"["admission_state_not_settlement_capable"]"#
+    ) -> String {
+        let switchAction = switchAction ?? Self.unavailableActionJSON()
+        return """
+        {"model_key":"qwen3-8b","served_model_id":"mlx-community/Qwen3-8B-4bit","display_model_id":"mlx-community/Qwen3-8B-4bit","action_model_id":"candidate-qwen","is_current":false,"weights_present_locally":true,"runtime_state":"catalog","estimated_gb":4.0,"fit":"fits","disabled_reason":null,"warning_codes":\(warningCodesJSON),"admission":{"state":"\(admissionState)","source":"coordinator","coordinator_event_id":"event-1","state_observed_at":"\(stateObservedAt)","catalog_economics_permitted":true,"settlement_capable":\(settlementCapable)},"rate_card_version":"rates-v1","rate_card_generated_at":"\(rateCardGeneratedAt)","rate_card_key":"qwen3-8b","rate_source":"live_signed","prompt_rate_usd_per_million_tokens":0.2,"completion_rate_usd_per_million_tokens":0.4,"provider_share_bps":9000,"provider_prompt_payout_usd_per_million_tokens":0.18,"provider_completion_payout_usd_per_million_tokens":0.36,"economics_state":"\(economicsState)","demand_rank":7,"demand_weight":0.65,"ready_provider_count":4,"supply_deficit_score":1.5,"switch":\(switchAction),"prepare":\(Self.unavailableActionJSON()),"evaluate":\(Self.unavailableActionJSON()),"adopt_recommendation":\(Self.unavailableActionJSON()),"cleanup_staging":\(Self.unavailableActionJSON())}
+        """
+    }
+
+    private func localOnlyBYOMRowJSON() -> String {
+        """
+        {"model_key":"local-candidate","served_model_id":"local/byom","display_model_id":"local/byom","action_model_id":"local-candidate","is_current":false,"weights_present_locally":true,"runtime_state":"ready","estimated_gb":3.0,"fit":"fits","disabled_reason":"local_inventory_only","warning_codes":["admission_state_missing"],"admission":{"state":"local_only","source":"local_default","coordinator_event_id":null,"state_observed_at":null,"catalog_economics_permitted":false,"settlement_capable":false},"rate_card_version":null,"rate_card_generated_at":null,"rate_card_key":null,"rate_source":"none","prompt_rate_usd_per_million_tokens":null,"completion_rate_usd_per_million_tokens":null,"provider_share_bps":null,"provider_prompt_payout_usd_per_million_tokens":null,"provider_completion_payout_usd_per_million_tokens":null,"economics_state":"blocked","demand_rank":null,"demand_weight":null,"ready_provider_count":null,"supply_deficit_score":null,"switch":\(Self.unavailableActionJSON()),"prepare":\(Self.unavailableActionJSON()),"evaluate":\(Self.unavailableActionJSON()),"adopt_recommendation":\(Self.unavailableActionJSON()),"cleanup_staging":\(Self.unavailableActionJSON())}
+        """
+    }
+
+    private static func unavailableActionJSON() -> String {
+        """
+        {"available":false,"requires_confirmation":false,"transaction_kind":null,"transaction_id":null,"action_timeout_seconds":null,"estimated_bytes":null,"unavailable_reason":"action_unavailable"}
+        """
+    }
+
+    private func availableActionJSON(
+        kind: String,
+        timeout: Int,
+        requiresConfirmation: Bool = true
+    ) -> String {
+        """
+        {"available":true,"requires_confirmation":\(requiresConfirmation),"transaction_kind":"\(kind)","transaction_id":"c23c5d4c-3e4f-47ac-b72d-7f8f172747a0","action_timeout_seconds":\(timeout),"estimated_bytes":null,"unavailable_reason":null}
+        """
+    }
+
+    private func peer(for capability: String) -> MalibuModelPeerEvidence {
+        let manifest = MalibuModelCapabilityManifest.checkedIn
+        let tier = manifest.tiers[capability]!
+        return peer(capabilities: tier.localStatusCapabilities
+            .union(tier.commandSchemas)
+            .union(tier.controlFrameSchemas), binaryVersion: tier.firstSupportingBinaryVersion)
+    }
+
+    private func peer(for capabilities: [String]) -> MalibuModelPeerEvidence {
+        let manifest = MalibuModelCapabilityManifest.checkedIn
+        var declaredCapabilities = Set<String>()
+        var binaryVersion: String?
+        for capability in capabilities {
+            let tier = manifest.tiers[capability]!
+            declaredCapabilities.formUnion(tier.localStatusCapabilities)
+            declaredCapabilities.formUnion(tier.commandSchemas)
+            declaredCapabilities.formUnion(tier.controlFrameSchemas)
+            if binaryVersion == nil
+                || ProviderCLIVersion.compare(tier.firstSupportingBinaryVersion, binaryVersion!) == .descending {
+                binaryVersion = tier.firstSupportingBinaryVersion
+            }
+        }
+        return peer(capabilities: declaredCapabilities, binaryVersion: binaryVersion!)
+    }
+
+    private func peer(capabilities: Set<String>, binaryVersion: String) -> MalibuModelPeerEvidence {
+        return MalibuModelPeerEvidence(
+            binaryVersion: binaryVersion,
+            capabilities: capabilities,
+            contractCompatible: true,
+            lifecycleOwner: "macprovider_cli",
+            serviceInstanceID: "instance",
+            servicePID: Int(getpid()),
+            observedAt: Date(),
+            observationValidForMS: 5_000,
+            observationFresh: true
+        )
+    }
+
+    private func testProviderPaths() -> ProviderPaths {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("malibu-model-management-tests-\(UUID().uuidString)", isDirectory: true)
+        return ProviderPaths(
+            configFile: root.appendingPathComponent("config.yaml"),
+            controlSocket: root.appendingPathComponent("ctl.sock"),
+            cliLogFile: root.appendingPathComponent("cli.log"),
+            launchdStdoutLog: root.appendingPathComponent("out.log"),
+            launchdStderrLog: root.appendingPathComponent("err.log"),
+            appSupport: root,
+            appMarkerFile: root.appendingPathComponent(".installed-by-app"),
+            onboardingStateFile: root.appendingPathComponent("onboarding.json"),
+            downloadsDirectory: root.appendingPathComponent("Downloads", isDirectory: true)
+        )
+    }
+
+    private static func recentTimestamp() -> String {
+        timestamp(offset: 0)
+    }
+
+    private static func timestamp(offset: TimeInterval) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.string(from: Date().addingTimeInterval(offset))
+    }
+
     private func recommendationJSON() -> String {
         let hashA = String(repeating: "a", count: 64)
         let hashB = String(repeating: "b", count: 64)
@@ -1027,4 +1793,39 @@ final class ModelManagementTests: XCTestCase {
 private enum ModelTestTimestamp {
     static let fractional = "2026-08-08T00:00:00.123Z"
     static let date = ISO8601DateFormatter().date(from: "2026-08-09T00:00:00Z")!
+}
+
+@MainActor
+private final class FakeModelCLI: MalibuModelCLIRunning {
+    var invocations: [[String]] = []
+    private var results: [ModelCLIResult]
+    private let returnDelaysNanoseconds: [UInt64?]
+
+    init(results: [ModelCLIResult], returnDelaysNanoseconds: [UInt64?] = []) {
+        self.results = results
+        self.returnDelaysNanoseconds = returnDelaysNanoseconds
+    }
+
+    func run(
+        arguments: [String],
+        peer: MalibuModelPeerEvidence?,
+        stdinData: Data?,
+        priority: ModelCLIWorkPriority,
+        onLine: @escaping @MainActor @Sendable (String) -> Void
+    ) async throws -> ModelCLIResult {
+        let invocationIndex = invocations.count
+        invocations.append(arguments)
+        guard !results.isEmpty else {
+            return ModelCLIResult(exitCode: 1, stdout: "", stderr: "missing fake result")
+        }
+        let result = results.removeFirst()
+        if invocationIndex < returnDelaysNanoseconds.count,
+           let delay = returnDelaysNanoseconds[invocationIndex] {
+            try await Task.sleep(nanoseconds: delay)
+        }
+        for line in result.stdout.split(whereSeparator: \.isNewline) {
+            onLine(String(line))
+        }
+        return result
+    }
 }

--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -6474,7 +6474,7 @@
         "phase3-binary/Tests/macprovider-cliTests/ModelCatalogEconomicsTests.swift::testCatalogPricedFreshSignedRateCardPermitsEconomicsWithoutSettlement",
         "phase3-binary/Tests/macprovider-cliTests/ModelCatalogEconomicsTests.swift::testSettlementCapableRequiresCoordinatorSettlementState",
         "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogEconomicsDecodeRejectsUnsupportedEnvelopeKeys",
-        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogEconomicsQuarantinesMalformedRowsWithoutBlockingTrustedRows",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogEconomicsFailsClosedOnAnyMalformedRow",
         "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogEconomicsDegradesUnsafeActionDescriptor",
         "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogEconomicsDegradesProjectionLevelTrustWarnings",
         "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogEconomicsDegradesContradictorySwitchableRows",
@@ -6664,7 +6664,7 @@
       "tests": [
         "phase3-binary/Tests/macprovider-cliTests/ModelCatalogEconomicsTests.swift::testLocalOnlyCandidateEncodesExplicitNullMoneyFields",
         "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogEconomicsDecodeRejectsUnsupportedEnvelopeKeys",
-        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogEconomicsQuarantinesMalformedRowsWithoutBlockingTrustedRows",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogEconomicsFailsClosedOnAnyMalformedRow",
         "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogEconomicsRejectsUnsafeProviderVisibleModelText"
       ],
       "journeys": [],

--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -6439,13 +6439,16 @@
         "phase3-binary/Sources/macprovider-cli/HTTPServer.swift:localStatusCapabilities",
         "phase3-binary/Sources/macprovider-cli/ModelCatalogEconomics.swift:struct ModelCatalogEconomicsBuilder",
         "phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift:struct ModelsCatalogEconomicsCommand",
-        "phase3-binary/app/Sources/Malibu/ModelManagement/ModelManagement.swift:catalogEconomics"
+        "phase3-binary/app/Sources/Malibu/ModelManagement/ModelManagement.swift:catalogEconomics",
+        "phase3-binary/app/Sources/Malibu/ModelManagement/ModelManagement.swift:private func refreshCatalogEconomics"
       ],
       "tests": [
         "phase3-binary/Tests/macprovider-cliTests/ModelCatalogEconomicsTests.swift::testLocalOnlyCandidateEncodesExplicitNullMoneyFields",
         "phase3-binary/Tests/macprovider-cliTests/ModelsSubcommandTests.swift::testModelsCatalogEconomicsRequiresJSON",
         "phase3-binary/Tests/macprovider-cliTests/ProviderStatusTests.swift::testStatusResponsePublishesVersionedLocalCapabilityContract",
-        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCapabilityManifestRequiresRecommendationAndAdoptionContracts"
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCapabilityManifestRequiresRecommendationAndAdoptionContracts",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testRefreshUsesCatalogEconomicsProjectionWhenAdvertised",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testRefreshFallsBackToLegacyListWhenCatalogEconomicsCapabilityMissing"
       ],
       "journeys": [],
       "evidence": [],
@@ -6453,7 +6456,7 @@
         "verdict": "DECISION_REQUIRED",
         "owner": "@Augustas11",
         "issue": "https://github.com/Augustas11/macprovider/issues/1257",
-        "rationale": "Slice #1256 adds the CLI-owned projection command and capability advertisement, but SPEC-044 remains pending until Malibu consumes the signed compatible projection in-product and release evidence exists."
+        "rationale": "Slices #1256 and #1257 add the CLI-owned projection command, capability advertisement, and Malibu consumption path for compatible projections. SPEC-044 remains pending until production release evidence exists and the full catalog transaction UX is complete."
       }
     },
     {
@@ -6463,12 +6466,20 @@
       "implementation": [
         "phase3-binary/Sources/macprovider-cli/ModelCatalogEconomics.swift:struct ModelCatalogEconomicsWire",
         "phase3-binary/Sources/macprovider-cli/ModelCatalogEconomics.swift:struct ModelCatalogEconomicsBuilder",
-        "phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift:struct ModelsCatalogEconomicsCommand"
+        "phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift:struct ModelsCatalogEconomicsCommand",
+        "phase3-binary/app/Sources/Malibu/ModelManagement/ModelManagement.swift:struct MalibuModelCatalogEconomicsDocument"
       ],
       "tests": [
         "phase3-binary/Tests/macprovider-cliTests/ModelCatalogEconomicsTests.swift::testLocalOnlyCandidateEncodesExplicitNullMoneyFields",
         "phase3-binary/Tests/macprovider-cliTests/ModelCatalogEconomicsTests.swift::testCatalogPricedFreshSignedRateCardPermitsEconomicsWithoutSettlement",
-        "phase3-binary/Tests/macprovider-cliTests/ModelCatalogEconomicsTests.swift::testSettlementCapableRequiresCoordinatorSettlementState"
+        "phase3-binary/Tests/macprovider-cliTests/ModelCatalogEconomicsTests.swift::testSettlementCapableRequiresCoordinatorSettlementState",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogEconomicsDecodeRejectsUnsupportedEnvelopeKeys",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogEconomicsQuarantinesMalformedRowsWithoutBlockingTrustedRows",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogEconomicsDegradesUnsafeActionDescriptor",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogEconomicsDegradesProjectionLevelTrustWarnings",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogEconomicsDegradesContradictorySwitchableRows",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogEconomicsDegradesTrustedRowsWithBlockingWarningsOrStaleAdmission",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogEconomicsRejectsUnsafeProviderVisibleModelText"
       ],
       "journeys": [],
       "evidence": [],
@@ -6476,7 +6487,7 @@
         "verdict": "DECISION_REQUIRED",
         "owner": "@Augustas11",
         "issue": "https://github.com/Augustas11/macprovider/issues/1257",
-        "rationale": "Slice #1256 defines and tests the JSON projection schema with fail-closed action descriptors, but forced model-action confirmation, long-evaluation transaction events, and Malibu decoding remain pending."
+        "rationale": "Slices #1256 and #1257 define the JSON projection schema, fail-closed action descriptors, and Malibu decoding for explicit nullable fields and malformed action confirmation. Long-evaluation transaction events and release evidence remain pending."
       }
     },
     {
@@ -6504,11 +6515,15 @@
       "spec_id": "SPEC-044",
       "state": "pending",
       "implementation": [
-        "phase3-binary/Sources/macprovider-cli/ModelCatalogEconomics.swift:struct ModelCatalogEconomicsBuilder"
+        "phase3-binary/Sources/macprovider-cli/ModelCatalogEconomics.swift:struct ModelCatalogEconomicsBuilder",
+        "phase3-binary/app/Sources/Malibu/ModelManagement/ModelManagementViews.swift:ModelRowView"
       ],
       "tests": [
         "phase3-binary/Tests/macprovider-cliTests/ModelCatalogEconomicsTests.swift::testLocalOnlyCandidateEncodesExplicitNullMoneyFields",
-        "phase3-binary/Tests/macprovider-cliTests/ModelCatalogEconomicsTests.swift::testCatalogPricedFreshSignedRateCardPermitsEconomicsWithoutSettlement"
+        "phase3-binary/Tests/macprovider-cliTests/ModelCatalogEconomicsTests.swift::testCatalogPricedFreshSignedRateCardPermitsEconomicsWithoutSettlement",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogEconomicsDisplayCopyAvoidsForbiddenRewardClaims",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogEconomicsDegradesProjectionLevelTrustWarnings",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogEconomicsDegradesTrustedRowsWithBlockingWarningsOrStaleAdmission"
       ],
       "journeys": [],
       "evidence": [],
@@ -6516,22 +6531,30 @@
         "verdict": "DECISION_REQUIRED",
         "owner": "@Augustas11",
         "issue": "https://github.com/Augustas11/macprovider/issues/1257",
-        "rationale": "Slice #1256 keeps unsafe money fields null and separates catalog_priced from settlement_capable in the CLI projection, but provider-facing Malibu copy, localization, and forbidden earnings-claim checks remain pending."
+        "rationale": "Slices #1256 and #1257 keep unsafe money fields null, separate catalog_priced from settlement_capable, and render provider share rates with variability disclosure and forbidden-claim tests. Localization/RTL release evidence remains pending."
       }
     },
     {
       "requirement_id": "SPEC-044-R005",
       "spec_id": "SPEC-044",
       "state": "pending",
-      "implementation": [],
-      "tests": [],
+      "implementation": [
+        "phase3-binary/app/Sources/Malibu/ModelManagement/ModelManagement.swift:struct MalibuModelRow",
+        "phase3-binary/app/Sources/Malibu/ModelManagement/ModelManagement.swift:func sortedForDisplay",
+        "phase3-binary/app/Sources/Malibu/ModelManagement/ModelManagementViews.swift:ModelSwitcherSheet"
+      ],
+      "tests": [
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogEconomicsValidationAcceptsTrustedCoordinatorRows",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogEconomicsHidesLocalDefaultBYOMRowsForThisRelease",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testRefreshUsesCatalogEconomicsProjectionWhenAdvertised"
+      ],
       "journeys": [],
       "evidence": [],
       "gap": {
         "verdict": "DECISION_REQUIRED",
         "owner": "@Augustas11",
-        "issue": "https://github.com/Augustas11/macprovider/issues/614",
-        "rationale": "Provider-friendly ranking, localized row-warning attribution, and hidden-row rules are not implemented for the new catalog experience."
+        "issue": "https://github.com/Augustas11/macprovider/issues/1257",
+        "rationale": "Slice #1257 adds deterministic grouping, trusted-rate ordering, row-warning copy, and the release decision to hide local-default BYOM rows from Malibu. Full provider-friendly ranking acceptance and release evidence remain pending."
       }
     },
     {
@@ -6540,10 +6563,17 @@
       "state": "pending",
       "implementation": [
         "phase3-binary/Sources/macprovider-cli/ModelCatalogEconomics.swift:struct ModelCatalogEconomicsWire",
-        "phase3-binary/Sources/macprovider-cli/ModelCatalogEconomics.swift:struct ModelCatalogEconomicsBuilder"
+        "phase3-binary/Sources/macprovider-cli/ModelCatalogEconomics.swift:struct ModelCatalogEconomicsBuilder",
+        "phase3-binary/app/Sources/Malibu/ModelManagement/ModelManagement.swift:private static func actionIsAvailable"
       ],
       "tests": [
-        "phase3-binary/Tests/macprovider-cliTests/ModelCatalogEconomicsTests.swift::testLocalOnlyCandidateEncodesExplicitNullMoneyFields"
+        "phase3-binary/Tests/macprovider-cliTests/ModelCatalogEconomicsTests.swift::testLocalOnlyCandidateEncodesExplicitNullMoneyFields",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogEconomicsDegradesUnsafeActionDescriptor",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogEconomicsDegradesProjectionLevelTrustWarnings",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogEconomicsDegradesContradictorySwitchableRows",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogEconomicsDegradesTrustedRowsWithBlockingWarningsOrStaleAdmission",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogEconomicsSwitchReconciliationSuspendsCatalogActionsUntilRefresh",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testRefreshFallsBackToLegacyListWhenCatalogEconomicsCapabilityMissing"
       ],
       "journeys": [],
       "evidence": [],
@@ -6551,15 +6581,21 @@
         "verdict": "DECISION_REQUIRED",
         "owner": "@Augustas11",
         "issue": "https://github.com/Augustas11/macprovider/issues/1257",
-        "rationale": "Slice #1256 emits explicit unavailable action descriptors with null transaction fields, but CLI/Malibu transaction execution, confirmation, and refresh handling remain pending."
+        "rationale": "Slices #1256 and #1257 emit explicit unavailable action descriptors and make Malibu require exact typed action metadata before showing switch/evaluate actions. Full prepare/evaluate/adopt/cleanup transaction execution remains pending."
       }
     },
     {
       "requirement_id": "SPEC-044-R007",
       "spec_id": "SPEC-044",
       "state": "pending",
-      "implementation": [],
-      "tests": [],
+      "implementation": [
+        "phase3-binary/app/Sources/Malibu/ModelManagement/ModelManagement.swift:private func refreshCatalogEconomics",
+        "phase3-binary/app/Sources/Malibu/ModelManagement/ModelManagementViews.swift:ModelSwitcherSheet"
+      ],
+      "tests": [
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testRefreshUsesCatalogEconomicsProjectionWhenAdvertised",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testRefreshFallsBackToStaticCurrentStateWhenProjectionFails"
+      ],
       "journeys": [],
       "evidence": [],
       "gap": {
@@ -6573,30 +6609,47 @@
       "requirement_id": "SPEC-044-R008",
       "spec_id": "SPEC-044",
       "state": "pending",
-      "implementation": [],
-      "tests": [],
+      "implementation": [
+        "phase3-binary/app/Sources/Malibu/ModelManagement/ModelManagement.swift:var catalogProjectionRetryAvailable",
+        "phase3-binary/app/Sources/Malibu/ModelManagement/ModelManagement.swift:private func refreshCatalogEconomics",
+        "phase3-binary/app/Sources/Malibu/ModelManagement/ModelManagementViews.swift:ModelSwitcherSheet"
+      ],
+      "tests": [
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testRefreshFallsBackToStaticCurrentStateWhenProjectionFails",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testLegacyFallbackCancelsPreviousCatalogProjectionExpiry",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogProjectionExpiryClearsRowsAfterOperationFailure",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogProjectionExpiryClearsRowsDuringRuntimeConflict",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogProjectionExpiryClearsRowsDuringReconciliation",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogProjectionExpiryClearsRowsDuringStalledSwitch",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testEqualCatalogProjectionSequenceIsIgnored"
+      ],
       "journeys": [],
       "evidence": [],
       "gap": {
         "verdict": "DECISION_REQUIRED",
         "owner": "@Augustas11",
-        "issue": "https://github.com/Augustas11/macprovider/issues/614",
-        "rationale": "The sectioned Malibu catalog layout and projection-failed fallback state are not implemented yet."
+        "issue": "https://github.com/Augustas11/macprovider/issues/1257",
+        "rationale": "Slice #1257 adds the sectioned catalog layout, projection-unavailable fallback warning, retry affordance, and regression coverage that old catalog expiry tasks cannot clear later legacy fallback rows. Release evidence remains pending."
       }
     },
     {
       "requirement_id": "SPEC-044-R009",
       "spec_id": "SPEC-044",
       "state": "pending",
-      "implementation": [],
-      "tests": [],
+      "implementation": [
+        "phase3-binary/app/Sources/Malibu/ModelManagement/ModelManagementViews.swift:ModelSwitcherSheet",
+        "phase3-binary/app/Sources/Malibu/ModelManagement/ModelManagementViews.swift:ModelRowView"
+      ],
+      "tests": [
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogEconomicsDisplayCopyAvoidsForbiddenRewardClaims"
+      ],
       "journeys": [],
       "evidence": [],
       "gap": {
         "verdict": "DECISION_REQUIRED",
         "owner": "@Augustas11",
-        "issue": "https://github.com/Augustas11/macprovider/issues/614",
-        "rationale": "Localization, accessibility, forbidden-meaning checks, and RTL release evidence are not implemented for the new strings and controls."
+        "issue": "https://github.com/Augustas11/macprovider/issues/1257",
+        "rationale": "Slice #1257 adds localizable operator-guidance strings, a screen-reader disclosure label, and forbidden-meaning source checks for the new rate copy. Full shipped-locale and RTL release evidence remain pending."
       }
     },
     {
@@ -6605,10 +6658,14 @@
       "state": "pending",
       "implementation": [
         "phase3-binary/Sources/macprovider-cli/ModelCatalogEconomics.swift:struct ModelCatalogEconomicsWire",
-        "phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift:struct ModelsCatalogEconomicsCommand"
+        "phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift:struct ModelsCatalogEconomicsCommand",
+        "phase3-binary/app/Sources/Malibu/ModelManagement/ModelManagement.swift:struct MalibuModelCatalogEconomicsDocument"
       ],
       "tests": [
-        "phase3-binary/Tests/macprovider-cliTests/ModelCatalogEconomicsTests.swift::testLocalOnlyCandidateEncodesExplicitNullMoneyFields"
+        "phase3-binary/Tests/macprovider-cliTests/ModelCatalogEconomicsTests.swift::testLocalOnlyCandidateEncodesExplicitNullMoneyFields",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogEconomicsDecodeRejectsUnsupportedEnvelopeKeys",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogEconomicsQuarantinesMalformedRowsWithoutBlockingTrustedRows",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogEconomicsRejectsUnsafeProviderVisibleModelText"
       ],
       "journeys": [],
       "evidence": [],
@@ -6616,15 +6673,25 @@
         "verdict": "DECISION_REQUIRED",
         "owner": "@Augustas11",
         "issue": "https://github.com/Augustas11/macprovider/issues/1257",
-        "rationale": "Slice #1256 limits the projection to feed digests, candidate identifiers, and coordinator admission status, but full diagnostics redaction and Malibu privacy treatment remain pending."
+        "rationale": "Slices #1256 and #1257 limit the projection to feed digests, candidate identifiers, and coordinator admission status, and Malibu rejects unknown fields rather than rendering secret-bearing extensions. Full diagnostics redaction evidence remains pending."
       }
     },
     {
       "requirement_id": "SPEC-044-R011",
       "spec_id": "SPEC-044",
       "state": "pending",
-      "implementation": [],
-      "tests": [],
+      "implementation": [
+        "phase3-binary/app/Sources/Malibu/ModelManagement/ModelManagement.swift:private func refreshCatalogEconomics"
+      ],
+      "tests": [
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testRefreshUsesCatalogEconomicsProjectionWhenAdvertised",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testRefreshFallsBackToStaticCurrentStateWhenProjectionFails",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testRefreshFallsBackToLegacyListWhenCatalogEconomicsCapabilityMissing",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogProjectionExpiryClearsRowsDuringRuntimeConflict",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogProjectionExpiryClearsRowsDuringReconciliation",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogProjectionExpiryClearsRowsDuringStalledSwitch",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogEconomicsSwitchReconciliationSuspendsCatalogActionsUntilRefresh"
+      ],
       "journeys": [],
       "evidence": [],
       "gap": {
@@ -6639,14 +6706,25 @@
       "spec_id": "SPEC-044",
       "state": "pending",
       "implementation": [],
-      "tests": [],
+      "tests": [
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogEconomicsDegradesTrustedRowsWithBlockingWarningsOrStaleAdmission",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogEconomicsDegradesProjectionLevelTrustWarnings",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogEconomicsDegradesContradictorySwitchableRows",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogProjectionExpiryClearsRowsAfterOperationFailure",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogProjectionExpiryClearsRowsDuringRuntimeConflict",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogProjectionExpiryClearsRowsDuringReconciliation",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogProjectionExpiryClearsRowsDuringStalledSwitch",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testEqualCatalogProjectionSequenceIsIgnored",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogEconomicsRejectsUnsafeProviderVisibleModelText",
+        "phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift::testCatalogEconomicsSwitchReconciliationSuspendsCatalogActionsUntilRefresh"
+      ],
       "journeys": [],
       "evidence": [],
       "gap": {
         "verdict": "DECISION_REQUIRED",
         "owner": "@Augustas11",
-        "issue": "https://github.com/Augustas11/macprovider/issues/614",
-        "rationale": "Release evidence, automated coverage, and signed journey results for the Malibu model catalog economics experience do not exist yet."
+        "issue": "https://github.com/Augustas11/macprovider/issues/1257",
+        "rationale": "Slice #1257 adds automated Malibu projection decoding, grouping, old-CLI fallback, projection-failed fallback, forbidden-copy, and action-gating coverage. Production promotion still requires signed release journey evidence that old CLIs receive static fallback UI and compatible CLIs render trusted rates without exposing secrets or unsupported actions."
       }
     },
     {

--- a/test/e2e/byom/README.md
+++ b/test/e2e/byom/README.md
@@ -1,0 +1,27 @@
+# BYOM CLI Onboarding E2E
+
+This harness exercises the provider-visible BYOM onboarding path through the
+real `macprovider-cli` executable with hermetic loopback fixtures:
+
+1. import provider credentials into the configured protected-file store;
+2. discover a local Ollama-compatible catalog candidate;
+3. evaluate the candidate locally without coordinator mutation;
+4. dry-run an offer without coordinator mutation;
+5. submit a coordinator-backed offer with the provider admission identity;
+6. read coordinator admission status;
+7. project catalog economics while money and settlement remain fail-closed;
+8. withdraw the admission and verify withdrawn economics remain fail-closed.
+
+Run from the repository root:
+
+```bash
+test/e2e/byom/run-cli-onboarding-e2e.py
+```
+
+Set `MACPROVIDER_CLI_BINARY=/path/to/macprovider-cli` to reuse an existing
+binary. The script otherwise runs `swift build --product macprovider-cli`.
+
+The fake coordinator uses `http://127.0.0.1:<port>` and the CLI accepts that
+only when the harness sets
+`MACPROVIDER_BYOM_ALLOW_INSECURE_LOOPBACK_COORDINATOR=1`; production coordinator
+URLs remain HTTPS/WSS-only by default.

--- a/test/e2e/byom/README.md
+++ b/test/e2e/byom/README.md
@@ -1,5 +1,14 @@
 # BYOM CLI Onboarding E2E
 
+**Status: manual macOS release evidence — not part of `make test` or required PR
+coverage.** This harness builds the Swift `macprovider-cli` and drives the
+provider-visible onboarding path end to end; run it on macOS
+(`make test-byom-e2e` from the repository root) before promoting a
+BYOM-affecting provider CLI/app release and capture the result as release
+evidence. It is deliberately not wired into the per-PR CI gate because it
+requires a Swift build and process orchestration; PR-level coverage of these
+contracts lives in the Swift unit tests and the coordinator Go tests.
+
 This harness exercises the provider-visible BYOM onboarding path through the
 real `macprovider-cli` executable with hermetic loopback fixtures:
 

--- a/test/e2e/byom/run-cli-onboarding-e2e.py
+++ b/test/e2e/byom/run-cli-onboarding-e2e.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import os
 import pathlib
+import secrets
 import shutil
 import subprocess
 import sys
@@ -13,8 +14,6 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from urllib.parse import parse_qs, urlparse
 
 
-PROVIDER_ID = "provider-byom-e2e"
-PROVIDER_TOKEN = "provider-token-e2e"
 MODEL_NAME = "qwen3-8b"
 SERVED_MODEL_REF = "ollama:" + MODEL_NAME
 CATALOG_MODEL_KEY = "qwen3-8b"
@@ -54,7 +53,13 @@ class LocalHTTPServer:
         self.state = state
         self.httpd = ThreadingHTTPServer(("127.0.0.1", 0), handler_class)
         self.httpd.state = state
-        self.thread = threading.Thread(target=self.httpd.serve_forever, daemon=True)
+        self.started = False
+        self.ready = threading.Event()
+        self.thread = threading.Thread(target=self._serve, daemon=True)
+
+    def _serve(self):
+        self.ready.set()
+        self.httpd.serve_forever()
 
     @property
     def origin(self):
@@ -62,11 +67,17 @@ class LocalHTTPServer:
         return "http://%s:%d" % (host, port)
 
     def start(self):
+        if self.started:
+            return
         self.thread.start()
+        self.ready.wait(timeout=5)
+        self.started = True
 
     def stop(self):
-        self.httpd.shutdown()
-        self.thread.join(timeout=5)
+        if self.started:
+            self.httpd.shutdown()
+            self.thread.join(timeout=5)
+            self.started = False
         self.httpd.server_close()
 
 
@@ -168,7 +179,8 @@ class CoordinatorHandler(BaseHTTPRequestHandler):
         for key in required:
             assert_true(key in payload, "offer request missing " + key)
         assert_true(payload["schema"] == "model_admission_offer_submit.v1", "wrong offer schema")
-        assert_true(payload["provider_id"] == PROVIDER_ID, "wrong provider_id in offer")
+        provider_id = self.server.state["provider_id"]
+        assert_true(payload["provider_id"] == provider_id, "wrong provider_id in offer")
         assert_true(payload["served_model_ref"] == SERVED_MODEL_REF, "wrong served_model_ref in offer")
         assert_true(payload["catalog_model_key"] == CATALOG_MODEL_KEY, "wrong catalog_model_key in offer")
         assert_true(len(payload["evaluation_digest_sha256"]) == 64, "offer missing evaluation digest")
@@ -186,7 +198,8 @@ class CoordinatorHandler(BaseHTTPRequestHandler):
 
     def handle_withdraw(self, payload):
         assert_true(payload["schema"] == "model_admission_withdraw_request.v1", "wrong withdraw schema")
-        assert_true(payload["provider_id"] == PROVIDER_ID, "wrong provider_id in withdraw")
+        provider_id = self.server.state["provider_id"]
+        assert_true(payload["provider_id"] == provider_id, "wrong provider_id in withdraw")
         assert_true(payload["served_model_ref"] == SERVED_MODEL_REF, "wrong served_model_ref in withdraw")
         assert_true(payload["reason_code"] == "provider_requested", "wrong withdraw reason")
         assert_true(payload.get("provider_signature"), "withdraw missing signature")
@@ -196,7 +209,7 @@ class CoordinatorHandler(BaseHTTPRequestHandler):
             "schema": "model_admission_withdraw.v1",
             "generated_at": "2027-01-15T08:00:01Z",
             "cli_version": "test",
-            "provider_id": PROVIDER_ID,
+            "provider_id": provider_id,
             "candidate_id": candidate_id,
             "served_model_ref": payload["served_model_ref"],
             "catalog_model_key": payload.get("catalog_model_key"),
@@ -224,7 +237,7 @@ class CoordinatorHandler(BaseHTTPRequestHandler):
             "schema": "model_admission_status.v1",
             "generated_at": NOW,
             "cli_version": "test",
-            "provider_id": PROVIDER_ID,
+            "provider_id": self.server.state["provider_id"],
             "candidate_id": candidate_id,
             "served_model_ref": served_model_ref,
             "catalog_model_key": catalog_model_key,
@@ -263,7 +276,7 @@ class CoordinatorHandler(BaseHTTPRequestHandler):
 
     def require_auth(self):
         got = self.headers.get("authorization")
-        assert_true(got == "Bearer " + PROVIDER_TOKEN, "bad Authorization header")
+        assert_true(got == "Bearer " + self.server.state["provider_token"], "bad Authorization header")
 
     def record(self, method, path, payload):
         self.server.state["requests"].append({
@@ -347,7 +360,14 @@ def main():
     root = repo_root()
     temp_root = pathlib.Path(tempfile.mkdtemp(prefix="macprovider-byom-e2e-"))
     ollama = LocalHTTPServer(OllamaHandler, {"paths": [], "chat_bodies": []})
-    coordinator = LocalHTTPServer(CoordinatorHandler, {"requests": [], "statuses": {}})
+    provider_id = "provider-byom-e2e-" + secrets.token_hex(8)
+    provider_token = "provider-token-e2e-" + secrets.token_hex(16)
+    coordinator = LocalHTTPServer(CoordinatorHandler, {
+        "requests": [],
+        "statuses": {},
+        "provider_id": provider_id,
+        "provider_token": provider_token,
+    })
     try:
         cli = build_cli(root, os.environ.get("MACPROVIDER_CLI_BINARY"))
         ollama.start()
@@ -361,8 +381,8 @@ def main():
         config = temp_root / "config.yaml"
         config.write_text(
             "\n".join([
-                "provider_id: " + PROVIDER_ID,
-                "provider_token: " + PROVIDER_TOKEN,
+                "provider_id: " + provider_id,
+                "provider_token: " + provider_token,
                 "coordinator_url: " + coordinator.origin,
                 "credential_store: protected_file",
                 "",

--- a/test/e2e/byom/run-cli-onboarding-e2e.py
+++ b/test/e2e/byom/run-cli-onboarding-e2e.py
@@ -1,0 +1,532 @@
+#!/usr/bin/env python3
+import argparse
+import hashlib
+import json
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlparse
+
+
+PROVIDER_ID = "provider-byom-e2e"
+PROVIDER_TOKEN = "provider-token-e2e"
+MODEL_NAME = "qwen3-8b"
+SERVED_MODEL_REF = "ollama:" + MODEL_NAME
+CATALOG_MODEL_KEY = "qwen3-8b"
+NOW = "2027-01-15T08:00:00Z"
+
+
+class HarnessFailure(Exception):
+    pass
+
+
+def assert_true(condition, message):
+    if not condition:
+        raise HarnessFailure(message)
+
+
+def repo_root():
+    return pathlib.Path(__file__).resolve().parents[3]
+
+
+def build_cli(root, explicit_binary):
+    if explicit_binary:
+        path = pathlib.Path(explicit_binary).expanduser().resolve()
+        assert_true(path.exists(), "MACPROVIDER_CLI_BINARY does not exist: " + str(path))
+        return path
+    subprocess.run(
+        ["swift", "build", "--product", "macprovider-cli"],
+        cwd=str(root / "phase3-binary"),
+        check=True,
+    )
+    path = root / "phase3-binary" / ".build" / "debug" / "macprovider-cli"
+    assert_true(path.exists(), "swift build did not produce " + str(path))
+    return path
+
+
+class LocalHTTPServer:
+    def __init__(self, handler_class, state):
+        self.state = state
+        self.httpd = ThreadingHTTPServer(("127.0.0.1", 0), handler_class)
+        self.httpd.state = state
+        self.thread = threading.Thread(target=self.httpd.serve_forever, daemon=True)
+
+    @property
+    def origin(self):
+        host, port = self.httpd.server_address
+        return "http://%s:%d" % (host, port)
+
+    def start(self):
+        self.thread.start()
+
+    def stop(self):
+        self.httpd.shutdown()
+        self.thread.join(timeout=5)
+        self.httpd.server_close()
+
+
+class OllamaHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path != "/api/tags":
+            self.send_error(404)
+            return
+        self.server.state["paths"].append(self.path)
+        self.send_json({
+            "models": [{
+                "name": MODEL_NAME,
+                "details": {
+                    "family": "qwen",
+                    "quantization_level": "Q4_0",
+                },
+            }],
+        })
+
+    def do_POST(self):
+        if self.path != "/v1/chat/completions":
+            self.send_error(404)
+            return
+        length = int(self.headers.get("content-length", "0"))
+        body = self.rfile.read(length)
+        self.server.state["paths"].append(self.path)
+        self.server.state["chat_bodies"].append(body.decode("utf-8", errors="replace"))
+        self.send_json({
+            "id": "chatcmpl-local",
+            "object": "chat.completion",
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "ok"},
+                "finish_reason": "stop",
+            }],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 2, "total_tokens": 12},
+        })
+
+    def log_message(self, *_args):
+        pass
+
+    def send_json(self, payload):
+        encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+
+class CoordinatorHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        if parsed.path != "/v1/provider/model-admission/status":
+            self.send_error(404)
+            return
+        self.require_auth()
+        candidate_id = parse_qs(parsed.query).get("candidate_id", [""])[0]
+        self.record("GET", parsed.path, {"candidate_id": candidate_id})
+        status = self.server.state["statuses"].get(candidate_id)
+        if not status:
+            status = self.status_payload(
+                candidate_id=candidate_id,
+                served_model_ref="",
+                catalog_model_key=None,
+                state="not_offered",
+                event_id=None,
+            )
+        self.send_json(status)
+
+    def do_POST(self):
+        if self.path not in (
+            "/v1/provider/model-admission/offers",
+            "/v1/provider/model-admission/withdrawals",
+        ):
+            self.send_error(404)
+            return
+        self.require_auth()
+        length = int(self.headers.get("content-length", "0"))
+        body = self.rfile.read(length).decode("utf-8")
+        payload = json.loads(body)
+        self.record("POST", self.path, payload)
+        if self.path.endswith("/offers"):
+            self.handle_offer(payload)
+        else:
+            self.handle_withdraw(payload)
+
+    def handle_offer(self, payload):
+        required = [
+            "schema",
+            "provider_id",
+            "candidate_id",
+            "served_model_ref",
+            "discovery_digest_sha256",
+            "evaluation_digest_sha256",
+            "signing_key_digest",
+            "provider_signature",
+        ]
+        for key in required:
+            assert_true(key in payload, "offer request missing " + key)
+        assert_true(payload["schema"] == "model_admission_offer_submit.v1", "wrong offer schema")
+        assert_true(payload["provider_id"] == PROVIDER_ID, "wrong provider_id in offer")
+        assert_true(payload["served_model_ref"] == SERVED_MODEL_REF, "wrong served_model_ref in offer")
+        assert_true(payload["catalog_model_key"] == CATALOG_MODEL_KEY, "wrong catalog_model_key in offer")
+        assert_true(len(payload["evaluation_digest_sha256"]) == 64, "offer missing evaluation digest")
+        assert_true("endpoint" not in json.dumps(payload), "offer reflected endpoint material")
+        candidate_id = payload["candidate_id"]
+        status = self.status_payload(
+            candidate_id=candidate_id,
+            served_model_ref=payload["served_model_ref"],
+            catalog_model_key=payload["catalog_model_key"],
+            state="offer_submitted",
+            event_id="event_test",
+        )
+        self.server.state["statuses"][candidate_id] = status
+        self.send_json(status)
+
+    def handle_withdraw(self, payload):
+        assert_true(payload["schema"] == "model_admission_withdraw_request.v1", "wrong withdraw schema")
+        assert_true(payload["provider_id"] == PROVIDER_ID, "wrong provider_id in withdraw")
+        assert_true(payload["served_model_ref"] == SERVED_MODEL_REF, "wrong served_model_ref in withdraw")
+        assert_true(payload["reason_code"] == "provider_requested", "wrong withdraw reason")
+        assert_true(payload.get("provider_signature"), "withdraw missing signature")
+        candidate_id = payload["candidate_id"]
+        previous = self.server.state["statuses"].get(candidate_id, {})
+        withdrawal = {
+            "schema": "model_admission_withdraw.v1",
+            "generated_at": "2027-01-15T08:00:01Z",
+            "cli_version": "test",
+            "provider_id": PROVIDER_ID,
+            "candidate_id": candidate_id,
+            "served_model_ref": payload["served_model_ref"],
+            "catalog_model_key": payload.get("catalog_model_key"),
+            "idempotency_key": payload["idempotency_key"],
+            "reason_code": payload["reason_code"],
+            "previous_admission_state": previous.get("admission_state", "offer_submitted"),
+            "coordinator_event_id": "withdraw_event_test",
+            "accepted_at": "2027-01-15T08:00:01Z",
+            "resulting_admission_state": "withdrawn",
+            "provider_guidance": self.guidance("withdrawn", reason_code=payload["reason_code"]),
+            "warnings": [],
+        }
+        self.server.state["statuses"][candidate_id] = self.status_payload(
+            candidate_id=candidate_id,
+            served_model_ref=payload["served_model_ref"],
+            catalog_model_key=payload.get("catalog_model_key"),
+            state="withdrawn",
+            event_id="withdraw_event_test",
+            reason_code=payload["reason_code"],
+        )
+        self.send_json(withdrawal)
+
+    def status_payload(self, candidate_id, served_model_ref, catalog_model_key, state, event_id, reason_code=None):
+        return {
+            "schema": "model_admission_status.v1",
+            "generated_at": NOW,
+            "cli_version": "test",
+            "provider_id": PROVIDER_ID,
+            "candidate_id": candidate_id,
+            "served_model_ref": served_model_ref,
+            "catalog_model_key": catalog_model_key,
+            "admission_state": state,
+            "admission_state_source": "coordinator",
+            "coordinator_event_id": event_id,
+            "state_observed_at": NOW,
+            "provider_guidance": self.guidance(state, reason_code=reason_code),
+            "allowed_next_states": self.allowed_next_states(state),
+            "warnings": [],
+        }
+
+    def guidance(self, state, reason_code=None):
+        return {
+            "state_label_key": "byom.admission." + state,
+            "state_meaning_key": "byom.admission.not_earning",
+            "next_action": "submit_offer" if state in ("not_offered", "withdrawn") else "wait_for_coordinator",
+            "transition_reason_code": reason_code,
+            "earning_path_class": "local_inventory_only" if state == "not_offered" else "no_earning_path_in_v0_1",
+        }
+
+    def allowed_next_states(self, state):
+        if state in ("not_offered", "withdrawn"):
+            return ["offer_submitted"]
+        if state == "offer_submitted":
+            return [
+                "offer_rejected",
+                "sandbox_probe_only",
+                "network_visible_unpriced",
+                "network_admitted_unsettled",
+                "catalog_priced",
+                "withdrawn",
+                "revoked",
+            ]
+        return []
+
+    def require_auth(self):
+        got = self.headers.get("authorization")
+        assert_true(got == "Bearer " + PROVIDER_TOKEN, "bad Authorization header")
+
+    def record(self, method, path, payload):
+        self.server.state["requests"].append({
+            "method": method,
+            "path": path,
+            "payload": payload,
+        })
+
+    def log_message(self, *_args):
+        pass
+
+    def send_json(self, payload):
+        encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+
+def run_cli(cli, args, env, cwd):
+    completed = subprocess.run(
+        [str(cli)] + args,
+        cwd=str(cwd),
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+    if completed.returncode != 0:
+        raise HarnessFailure(
+            "CLI failed (%d): %s\nstdout:\n%s\nstderr:\n%s"
+            % (completed.returncode, " ".join(args), completed.stdout, completed.stderr)
+        )
+    return completed
+
+
+def parse_json_output(completed):
+    try:
+        return json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise HarnessFailure("invalid JSON stdout: %s\n%s" % (exc, completed.stdout))
+
+
+def find_candidate(document):
+    candidates = document.get("candidates", [])
+    for candidate in candidates:
+        if candidate.get("served_model_ref") == SERVED_MODEL_REF:
+            return candidate
+    raise HarnessFailure("candidate not found in discovery output")
+
+
+def assert_null_money(row):
+    null_fields = [
+        "prompt_rate_usd_per_million_tokens",
+        "completion_rate_usd_per_million_tokens",
+        "provider_prompt_payout_usd_per_million_tokens",
+        "provider_completion_payout_usd_per_million_tokens",
+    ]
+    for field in null_fields:
+        assert_true(row.get(field) is None, "expected null " + field)
+    assert_true(row.get("economics_state") == "blocked", "economics did not remain blocked")
+    assert_true(row.get("rate_source") == "none", "rate source did not remain none")
+    admission = row.get("admission") or {}
+    assert_true(admission.get("catalog_economics_permitted") is False, "catalog economics became permitted")
+    assert_true(admission.get("settlement_capable") is False, "settlement became capable")
+
+
+def catalog_row(document, candidate_id):
+    assert_true(document.get("schema") == "model_catalog_economics.v1", "wrong catalog economics schema")
+    for row in document.get("rows", []):
+        if row.get("action_model_id") == candidate_id:
+            return row
+    raise HarnessFailure("catalog economics row not found for " + candidate_id)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run the BYOM CLI onboarding E2E harness.")
+    parser.add_argument("--keep-temp", action="store_true", help="Keep the temporary harness directory.")
+    args = parser.parse_args()
+
+    root = repo_root()
+    temp_root = pathlib.Path(tempfile.mkdtemp(prefix="macprovider-byom-e2e-"))
+    ollama = LocalHTTPServer(OllamaHandler, {"paths": [], "chat_bodies": []})
+    coordinator = LocalHTTPServer(CoordinatorHandler, {"requests": [], "statuses": {}})
+    try:
+        cli = build_cli(root, os.environ.get("MACPROVIDER_CLI_BINARY"))
+        ollama.start()
+        coordinator.start()
+
+        home = temp_root / "home"
+        home.mkdir(mode=0o700)
+        protected_root = temp_root / "protected-credentials"
+        namespace = temp_root / "local-discovery.namespace"
+        hf_cache = temp_root / "hf-cache"
+        config = temp_root / "config.yaml"
+        config.write_text(
+            "\n".join([
+                "provider_id: " + PROVIDER_ID,
+                "provider_token: " + PROVIDER_TOKEN,
+                "coordinator_url: " + coordinator.origin,
+                "credential_store: protected_file",
+                "",
+            ]),
+            encoding="utf-8",
+        )
+
+        env = os.environ.copy()
+        env.update({
+            "HOME": str(home),
+            "MACPROVIDER_CONFIG": str(config),
+            "MACPROVIDER_PROTECTED_CREDENTIAL_ROOT": str(protected_root),
+            "MACPROVIDER_BYOM_ALLOW_INSECURE_LOOPBACK_COORDINATOR": "1",
+        })
+
+        common_discovery_args = [
+            "--local-discovery-namespace-path", str(namespace),
+            "--mlx-cache-dir", str(hf_cache),
+            "--ollama-origin", ollama.origin,
+        ]
+
+        credentials = parse_json_output(run_cli(
+            cli,
+            ["credentials", "import", "--config", str(config)],
+            env,
+            root,
+        ))
+        assert_true(credentials.get("status") == "ok", "credential import failed")
+        assert_true(credentials.get("credential_store") == "protected_file", "wrong credential store")
+
+        discovery = parse_json_output(run_cli(
+            cli,
+            ["models", "discover", "--json"] + common_discovery_args,
+            env,
+            root,
+        ))
+        assert_true(discovery.get("schema") == "provider_byom_discovery.v1", "wrong discovery schema")
+        candidate = find_candidate(discovery)
+        candidate_id = candidate["candidate_id"]
+        assert_true(candidate.get("admission_state_source") == "local_default", "discovery admission source mutated")
+        assert_true(candidate.get("admission_state") == "offerable", "candidate not locally offerable")
+        assert_true(candidate.get("catalog_model_key") == CATALOG_MODEL_KEY, "catalog key was not discovered")
+        assert_true(coordinator.state["requests"] == [], "discovery contacted coordinator")
+
+        evaluation_result = run_cli(
+            cli,
+            ["models", "evaluate", SERVED_MODEL_REF, "--json"] + common_discovery_args,
+            env,
+            root,
+        )
+        evaluation = parse_json_output(evaluation_result)
+        assert_true(evaluation.get("schema") == "provider_byom_evaluation.v1", "wrong evaluation schema")
+        assert_true(evaluation.get("health_result") == "passed", "evaluation did not pass")
+        assert_true(evaluation.get("offer_preconditions_appear_satisfied") is True, "evaluation did not satisfy offer preconditions")
+        mutations = evaluation.get("mutation_summary") or {}
+        assert_true(mutations.get("coordinator_state_mutated") is False, "evaluation claims coordinator mutation")
+        assert_true(mutations.get("production_config_mutated") is False, "evaluation claims config mutation")
+        assert_true(coordinator.state["requests"] == [], "evaluation contacted coordinator")
+
+        evaluation_digest = hashlib.sha256(evaluation_result.stdout.encode("utf-8")).hexdigest()
+        dry_run = parse_json_output(run_cli(
+            cli,
+            ["models", "offer", SERVED_MODEL_REF, "--dry-run", "--json"] + common_discovery_args,
+            env,
+            root,
+        ))
+        assert_true(dry_run.get("schema") == "model_admission_offer_dry_run.v1", "wrong dry-run schema")
+        assert_true(dry_run.get("candidate_id") == candidate_id, "dry-run resolved a different candidate")
+        assert_true(dry_run.get("would_submit") is False, "dry-run unexpectedly submits without evaluation digest")
+        assert_true(dry_run.get("reason_code") == "evaluation_required", "dry-run did not explain evaluation gate")
+        assert_true(coordinator.state["requests"] == [], "dry-run contacted coordinator")
+
+        offer = parse_json_output(run_cli(
+            cli,
+            [
+                "models", "offer", SERVED_MODEL_REF,
+                "--yes",
+                "--json",
+                "--config", str(config),
+                "--evaluation-digest-sha256", evaluation_digest,
+            ] + common_discovery_args,
+            env,
+            root,
+        ))
+        assert_true(offer.get("schema") == "model_admission_status.v1", "wrong offer response schema")
+        assert_true(offer.get("admission_state") == "offer_submitted", "offer was not submitted")
+        assert_true(offer.get("admission_state_source") == "coordinator", "offer status was not coordinator-backed")
+        assert_true(offer.get("candidate_id") == candidate_id, "offer used a different candidate")
+        assert_true(len(coordinator.state["requests"]) == 1, "offer did not make exactly one coordinator request")
+
+        status = parse_json_output(run_cli(
+            cli,
+            ["models", "admission", "status", SERVED_MODEL_REF, "--json", "--config", str(config)] + common_discovery_args,
+            env,
+            root,
+        ))
+        assert_true(status.get("admission_state") == "offer_submitted", "status did not read submitted offer")
+        assert_true(status.get("candidate_id") == candidate_id, "status candidate mismatch")
+
+        economics = parse_json_output(run_cli(
+            cli,
+            ["models", "catalog-economics", "--json", "--config", str(config)] + common_discovery_args,
+            env,
+            root,
+        ))
+        row = catalog_row(economics, candidate_id)
+        admission = row.get("admission") or {}
+        assert_true(admission.get("state") == "offer_submitted", "catalog economics did not use coordinator admission")
+        assert_true(admission.get("source") == "coordinator", "catalog economics admission source was not coordinator")
+        assert_null_money(row)
+
+        withdrawal = parse_json_output(run_cli(
+            cli,
+            [
+                "models", "admission", "withdraw", SERVED_MODEL_REF,
+                "--yes",
+                "--json",
+                "--config", str(config),
+                "--reason-code", "provider_requested",
+            ] + common_discovery_args,
+            env,
+            root,
+        ))
+        assert_true(withdrawal.get("schema") == "model_admission_withdraw.v1", "wrong withdrawal schema")
+        assert_true(withdrawal.get("resulting_admission_state") == "withdrawn", "withdrawal did not withdraw")
+
+        withdrawn_status = parse_json_output(run_cli(
+            cli,
+            ["models", "admission", "status", SERVED_MODEL_REF, "--json", "--config", str(config)] + common_discovery_args,
+            env,
+            root,
+        ))
+        assert_true(withdrawn_status.get("admission_state") == "withdrawn", "withdrawn status was not observed")
+
+        withdrawn_economics = parse_json_output(run_cli(
+            cli,
+            ["models", "catalog-economics", "--json", "--config", str(config)] + common_discovery_args,
+            env,
+            root,
+        ))
+        withdrawn_row = catalog_row(withdrawn_economics, candidate_id)
+        withdrawn_admission = withdrawn_row.get("admission") or {}
+        assert_true(withdrawn_admission.get("state") == "withdrawn", "withdrawn economics did not use coordinator state")
+        assert_true(withdrawn_admission.get("source") == "coordinator", "withdrawn economics source was not coordinator")
+        assert_null_money(withdrawn_row)
+
+        print("BYOM CLI onboarding E2E passed")
+        print("candidate_id=%s coordinator_requests=%d" % (candidate_id, len(coordinator.state["requests"])))
+        return 0
+    except Exception as exc:
+        print("BYOM CLI onboarding E2E failed: %s" % exc, file=sys.stderr)
+        if args.keep_temp:
+            print("temp_root=%s" % temp_root, file=sys.stderr)
+        return 1
+    finally:
+        try:
+            ollama.stop()
+        finally:
+            coordinator.stop()
+        if args.keep_temp:
+            print("kept temp_root=%s" % temp_root)
+        else:
+            shutil.rmtree(str(temp_root), ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
BYOM slice-8 (#1257): Malibu consumption of the stable CLI catalog-economics contract. The FINAL slice of the BYOM epic (#1240). Malibu decodes and presents the CLI-owned catalog-economics projection as a conservative, fail-closed consumer; the CLI and coordinator remain the sole economics authority. Reworked onto current main (supersedes the codex/1257 stack). With this, #1255 (credit-gate, folded into slice-7) and the full ladder are complete.

## What this adds
- **Malibu catalog-economics consumption**: strict closed-schema decode of `model_catalog_economics.v1`; a duplicate-key preflight before decoding; any malformed/unknown-field row fails the whole projection (fail-closed). Non-catalog/local rows carry explicit null money fields; `catalog_priced` may show signed catalog rates but always alongside a "No provider credit yet" non-earning disclosure (rendered independent of block/action state, so a switchable catalog_priced row cannot show rates without the caveat); `settlement_capable` is required for earning claims. Coordinator-verified catalog identity (`model_key`) is displayed as authoritative with `display_model_id` labelled provider-reported.
- **Projection safety**: a late projection from an older CLI process (older `generated_at`) cannot overwrite newer accepted state.
- **BYOM onboarding E2E harness** (`make test-byom-e2e`): manual macOS release evidence driving the real `macprovider-cli` offer/status/catalog-economics/withdraw path against a hermetic loopback fake coordinator.

## Money-path / disclosure invariants held (verified by 3-lane audit)
Malibu never fabricates or upgrades economics beyond the signed CLI projection, fails closed on malformed/duplicate-key/unsigned/stale input, distinguishes provider-reported from catalog-verified identity, and shows the non-earning disclosure for every non-settlement economics row. Nothing here enables earning; earning stays deferred to the future SPEC-005 pricing-conversion spec.

## Audit
3-lane codex audit (code / security / architecture) over the full combined diff to 0 CRITICAL / 0 HIGH / 0 MEDIUM across all lanes. Fixes with regression tests (94 ModelManagementTests pass via `xcodebuild test`): strict fail-closed row decode; projection-staleness guard; non-earning disclosure carried + rendered for switchable non-settlement rows; provider-vs-verified identity display; action-descriptor reason requirement; duplicate-key preflight; VoiceOver disclosure exposure; `test-byom-e2e` target + honest manual-evidence README; corrected CONFORMANCE test selectors. A round-1 code HIGH proposing to gate the switch action on `settlement_capable` was reassessed as over-strict (catalog_priced models are intentionally switchable to run locally; a passing test relies on it) and reframed as the disclosure guard above.

Carried LOWs (money-safe, documented follow-ups): Malibu's closed `disabled_reason` list omits CLI values `fallback`/`stale`/`unavailable` (rows stay money-safe, lose warning copy); the onboarding E2E harness can exit early on a fresh namespace before its assertions (now explicitly manual release evidence; harness namespace-provisioning hardening deferred).

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "issue": "https://github.com/Augustas11/macprovider/issues/1257",
  "specs": [
    "SPEC-044",
    "SPEC-047",
    "SPEC-001"
  ],
  "requirements": [
    "SPEC-044-R001",
    "SPEC-044-R002",
    "SPEC-044-R005",
    "SPEC-044-R007",
    "SPEC-044-R008",
    "SPEC-044-R009",
    "SPEC-044-R010",
    "SPEC-044-R011"
  ],
  "authority_domains": [
    "malibu-model-economics-ux",
    "network-model-admission"
  ],
  "arbitration": [
    "DECISION_REQUIRED"
  ],
  "tests": [
    "cd phase3-binary/app && xcodegen generate && xcodebuild test -project Malibu.xcodeproj -scheme Malibu -destination 'platform=macOS' -only-testing:MalibuTests/ModelManagementTests",
    "cd phase3-binary && swift test --filter BYOMDiscovery",
    "python3 scripts/check_spec_governance.py --base-ref origin/main",
    "git diff --check"
  ],
  "journeys": [
    "not-required"
  ]
}
SPEC-GOVERNANCE-DECLARATION-END
