### PR TITLE
trustpool: SPEC-043 on-call operations-authority signing path (#1233)

### DIFF
--- a/.github/workflows/build-signed-oncall-readiness.yml
+++ b/.github/workflows/build-signed-oncall-readiness.yml
@@ -1,0 +1,208 @@
+name: Build signed SPEC-043 on-call readiness record
+
+on:
+  workflow_dispatch:
+    inputs:
+      operation_id:
+        description: "Idempotency key for the on-call upsert"
+        required: true
+        type: string
+      launch_environment_id:
+        description: "Launch environment id (e.g. production)"
+        required: true
+        type: string
+      record_version:
+        description: "On-call record version label"
+        required: true
+        type: string
+      primary_operator_contact:
+        required: true
+        type: string
+      secondary_operator_contact:
+        required: true
+        type: string
+      break_glass_escalation_path:
+        required: true
+        type: string
+      compromise_notification_channel:
+        required: true
+        type: string
+      creator_agreement_notification_commitment_ack:
+        required: true
+        type: string
+      creator_emergency_notification_mechanism:
+        required: true
+        type: string
+      confirmation_ttl_seconds:
+        description: "TTL in seconds, 0 < ttl <= 7776000 (90 days)"
+        required: true
+        default: "7776000"
+        type: string
+      signing_confirmed:
+        description: "Confirm an on-call readiness record should be signed"
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: signed-oncall-readiness-${{ github.event.inputs.launch_environment_id }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build and sign an on-call readiness record
+    runs-on: ubuntu-latest
+    environment: production-release
+    steps:
+      - name: Checkout reviewed main controls
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
+        with:
+          go-version-file: phase4-coordinator/go.mod
+          cache: false
+
+      - name: Validate exact main source and fail-closed keyring
+        id: request
+        shell: bash
+        env:
+          OPERATION_ID_INPUT: ${{ github.event.inputs.operation_id }}
+          LAUNCH_ENV_INPUT: ${{ github.event.inputs.launch_environment_id }}
+          RECORD_VERSION_INPUT: ${{ github.event.inputs.record_version }}
+          TTL_INPUT: ${{ github.event.inputs.confirmation_ttl_seconds }}
+          SIGNING_CONFIRMED_INPUT: ${{ github.event.inputs.signing_confirmed || 'false' }}
+        run: |
+          set -euo pipefail
+          [[ "$GITHUB_EVENT_NAME" == workflow_dispatch ]] || { echo "::error::manual dispatch required" >&2; exit 1; }
+          [[ "$GITHUB_REF" == refs/heads/main ]] || { echo "::error::workflow must run from main" >&2; exit 1; }
+          [[ "$SIGNING_CONFIRMED_INPUT" == true ]] || { echo "::error::signing confirmation is required" >&2; exit 1; }
+          [[ "$OPERATION_ID_INPUT" =~ ^[A-Za-z0-9][A-Za-z0-9._:-]*$ ]] || { echo "::error::invalid operation id" >&2; exit 1; }
+          [[ "$LAUNCH_ENV_INPUT" =~ ^[A-Za-z0-9][A-Za-z0-9._:-]*$ ]] || { echo "::error::invalid launch environment id" >&2; exit 1; }
+          [[ "$RECORD_VERSION_INPUT" =~ ^[A-Za-z0-9][A-Za-z0-9._:-]*$ ]] || { echo "::error::invalid record version" >&2; exit 1; }
+          [[ "$TTL_INPUT" =~ ^[1-9][0-9]*$ ]] || { echo "::error::invalid confirmation ttl" >&2; exit 1; }
+          (( TTL_INPUT <= 7776000 )) || { echo "::error::confirmation ttl exceeds 90 days" >&2; exit 1; }
+          git fetch --quiet origin refs/heads/main:refs/remotes/origin/main
+          main_sha="$(git rev-parse refs/remotes/origin/main)"
+          [[ "$main_sha" == "$GITHUB_SHA" ]] || { echo "::error::workflow commit is no longer origin/main" >&2; exit 1; }
+          registered_digest="$(python3 scripts/register-spec043-oncall-authority-key.py --check | sed -n 's/^MACPROVIDER_SPEC043_ONCALL_AUTHORITY_KEY_SHA256=//p')"
+          [[ "$registered_digest" =~ ^[0-9a-f]{64}$ ]] || { echo "::error::keyring is fail-closed or digest unavailable" >&2; exit 1; }
+          printf 'registered_digest=%s\n' "$registered_digest" >> "$GITHUB_OUTPUT"
+          printf 'short_sha=%s\n' "${GITHUB_SHA:0:12}" >> "$GITHUB_OUTPUT"
+
+      - name: Build unsigned on-call readiness payload
+        id: payload
+        shell: bash
+        env:
+          OPERATION_ID: ${{ github.event.inputs.operation_id }}
+          LAUNCH_ENV: ${{ github.event.inputs.launch_environment_id }}
+          RECORD_VERSION: ${{ github.event.inputs.record_version }}
+          PRIMARY: ${{ github.event.inputs.primary_operator_contact }}
+          SECONDARY: ${{ github.event.inputs.secondary_operator_contact }}
+          BREAK_GLASS: ${{ github.event.inputs.break_glass_escalation_path }}
+          COMPROMISE: ${{ github.event.inputs.compromise_notification_channel }}
+          AGREEMENT_ACK: ${{ github.event.inputs.creator_agreement_notification_commitment_ack }}
+          EMERGENCY: ${{ github.event.inputs.creator_emergency_notification_mechanism }}
+          TTL: ${{ github.event.inputs.confirmation_ttl_seconds }}
+        run: |
+          set -euo pipefail
+          unsigned="$RUNNER_TEMP/oncall-unsigned.json"
+          python3 - "$unsigned" <<'PY'
+          import datetime
+          import json
+          import os
+          import sys
+
+          now = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0)
+          record = {
+              "operation_id": os.environ["OPERATION_ID"],
+              "launch_environment_id": os.environ["LAUNCH_ENV"],
+              "record_version": os.environ["RECORD_VERSION"],
+              "primary_operator_contact": os.environ["PRIMARY"],
+              "secondary_operator_contact": os.environ["SECONDARY"],
+              "break_glass_escalation_path": os.environ["BREAK_GLASS"],
+              "compromise_notification_channel": os.environ["COMPROMISE"],
+              "creator_agreement_notification_commitment_ack": os.environ["AGREEMENT_ACK"],
+              "creator_emergency_notification_mechanism": os.environ["EMERGENCY"],
+              "last_confirmed_at_utc": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+              "confirmation_ttl_seconds": int(os.environ["TTL"]),
+          }
+          for key, value in record.items():
+              if isinstance(value, str) and not value.strip():
+                  raise SystemExit(f"empty field: {key}")
+          with open(sys.argv[1], "w", encoding="utf-8") as handle:
+              json.dump(record, handle, indent=2)
+              handle.write("\n")
+          PY
+          printf 'unsigned=%s\n' "$unsigned" >> "$GITHUB_OUTPUT"
+
+      - name: Verify protected environment and repository posture
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_POSTURE_TOKEN }}
+        run: bash scripts/verify-github-release-posture.sh "$GITHUB_REPOSITORY" production-release 28995904
+
+      - name: Sign on-call readiness record
+        id: sign
+        shell: bash
+        env:
+          MACPROVIDER_SPEC043_ONCALL_AUTHORITY_SIGNING_KEY_PEM: ${{ secrets.MACPROVIDER_SPEC043_ONCALL_AUTHORITY_SIGNING_KEY_PEM }}
+          UNSIGNED: ${{ steps.payload.outputs.unsigned }}
+        run: |
+          set -euo pipefail
+          [[ -n "${MACPROVIDER_SPEC043_ONCALL_AUTHORITY_SIGNING_KEY_PEM:-}" ]] || { echo "::error::on-call signing key secret is not set" >&2; exit 1; }
+          signed="$RUNNER_TEMP/oncall-signed.json"
+          ( cd phase4-coordinator && go run ./cmd/coordinator-cli trust-pool-oncall sign --in "$UNSIGNED" --out "$signed" )
+          printf 'signed=%s\n' "$signed" >> "$GITHUB_OUTPUT"
+
+      - name: Validate signed record binds the registered authority key
+        shell: bash
+        env:
+          SIGNED: ${{ steps.sign.outputs.signed }}
+          REGISTERED_DIGEST: ${{ steps.request.outputs.registered_digest }}
+        run: |
+          set -euo pipefail
+          python3 - "$SIGNED" "$REGISTERED_DIGEST" <<'PY'
+          import base64
+          import hashlib
+          import json
+          import sys
+
+          signed = json.loads(open(sys.argv[1], encoding="utf-8").read())
+          for field in ("operations_authority_public_key", "operations_authority_signature", "operation_id"):
+              if not signed.get(field):
+                  raise SystemExit(f"signed record missing {field}")
+          pub = base64.b64decode(signed["operations_authority_public_key"])
+          if len(pub) != 32:
+              raise SystemExit("operations authority public key is not a raw Ed25519 key")
+          digest = hashlib.sha256(pub).hexdigest()
+          if digest != sys.argv[2]:
+              raise SystemExit(f"signed record key digest {digest} != registered {sys.argv[2]}")
+          print("signed on-call record binds the registered operations-authority key")
+          PY
+
+      - name: Export signed on-call readiness artifact
+        shell: bash
+        env:
+          SIGNED: ${{ steps.sign.outputs.signed }}
+        run: |
+          set -euo pipefail
+          export_dir="$RUNNER_TEMP/signed-oncall-readiness"
+          mkdir -p "$export_dir"
+          cp "$SIGNED" "$export_dir/oncall-readiness.signed.json"
+
+      - name: Upload signed on-call readiness artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: signed-oncall-readiness-${{ steps.request.outputs.short_sha }}
+          path: ${{ runner.temp }}/signed-oncall-readiness/
+          if-no-files-found: error
+          include-hidden-files: false
+          retention-days: 1

