### PR TITLE
F2 (RFC-001 #1383): model-liveness token in /v1/status

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/HTTPServer.swift
+++ b/phase3-binary/Sources/macprovider-cli/HTTPServer.swift
@@ -226,6 +226,7 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
         "lifecycle_lease_v1",
         "legacy_reader_fallback_v1",
         "service_instance_v1",
+        "model_liveness_token_v1",
         "status_observation_v1",
         "provider_safety_telemetry_v1",
         "referral_bootstrap_v1",
@@ -1531,6 +1532,9 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
     ) -> [String: Any] {
         let observedAt = Date()
         let observationID = UUID().uuidString.lowercased()
+        // SPEC-025 §5.2 (capability model_liveness_token_v1): read the last-published
+        // model-thread progress values without blocking on the model thread.
+        let modelLiveness = ModelLivenessTracker.shared.snapshot()
         let effectiveModelID = runtimeSnapshot?.modelID ?? snapshot.modelID
         let effectiveModelLoaded = runtimeSnapshot.map { $0.container != nil || $0.modelID != nil } ?? snapshot.modelLoaded
         var body: [String: Any] = [
@@ -1554,6 +1558,16 @@ final class RouterHandler: ChannelInboundHandler, @unchecked Sendable {
                 "boot_session": jsonNullable(serviceBootSession),
                 "started_at": iso8601(serviceStartedAt),
                 "role": "serve",
+            ],
+            // SPEC-025 §5.2: model-thread liveness (observability only; no
+            // buyer-serving authority). token advances on model forward progress;
+            // ages use a monotonic clock; token resets per service_instance.
+            "model_liveness": [
+                "token": NSNumber(value: modelLiveness.token),
+                "token_age_ms": nullableNumber(modelLiveness.tokenAgeMs.map(Double.init)),
+                "active_inference": modelLiveness.activeInference,
+                "active_inference_age_ms": nullableNumber(modelLiveness.activeInferenceAgeMs.map(Double.init)),
+                "last_advanced_at": jsonNullable(modelLiveness.lastAdvancedAt.map { iso8601($0) }),
             ],
             "lifecycle": lifecycleStateStatus(lifecycleStateInspection),
             "lifecycle_lease": lifecycleLeaseStatus(lifecycleLeaseInspection),

--- a/phase3-binary/Sources/macprovider-cli/ModelLivenessTracker.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelLivenessTracker.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// SPEC-025 §5.2 (capability `model_liveness_token_v1`) — model-thread liveness.
+///
+/// A bare `/v1/health` 200 does not prove the model thread is alive: the HTTP
+/// listener can answer while the inference thread is dead. This tracker exposes a
+/// monotone token that advances ONLY on model/inference forward progress, plus
+/// the monotonic age since it last advanced, so an out-of-process observer can
+/// distinguish a healthy provider from a listener-alive / model-dead wedge.
+///
+/// Observability-only in this version: the value is surfaced on `/v1/status` and
+/// carries no buyer-serving authority and does not gate admission. Wiring it into
+/// a watchdog restart decision is a deferred RFC-001 follow-up.
+///
+/// The token is process-scoped (starts at 0 each process/service instance), so it
+/// resets on restart and must not be compared across `service_instance.instance_id`.
+/// Reads never block on the model thread — the model loop only briefly bumps a
+/// lock-guarded counter, and `snapshot()` reads the last-published values.
+final class ModelLivenessTracker: @unchecked Sendable {
+    static let shared = ModelLivenessTracker()
+
+    struct Snapshot: Sendable {
+        let token: UInt64
+        let tokenAgeMs: UInt64?
+        let activeInference: Bool
+        let activeInferenceAgeMs: UInt64?
+        let lastAdvancedAt: Date?
+    }
+
+    private let lock = NSLock()
+    private var token: UInt64 = 0
+    private var lastAdvanceMonoNs: UInt64?
+    private var lastAdvanceWall: Date?
+    private var activeCount = 0
+    private var activeSinceMonoNs: UInt64?
+
+    // Injectable monotonic clock for tests; defaults to the process uptime clock,
+    // which is immune to wall-clock jumps.
+    private let monotonicNs: @Sendable () -> UInt64
+    private let wallClock: @Sendable () -> Date
+
+    init(
+        monotonicNs: @escaping @Sendable () -> UInt64 = { DispatchTime.now().uptimeNanoseconds },
+        wallClock: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        self.monotonicNs = monotonicNs
+        self.wallClock = wallClock
+    }
+
+    /// Called by the inference loop whenever the model produces forward progress
+    /// (one or more tokens). Advances the token and restarts the
+    /// active-without-progress clock.
+    func recordProgress() {
+        lock.lock(); defer { lock.unlock() }
+        // Sample the clock INSIDE the lock so published timestamps are serialized
+        // with readers and never move backward relative to a later snapshot.
+        let now = monotonicNs()
+        // Saturating increment: never wrap UInt64.max -> 0 (monotone contract).
+        if token != .max { token += 1 }
+        lastAdvanceMonoNs = now
+        lastAdvanceWall = wallClock()
+        if activeCount > 0 { activeSinceMonoNs = now }
+    }
+
+    /// Bracket around a unit of buyer-serving model work. `beginInference` marks
+    /// active inference (so a stalled token is meaningful); `endInference` clears
+    /// it when no work remains.
+    func beginInference() {
+        lock.lock(); defer { lock.unlock() }
+        if activeCount == 0 { activeSinceMonoNs = monotonicNs() }
+        activeCount += 1
+    }
+
+    func endInference() {
+        lock.lock(); defer { lock.unlock() }
+        if activeCount > 0 { activeCount -= 1 }
+        if activeCount == 0 { activeSinceMonoNs = nil }
+    }
+
+    func snapshot() -> Snapshot {
+        lock.lock(); defer { lock.unlock() }
+        // Sample `now` under the lock, after any concurrent writer has published,
+        // so the monotonic clock guarantees now >= every stored timestamp.
+        let now = monotonicNs()
+        let tokenAge = lastAdvanceMonoNs.map { Self.ageMs(now: now, then: $0) }
+        let active = activeCount > 0
+        let activeAge = active ? activeSinceMonoNs.map { Self.ageMs(now: now, then: $0) } : nil
+        return Snapshot(
+            token: token,
+            tokenAgeMs: tokenAge,
+            activeInference: active,
+            activeInferenceAgeMs: activeAge,
+            lastAdvancedAt: lastAdvanceWall
+        )
+    }
+
+    /// Clamped elapsed-ms: never underflow if `now < then` (defense in depth
+    /// against clock quirks / test seams that move the sampled clock backward).
+    private static func ageMs(now: UInt64, then: UInt64) -> UInt64 {
+        (now >= then ? now - then : 0) / 1_000_000
+    }
+}

--- a/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
@@ -2218,6 +2218,12 @@ actor ModelRuntime: ModelRuntimeServing {
     }
 
     func preflight(_ request: ChatCompletionRequest, with handle: RequestHandle) async throws {
+        // SPEC-025 §5.2: the streaming path runs preflight (prompt prepare inside
+        // container.perform — real model-thread work) before stream() brackets
+        // active inference. Bracket it here too so a pre-first-token wedge during
+        // preflight is observable (active_inference true) rather than reading idle.
+        ModelLivenessTracker.shared.beginInference()
+        defer { ModelLivenessTracker.shared.endInference() }
         try applyContinuousBatchingPolicy(request: request, snapshot: handle.snapshot)
         try Self.enforcePagedKVPreflight(pagedKVAttachDecision)
         try handle.drainCancelled.check()
@@ -2346,6 +2352,7 @@ actor ModelRuntime: ModelRuntimeServing {
                     BlockingGenerateResult(generate(input: lmInput, context: context, iterator: iterator) { tokens in
                         if !tokens.isEmpty {
                             firstToken.recordIfMissing()
+                            ModelLivenessTracker.shared.recordProgress()
                         }
                         if Task.isCancelled || inferenceCancellation.isCancelled || shouldCancel() {
                             cancellation.record()
@@ -2387,6 +2394,10 @@ actor ModelRuntime: ModelRuntimeServing {
         with handle: RequestHandle,
         shouldCancel: @escaping @Sendable () -> Bool = { false }
     ) async throws -> (CompletionResult, RuntimeSnapshot) {
+        // SPEC-025 §5.2 model-liveness: mark active buyer inference so a stalled
+        // progress token is interpretable as a wedge (observability only).
+        ModelLivenessTracker.shared.beginInference()
+        defer { ModelLivenessTracker.shared.endInference() }
         let completionStartedAt = Date()
         let snapshot = handle.snapshot
         let drainCancelled = handle.drainCancelled
@@ -2535,6 +2546,7 @@ actor ModelRuntime: ModelRuntimeServing {
                                 BlockingGenerateResult(generate(input: iteratorInput, context: generationContext, iterator: iterator) { tokens in
                                     if !tokens.isEmpty {
                                         firstToken.recordIfMissing()
+                                        ModelLivenessTracker.shared.recordProgress()
                                     }
                                     if Task.isCancelled || inferenceCancellation.isCancelled || shouldCancel() || drainCancelled.isFired {
                                         return GenerateDisposition.stop
@@ -2762,6 +2774,7 @@ actor ModelRuntime: ModelRuntimeServing {
                             break
                         }
                         firstToken.recordIfMissing()
+                        ModelLivenessTracker.shared.recordProgress()
                         tokenIDs.append(token)
                         detokenizer.append(token: token)
                         if let chunk = detokenizer.next() {
@@ -2819,6 +2832,10 @@ actor ModelRuntime: ModelRuntimeServing {
         shouldCancel: @escaping @Sendable () -> Bool = { false },
         onChunk: @escaping @Sendable (StreamChunk) -> Void
     ) async throws -> CompletionResult {
+        // SPEC-025 §5.2 model-liveness: mark active buyer inference so a stalled
+        // progress token is interpretable as a wedge (observability only).
+        ModelLivenessTracker.shared.beginInference()
+        defer { ModelLivenessTracker.shared.endInference() }
         let snapshot = handle.snapshot
         let drainCancelled = handle.drainCancelled
         try applyContinuousBatchingPolicy(request: request, snapshot: snapshot, emitTelemetry: false)
@@ -3100,6 +3117,7 @@ actor ModelRuntime: ModelRuntimeServing {
                                 // guards elsewhere in this file.
                                 if !tokens.isEmpty {
                                     decodeTimer.recordIfMissing()
+                                    ModelLivenessTracker.shared.recordProgress()
                                 }
                                 if Task.isCancelled || inferenceCancellation.isCancelled || shouldCancel() || drainCancelled.isFired || idleCancellation.isFired {
                                     return .stop

--- a/phase3-binary/Tests/macprovider-cliTests/ModelLivenessTrackerTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ModelLivenessTrackerTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+import XCTest
+@testable import macprovider_cli
+
+/// SPEC-025 §5.2 (capability `model_liveness_token_v1`).
+final class ModelLivenessTrackerTests: XCTestCase {
+    /// Mutable monotonic clock so age assertions are deterministic.
+    private final class FakeClock: @unchecked Sendable { var ns: UInt64 = 1_000_000_000 }
+
+    private func makeTracker(_ clock: FakeClock) -> ModelLivenessTracker {
+        ModelLivenessTracker(
+            monotonicNs: { clock.ns },
+            wallClock: { Date(timeIntervalSince1970: 1_000) }
+        )
+    }
+
+    private func ms(_ n: UInt64) -> UInt64 { n * 1_000_000 }
+
+    func testFreshTrackerHasNoProgress() {
+        let t = makeTracker(FakeClock())
+        let s = t.snapshot()
+        XCTAssertEqual(s.token, 0)
+        XCTAssertNil(s.tokenAgeMs)
+        XCTAssertFalse(s.activeInference)
+        XCTAssertNil(s.activeInferenceAgeMs)
+        XCTAssertNil(s.lastAdvancedAt)
+    }
+
+    func testRecordProgressAdvancesTokenAndAge() {
+        let clock = FakeClock()
+        let t = makeTracker(clock)
+        t.recordProgress()
+        clock.ns += ms(50)
+        let s = t.snapshot()
+        XCTAssertEqual(s.token, 1)
+        XCTAssertEqual(s.tokenAgeMs, 50)
+        XCTAssertNotNil(s.lastAdvancedAt)
+    }
+
+    func testTokenIsMonotoneAcrossProgress() {
+        let t = makeTracker(FakeClock())
+        t.recordProgress(); t.recordProgress(); t.recordProgress()
+        XCTAssertEqual(t.snapshot().token, 3)
+    }
+
+    func testActiveInferenceLifecycleAndAge() {
+        let clock = FakeClock()
+        let t = makeTracker(clock)
+        t.beginInference()
+        XCTAssertTrue(t.snapshot().activeInference)
+        clock.ns += ms(30)
+        XCTAssertEqual(t.snapshot().activeInferenceAgeMs, 30)
+        t.endInference()
+        let s = t.snapshot()
+        XCTAssertFalse(s.activeInference)
+        XCTAssertNil(s.activeInferenceAgeMs)
+    }
+
+    func testProgressResetsActiveAgeButNotToken() {
+        let clock = FakeClock()
+        let t = makeTracker(clock)
+        t.beginInference()
+        clock.ns += ms(20)
+        t.recordProgress()             // advances token, resets active-without-progress clock
+        clock.ns += ms(10)
+        let s = t.snapshot()
+        XCTAssertEqual(s.token, 1)
+        XCTAssertEqual(s.activeInferenceAgeMs, 10)  // since last progress, not since begin
+        XCTAssertEqual(s.tokenAgeMs, 10)
+    }
+
+    func testAgeClampsToZeroIfClockMovesBackward() {
+        // The clock is sampled under the lock (no real backward motion), but the
+        // age math must still clamp rather than wrap to a huge UInt64 if a stored
+        // timestamp is ever ahead of `now`.
+        let clock = FakeClock()
+        let t = makeTracker(clock)
+        clock.ns = ms(1_000)
+        t.recordProgress()          // lastAdvance recorded at 1000ms
+        clock.ns = ms(400)          // clock moves backward
+        let s = t.snapshot()
+        XCTAssertEqual(s.tokenAgeMs, 0, "age must clamp to 0, never wrap")
+    }
+
+    func testNestedInferenceStaysActiveUntilZero() {
+        let t = makeTracker(FakeClock())
+        t.beginInference()
+        t.beginInference()
+        t.endInference()
+        XCTAssertTrue(t.snapshot().activeInference, "still active while one inference remains")
+        t.endInference()
+        XCTAssertFalse(t.snapshot().activeInference)
+    }
+
+    func testIdleProviderTokenAgeGrowsButActiveIsFalse() {
+        // A healthy idle provider: a token advanced once, then no work. token_age_ms
+        // grows, but active_inference is false so it must not read as a wedge.
+        let clock = FakeClock()
+        let t = makeTracker(clock)
+        t.recordProgress()
+        clock.ns += ms(5_000)
+        let s = t.snapshot()
+        XCTAssertFalse(s.activeInference)
+        XCTAssertNil(s.activeInferenceAgeMs)
+        XCTAssertEqual(s.tokenAgeMs, 5_000)
+    }
+}

--- a/phase3-binary/Tests/macprovider-cliTests/ProviderStatusTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ProviderStatusTests.swift
@@ -60,6 +60,28 @@ final class ProviderStatusTests: XCTestCase {
         XCTAssertFalse(String(describing: body).contains("provider_token"))
     }
 
+    func testStatusResponseSurfacesModelLivenessTokenAndCapability() async throws {
+        // SPEC-025 §5.2: /v1/status exposes the model_liveness object and advertises
+        // model_liveness_token_v1. Assert structure/types (the shared tracker's
+        // numeric values are process-global and not fixed across tests).
+        let status = ProviderStatus(modelID: "m", modelLoaded: true, capacity: makeCapacity())
+        let snap = await status.snapshot()
+        let body = RouterHandler.statusResponse(snap, providerID: "provider-a", coordinatorURL: nil)
+
+        let contract = try XCTUnwrap(body["local_status_contract"] as? [String: Any])
+        let capabilities = try XCTUnwrap(contract["capabilities"] as? [String])
+        XCTAssertTrue(capabilities.contains("model_liveness_token_v1"))
+
+        let liveness = try XCTUnwrap(body["model_liveness"] as? [String: Any])
+        XCTAssertNotNil(liveness["token"] as? NSNumber, "token must be a number")
+        XCTAssertNotNil(liveness["active_inference"] as? Bool, "active_inference must be a bool")
+        // Age fields and last_advanced_at are present but may be JSON null before
+        // any progress; assert the keys exist.
+        XCTAssertTrue(liveness.keys.contains("token_age_ms"))
+        XCTAssertTrue(liveness.keys.contains("active_inference_age_ms"))
+        XCTAssertTrue(liveness.keys.contains("last_advanced_at"))
+    }
+
     func testStatusResponsePublishesVersionedLocalCapabilityContract() async throws {
         let status = ProviderStatus(modelID: "m", modelLoaded: true, capacity: makeCapacity())
         let snapshot = await status.snapshot()


### PR DESCRIPTION
## Summary

Implements **F2** of RFC-001 (#1383): surface a **model-thread liveness token**
on `/v1/status` so an out-of-process observer can distinguish a healthy provider
from a listener-alive / model-dead wedge. Normative contract is SPEC-025 §5.2
(capability `model_liveness_token_v1`) + SPEC-001 local-status contract (SPEC
bundle #1388, merged). **Observability-only**: the signal carries no
buyer-serving authority and does not gate admission; wiring it into a watchdog
restart decision is a deferred RFC-001 follow-up. Passed a 3-lane codex BUILD
audit (code/security/architect, `gpt-5.5` high) to **0 CRITICAL/HIGH/MEDIUM**.

### Changes
- **`ModelLivenessTracker.swift`** (new): process-scoped, `NSLock`-guarded
  monotone progress token + monotonic-clock ages. `recordProgress()` advances
  the token on model forward progress; `beginInference`/`endInference` bracket
  active buyer work; `snapshot()` reads last-published values without blocking
  the model thread. The monotonic clock is sampled **inside the lock** and ages
  use a clamped `now>=then ? now-then : 0` helper (no wrapping underflow); the
  token increment saturates at `UInt64.max`. Token resets to 0 per
  process/service instance (never compared across `instance_id`). Clocks are
  injectable for tests.
- **`ModelRuntime.swift`**: `recordProgress()` at every model token-production
  site (warmup, non-streaming complete, streaming detokenizer loop, harmony/tools
  streaming path); `completeWithServedSnapshot`, `stream`, and the streaming
  `preflight()` bracketed with `beginInference()` / `defer endInference()` so a
  pre-first-token wedge is observable as `active_inference: true`.
- **`HTTPServer.swift`**: `/v1/status` emits the `model_liveness` object
  {`token`, `token_age_ms`, `active_inference`, `active_inference_age_ms`,
  `last_advanced_at`} and advertises `model_liveness_token_v1`. Ages come from
  the monotonic snapshot; `last_advanced_at` is diagnostic wall-clock.
- **Tests**: `ModelLivenessTrackerTests` (8: fresh / advance / monotone /
  active-lifecycle / progress-resets-active-age / backward-clock-clamp / nested /
  idle-not-wedge) + a `ProviderStatus` `/v1/status` integration test asserting the
  object + capability. `swift build` clean; 50 filtered tests green.

### Carried LOW findings (non-blocking, per stop-on-0/0/0)
- Age fields are serialized via `Double` (`nullableNumber`); values stay integral
  and exact for any real uptime (< 2^53 ms), so the observable wire shape is an
  integer. A follow-up could add an exact `uint64|null` helper.
- The hot model path and `/v1/status` reader share one `NSLock`; the critical
  section is tiny and calls nothing into the model, so no contention/deadlock
  risk today.

Depends on #1388 (SPEC bundle, merged); builds on F1 (#1390, merged).

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "issue": "https://github.com/Augustas11/macprovider/issues/1383",
  "specs": ["SPEC-025", "SPEC-001"],
  "requirements": ["SPEC-020-R005"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["DECISION_REQUIRED"],
  "tests": ["phase3-binary swift test --filter ModelLivenessTrackerTests", "phase3-binary swift test --filter ProviderStatusTests"],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
