### PR TITLE
F1 (RFC-001 #1382): launchd is the single provider exit-restart owner

### DIFF
--- a/ops/macprovider-watchdog/watchdog.sh
+++ b/ops/macprovider-watchdog/watchdog.sh
@@ -223,13 +223,6 @@ valid_lifecycle_lease() {
   valid_lifecycle_lease_record maintenance ""
 }
 
-valid_unbound_lifecycle_lease() {
-  if valid_lifecycle_lease_record startup ""; then
-    return 0
-  fi
-  valid_lifecycle_lease_record maintenance ""
-}
-
 valid_lifecycle_lease_record() {
   expected_kind="$1"
   expected_pid="${2:-}"
@@ -502,14 +495,13 @@ main() {
   fi
   provider_pid="$(provider_process_pid || true)"
   if [ -z "$provider_pid" ]; then
-    log "provider process unhealthy: launchd service $LABEL has no validated PID at $BINARY_PATH"
-    if valid_unbound_lifecycle_lease; then
-      log "launchd service $LABEL has no validated PID but is inside a validated startup/maintenance lease; watchdog grants bounded grace"
-      exit 0
-    fi
-    if ! provider_restart_cooldown_active; then
-      kickstart_provider "missing_validated_pid" || true
-    fi
+    # No validated launchd PID: the provider service is not running. Per
+    # SPEC-020 R-4.14 the launchd provider-service KeepAlive is the SINGLE
+    # exit-restart owner; the watchdog no longer kickstarts here. This removes
+    # the second, mutable exit-restart authority behind #1189. launchd restarts
+    # a crashed/nonzero exit, and an unsolicited clean exit now exits nonzero
+    # (SPEC-001 FR-12) so KeepAlive relaunches it — the watchdog only observes.
+    log "provider process not running: launchd service $LABEL has no validated PID at $BINARY_PATH; exit-restart owned by launchd KeepAlive (watchdog does not kick)"
     exit 0
   fi
   boot_id="$(current_boot_id)"

--- a/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
+++ b/phase3-binary/Sources/macprovider-cli/MacProviderCLI.swift
@@ -3215,24 +3215,63 @@ private func execCanonicalInstall(_ canonical: URL) throws -> Never {
     )
 }
 
+/// Ensures only the first SIGTERM/SIGINT drives shutdown. A second signal during
+/// the bounded drain must NOT re-evaluate the (already consumed, consume-once)
+/// stop-intent marker, which would reclassify a legitimate local stop as
+/// unsolicited and change the exit code.
+private final class TerminationLatch: @unchecked Sendable {
+    private let lock = NSLock()
+    private var started = false
+    func beginIfFirst() -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        if started { return false }
+        started = true
+        return true
+    }
+}
+
 private func installTerminationHandlers(
     coordinatorClient: CoordinatorClient?,
     controlSocket: ControlSocketServer?,
     idlePrewarmer: IdlePrewarmer?,
     kvDiskTier: KVDiskTier?
 ) -> [DispatchSourceSignal] {
-    [SIGTERM, SIGINT].map { signalNumber in
+    let latch = TerminationLatch()
+    return [SIGTERM, SIGINT].map { signalNumber in
         signal(signalNumber, SIG_IGN)
         let source = DispatchSource.makeSignalSource(signal: signalNumber, queue: .global(qos: .userInitiated))
         source.setEventHandler {
             Task {
+                // Only the first signal decides and consumes the marker; a second
+                // signal during drain is ignored so it cannot reclassify the stop.
+                guard latch.beginIfFirst() else { return }
+                // SPEC-001 FR-12 / SPEC-020 R-4.14: decide the exit code BEFORE
+                // draining. `drainAndExit` calls Darwin.exit itself for the normal
+                // coordinator-joined provider, so the decision and the exit code
+                // must be computed up front and threaded through it — otherwise the
+                // gate is unreachable on the common path. Exit 0 only under a
+                // validated local stop intent (uninstall/operator-disable/local
+                // stop, which records a PID+boot+process-start-bound marker). An
+                // unsolicited SIGTERM/SIGINT — a stray kill or a macOS
+                // memory-pressure/jetsam SIGTERM while the launchd job is still
+                // loaded — exits nonzero so launchd KeepAlive{SuccessfulExit:false}
+                // relaunches the provider instead of leaving the node down
+                // (removing the watchdog exit-restart is safe only because of this).
+                // A coordinator drain drops registration only and never reaches here.
+                let exitCode: Int32 = StopIntentMarker.consumeIfValid(currentPID: getpid())
+                    ? 0
+                    : (128 + signalNumber)
                 await idlePrewarmer?.stop()
                 await controlSocket?.stop()
-                await coordinatorClient?.drainAndExit(reason: "\(signalName(signalNumber)) received")
+                await coordinatorClient?.drainAndExit(
+                    reason: "\(signalName(signalNumber)) received",
+                    exitCode: exitCode
+                )
                 // M-A: drain queued cold writes (bounded by shutdownDrainSeconds) and
                 // release the namespace lock BEFORE exit, on the signal path too.
+                // (Reached only when there is no coordinator client, e.g. --no-join.)
                 await kvDiskTier?.shutdown()
-                Darwin.exit(0)
+                Darwin.exit(exitCode)
             }
         }
         source.resume()

--- a/phase3-binary/Sources/macprovider-cli/StopIntentMarker.swift
+++ b/phase3-binary/Sources/macprovider-cli/StopIntentMarker.swift
@@ -1,0 +1,203 @@
+import Darwin
+import Foundation
+
+/// SPEC-001 FR-12 / SPEC-020 R-4.14 — validated local stop intent.
+///
+/// The provider LaunchAgent runs under `KeepAlive{SuccessfulExit:false}`
+/// (`consumer_user`), so launchd restarts a crash/nonzero exit but NOT a clean
+/// (exit 0) termination. The companion watchdog no longer restarts on a missing
+/// PID, so an *unsolicited* SIGTERM/SIGINT — a stray `kill` or a macOS
+/// memory-pressure/jetsam SIGTERM while the launchd job is still loaded — must
+/// exit nonzero so launchd relaunches the provider instead of leaving the node
+/// down. A genuine local stop transaction (uninstall / operator-disable / local
+/// stop) records this marker first so the serve process exits 0 for that case.
+///
+/// The marker is bound to the target PID, its process-start time (so a reused
+/// PID cannot replay a stale marker against a different process instance), and
+/// the current boot session; it is short-lived and consumed on read. Storage is
+/// hardened (private dir, `O_NOFOLLOW`, regular file owned by the current user,
+/// mode `0600`, single link, bounded size). Evaluation is fail-closed: any
+/// missing, malformed, expired, mismatched, or unhardened marker is treated as
+/// "no stop intent" and the process exits nonzero.
+enum StopIntentMarker {
+    static let schema = "macprovider.stop-intent.v1"
+    /// Default TTL for a recorded stop intent. Bounded so a stale marker cannot
+    /// authorize a much later unsolicited signal (belt-and-braces with boot +
+    /// process-start binding and consume-on-read).
+    static let defaultTTLSeconds: Int64 = 120
+    /// Hard cap on the marker file size read on consume; a well-formed marker is
+    /// a few hundred bytes.
+    static let maxMarkerBytes = 8 * 1024
+
+    typealias ProcessStartProvider = @Sendable (pid_t) -> Int64?
+
+    /// Process-start microseconds for `pid` via `proc_pidinfo(PROC_PIDTBSDINFO)`,
+    /// matching `ProviderLifecycleLease`'s process-identity binding.
+    static let liveProcessStartMicroseconds: ProcessStartProvider = { pid in
+        var info = proc_bsdinfo()
+        let count = proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, &info, Int32(MemoryLayout<proc_bsdinfo>.size))
+        guard count == Int32(MemoryLayout<proc_bsdinfo>.size) else { return nil }
+        let seconds = Int64(info.pbi_start_tvsec)
+        let micros = Int64(info.pbi_start_tvusec)
+        let (scaled, overflow) = seconds.multipliedReportingOverflow(by: 1_000_000)
+        guard !overflow else { return nil }
+        let (combined, addOverflow) = scaled.addingReportingOverflow(micros)
+        return addOverflow ? nil : combined
+    }
+
+    static func markerURL(home: URL = FileManager.default.homeDirectoryForCurrentUser) -> URL {
+        home
+            .appendingPathComponent(".local/share/macprovider", isDirectory: true)
+            .appendingPathComponent("stop-intent.json", isDirectory: false)
+    }
+
+    /// Record a validated stop intent for `targetPID` in the current boot
+    /// session. Called by a local stop transaction immediately before it stops
+    /// the provider service. Best-effort: a write failure or an unresolvable
+    /// process-start simply means the serve process will exit nonzero on the
+    /// incoming signal (fail-closed).
+    @discardableResult
+    static func record(
+        targetPID: Int32,
+        reason: String,
+        ttlSeconds: Int64 = defaultTTLSeconds,
+        home: URL = FileManager.default.homeDirectoryForCurrentUser,
+        bootSession: String? = CredentialRestartProver.currentBootSessionUUID(),
+        now: Date = Date(),
+        processStartMicroseconds: ProcessStartProvider = liveProcessStartMicroseconds
+    ) -> Bool {
+        guard targetPID > 0, let bootSession, !bootSession.isEmpty else { return false }
+        guard let processStart = processStartMicroseconds(targetPID) else { return false }
+        let expiresWallMs = Int64(now.timeIntervalSince1970 * 1000) + max(1, ttlSeconds) * 1000
+        let payload: [String: Any] = [
+            "schema": schema,
+            "pid": Int(targetPID),
+            "process_start_us": processStart,
+            "boot_session": bootSession,
+            "expires_wall_ms": expiresWallMs,
+            "reason": reason,
+        ]
+        guard let data = try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys]) else {
+            return false
+        }
+        let url = markerURL(home: home)
+        let dir = url.deletingLastPathComponent()
+        do {
+            try FileManager.default.createDirectory(
+                at: dir,
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700]
+            )
+            // Exclusive-create a fresh private temp, write, then atomically rename
+            // over the destination so a reader never sees a partial file and the
+            // final file carries our owner/mode (not a pre-existing file's).
+            let tmp = dir.appendingPathComponent(".stop-intent.\(getpid()).\(UUID().uuidString).tmp")
+            let fd = open(tmp.path, O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW, 0o600)
+            guard fd >= 0 else { return false }
+            var wrote = false
+            defer { if !wrote { try? FileManager.default.removeItem(at: tmp) } }
+            let written = data.withUnsafeBytes { raw in
+                write(fd, raw.baseAddress, raw.count)
+            }
+            close(fd)
+            guard written == data.count else { return false }
+            // Publish with POSIX rename(2): atomic, and the destination becomes the
+            // temp's inode — so the final file carries the temp's 0600 mode and our
+            // ownership, never a pre-existing destination's (looser) metadata the way
+            // FileManager.replaceItemAt can. Then reopen with O_NOFOLLOW and confirm
+            // the published file is a private, single-linked regular file owned by us
+            // before returning success.
+            guard rename(tmp.path, url.path) == 0 else { return false }
+            wrote = true  // tmp no longer exists after a successful rename
+            let vfd = open(url.path, O_RDONLY | O_NOFOLLOW)
+            guard vfd >= 0 else { try? FileManager.default.removeItem(at: url); return false }
+            defer { close(vfd) }
+            var vst = stat()
+            guard fstat(vfd, &vst) == 0,
+                  (vst.st_mode & S_IFMT) == S_IFREG,
+                  vst.st_uid == getuid(),
+                  (vst.st_mode & 0o777) == 0o600,
+                  vst.st_nlink == 1 else {
+                try? FileManager.default.removeItem(at: url)
+                return false
+            }
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    /// Consume the marker and report whether it authorizes a clean (exit 0)
+    /// termination of `currentPID`. Always deletes the marker (consume-once), so
+    /// a single recorded intent can authorize at most one stop. Fail-closed on
+    /// any missing/malformed/expired/mismatched/unhardened marker.
+    @discardableResult
+    static func consumeIfValid(
+        currentPID: Int32 = getpid(),
+        home: URL = FileManager.default.homeDirectoryForCurrentUser,
+        bootSession: String? = CredentialRestartProver.currentBootSessionUUID(),
+        now: Date = Date(),
+        processStartMicroseconds: ProcessStartProvider = liveProcessStartMicroseconds
+    ) -> Bool {
+        let url = markerURL(home: home)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        // Open without following symlinks and validate the file is a private,
+        // single-linked regular file owned by us before trusting its bytes.
+        let fd = open(url.path, O_RDONLY | O_NOFOLLOW)
+        guard fd >= 0 else { return false }
+        defer { close(fd) }
+        var st = stat()
+        guard fstat(fd, &st) == 0,
+              (st.st_mode & S_IFMT) == S_IFREG,
+              st.st_uid == getuid(),
+              (st.st_mode & 0o777) == 0o600,
+              st.st_nlink == 1,
+              st.st_size > 0, st.st_size <= maxMarkerBytes else {
+            return false
+        }
+        var buffer = [UInt8](repeating: 0, count: Int(st.st_size))
+        let readCount = read(fd, &buffer, buffer.count)
+        guard readCount == buffer.count else { return false }
+        let data = Data(buffer)
+
+        guard let object = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+              object["schema"] as? String == schema else {
+            return false
+        }
+        guard let pid = strictInt64(object["pid"]), pid > 0, pid == Int64(currentPID) else {
+            return false
+        }
+        guard let recordedBoot = object["boot_session"] as? String,
+              let bootSession, !bootSession.isEmpty,
+              recordedBoot == bootSession else {
+            return false
+        }
+        guard let recordedStart = strictInt64(object["process_start_us"]),
+              let currentStart = processStartMicroseconds(currentPID),
+              recordedStart == currentStart else {
+            return false
+        }
+        guard let expiresWallMs = strictInt64(object["expires_wall_ms"]) else { return false }
+        let nowMs = Int64(now.timeIntervalSince1970 * 1000)
+        return nowMs < expiresWallMs
+    }
+
+    /// Strict integral parse: accept only an exact integer JSON number (no
+    /// fractional, string, or out-of-range values). `JSONSerialization` yields
+    /// `NSNumber`; reject anything whose value is not an exact `Int64`.
+    private static func strictInt64(_ value: Any?) -> Int64? {
+        guard let number = value as? NSNumber else { return nil }
+        // Reject booleans and non-integral / floating values.
+        if CFGetTypeID(number) == CFBooleanGetTypeID() { return nil }
+        let type = String(cString: number.objCType)
+        // Allowable integral encodings from JSONSerialization: q/l/i/s/c and unsigned.
+        guard !type.contains("f"), !type.contains("d") else { return nil }
+        let doubleValue = number.doubleValue
+        guard doubleValue.rounded() == doubleValue,
+              doubleValue >= Double(Int64.min), doubleValue <= Double(Int64.max) else {
+            return nil
+        }
+        return number.int64Value
+    }
+}

--- a/phase3-binary/Sources/macprovider-cli/UninstallCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/UninstallCommand.swift
@@ -45,9 +45,34 @@ struct UninstallCommand: AsyncParsableCommand {
         }
         try Self.validateUninstallProfile(manifest)
 
-        try Self.stopLaunchdServices(labels: manifest.launchdLabels, uid: getuid()) { arguments in
-            try runProcess("/bin/launchctl", arguments: arguments)
+        // SPEC-001 FR-12 / SPEC-020 R-4.14: an uninstall is a validated local
+        // stop intent. Resolve the running provider PID now, and record the
+        // intent (PID+boot+process-start-bound, short-lived, consumed-once) at
+        // the exact moment its launchd job is booted out — so the serve process
+        // exits 0 for that SIGTERM rather than treating it as unsolicited. The
+        // marker is written inside `stopLaunchdServices` right before the
+        // provider bootout (after restart-capable watchdog jobs are gone), so it
+        // opens no fail-open window. Best-effort: if the PID is unresolvable or
+        // the write fails the serve simply exits nonzero, and `bootout` removes
+        // the job either way (no relaunch).
+        let providerStopPID: Int32?
+        if case .launchdManaged(let pid?) = ((try? ProviderConflictDetector().detect()) ?? .none) {
+            providerStopPID = pid
+        } else {
+            providerStopPID = nil
+            warnings.append("could not resolve running provider PID; stop-intent marker not recorded (serve will exit nonzero, launchd job still booted out)")
         }
+        try Self.stopLaunchdServices(
+            labels: manifest.launchdLabels,
+            uid: getuid(),
+            run: { arguments in try runProcess("/bin/launchctl", arguments: arguments) },
+            beforeBootout: { label in
+                guard label == ProviderConflictDetector.launchdLabel, let pid = providerStopPID else { return }
+                if !StopIntentMarker.record(targetPID: pid, reason: "uninstall", home: home) {
+                    warnings.append("failed to record stop-intent marker for provider uninstall (serve may exit nonzero)")
+                }
+            }
+        )
         // The signed CLI remains the sole lifecycle author. Publish the
         // uninstall tombstone only after both launchd jobs are proven absent,
         // and before removing the executable that can author it.
@@ -208,7 +233,8 @@ struct UninstallCommand: AsyncParsableCommand {
     static func stopLaunchdServices(
         labels: [String],
         uid: uid_t,
-        run: ([String]) throws -> Int32
+        run: ([String]) throws -> Int32,
+        beforeBootout: (String) -> Void = { _ in }
     ) throws {
         let managedLabels = Set(managedLaunchdStopOrder)
         for label in Set(labels) where !managedLabels.contains(label) {
@@ -217,6 +243,13 @@ struct UninstallCommand: AsyncParsableCommand {
 
         for label in managedLaunchdStopOrder {
             let target = "gui/\(uid)/\(label)"
+            // Hook fires immediately before this label's bootout. The stop order
+            // stops restart-capable watchdog jobs first, so by the time the
+            // provider label is booted out no watchdog remains to fight it — and
+            // a validated stop-intent marker recorded here (SPEC-001 FR-12) has no
+            // fail-open window: if an earlier bootout failed we throw before ever
+            // reaching the provider label.
+            beforeBootout(label)
             _ = try run(["bootout", target])
             // `bootout` returns nonzero both for an absent job and for real
             // failures. A follow-up `print` is the stop proof: only a missing

--- a/phase3-binary/Tests/macprovider-cliTests/StopIntentMarkerTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/StopIntentMarkerTests.swift
@@ -1,0 +1,182 @@
+import Foundation
+import XCTest
+@testable import macprovider_cli
+
+/// SPEC-001 FR-12 / SPEC-020 R-4.14 — validated local stop intent.
+final class StopIntentMarkerTests: XCTestCase {
+    private var home: URL!
+    /// Deterministic process-start provider so tests do not depend on real PIDs.
+    private let startFor: @Sendable (pid_t) -> Int64? = { pid in Int64(pid) * 1_000 + 7 }
+
+    override func setUpWithError() throws {
+        home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("stop-intent-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: home)
+    }
+
+    private func recordMarker(pid: Int32 = 4242, ttl: Int64 = 120, now: Date, boot: String = "boot-a") -> Bool {
+        StopIntentMarker.record(
+            targetPID: pid, reason: "uninstall", ttlSeconds: ttl,
+            home: home, bootSession: boot, now: now, processStartMicroseconds: startFor)
+    }
+
+    private func consume(pid: Int32 = 4242, now: Date, boot: String = "boot-a",
+                         start: (@Sendable (pid_t) -> Int64?)? = nil) -> Bool {
+        StopIntentMarker.consumeIfValid(
+            currentPID: pid, home: home, bootSession: boot, now: now,
+            processStartMicroseconds: start ?? startFor)
+    }
+
+    // Write a raw marker payload directly, bypassing record(), to exercise the
+    // consumer's fail-closed parsing.
+    private func writeRaw(_ object: [String: Any], mode: Int = 0o600) throws {
+        let url = StopIntentMarker.markerURL(home: home)
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try JSONSerialization.data(withJSONObject: object).write(to: url)
+        try FileManager.default.setAttributes([.posixPermissions: mode], ofItemAtPath: url.path)
+    }
+
+    private func validObject(pid: Int = 4242, now: Date) -> [String: Any] {
+        [
+            "schema": StopIntentMarker.schema,
+            "pid": pid,
+            "process_start_us": startFor(pid_t(pid))!,
+            "boot_session": "boot-a",
+            "expires_wall_ms": Int64(now.timeIntervalSince1970 * 1000) + 60_000,
+            "reason": "uninstall",
+        ]
+    }
+
+    func testRecordThenConsumeMatchingIsValidAndConsumesOnce() {
+        let now = Date()
+        XCTAssertTrue(recordMarker(now: now))
+        XCTAssertTrue(consume(now: now))
+        // Consume-once: the marker is deleted, so a second consume is invalid.
+        XCTAssertFalse(consume(now: now))
+    }
+
+    func testConsumeWithDifferentPIDIsInvalid() {
+        let now = Date()
+        _ = recordMarker(pid: 4242, now: now)
+        XCTAssertFalse(consume(pid: 9999, now: now))
+    }
+
+    func testConsumeWithDifferentBootSessionIsInvalid() {
+        let now = Date()
+        _ = recordMarker(now: now, boot: "boot-a")
+        XCTAssertFalse(consume(now: now, boot: "boot-b"))
+    }
+
+    func testProcessStartMismatchIsInvalid() {
+        // PID reuse within the same boot: same pid, different process-start time.
+        let now = Date()
+        _ = recordMarker(pid: 4242, now: now)
+        XCTAssertFalse(consume(pid: 4242, now: now, start: { _ in 999_999 }))
+    }
+
+    func testExpiredMarkerIsInvalid() {
+        let recordedAt = Date()
+        _ = recordMarker(ttl: 60, now: recordedAt)
+        XCTAssertFalse(consume(now: recordedAt.addingTimeInterval(61)))
+    }
+
+    func testMissingMarkerIsInvalid() {
+        XCTAssertFalse(consume(now: Date()))
+    }
+
+    func testMalformedMarkerIsInvalidAndConsumed() throws {
+        let url = StopIntentMarker.markerURL(home: home)
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data("not-json".utf8).write(to: url)
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+        XCTAssertFalse(consume(now: Date()))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: url.path),
+                       "a malformed marker must still be consumed (deleted)")
+    }
+
+    func testWrongSchemaIsInvalid() throws {
+        let now = Date()
+        var obj = validObject(now: now)
+        obj["schema"] = "macprovider.stop-intent.v2"
+        try writeRaw(obj)
+        XCTAssertFalse(consume(now: now))
+    }
+
+    func testFractionalPIDIsInvalid() throws {
+        let now = Date()
+        var obj = validObject(now: now)
+        obj["pid"] = 4242.5
+        try writeRaw(obj)
+        XCTAssertFalse(consume(now: now))
+    }
+
+    func testStringPIDIsInvalid() throws {
+        let now = Date()
+        var obj = validObject(now: now)
+        obj["pid"] = "4242"
+        try writeRaw(obj)
+        XCTAssertFalse(consume(now: now))
+    }
+
+    func testNegativePIDIsInvalid() throws {
+        let now = Date()
+        var obj = validObject(now: now)
+        obj["pid"] = -1
+        try writeRaw(obj)
+        XCTAssertFalse(consume(pid: -1, now: now))
+    }
+
+    func testWorldReadableMarkerIsRejected() throws {
+        let now = Date()
+        try writeRaw(validObject(now: now), mode: 0o644)
+        XCTAssertFalse(consume(now: now), "a marker not mode 0600 must be rejected")
+    }
+
+    func testRecordFailsClosedWithoutBootSession() {
+        XCTAssertFalse(StopIntentMarker.record(
+            targetPID: 4242, reason: "uninstall", home: home, bootSession: nil,
+            now: Date(), processStartMicroseconds: startFor))
+        XCTAssertFalse(FileManager.default.fileExists(
+            atPath: StopIntentMarker.markerURL(home: home).path))
+    }
+
+    func testRecordFailsClosedWhenProcessStartUnresolvable() {
+        XCTAssertFalse(StopIntentMarker.record(
+            targetPID: 4242, reason: "uninstall", home: home, bootSession: "boot-a",
+            now: Date(), processStartMicroseconds: { _ in nil }))
+    }
+
+    func testConsumeFailsClosedWhenCurrentBootSessionUnavailable() {
+        let now = Date()
+        _ = recordMarker(now: now)
+        XCTAssertFalse(StopIntentMarker.consumeIfValid(
+            currentPID: 4242, home: home, bootSession: nil, now: now,
+            processStartMicroseconds: startFor))
+    }
+
+    func testRecordedMarkerIsPrivateMode0600() {
+        let now = Date()
+        XCTAssertTrue(recordMarker(now: now))
+        let mode = (try? FileManager.default.attributesOfItem(
+            atPath: StopIntentMarker.markerURL(home: home).path)[.posixPermissions] as? Int)
+        XCTAssertEqual((mode ?? 0) & 0o777, 0o600)
+    }
+
+    func testRecordOverPreExistingWorldReadableMarkerPublishesPrivate() throws {
+        let now = Date()
+        // A pre-existing loose-mode marker at the destination must not leak its
+        // permissions onto the freshly recorded marker (rename(2) publish).
+        try writeRaw(validObject(now: now), mode: 0o644)
+        XCTAssertTrue(recordMarker(now: now))
+        let mode = (try? FileManager.default.attributesOfItem(
+            atPath: StopIntentMarker.markerURL(home: home).path)[.posixPermissions] as? Int)
+        XCTAssertEqual((mode ?? 0) & 0o777, 0o600, "republish must land 0600, not inherit 0644")
+        XCTAssertTrue(consume(now: now))
+    }
+}

--- a/phase3-binary/dist/install.sh
+++ b/phase3-binary/dist/install.sh
@@ -11437,13 +11437,6 @@ valid_lifecycle_lease() {
   valid_lifecycle_lease_record maintenance ""
 }
 
-valid_unbound_lifecycle_lease() {
-  if valid_lifecycle_lease_record startup ""; then
-    return 0
-  fi
-  valid_lifecycle_lease_record maintenance ""
-}
-
 valid_lifecycle_lease_record() {
   expected_kind="$1"
   expected_pid="${2:-}"
@@ -11715,14 +11708,13 @@ main() {
   fi
   provider_pid="$(provider_process_pid || true)"
   if [ -z "$provider_pid" ]; then
-    log "provider process unhealthy: launchd service $LABEL has no validated PID at $BINARY_PATH"
-    if valid_unbound_lifecycle_lease; then
-      log "launchd service $LABEL has no validated PID but is inside a validated startup/maintenance lease; watchdog grants bounded grace"
-      exit 0
-    fi
-    if ! provider_restart_cooldown_active; then
-      kickstart_provider "missing_validated_pid" || true
-    fi
+    # No validated launchd PID: the provider service is not running. Per
+    # SPEC-020 R-4.14 the launchd provider-service KeepAlive is the SINGLE
+    # exit-restart owner; the watchdog no longer kickstarts here. This removes
+    # the second, mutable exit-restart authority behind #1189. launchd restarts
+    # a crashed/nonzero exit, and an unsolicited clean exit now exits nonzero
+    # (SPEC-001 FR-12) so KeepAlive relaunches it — the watchdog only observes.
+    log "provider process not running: launchd service $LABEL has no validated PID at $BINARY_PATH; exit-restart owned by launchd KeepAlive (watchdog does not kick)"
     exit 0
   fi
   boot_id="$(current_boot_id)"

--- a/phase3-binary/dist/test/watchdog_health_scope.test.sh
+++ b/phase3-binary/dist/test/watchdog_health_scope.test.sh
@@ -171,112 +171,33 @@ PY
   chmod 600 "$TMP/home/Library/Application Support/macprovider/lifecycle/lease.json"
 }
 
+# F1 (RFC-001 #1382, SPEC-020 R-4.14): with no validated launchd PID the
+# watchdog MUST only observe — launchd KeepAlive is the single exit-restart
+# owner, so the watchdog no longer kickstarts a missing provider (this removes
+# the second, mutable exit-restart authority behind #1189).
 make_fake_common
 : > "$TMP/launchctl.log"
 run_watchdog
-grep -F 'kickstart -k gui/' "$TMP/launchctl.log" >/dev/null
-grep -F 'provider restart requested for live.malibu.provider via launchctl kickstart -k reason=missing_validated_pid' "$TMP/logs/watchdog.log" >/dev/null
+grep -F 'has no validated PID' "$TMP/logs/watchdog.log" >/dev/null
+grep -F 'watchdog does not kick' "$TMP/logs/watchdog.log" >/dev/null
+if grep -F 'kickstart' "$TMP/launchctl.log" >/dev/null; then
+  echo "missing validated PID must not trigger any watchdog kickstart (launchd KeepAlive owns exit-restart)" >&2
+  exit 1
+fi
 
+# The kickstart failure status is now irrelevant on the missing-PID path: the
+# watchdog never issues a kickstart there, so no restart is attempted.
 rm -rf "$TMP/bin" "$TMP/logs" "$TMP/launchctl.log" "$TMP/home/.local/share/macprovider-watchdog/state"
 make_fake_common
 WATCHDOG_TEST_KICKSTART_STATUS=73
 export WATCHDOG_TEST_KICKSTART_STATUS
 : > "$TMP/launchctl.log"
 run_watchdog
-grep -F 'provider restart request failed for live.malibu.provider via launchctl kickstart -k reason=missing_validated_pid exit_status=73' "$TMP/logs/watchdog.log" >/dev/null
-if [ -f "$TMP/home/.local/share/macprovider-watchdog/state/last_kick" ]; then
-  echo "failed kickstart must not consume restart cooldown" >&2
+if grep -F 'kickstart' "$TMP/launchctl.log" >/dev/null; then
+  echo "missing validated PID must not kick regardless of kickstart status" >&2
   exit 1
 fi
 unset WATCHDOG_TEST_KICKSTART_STATUS
-
-rm -rf "$TMP/bin" "$TMP/logs" "$TMP/launchctl.log" "$TMP/home/.local/share/macprovider-watchdog/state"
-make_fake_common
-MACPROVIDER_WATCHDOG_KICK_GRACE_SECONDS=nonnumeric
-export MACPROVIDER_WATCHDOG_KICK_GRACE_SECONDS
-: > "$TMP/launchctl.log"
-run_watchdog
-run_watchdog
-if [ "$(grep -c -F 'kickstart -k gui/' "$TMP/launchctl.log")" -ne 1 ]; then
-  echo "invalid cooldown override must fall back to bounded default" >&2
-  exit 1
-fi
-unset MACPROVIDER_WATCHDOG_KICK_GRACE_SECONDS
-
-if [ "$(uname -s)" != "Darwin" ]; then
-  echo "SKIP: Darwin-only lifecycle lease process-identity cases require libproc.dylib"
-  echo "watchdog health scope ok"
-  exit 0
-fi
-
-rm -rf "$TMP/bin" "$TMP/logs" "$TMP/launchctl.log" "$TMP/home/.local/share/macprovider-watchdog/state"
-make_fake_common
-WATCHDOG_TEST_BINARY_PATH="/bin/sleep"
-export WATCHDOG_TEST_BINARY_PATH
-/bin/sleep 300 &
-provider_owner_pid=$!
-/usr/bin/tail -f /dev/null &
-forged_owner_pid=$!
-WATCHDOG_TEST_LEASE_LOG="$TMP/lease.log"
-export WATCHDOG_TEST_LEASE_LOG
-MACPROVIDER_HEADLESS=1
-export MACPROVIDER_HEADLESS
-for lease_mode in startup maintenance; do
-  : > "$TMP/logs/watchdog.log"
-  : > "$TMP/launchctl.log"
-  : > "$TMP/lease.log"
-  WATCHDOG_TEST_LEASE_MODE="$lease_mode"
-  export WATCHDOG_TEST_LEASE_MODE
-  write_watchdog_lease "$lease_mode" "$provider_owner_pid"
-  run_watchdog
-  grep -F 'has no validated PID but is inside a validated startup/maintenance lease; watchdog grants bounded grace' "$TMP/logs/watchdog.log" >/dev/null
-  if [ -s "$TMP/lease.log" ]; then
-    echo "watchdog must not execute the provider binary to validate $lease_mode lease grace" >&2
-    exit 1
-  fi
-  if grep -F 'kickstart -k' "$TMP/launchctl.log" >/dev/null; then
-    echo "valid $lease_mode lease must suppress missing-PID kickstart" >&2
-    exit 1
-  fi
-  rm -f "$TMP/home/Library/Application Support/macprovider/lifecycle/lease.json"
-done
-for lease_mode in startup maintenance; do
-  rm -rf "$TMP/home/.local/share/macprovider-watchdog/state"
-  : > "$TMP/logs/watchdog.log"
-  : > "$TMP/launchctl.log"
-  WATCHDOG_TEST_LEASE_MODE="$lease_mode"
-  export WATCHDOG_TEST_LEASE_MODE
-  write_watchdog_lease "$lease_mode" "$provider_owner_pid" valid 1
-  run_watchdog
-  if grep -F 'inside a validated startup/maintenance lease' "$TMP/logs/watchdog.log" >/dev/null; then
-    echo "stale process_start_us must not validate $lease_mode lease grace" >&2
-    exit 1
-  fi
-  grep -F 'kickstart -k gui/' "$TMP/launchctl.log" >/dev/null
-  rm -f "$TMP/home/Library/Application Support/macprovider/lifecycle/lease.json"
-done
-for lease_mode in startup maintenance; do
-  rm -rf "$TMP/home/.local/share/macprovider-watchdog/state"
-  : > "$TMP/logs/watchdog.log"
-  : > "$TMP/launchctl.log"
-  WATCHDOG_TEST_LEASE_MODE="$lease_mode"
-  export WATCHDOG_TEST_LEASE_MODE
-  write_watchdog_lease "$lease_mode" "$forged_owner_pid"
-  run_watchdog
-  if grep -F 'inside a validated startup/maintenance lease' "$TMP/logs/watchdog.log" >/dev/null; then
-    echo "foreign live PID must not validate $lease_mode lease grace" >&2
-    exit 1
-  fi
-  grep -F 'kickstart -k gui/' "$TMP/launchctl.log" >/dev/null
-  rm -f "$TMP/home/Library/Application Support/macprovider/lifecycle/lease.json"
-done
-kill "$provider_owner_pid"
-wait "$provider_owner_pid" >/dev/null 2>&1 || true
-provider_owner_pid=""
-kill "$forged_owner_pid"
-wait "$forged_owner_pid" >/dev/null 2>&1 || true
-forged_owner_pid=""
-unset WATCHDOG_TEST_LEASE_LOG WATCHDOG_TEST_LEASE_MODE MACPROVIDER_HEADLESS WATCHDOG_TEST_BINARY_PATH
 
 rm -rf "$TMP/bin" "$TMP/logs" "$TMP/launchctl.log" "$TMP/home/.local/share/macprovider-watchdog/state"
 make_fake_common
@@ -417,6 +338,19 @@ run_watchdog
 grep -F 'provider process 4242 failed local /v1/health after arming; requesting launchd restart' "$TMP/logs/watchdog.log" >/dev/null
 grep -F 'provider restart requested for live.malibu.provider via launchctl kickstart -k reason=local_health_failed_after_arming' "$TMP/logs/watchdog.log" >/dev/null
 unset WATCHDOG_TEST_HEALTH_STATUS WATCHDOG_TEST_STATUS_BODY
+
+# Darwin-only below: the lifecycle-lease process-identity cases use
+# /usr/lib/libproc.dylib (proc_pidinfo) via write_watchdog_lease, which is absent
+# on Linux CI runners. Everything above — observe-only missing-PID (J2 removed)
+# and the J1 health-wedge kick / pause / drain / malformed-status cases — is
+# platform-independent and has already run. (This guard was previously higher in
+# the file; the F1 rewrite of the missing-PID scenarios must keep it before the
+# libproc-dependent lease block.)
+if [ "$(uname -s)" != "Darwin" ]; then
+  echo "SKIP: Darwin-only lifecycle-lease process-identity cases require libproc.dylib"
+  echo "watchdog health scope ok"
+  exit 0
+fi
 
 rm -rf "$TMP/bin" "$TMP/logs" "$TMP/launchctl.log" "$TMP/home/.local/share/macprovider-watchdog/state"
 make_fake_common


### PR DESCRIPTION
## Summary

Implements **F1** of RFC-001 (#1382): make the launchd provider-service
`KeepAlive` the **single** provider exit-restart owner and remove the companion
watchdog's exit-restart, closing out the #1189 stranded-provider class. Normative
contract is SPEC-020 R-4.14 / SPEC-025 §5.3 / SPEC-001 FR-12 (SPEC bundle #1388,
merged). Passed a 3-lane codex BUILD audit (code/security/architect, `gpt-5.5`
high) to **0 CRITICAL / HIGH / MEDIUM**.

### Changes
- **Watchdog J2 removal** (`ops/macprovider-watchdog/watchdog.sh` +
  `phase3-binary/dist/install.sh` heredoc, drift-synced): with no validated
  launchd PID the watchdog now only observes and exits — the
  `kickstart_provider "missing_validated_pid"` path and the now-unused
  `valid_unbound_lifecycle_lease` helper are gone. The J1 health-wedge kickstart,
  boot-arming, cooldown, and lifecycle-lease grace are unchanged.
- **Clean-exit gap closed** (`MacProviderCLI.swift`): the serve SIGTERM/SIGINT
  handler decides the exit code *before* draining and threads it through
  `drainAndExit(reason:exitCode:)` — exit 0 only under a validated local stop
  intent, otherwise `128+signal` so a still-loaded
  `KeepAlive{SuccessfulExit:false}` service relaunches the provider (covers
  stray `kill` and macOS memory-pressure/jetsam SIGTERM). A `TerminationLatch`
  ensures only the first signal decides. A coordinator drain never reaches this
  path.
- **`StopIntentMarker.swift`** (new): a fail-closed local stop-intent marker
  bound to PID + process-start (`proc_pidinfo`, so a reused PID can't replay) +
  boot session, short-lived (120s), consumed-once, with hardened storage
  (`O_NOFOLLOW`, regular-file / owner / `0600` / single-link / bounded-size,
  `rename(2)` publish + reopen-verify).
- **`UninstallCommand.swift`**: records the stop intent immediately before the
  provider `bootout` (after watchdog jobs are stopped, via a `beforeBootout`
  hook) so an intentional uninstall exits 0 with no fail-open window; warns if
  the PID can't be resolved or the record fails.
- **Tests**: `StopIntentMarkerTests` (17 cases — match / pid / boot /
  process-start mismatch / expiry / missing / malformed / schema / fractional /
  string / negative pid / world-readable rejected / consume-once / fail-closed /
  0600 / republish-over-0644); watchdog `watchdog_health_scope` rewritten to
  assert observe-only on missing PID (J1 wedge scenarios unchanged).

`swift build` clean; watchdog drift + all watchdog dist tests green.

Depends on #1388 (SPEC bundle, merged). 

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "issue": "https://github.com/Augustas11/macprovider/issues/1382",
  "specs": ["SPEC-020", "SPEC-001", "SPEC-025"],
  "requirements": ["SPEC-020-R005"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["DECISION_REQUIRED"],
  "tests": ["phase3-binary swift test --filter StopIntentMarkerTests", "phase3-binary/dist/test/watchdog_health_scope.test.sh", "scripts/test-watchdog-inline-drift.sh"],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