--- a/docs/runbooks/trusted-pool-creator-launch.md
+++ b/docs/runbooks/trusted-pool-creator-launch.md
@@ -113,6 +113,56 @@ coordinator allowlists that key as SHA-256 of the 32-byte public key via
 rejects longer intervals. Missing or expired rows are launch blockers; they are
 not yet a `PromotePool` production-gate check.
 
+### On-call operations-authority signing path
+
+The on-call authority key follows the same custody model as the production-release
+key: only the public half is committed, and the private half lives solely in the
+GitHub `production-release` environment secret
+`MACPROVIDER_SPEC043_ONCALL_AUTHORITY_SIGNING_KEY_PEM`. The committed keyring
+`security/spec-043-oncall-authority-ed25519-keyring.json` ships **empty and
+fail-closed**: nothing can be signed or accepted until an operator registers a
+key.
+
+Provision (operator only; do not run from an automated agent session):
+
+1. Generate an Ed25519 key with a tool you control, or mirror
+   `scripts/provision-spec043-production-release-key.sh` for the generate →
+   pipe-private-into-env-secret → register-public flow. Store the private half
+   only in the `production-release` environment secret above; never commit or log
+   it.
+2. Register the public half and read back the deploy digest:
+
+   ```bash
+   python3 scripts/register-spec043-oncall-authority-key.py \
+     --public-key <operator-public-key.pem> \
+     --valid-from 2026-09-05T00:00:00Z \
+     --valid-until 2027-09-05T00:00:00Z
+   # prints MACPROVIDER_SPEC043_ONCALL_AUTHORITY_KEY_SHA256=<digest>
+   ```
+
+   Commit `security/spec-043-oncall-authority-ed25519-v1.pem` and the updated
+   keyring. `--check` re-derives the digest and fail-closes if no key is
+   registered.
+3. Set `MACPROVIDER_SPEC043_ONCALL_AUTHORITY_KEY_SHA256=<digest>` in the
+   coordinator launch environment (Pearl `/etc/macprovider/coordinator.env`), then
+   restart the coordinator so it allowlists the key.
+
+Sign a record (dispatch the workflow — the private key never leaves the
+`production-release` environment):
+
+- `.github/workflows/build-signed-oncall-readiness.yml` (manual dispatch from
+  `main`) builds an unsigned record from the record fields, signs it with the
+  environment secret via `coordinator-cli trust-pool-oncall sign`, verifies the
+  signed record binds the registered key digest, and uploads the signed JSON as a
+  workflow artifact.
+- Then apply it with the operator admin key:
+  `coordinator-cli trust-pool-oncall upsert --json-file <signed-oncall.json>`.
+
+`coordinator-cli trust-pool-oncall sign` is an offline signer (no HTTP, no
+operator key). It reuses `trustpool.SignOnCallReadiness`, so the signed preimage
+is byte-identical to what the coordinator verifies. It reads the key from
+`--key-file` or `MACPROVIDER_SPEC043_ONCALL_AUTHORITY_SIGNING_KEY_PEM`.
+
 Reviewed-artifact lifecycle ownership is a separate durable row from
 `review-distribution-artifact`. Assign an owner and `environment_class` of
 `candidate` or `production` before treating a pool as live-ready. Operator

