### PR TITLE
trustpool: fail-close operator promote without production reviewed-artifact lifecycle owner (#1233)

### DIFF
--- a/docs/runbooks/trusted-pool-creator-launch.md
+++ b/docs/runbooks/trusted-pool-creator-launch.md
@@ -76,7 +76,12 @@ Also still missing before any live announcement:
 - a reviewed-artifact lifecycle owner for the live pool
   (`POST /admin/trust-pools/pools/{id}/reviewed-artifact-lifecycle`, CLI
   `coordinator-cli trust-pool-artifact-lifecycle`). This is separate from the
-  digest-bound reviewed-artifact upsert.
+  digest-bound reviewed-artifact upsert. Operator HTTP/CLI production promote
+  now fail-closes without a current production lifecycle owner (missing,
+  candidate-class, or overdue), the same unmapped-wrapper gate as on-call.
+  In-process `Store.PromotePool` still does not consult it; wiring
+  `validatePromotion` needs a recapture window because that function is
+  evidence-mapped.
 - a production timing-floor remeasure. Isolated-candidate oracle proof is not
   that remeasure. Use `scripts/measure-pool-rejection-timing-floor.py`; it
   refuses production hosts unless `--environment production --allow-production`
@@ -110,7 +115,11 @@ not yet a `PromotePool` production-gate check.
 
 Reviewed-artifact lifecycle ownership is a separate durable row from
 `review-distribution-artifact`. Assign an owner and `environment_class` of
-`candidate` or `production` before treating a pool as live-ready.
+`candidate` or `production` before treating a pool as live-ready. Operator
+HTTP/CLI production promote fail-closes (`reviewed_artifact_lifecycle_rejected`,
+409) unless the pool has a current production lifecycle owner whose
+`next_review_due_utc` is still in the future. This is not yet a
+`Store.PromotePool` production-gate check.
 
 Offline timing-floor check (does **not** count as production remeasure):
 

--- a/phase4-coordinator/internal/trustpool/admin_live_readiness.go
+++ b/phase4-coordinator/internal/trustpool/admin_live_readiness.go
@@ -2,7 +2,6 @@ package trustpool
 
 import (
 	"encoding/json"
-	"errors"
 	"io"
 	"net/http"
 	"os"
@@ -14,7 +13,18 @@ func (h *adminHandler) handlePromotePoolGuarded(w http.ResponseWriter, r *http.R
 	if r.Method == http.MethodPost {
 		poolID := strings.TrimSpace(strings.TrimPrefix(strings.TrimSuffix(r.URL.Path, "/promote"), "/admin/trust-pools/pools/"))
 		if poolID != "" && !strings.Contains(poolID, "/") {
-			if err := h.deps.Store.RequireOnCallReadinessForPromotion(r.Context(), poolID); errors.Is(err, ErrOnCallReadiness) {
+			// Both live-readiness gates fail closed on ANY non-nil error, not
+			// only their sentinel: a lifecycle/on-call read that fails (missing
+			// table, malformed row, storage error) must block production
+			// promote rather than fall through to the mapped handler, which
+			// does not re-check these rows. writeMutationError maps the
+			// sentinels to their rejection codes and unexpected errors to a
+			// closed response.
+			if err := h.deps.Store.RequireOnCallReadinessForPromotion(r.Context(), poolID); err != nil {
+				h.writeMutationError(w, err)
+				return
+			}
+			if err := h.deps.Store.RequireReviewedArtifactLifecycleForPromotion(r.Context(), poolID); err != nil {
 				h.writeMutationError(w, err)
 				return
 			}

--- a/phase4-coordinator/internal/trustpool/live_readiness_test.go
+++ b/phase4-coordinator/internal/trustpool/live_readiness_test.go
@@ -246,6 +246,12 @@ func TestAdminHandler_PromoteProductionRequiresOnCallReadiness(t *testing.T) {
 	assertAdminErrorCode(t, missing, "on_call_readiness_rejected")
 
 	upsertSignedOnCall(t, store, "op-oncall-http", "production")
+	// On-call is satisfied, but the reviewed-artifact lifecycle gate now blocks
+	// production promote until a current production lifecycle owner exists.
+	blockedOnLifecycle := postAdminPromote(t, handler, "operator-secret", root.poolID, "op-promote-oncall-no-lifecycle", http.StatusConflict)
+	assertAdminErrorCode(t, blockedOnLifecycle, "reviewed_artifact_lifecycle_rejected")
+
+	upsertProductionArtifactLifecycle(t, handler, "operator-secret", root.poolID, "op-lifecycle-http")
 	postAdminPromote(t, handler, "operator-secret", root.poolID, "op-promote-with-oncall", http.StatusAccepted)
 }
 
@@ -263,6 +269,127 @@ func TestAdminHandler_PromoteProductionRejectsExpiredOnCallReadiness(t *testing.
 	expireStoredOnCall(t, db, "production")
 	expired := postAdminPromote(t, handler, "operator-secret", root.poolID, "op-promote-expired-oncall", http.StatusConflict)
 	assertAdminErrorCode(t, expired, "on_call_readiness_rejected")
+}
+
+func TestRequireReviewedArtifactLifecycleForPromotion(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("candidate skips", func(t *testing.T) {
+		t.Parallel()
+		store, err := trustpool.NewStore(openTrustPoolDB(t))
+		if err != nil {
+			t.Fatalf("NewStore: %v", err)
+		}
+		root := seedCandidatePool(t, store)
+		if err := store.RequireReviewedArtifactLifecycleForPromotion(ctx, root.poolID); err != nil {
+			t.Fatalf("candidate RequireReviewedArtifactLifecycleForPromotion: %v", err)
+		}
+	})
+
+	t.Run("missing production owner fails closed and PromotePool still succeeds", func(t *testing.T) {
+		t.Parallel()
+		db := openTrustPoolDB(t)
+		store := newProductionActivationStore(t, db)
+		root := seedProductionPromotablePool(t, store)
+		if err := store.RequireReviewedArtifactLifecycleForPromotion(ctx, root.poolID); err == nil || !errors.Is(err, trustpool.ErrReviewedArtifactLifecycle) {
+			t.Fatalf("missing lifecycle err=%v, want ErrReviewedArtifactLifecycle", err)
+		}
+		state, _, _, err := store.PromotePool(ctx, trustpool.DurableEvent{
+			OperationID: "op-promote-store-bypass-lifecycle",
+			PoolID:      root.poolID,
+		})
+		if err != nil {
+			t.Fatalf("PromotePool without lifecycle owner: %v", err)
+		}
+		if got := state.Pools[root.poolID].Lifecycle; got != trustpool.LifecycleActive {
+			t.Fatalf("in-process PromotePool lifecycle=%q, want active", got)
+		}
+	})
+
+	t.Run("candidate-class owner on production pool fails closed", func(t *testing.T) {
+		t.Parallel()
+		db := openTrustPoolDB(t)
+		store := newProductionActivationStore(t, db)
+		root := seedProductionPromotablePool(t, store)
+		upsertArtifactLifecycleStore(t, store, root.poolID, "op-lifecycle-candidate-class", trustpool.ReviewedArtifactEnvironmentCandidate)
+		if err := store.RequireReviewedArtifactLifecycleForPromotion(ctx, root.poolID); err == nil || !errors.Is(err, trustpool.ErrReviewedArtifactLifecycle) {
+			t.Fatalf("candidate-class lifecycle err=%v, want ErrReviewedArtifactLifecycle", err)
+		}
+	})
+
+	t.Run("current production owner allows", func(t *testing.T) {
+		t.Parallel()
+		db := openTrustPoolDB(t)
+		store := newProductionActivationStore(t, db)
+		root := seedProductionPromotablePool(t, store)
+		upsertArtifactLifecycleStore(t, store, root.poolID, "op-lifecycle-prod", trustpool.ReviewedArtifactEnvironmentProduction)
+		if err := store.RequireReviewedArtifactLifecycleForPromotion(ctx, root.poolID); err != nil {
+			t.Fatalf("current lifecycle owner: %v", err)
+		}
+	})
+
+	t.Run("overdue production owner fails closed", func(t *testing.T) {
+		t.Parallel()
+		db := openTrustPoolDB(t)
+		store := newProductionActivationStore(t, db)
+		root := seedProductionPromotablePool(t, store)
+		upsertArtifactLifecycleStore(t, store, root.poolID, "op-lifecycle-overdue", trustpool.ReviewedArtifactEnvironmentProduction)
+		expireStoredArtifactLifecycle(t, db, root.poolID)
+		if err := store.RequireReviewedArtifactLifecycleForPromotion(ctx, root.poolID); err == nil || !errors.Is(err, trustpool.ErrReviewedArtifactLifecycle) {
+			t.Fatalf("overdue lifecycle err=%v, want ErrReviewedArtifactLifecycle", err)
+		}
+	})
+
+	t.Run("unknown pool is left to PromotePool", func(t *testing.T) {
+		t.Parallel()
+		store, err := trustpool.NewStore(openTrustPoolDB(t))
+		if err != nil {
+			t.Fatalf("NewStore: %v", err)
+		}
+		if err := store.RequireReviewedArtifactLifecycleForPromotion(ctx, "pool-missing"); err != nil {
+			t.Fatalf("missing pool: %v", err)
+		}
+	})
+}
+
+func TestAdminHandler_PromoteProductionRejectsOverdueReviewedArtifactLifecycle(t *testing.T) {
+	t.Parallel()
+	db := openTrustPoolDB(t)
+	store := newProductionActivationStore(t, db)
+	handler := trustpool.NewAdminHandler(trustpool.AdminDeps{
+		Store:       store,
+		Registry:    trustpool.NewRegistry(),
+		OperatorKey: "operator-secret",
+	})
+	root := seedProductionPromotablePool(t, store)
+	upsertSignedOnCall(t, store, "op-oncall-overdue-lifecycle", "production")
+	upsertProductionArtifactLifecycle(t, handler, "operator-secret", root.poolID, "op-lifecycle-overdue-http")
+	expireStoredArtifactLifecycle(t, db, root.poolID)
+	overdue := postAdminPromote(t, handler, "operator-secret", root.poolID, "op-promote-overdue-lifecycle", http.StatusConflict)
+	assertAdminErrorCode(t, overdue, "reviewed_artifact_lifecycle_rejected")
+}
+
+func TestAdminHandler_PromoteProductionFailsClosedOnUnreadableLifecycle(t *testing.T) {
+	t.Parallel()
+	db := openTrustPoolDB(t)
+	store := newProductionActivationStore(t, db)
+	handler := trustpool.NewAdminHandler(trustpool.AdminDeps{
+		Store:       store,
+		Registry:    trustpool.NewRegistry(),
+		OperatorKey: "operator-secret",
+	})
+	root := seedProductionPromotablePool(t, store)
+	upsertSignedOnCall(t, store, "op-oncall-corrupt-lifecycle", "production")
+	upsertProductionArtifactLifecycle(t, handler, "operator-secret", root.poolID, "op-lifecycle-corrupt-http")
+	// Corrupt the stored row so the lifecycle read returns a non-sentinel parse
+	// error. The wrapper must still fail closed (not fall through to promote).
+	if _, err := db.Exec(`UPDATE trustpool_reviewed_artifact_lifecycle SET next_review_due_utc = 'not-a-timestamp' WHERE pool_id = ?`, root.poolID); err != nil {
+		t.Fatalf("corrupt lifecycle row: %v", err)
+	}
+	// A non-sentinel read error maps through writeMutationError's default to a
+	// closed 400 response; the request must not reach the mapped promote.
+	postAdminPromote(t, handler, "operator-secret", root.poolID, "op-promote-corrupt-lifecycle", http.StatusBadRequest)
 }
 
 func TestOnCallReadiness_ExpiredMethod(t *testing.T) {
@@ -644,6 +771,48 @@ func expireStoredOnCall(t *testing.T, db *sql.DB, envID string) {
 	n, err := res.RowsAffected()
 	if err != nil || n != 1 {
 		t.Fatalf("expire on-call rows=%d err=%v, want 1", n, err)
+	}
+}
+
+func upsertArtifactLifecycleStore(t *testing.T, store *trustpool.Store, poolID, operationID, environmentClass string) trustpool.ReviewedArtifactLifecycle {
+	t.Helper()
+	rec, err := store.UpsertReviewedArtifactLifecycle(context.Background(), trustpool.ReviewedArtifactLifecycle{
+		OperationID:      operationID,
+		PoolID:           poolID,
+		Owner:            "ops-oncall",
+		EnvironmentClass: environmentClass,
+		NextReviewDueUTC: time.Now().UTC().Add(30 * 24 * time.Hour),
+		Notes:            "lifecycle owner for promote gate",
+	})
+	if err != nil {
+		t.Fatalf("UpsertReviewedArtifactLifecycle: %v", err)
+	}
+	return rec
+}
+
+func upsertProductionArtifactLifecycle(t *testing.T, handler http.Handler, operatorKey, poolID, operationID string) {
+	t.Helper()
+	rec := trustpool.ReviewedArtifactLifecycle{
+		OperationID:      operationID,
+		PoolID:           poolID,
+		Owner:            "ops-oncall",
+		EnvironmentClass: trustpool.ReviewedArtifactEnvironmentProduction,
+		NextReviewDueUTC: time.Now().UTC().Add(30 * 24 * time.Hour),
+		Notes:            "production lifecycle owner for promote gate",
+	}
+	postAdminReviewedArtifactLifecycle(t, handler, operatorKey, poolID, rec, http.StatusOK)
+}
+
+func expireStoredArtifactLifecycle(t *testing.T, db *sql.DB, poolID string) {
+	t.Helper()
+	overdue := time.Now().UTC().Add(-time.Hour).Format(time.RFC3339Nano)
+	res, err := db.Exec(`UPDATE trustpool_reviewed_artifact_lifecycle SET next_review_due_utc = ? WHERE pool_id = ?`, overdue, poolID)
+	if err != nil {
+		t.Fatalf("expire lifecycle: %v", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil || n != 1 {
+		t.Fatalf("expire lifecycle rows=%d err=%v, want 1", n, err)
 	}
 }
 

--- a/phase4-coordinator/internal/trustpool/reviewed_artifact_lifecycle.go
+++ b/phase4-coordinator/internal/trustpool/reviewed_artifact_lifecycle.go
@@ -256,3 +256,46 @@ func sameReviewedArtifactLifecycleExceptRevision(a, b ReviewedArtifactLifecycle)
 		a.NextReviewDueUTC.Equal(b.NextReviewDueUTC) &&
 		a.Notes == b.Notes
 }
+
+// RequireReviewedArtifactLifecycleForPromotion fail-closes operator HTTP/CLI
+// production promote when the reconstructed pool is non-candidate and it has no
+// current production reviewed-artifact lifecycle owner. Candidate pools skip
+// this check so the isolated-candidate journey stays valid. Missing pools and
+// pools without a root issuer are left to PromotePool preconditions. Mirrors
+// RequireOnCallReadinessForPromotion: an unmapped wrapper gate that is not
+// inside the evidence-mapped PromotePool transaction.
+func (s *Store) RequireReviewedArtifactLifecycleForPromotion(ctx context.Context, poolID string) error {
+	poolID = strings.TrimSpace(poolID)
+	if poolID == "" {
+		return nil
+	}
+	state, err := s.Reconstruct(ctx)
+	if err != nil {
+		return err
+	}
+	if state == nil {
+		return nil
+	}
+	p := state.Pools[poolID]
+	if p == nil || p.RootIssuer == nil {
+		return nil
+	}
+	environment := strings.TrimSpace(p.RootIssuer.LaunchEnvironment)
+	if environment == "" || environment == promotionLaunchEnvironmentCandidate {
+		return nil
+	}
+	rec, ok, err := s.ReviewedArtifactLifecycle(ctx, poolID)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("%w: production promotion requires a reviewed-artifact lifecycle owner for %s", ErrReviewedArtifactLifecycle, poolID)
+	}
+	if rec.EnvironmentClass != ReviewedArtifactEnvironmentProduction {
+		return fmt.Errorf("%w: production promotion requires a production reviewed-artifact lifecycle owner for %s", ErrReviewedArtifactLifecycle, poolID)
+	}
+	if rec.Overdue(time.Now().UTC()) {
+		return fmt.Errorf("%w: reviewed-artifact lifecycle review overdue for %s", ErrReviewedArtifactLifecycle, poolID)
+	}
+	return nil
+}


### PR DESCRIPTION
## What

Fail-close operator HTTP/CLI production `promote` when a Trusted Pool has no
current **production reviewed-artifact lifecycle owner**. This is a SPEC-043
live-readiness launch blocker tracked in #1233.

Operator production promote already fail-closes without a current on-call
readiness row (#1232). The reviewed-artifact lifecycle owner — also a
SPEC-043-R008 production-enablement precondition ("reviewed creator
distribution package ... artifact digest") — was **not** gated, so production
promote could succeed with no lifecycle owner assigned.

## How

- Add `Store.RequireReviewedArtifactLifecycleForPromotion`, mirroring
  `RequireOnCallReadinessForPromotion`: an **unmapped wrapper** gate in
  `handlePromotePoolGuarded`, outside the evidence-mapped
  `Store.PromotePool` / `validatePromotion` transaction, so **no CONFORMANCE
  recapture** is triggered. It fail-closes a non-candidate pool promote when
  the production lifecycle owner is missing, candidate-class, or overdue.
  `ErrReviewedArtifactLifecycle` already maps to
  `409 reviewed_artifact_lifecycle_rejected`.
- Both live-readiness gates in the wrapper now fail closed on **any** non-nil
  error, not only their sentinel. Previously a non-sentinel read error
  (missing table, malformed row, storage error) fell through to the mapped
  promote, which does not re-check these rows — a real fail-open. This also
  closes the identical pre-existing latent fail-open on the on-call gate in
  the same wrapper. (Found and fixed during the three-lane audit below.)
- Runbook updated to document the new gate and its mapped-vs-unmapped boundary.

Candidate pools and in-process `Store.PromotePool` are intentionally unchanged;
wiring the mapped `validatePromotion` stays deferred to a recapture window.

## Tests

- `TestRequireReviewedArtifactLifecycleForPromotion` (candidate skips, missing
  fails closed + `PromotePool` still succeeds, candidate-class fails closed,
  current production allows, overdue fails closed, unknown pool passthrough)
- `TestAdminHandler_PromoteProductionRequiresReviewedArtifactLifecycle` behavior
  folded into the existing on-call admin test + overdue and corrupt-row admin
  tests (`...RejectsOverdueReviewedArtifactLifecycle`,
  `...FailsClosedOnUnreadableLifecycle`)
- `go test ./internal/trustpool -count=1` green (incl. the candidate journey)

## Audit

Three-lane codex audit over the full fix diff, second round after the fail-open
fix: **0 CRITICAL / 0 HIGH / 0 MEDIUM** across code, security, and architecture
lanes. One LOW carried (security): the gate does not re-validate `owner != ''`
from a directly DB-tampered row; the upsert path already enforces non-empty
owner, so this is only reachable by bypassing the write path.

<!-- SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-043"],
  "requirements": ["SPEC-043-R008"],
  "authority_domains": ["trusted-pool-creator-onboarding"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "phase4-coordinator/internal/trustpool/live_readiness_test.go::TestRequireReviewedArtifactLifecycleForPromotion",
    "phase4-coordinator/internal/trustpool/live_readiness_test.go::TestAdminHandler_PromoteProductionRejectsOverdueReviewedArtifactLifecycle",
    "phase4-coordinator/internal/trustpool/live_readiness_test.go::TestAdminHandler_PromoteProductionFailsClosedOnUnreadableLifecycle"
  ],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/1233"
}
SPEC-GOVERNANCE-DECLARATION-END -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