--- a/phase4-coordinator/cmd/coordinator-cli/trust_pool_live_readiness.go
+++ b/phase4-coordinator/cmd/coordinator-cli/trust_pool_live_readiness.go
@@ -17,6 +17,8 @@ func trustPoolOnCall(args []string, getenv func(string) string, stdin io.Reader,
 		return fmt.Errorf("trust-pool-oncall subcommand required")
 	}
 	switch args[0] {
+	case "sign":
+		return trustPoolOnCallSign(args[1:], getenv, stdin, stdout)
 	case "upsert":
 		return trustPoolOnCallUpsert(args[1:], getenv, stdin, stdout)
 	case "get":

--- a/phase4-coordinator/cmd/coordinator-cli/trust_pool_oncall_sign.go
+++ b/phase4-coordinator/cmd/coordinator-cli/trust_pool_oncall_sign.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/augstar/macprovider-coordinator/internal/trustpool"
+)
+
+// oncallSigningKeyEnv holds the Ed25519 operations-authority private key PEM.
+// It is populated only inside the GitHub production-release environment by the
+// build-signed-oncall-readiness workflow; it must never be committed or logged.
+const oncallSigningKeyEnv = "MACPROVIDER_SPEC043_ONCALL_AUTHORITY_SIGNING_KEY_PEM"
+
+// trustPoolOnCallSign signs an unsigned on-call readiness record with the
+// Ed25519 operations-authority key and writes the signed record (ready for
+// `trust-pool-oncall upsert`) to --out or stdout. Signing reuses
+// trustpool.SignOnCallReadiness so the preimage is byte-identical to what the
+// coordinator verifies. This subcommand is offline: it makes no HTTP request
+// and needs no operator/base URL.
+func trustPoolOnCallSign(args []string, getenv func(string) string, stdin io.Reader, stdout io.Writer) error {
+	fs := flag.NewFlagSet("oncall-sign", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	inPath := fs.String("in", "", "unsigned on-call readiness JSON; use - for stdin")
+	outPath := fs.String("out", "", "signed output path; empty writes to stdout")
+	keyFile := fs.String("key-file", "", "Ed25519 private key PEM path; overrides "+oncallSigningKeyEnv)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if strings.TrimSpace(*inPath) == "" {
+		return fmt.Errorf("--in is required")
+	}
+
+	raw, err := readCLIInput(*inPath, stdin)
+	if err != nil {
+		return err
+	}
+	var rec trustpool.OnCallReadiness
+	dec := json.NewDecoder(strings.NewReader(string(raw)))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&rec); err != nil {
+		return fmt.Errorf("unsigned on-call readiness JSON: %w", err)
+	}
+	var trailing struct{}
+	if err := dec.Decode(&trailing); err != io.EOF {
+		return fmt.Errorf("unsigned on-call readiness JSON must contain exactly one object")
+	}
+	if strings.TrimSpace(rec.OperationID) == "" {
+		return fmt.Errorf("operation_id is required")
+	}
+
+	priv, err := loadOnCallSigningKey(*keyFile, getenv)
+	if err != nil {
+		return err
+	}
+	signed, err := trustpool.SignOnCallReadiness(priv, rec)
+	if err != nil {
+		return err
+	}
+
+	out, err := json.MarshalIndent(onCallReadinessRequest{
+		OperationID:                           signed.OperationID,
+		LaunchEnvironmentID:                   signed.LaunchEnvironmentID,
+		RecordVersion:                         signed.RecordVersion,
+		PrimaryOperatorContact:                signed.PrimaryOperatorContact,
+		SecondaryOperatorContact:              signed.SecondaryOperatorContact,
+		BreakGlassEscalationPath:              signed.BreakGlassEscalationPath,
+		CompromiseNotificationChannel:         signed.CompromiseNotificationChannel,
+		CreatorAgreementNotificationAck:       signed.CreatorAgreementNotificationAck,
+		CreatorEmergencyNotificationMechanism: signed.CreatorEmergencyNotificationMechanism,
+		LastConfirmedAtUTC:                    signed.LastConfirmedAtUTC,
+		ConfirmationTTLSeconds:                signed.ConfirmationTTLSeconds,
+		OperationsAuthorityPublicKey:          signed.OperationsAuthorityPublicKey,
+		OperationsAuthoritySignature:          signed.OperationsAuthoritySignature,
+	}, "", "  ")
+	if err != nil {
+		return err
+	}
+	out = append(out, '\n')
+	if strings.TrimSpace(*outPath) == "" {
+		_, err = stdout.Write(out)
+		return err
+	}
+	return os.WriteFile(strings.TrimSpace(*outPath), out, 0o600)
+}
+
+func loadOnCallSigningKey(keyFile string, getenv func(string) string) (ed25519.PrivateKey, error) {
+	var pemBytes []byte
+	if strings.TrimSpace(keyFile) != "" {
+		data, err := os.ReadFile(strings.TrimSpace(keyFile))
+		if err != nil {
+			return nil, fmt.Errorf("read signing key file: %w", err)
+		}
+		pemBytes = data
+	} else {
+		env := strings.TrimSpace(getenv(oncallSigningKeyEnv))
+		if env == "" {
+			return nil, fmt.Errorf("no signing key: set --key-file or %s", oncallSigningKeyEnv)
+		}
+		pemBytes = []byte(env)
+	}
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return nil, fmt.Errorf("signing key is not PEM-encoded")
+	}
+	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse Ed25519 PKCS8 private key: %w", err)
+	}
+	priv, ok := parsed.(ed25519.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("signing key is not Ed25519")
+	}
+	return priv, nil
+}

--- a/phase4-coordinator/cmd/coordinator-cli/trust_pool_oncall_sign_test.go
+++ b/phase4-coordinator/cmd/coordinator-cli/trust_pool_oncall_sign_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/augstar/macprovider-coordinator/internal/trustpool"
+)
+
+func writeEd25519PKCS8PEM(t *testing.T, dir string) (string, ed25519.PrivateKey) {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatalf("MarshalPKCS8PrivateKey: %v", err)
+	}
+	path := filepath.Join(dir, "priv.pem")
+	if err := os.WriteFile(path, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}), 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	return path, priv
+}
+
+const unsignedOnCallJSON = `{
+  "operation_id": "op-oncall-sign-1",
+  "launch_environment_id": "production",
+  "record_version": "oncall-v1",
+  "primary_operator_contact": "ops-primary@example.test",
+  "secondary_operator_contact": "ops-secondary@example.test",
+  "break_glass_escalation_path": "page break-glass on-call",
+  "compromise_notification_channel": "security-alerts@example.test",
+  "creator_agreement_notification_commitment_ack": "creator-agreement-notify-ack-v1",
+  "creator_emergency_notification_mechanism": "creator-emergency-webhook",
+  "last_confirmed_at_utc": "2026-09-05T00:00:00Z",
+  "confirmation_ttl_seconds": 7776000
+}`
+
+func TestTrustPoolOnCallSign_MatchesLibraryAndVerifies(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	keyPath, priv := writeEd25519PKCS8PEM(t, dir)
+	inPath := filepath.Join(dir, "unsigned.json")
+	if err := os.WriteFile(inPath, []byte(unsignedOnCallJSON), 0o600); err != nil {
+		t.Fatalf("write unsigned: %v", err)
+	}
+
+	var out bytes.Buffer
+	if err := trustPoolOnCallSign(
+		[]string{"--in", inPath, "--key-file", keyPath},
+		func(string) string { return "" },
+		nil,
+		&out,
+	); err != nil {
+		t.Fatalf("trustPoolOnCallSign: %v", err)
+	}
+
+	var signed trustpool.OnCallReadiness
+	if err := json.Unmarshal(out.Bytes(), &signed); err != nil {
+		t.Fatalf("decode signed output: %v", err)
+	}
+	if signed.OperationsAuthorityPublicKey == "" || signed.OperationsAuthoritySignature == "" {
+		t.Fatalf("signed output missing authority fields: %+v", signed)
+	}
+
+	// The CLI output must be byte-identical to the library the coordinator
+	// verifies with: same deterministic Ed25519 signature over the same
+	// preimage. Re-sign the same input via the library and compare.
+	var input trustpool.OnCallReadiness
+	if err := json.Unmarshal([]byte(unsignedOnCallJSON), &input); err != nil {
+		t.Fatalf("decode input: %v", err)
+	}
+	lib, err := trustpool.SignOnCallReadiness(priv, input)
+	if err != nil {
+		t.Fatalf("SignOnCallReadiness: %v", err)
+	}
+	if signed.OperationsAuthoritySignature != lib.OperationsAuthoritySignature {
+		t.Fatalf("CLI signature %q != library signature %q", signed.OperationsAuthoritySignature, lib.OperationsAuthoritySignature)
+	}
+	if signed.OperationsAuthorityPublicKey != lib.OperationsAuthorityPublicKey {
+		t.Fatalf("CLI pubkey %q != library pubkey %q", signed.OperationsAuthorityPublicKey, lib.OperationsAuthorityPublicKey)
+	}
+}
+
+func TestTrustPoolOnCallSign_RequiresKey(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	inPath := filepath.Join(dir, "unsigned.json")
+	if err := os.WriteFile(inPath, []byte(unsignedOnCallJSON), 0o600); err != nil {
+		t.Fatalf("write unsigned: %v", err)
+	}
+	err := trustPoolOnCallSign([]string{"--in", inPath}, func(string) string { return "" }, nil, &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), oncallSigningKeyEnv) {
+		t.Fatalf("missing key err=%v, want mention of %s", err, oncallSigningKeyEnv)
+	}
+}
+
+func TestTrustPoolOnCallSign_RejectsTrailingJSON(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	keyPath, _ := writeEd25519PKCS8PEM(t, dir)
+	inPath := filepath.Join(dir, "unsigned.json")
+	if err := os.WriteFile(inPath, []byte(unsignedOnCallJSON+"\n{\"operation_id\":\"ignored\"}"), 0o600); err != nil {
+		t.Fatalf("write unsigned: %v", err)
+	}
+	if err := trustPoolOnCallSign([]string{"--in", inPath, "--key-file", keyPath}, func(string) string { return "" }, nil, &bytes.Buffer{}); err == nil {
+		t.Fatalf("expected error for trailing JSON")
+	}
+}
+
+func TestTrustPoolOnCallSign_RejectsNonEd25519Key(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	inPath := filepath.Join(dir, "unsigned.json")
+	if err := os.WriteFile(inPath, []byte(unsignedOnCallJSON), 0o600); err != nil {
+		t.Fatalf("write unsigned: %v", err)
+	}
+	// A non-PEM key file must fail closed.
+	keyPath := filepath.Join(dir, "bad.pem")
+	if err := os.WriteFile(keyPath, []byte("not a pem"), 0o600); err != nil {
+		t.Fatalf("write bad key: %v", err)
+	}
+	if err := trustPoolOnCallSign([]string{"--in", inPath, "--key-file", keyPath}, func(string) string { return "" }, nil, &bytes.Buffer{}); err == nil {
+		t.Fatalf("expected error for non-PEM key")
+	}
+}

--- a/scripts/register-spec043-oncall-authority-key.py
+++ b/scripts/register-spec043-oncall-authority-key.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Register or preflight the SPEC-043 on-call readiness operations-authority key.
+
+This tool never generates a key and never writes private key material. An empty
+committed keyring stays fail-closed until an operator supplies an Ed25519 public
+key PEM from a key they already control. Provision the private half into the
+GitHub production-release environment secret the same way
+scripts/provision-spec043-production-release-key.sh handles the production-release
+key; this tool only registers the public half.
+
+On success it prints the SHA-256 allowlist digest to set as
+MACPROVIDER_SPEC043_ONCALL_AUTHORITY_KEY_SHA256 in the coordinator environment.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from spec043_oncall_authority import (  # noqa: E402
+    KEYRING_PATH,
+    PUBLIC_KEY_PATH,
+    preflight_keyring,
+    register_public_key,
+)
+
+
+def die(message: str) -> None:
+    print(f"register-spec043-oncall-authority-key: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", default=".", help="repository root")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="fail closed unless an on-call authority key is registered",
+    )
+    parser.add_argument("--public-key", default=None, help="operator-supplied Ed25519 public key PEM")
+    parser.add_argument("--issuer", default="macprovider-ops")
+    parser.add_argument("--valid-from", default=None, help="UTC timestamp like 2026-09-05T00:00:00Z")
+    parser.add_argument("--valid-until", default=None, help="UTC timestamp like 2027-09-05T00:00:00Z")
+    parser.add_argument("--openssl-bin", default=None, help="absolute path to trusted OpenSSL")
+    args = parser.parse_args(argv)
+
+    root = Path(args.root).resolve()
+    if args.check:
+        if args.public_key or args.valid_from or args.valid_until:
+            die("--check cannot be combined with registration flags")
+        outcome = preflight_keyring(root, openssl_bin=args.openssl_bin)
+        if outcome.errors:
+            for error in outcome.errors:
+                print(f"error: {error}", file=sys.stderr)
+            return 1
+        print(f"register-spec043-oncall-authority-key: registered key present in {KEYRING_PATH.as_posix()}")
+        print(f"MACPROVIDER_SPEC043_ONCALL_AUTHORITY_KEY_SHA256={outcome.digest}")
+        return 0
+
+    if not args.public_key or not args.valid_from or not args.valid_until:
+        die("--public-key, --valid-from, and --valid-until are required unless --check")
+    public_path = Path(args.public_key)
+    if not public_path.is_absolute():
+        public_path = Path.cwd() / public_path
+    if public_path.is_symlink() or not public_path.is_file():
+        die(f"public key is absent or unsafe: {public_path}")
+    try:
+        pem = public_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        die(f"cannot read public key: {exc}")
+    outcome = register_public_key(
+        root,
+        pem,
+        issuer=args.issuer,
+        valid_from=args.valid_from,
+        valid_until=args.valid_until,
+        openssl_bin=args.openssl_bin,
+    )
+    if outcome.errors:
+        for error in outcome.errors:
+            print(f"error: {error}", file=sys.stderr)
+        return 1
+    print(
+        "register-spec043-oncall-authority-key: "
+        f"wrote {PUBLIC_KEY_PATH.as_posix()} and updated {KEYRING_PATH.as_posix()}"
+    )
+    print(f"MACPROVIDER_SPEC043_ONCALL_AUTHORITY_KEY_SHA256={outcome.digest}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/spec043_oncall_authority.py
+++ b/scripts/spec043_oncall_authority.py
@@ -1,0 +1,282 @@
+"""SPEC-043 on-call readiness operations-authority Ed25519 keyring helpers.
+
+This module never generates a key and never writes private key material. An
+empty committed keyring stays fail-closed: no on-call readiness record can be
+signed or accepted until an operator registers a public key from an offline (or
+GitHub-environment-held) Ed25519 key they already control.
+
+The coordinator allowlists the operations authority by SHA-256 of the raw
+32-byte Ed25519 public key (see trustpool.OnCallAuthorityKeySHA256). This module
+derives that digest with the system OpenSSL so it needs no third-party Python
+dependency and stays byte-identical to the Go verifier.
+"""
+
+from __future__ import annotations
+
+import datetime
+import hashlib
+import json
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+
+KEYRING_PATH = Path("security/spec-043-oncall-authority-ed25519-keyring.json")
+PUBLIC_KEY_PATH = Path("security/spec-043-oncall-authority-ed25519-v1.pem")
+KEY_ID = "macprovider-spec043-oncall-authority-ed25519-v1"
+KEYRING_SCHEMA_VERSION = "spec-043-launch-keyring-v1"
+KEYRING_PURPOSE = "oncall-readiness-operations-authority"
+
+# Ed25519 SubjectPublicKeyInfo DER is a fixed 44 bytes: a 12-byte header
+# carrying the Ed25519 algorithm OID (1.3.101.112) followed by the raw 32-byte
+# public key. The coordinator hashes those raw 32 bytes, so the allowlist digest
+# is sha256(DER[-32:]). The fixed header also distinguishes Ed25519 from X25519
+# (1.3.101.110), which shares the 44-byte length.
+_ED25519_SPKI_DER_LEN = 44
+_ED25519_RAW_PUBKEY_LEN = 32
+_ED25519_SPKI_HEADER = bytes.fromhex("302a300506032b6570032100")
+
+
+@dataclass
+class Outcome:
+    digest: str = ""
+    errors: list[str] = field(default_factory=list)
+
+    def error(self, message: str) -> None:
+        self.errors.append(message)
+
+
+def _safe_repo_file(root: Path, rel: Path) -> Path | None:
+    path = (root / rel).resolve()
+    try:
+        path.relative_to(root.resolve())
+    except ValueError:
+        return None
+    if path.is_symlink():
+        return None
+    return path
+
+
+def _openssl(openssl_bin: str | None) -> str:
+    return openssl_bin or "openssl"
+
+
+def authority_key_sha256(public_pem: str, openssl_bin: str | None = None) -> tuple[str, list[str]]:
+    """Return (hex_digest, errors) for an Ed25519 public key PEM."""
+    errors: list[str] = []
+    try:
+        der = subprocess.run(
+            [_openssl(openssl_bin), "pkey", "-pubin", "-outform", "DER"],
+            input=public_pem.encode("utf-8"),
+            capture_output=True,
+            check=True,
+        ).stdout
+    except (OSError, subprocess.CalledProcessError) as exc:
+        errors.append(f"openssl could not parse the public key: {exc}")
+        return "", errors
+    if len(der) != _ED25519_SPKI_DER_LEN:
+        errors.append(
+            f"public key is not a raw Ed25519 SubjectPublicKeyInfo "
+            f"(got {len(der)} DER bytes, want {_ED25519_SPKI_DER_LEN})"
+        )
+        return "", errors
+    if der[: len(_ED25519_SPKI_HEADER)] != _ED25519_SPKI_HEADER:
+        errors.append("public key is not Ed25519 (algorithm OID mismatch; X25519 and others are rejected)")
+        return "", errors
+    raw = der[-_ED25519_RAW_PUBKEY_LEN:]
+    return hashlib.sha256(raw).hexdigest(), errors
+
+
+def _require_public_only_pem(public_pem: str) -> list[str]:
+    """Reject anything but exactly one PUBLIC KEY block so private material can
+    never be written into the committed public key file."""
+    if "PRIVATE KEY" in public_pem:
+        return ["public key input must not contain private key material"]
+    begins = public_pem.count("-----BEGIN PUBLIC KEY-----")
+    ends = public_pem.count("-----END PUBLIC KEY-----")
+    if begins != 1 or ends != 1:
+        return ["public key input must contain exactly one PUBLIC KEY block"]
+    return []
+
+
+def _parse_utc(value: str) -> datetime.datetime | None:
+    try:
+        parsed = datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return None
+    return parsed.astimezone(datetime.timezone.utc)
+
+
+def _load_keyring(root: Path) -> tuple[dict | None, Outcome]:
+    outcome = Outcome()
+    path = _safe_repo_file(root, KEYRING_PATH)
+    if path is None or not path.is_file():
+        outcome.error(f"{KEYRING_PATH}: keyring is absent or unsafe")
+        return None, outcome
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        outcome.error(f"{KEYRING_PATH}: cannot read keyring: {exc}")
+        return None, outcome
+    if not isinstance(data, dict):
+        outcome.error(f"{KEYRING_PATH}: must be a JSON object")
+        return None, outcome
+    if data.get("schema_version") != KEYRING_SCHEMA_VERSION:
+        outcome.error(f"{KEYRING_PATH}: schema_version must equal {KEYRING_SCHEMA_VERSION!r}")
+        return None, outcome
+    if data.get("purpose") != KEYRING_PURPOSE:
+        outcome.error(f"{KEYRING_PATH}: purpose must equal {KEYRING_PURPOSE!r}")
+        return None, outcome
+    if not isinstance(data.get("keys"), list):
+        outcome.error(f"{KEYRING_PATH}.keys: must be an array")
+        return None, outcome
+    return data, outcome
+
+
+def preflight_keyring(root: Path, openssl_bin: str | None = None) -> Outcome:
+    """Fail closed unless the committed keyring entry authoritatively matches
+    the committed public key PEM.
+
+    The committed keyring, not the sidecar PEM, is the reviewed allowlist
+    authority: this validates the single entry's purpose, environment class, and
+    recorded digest, reads the PEM the entry names, and only returns the digest
+    when the derived digest equals the entry's recorded public_key_sha256. That
+    prevents a stale or mismatched keyring entry from silently signing/verifying
+    against a swapped PEM.
+    """
+    data, outcome = _load_keyring(root)
+    if data is None:
+        return outcome
+    keys = data["keys"]
+    if len(keys) != 1:
+        outcome.error(
+            f"{KEYRING_PATH}: is fail-closed: exactly one on-call authority key must be registered"
+        )
+        return outcome
+    entry = keys[0]
+    if not isinstance(entry, dict):
+        outcome.error(f"{KEYRING_PATH}.keys[0]: must be an object")
+        return outcome
+    if entry.get("purpose") != KEYRING_PURPOSE:
+        outcome.error(f"{KEYRING_PATH}.keys[0].purpose: must equal {KEYRING_PURPOSE!r}")
+        return outcome
+    if entry.get("key_id") != KEY_ID:
+        outcome.error(f"{KEYRING_PATH}.keys[0].key_id: must equal {KEY_ID!r}")
+        return outcome
+    allowed = entry.get("allowed_environment_classes")
+    if not isinstance(allowed, list) or "production" not in allowed:
+        outcome.error(f"{KEYRING_PATH}.keys[0].allowed_environment_classes: must include 'production'")
+        return outcome
+    if not isinstance(entry.get("issuer"), str) or not entry["issuer"].strip():
+        outcome.error(f"{KEYRING_PATH}.keys[0].issuer: must be a non-empty string")
+        return outcome
+    window_from = _parse_utc(entry["valid_from"]) if isinstance(entry.get("valid_from"), str) else None
+    window_until = _parse_utc(entry["valid_until"]) if isinstance(entry.get("valid_until"), str) else None
+    if window_from is None or window_until is None:
+        outcome.error(f"{KEYRING_PATH}.keys[0]: valid_from/valid_until must be UTC ISO-8601 timestamps")
+        return outcome
+    if window_until <= window_from:
+        outcome.error(f"{KEYRING_PATH}.keys[0]: valid_until must be after valid_from")
+        return outcome
+    now = datetime.datetime.now(datetime.timezone.utc)
+    if now < window_from:
+        outcome.error(f"{KEYRING_PATH}.keys[0]: key is not yet valid")
+        return outcome
+    if now >= window_until:
+        outcome.error(f"{KEYRING_PATH}.keys[0]: key validity window has expired")
+        return outcome
+    recorded = entry.get("public_key_sha256")
+    if not isinstance(recorded, str) or len(recorded) != 64 or any(c not in "0123456789abcdef" for c in recorded):
+        outcome.error(f"{KEYRING_PATH}.keys[0].public_key_sha256: must be lowercase hex sha256")
+        return outcome
+    if entry.get("public_key_path") != str(PUBLIC_KEY_PATH):
+        outcome.error(f"{KEYRING_PATH}.keys[0].public_key_path: must equal {str(PUBLIC_KEY_PATH)!r}")
+        return outcome
+    pem_path = _safe_repo_file(root, PUBLIC_KEY_PATH)
+    if pem_path is None or not pem_path.is_file():
+        outcome.error(f"{PUBLIC_KEY_PATH}: public key is absent or unsafe")
+        return outcome
+    try:
+        pem = pem_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        outcome.error(f"{PUBLIC_KEY_PATH}: cannot read: {exc}")
+        return outcome
+    digest, errors = authority_key_sha256(pem, openssl_bin=openssl_bin)
+    if errors:
+        for message in errors:
+            outcome.error(message)
+        return outcome
+    if digest != recorded:
+        outcome.error(
+            f"{KEYRING_PATH}: registered public_key_sha256 does not match the committed public key digest"
+        )
+        return outcome
+    outcome.digest = digest
+    return outcome
+
+
+def register_public_key(
+    root: Path,
+    public_pem: str,
+    *,
+    issuer: str,
+    valid_from: str,
+    valid_until: str,
+    openssl_bin: str | None = None,
+) -> Outcome:
+    """Write PUBLIC_KEY_PATH and add a single key entry to the empty keyring."""
+    outcome = Outcome()
+    if not issuer.strip():
+        outcome.error("issuer must be a non-empty string")
+        return outcome
+    pem_errors = _require_public_only_pem(public_pem)
+    if pem_errors:
+        for message in pem_errors:
+            outcome.error(message)
+        return outcome
+    window_from = _parse_utc(valid_from)
+    window_until = _parse_utc(valid_until)
+    if window_from is None or window_until is None:
+        outcome.error("valid_from and valid_until must be UTC ISO-8601 timestamps")
+        return outcome
+    if window_until <= window_from:
+        outcome.error("valid_until must be after valid_from")
+        return outcome
+    digest, errors = authority_key_sha256(public_pem, openssl_bin=openssl_bin)
+    outcome.digest = digest
+    if errors:
+        for message in errors:
+            outcome.error(message)
+        return outcome
+    data, load = _load_keyring(root)
+    if data is None:
+        outcome.errors.extend(load.errors)
+        return outcome
+    if data["keys"]:
+        outcome.error(f"{KEYRING_PATH}: already has a registered key; refusing to overwrite")
+        return outcome
+    pem_path = _safe_repo_file(root, PUBLIC_KEY_PATH)
+    if pem_path is None:
+        outcome.error(f"{PUBLIC_KEY_PATH}: unsafe path")
+        return outcome
+    if pem_path.exists():
+        outcome.error(f"{PUBLIC_KEY_PATH}: already exists; refusing to overwrite")
+        return outcome
+    pem_path.write_text(public_pem if public_pem.endswith("\n") else public_pem + "\n", encoding="utf-8")
+    data["keys"] = [
+        {
+            "key_id": KEY_ID,
+            "purpose": KEYRING_PURPOSE,
+            "issuer": issuer,
+            "valid_from": valid_from,
+            "valid_until": valid_until,
+            "allowed_environment_classes": ["production"],
+            "public_key_sha256": digest,
+            "public_key_path": str(PUBLIC_KEY_PATH),
+        }
+    ]
+    keyring_path = _safe_repo_file(root, KEYRING_PATH)
+    assert keyring_path is not None
+    keyring_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    return outcome

--- a/scripts/tests/test_spec043_oncall_authority.py
+++ b/scripts/tests/test_spec043_oncall_authority.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = REPO_ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import spec043_oncall_authority as oncall  # noqa: E402
+
+
+def _gen_ed25519_public_pem(tmp: Path) -> str:
+    priv = tmp / "priv.pem"
+    pub = tmp / "pub.pem"
+    subprocess.run(["openssl", "genpkey", "-algorithm", "ED25519", "-out", str(priv)], check=True)
+    subprocess.run(["openssl", "pkey", "-in", str(priv), "-pubout", "-out", str(pub)], check=True)
+    return pub.read_text(encoding="utf-8")
+
+
+def _empty_keyring(root: Path) -> None:
+    (root / "security").mkdir(parents=True, exist_ok=True)
+    (root / oncall.KEYRING_PATH).write_text(
+        json.dumps(
+            {
+                "schema_version": oncall.KEYRING_SCHEMA_VERSION,
+                "purpose": oncall.KEYRING_PURPOSE,
+                "allowed_environment_classes": ["production"],
+                "keys": [],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+@unittest.skipUnless(shutil.which("openssl"), "openssl required")
+class OnCallAuthorityKeyringTest(unittest.TestCase):
+    def test_digest_matches_sha256_of_raw_pubkey(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            pem = _gen_ed25519_public_pem(tmp)
+            der = subprocess.run(
+                ["openssl", "pkey", "-pubin", "-outform", "DER"],
+                input=pem.encode(),
+                capture_output=True,
+                check=True,
+            ).stdout
+            self.assertEqual(len(der), 44)
+            expected = hashlib.sha256(der[-32:]).hexdigest()
+            digest, errors = oncall.authority_key_sha256(pem)
+            self.assertEqual(errors, [])
+            self.assertEqual(digest, expected)
+
+    def test_preflight_is_fail_closed_on_empty_keyring(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            _empty_keyring(root)
+            outcome = oncall.preflight_keyring(root)
+            self.assertTrue(outcome.errors)
+            self.assertIn("fail-closed", " ".join(outcome.errors))
+
+    def test_register_then_preflight_passes_and_digests_match(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            _empty_keyring(root)
+            with tempfile.TemporaryDirectory() as keydir:
+                pem = _gen_ed25519_public_pem(Path(keydir))
+            reg = oncall.register_public_key(
+                root,
+                pem,
+                issuer="macprovider-ops",
+                valid_from="2026-09-05T00:00:00Z",
+                valid_until="2027-09-05T00:00:00Z",
+            )
+            self.assertEqual(reg.errors, [])
+            self.assertTrue((root / oncall.PUBLIC_KEY_PATH).is_file())
+            data = json.loads((root / oncall.KEYRING_PATH).read_text())
+            self.assertEqual(len(data["keys"]), 1)
+            self.assertEqual(data["keys"][0]["public_key_sha256"], reg.digest)
+            pre = oncall.preflight_keyring(root)
+            self.assertEqual(pre.errors, [])
+            self.assertEqual(pre.digest, reg.digest)
+
+    def test_register_refuses_to_overwrite_existing_key(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            _empty_keyring(root)
+            with tempfile.TemporaryDirectory() as keydir:
+                pem = _gen_ed25519_public_pem(Path(keydir))
+            first = oncall.register_public_key(
+                root, pem, issuer="macprovider-ops",
+                valid_from="2026-09-05T00:00:00Z", valid_until="2027-09-05T00:00:00Z",
+            )
+            self.assertEqual(first.errors, [])
+            with tempfile.TemporaryDirectory() as keydir2:
+                pem2 = _gen_ed25519_public_pem(Path(keydir2))
+            second = oncall.register_public_key(
+                root, pem2, issuer="macprovider-ops",
+                valid_from="2026-09-05T00:00:00Z", valid_until="2027-09-05T00:00:00Z",
+            )
+            self.assertTrue(second.errors)
+
+    def test_preflight_rejects_digest_drift(self) -> None:
+        # The committed keyring is the authority: if the recorded digest does not
+        # match the committed PEM, preflight must fail closed rather than trust
+        # the PEM.
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            _empty_keyring(root)
+            with tempfile.TemporaryDirectory() as keydir:
+                pem = _gen_ed25519_public_pem(Path(keydir))
+            reg = oncall.register_public_key(
+                root, pem, issuer="macprovider-ops",
+                valid_from="2026-09-05T00:00:00Z", valid_until="2027-09-05T00:00:00Z",
+            )
+            self.assertEqual(reg.errors, [])
+            # Tamper the recorded digest to simulate a stale/mismatched entry.
+            data = json.loads((root / oncall.KEYRING_PATH).read_text())
+            data["keys"][0]["public_key_sha256"] = "0" * 64
+            (root / oncall.KEYRING_PATH).write_text(json.dumps(data) + "\n", encoding="utf-8")
+            outcome = oncall.preflight_keyring(root)
+            self.assertTrue(outcome.errors)
+            self.assertIn("does not match", " ".join(outcome.errors))
+
+    def test_register_rejects_private_key_material(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            _empty_keyring(root)
+            with tempfile.TemporaryDirectory() as keydir:
+                priv = Path(keydir) / "priv.pem"
+                subprocess.run(["openssl", "genpkey", "-algorithm", "ED25519", "-out", str(priv)], check=True)
+                pub = _gen_ed25519_public_pem(Path(keydir))
+                # Concatenate public + private material.
+                poisoned = pub + priv.read_text(encoding="utf-8")
+            outcome = oncall.register_public_key(
+                root, poisoned, issuer="macprovider-ops",
+                valid_from="2026-09-05T00:00:00Z", valid_until="2027-09-05T00:00:00Z",
+            )
+            self.assertTrue(outcome.errors)
+            self.assertFalse((root / oncall.PUBLIC_KEY_PATH).exists())
+
+    def test_register_rejects_non_ed25519_key(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            _empty_keyring(root)
+            with tempfile.TemporaryDirectory() as keydir:
+                priv = Path(keydir) / "x.pem"
+                pub = Path(keydir) / "x_pub.pem"
+                subprocess.run(["openssl", "genpkey", "-algorithm", "X25519", "-out", str(priv)], check=True)
+                subprocess.run(["openssl", "pkey", "-in", str(priv), "-pubout", "-out", str(pub)], check=True)
+                x25519_pem = pub.read_text(encoding="utf-8")
+            outcome = oncall.register_public_key(
+                root, x25519_pem, issuer="macprovider-ops",
+                valid_from="2026-09-05T00:00:00Z", valid_until="2027-09-05T00:00:00Z",
+            )
+            self.assertTrue(outcome.errors)
+
+    def test_preflight_rejects_expired_validity_window(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            _empty_keyring(root)
+            with tempfile.TemporaryDirectory() as keydir:
+                pem = _gen_ed25519_public_pem(Path(keydir))
+            oncall.register_public_key(
+                root, pem, issuer="macprovider-ops",
+                valid_from="2020-01-01T00:00:00Z", valid_until="2020-01-02T00:00:00Z",
+            )
+            outcome = oncall.preflight_keyring(root)
+            self.assertTrue(outcome.errors)
+            self.assertIn("expired", " ".join(outcome.errors))
+
+    def test_preflight_rejects_wrong_purpose(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            _empty_keyring(root)
+            with tempfile.TemporaryDirectory() as keydir:
+                pem = _gen_ed25519_public_pem(Path(keydir))
+            oncall.register_public_key(
+                root, pem, issuer="macprovider-ops",
+                valid_from="2026-09-05T00:00:00Z", valid_until="2027-09-05T00:00:00Z",
+            )
+            data = json.loads((root / oncall.KEYRING_PATH).read_text())
+            data["keys"][0]["purpose"] = "not-the-oncall-purpose"
+            (root / oncall.KEYRING_PATH).write_text(json.dumps(data) + "\n", encoding="utf-8")
+            outcome = oncall.preflight_keyring(root)
+            self.assertTrue(outcome.errors)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/security/spec-043-oncall-authority-ed25519-keyring.json
+++ b/security/spec-043-oncall-authority-ed25519-keyring.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": "spec-043-launch-keyring-v1",
+  "purpose": "oncall-readiness-operations-authority",
+  "allowed_environment_classes": [
+    "production"
+  ],
+  "keys": [],
+  "note": "SPEC-043-R008/R011 on-call readiness operations-authority Ed25519 keys are registered here. An empty keys array is fail-closed: no on-call readiness record can be signed or accepted until an operator registers a public key with scripts/register-spec043-oncall-authority-key.py. Only the public half is committed; the private half lives solely in the GitHub production-release environment secret MACPROVIDER_SPEC043_ONCALL_AUTHORITY_SIGNING_KEY_PEM (provision it the same way scripts/provision-spec043-production-release-key.sh handles the production-release key). The coordinator allowlists the key by SHA-256 of the raw 32-byte public key via MACPROVIDER_SPEC043_ONCALL_AUTHORITY_KEY_SHA256; register-spec043-oncall-authority-key.py prints that digest for the deploy environment."
+}


### PR DESCRIPTION
## What

Build the SPEC-043 on-call readiness **operations-authority signing path** (#1233).

The on-call readiness feature shipped its coordinator + CLI surface in #1229, but
it never had a signing authority: no committed keyring, no register/preflight
tooling, no signing path, and production allowlists no operations authority. So
**no signed on-call record could be produced or accepted** — which is why the
#1233 on-call ops item could not be executed. It was never merely an operator
"click a button" step; the tooling did not exist.

## How

Mirrors the existing production-release key custody model — only the public half
is committed; the private half lives solely in the GitHub `production-release`
environment secret.

- `security/spec-043-oncall-authority-ed25519-keyring.json`: committed **empty and
  fail-closed**. No signature is accepted until an operator registers a key.
- `scripts/spec043_oncall_authority.py` + `scripts/register-spec043-oncall-authority-key.py`:
  register/preflight an **operator-supplied** Ed25519 public key. The committed
  keyring is the authority — preflight requires exactly one entry, validates
  purpose/`key_id`/environment-class/issuer/validity-window, checks the Ed25519
  SPKI algorithm OID (rejects X25519 and other 44-byte keys), rejects any input
  containing private-key material, and requires the derived digest to equal the
  entry's recorded `public_key_sha256`. The digest is `sha256(raw 32-byte key)`,
  byte-identical to `trustpool.OnCallAuthorityKeySHA256`.
- `coordinator-cli trust-pool-oncall sign`: an **offline** signer that reuses
  `trustpool.SignOnCallReadiness`, so the signed preimage is byte-identical to
  what the coordinator verifies. Loads an Ed25519 PKCS8 PEM from `--key-file` or
  the env secret; rejects non-Ed25519 keys and trailing JSON.
- `.github/workflows/build-signed-oncall-readiness.yml`: manual dispatch from
  `main`, `production-release` environment, `register --check`,
  `verify-github-release-posture.sh`, sign with the env secret, verify the signed
  record binds the registered key digest, upload artifact (never commits).
- Runbook documents the operator provisioning + signing flow.

**Deliberately does NOT generate or commit a private key** (per #1233's "do not
generate or commit SPEC-043 launch/on-call private keys"): the keyring ships
empty and an operator mints the authority the same way the production-release key
was provisioned. **No coordinator runtime behavior change**; the mapped
`validatePromotion` wiring stays deferred.

## Tests

- Python: digest parity with openssl, empty-keyring fail-closed, digest-drift and
  wrong-purpose and expired-window rejection, private-material and X25519
  rejection.
- Go: signer round-trip proving CLI output is byte-identical to the library,
  PKCS8 loading, missing-key / non-Ed25519 / trailing-JSON fail-closed.
- `go test ./cmd/coordinator-cli` and `python3 -m unittest
  scripts.tests.test_spec043_oncall_authority` green; committed keyring
  `--check` fails closed.

## Audit

Three-lane codex audit over the full fix diff. Rounds 1–2 found and fixed a
fall-through in preflight, a missing posture step, a private-key-leak path in the
registrar, a missing validity-window/`key_id` check, an X25519 look-alike gap,
and a trailing-JSON gap. Final round: **0 CRITICAL / 0 HIGH / 0 MEDIUM** across
code, security, and architecture.

<!-- SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-043"],
  "requirements": ["SPEC-043-R008", "SPEC-043-R011"],
  "authority_domains": ["trusted-pool-creator-onboarding"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "scripts/tests/test_spec043_oncall_authority.py",
    "phase4-coordinator/cmd/coordinator-cli/trust_pool_oncall_sign_test.go::TestTrustPoolOnCallSign_MatchesLibraryAndVerifies"
  ],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/1233"
}
SPEC-GOVERNANCE-DECLARATION-END -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
