### PR TITLE
F3 (RFC-001 #1384): runtime test for domain-aware watchdog target

### DIFF
--- a/phase3-binary/dist/test/install_headless_fleet.test.sh
+++ b/phase3-binary/dist/test/install_headless_fleet.test.sh
@@ -91,6 +91,37 @@ if bad:
     raise SystemExit("hardcoded GUI launchd reference in watchdog script:\n" + "\n".join(bad))
 PY
 
+# RFC-001 F3 (#1384): the static check above rejects a hardcoded gui/ target;
+# this RUNTIME check exercises the deployed watchdog's launchd target selection
+# to prove it is domain-aware — system/<label> under MACPROVIDER_LAUNCHD_DOMAIN=
+# system (headless_fleet), gui/<uid>/<label> otherwise (consumer_user).
+ADAPTER_SNIPPET="$TMP/watchdog-launchd-adapter.sh"
+python3 - "$INSTALL_SH" "$ADAPTER_SNIPPET" <<'PY'
+import sys
+
+text = open(sys.argv[1], encoding="utf-8").read()
+marker = "write_atomic_install_file \"$WATCHDOG_PATH\" 0755 <<'WATCHDOG_EOF'"
+start = text.index(marker) + len(marker)
+end = text.index("\nWATCHDOG_EOF", start)
+watchdog = text[start:end]
+begin = watchdog.index('LAUNCHD_DOMAIN="${MACPROVIDER_LAUNCHD_DOMAIN')
+fn = watchdog.index("launchd_service_target()", begin)
+close = watchdog.index("\n}", fn) + 2
+open(sys.argv[2], "w", encoding="utf-8").write(watchdog[begin:close] + "\n")
+PY
+
+consumer_target="$(unset MACPROVIDER_LAUNCHD_DOMAIN; LABEL=live.malibu.provider; . "$ADAPTER_SNIPPET"; launchd_service_target)"
+if [ "$consumer_target" != "gui/$(id -u)/live.malibu.provider" ]; then
+  echo "consumer_user watchdog target is not GUI-domain: $consumer_target" >&2
+  exit 1
+fi
+system_target="$(MACPROVIDER_LAUNCHD_DOMAIN=system; LABEL=live.malibu.provider; . "$ADAPTER_SNIPPET"; launchd_service_target)"
+if [ "$system_target" != "system/live.malibu.provider" ]; then
+  echo "headless_fleet watchdog target is not system-domain: $system_target" >&2
+  exit 1
+fi
+echo "[install-headless-fleet-test] watchdog launchd target is domain-aware (consumer=$consumer_target headless=$system_target)"
+
 mkdir -p "$TMP/bin" "$TMP/home/.config/macprovider/launchd" "$TMP/system" "$TMP/users/other/Library/LaunchAgents"
 
 cat > "$TMP/bin/sudo" <<'EOF'


### PR DESCRIPTION
## Summary

**F3** of RFC-001 (#1384): add a **runtime** test proving the deployed watchdog's
launchd target selection is domain-aware. **No production code change** — the
behavior already ships.

### Finding
The domain-aware target RFC-001 `[^domain]` / #1384 described as missing is
**already implemented and CI-tested** in the deployed `install.sh` watchdog:
`LAUNCHD_DOMAIN="${MACPROVIDER_LAUNCHD_DOMAIN:-gui/$(id -u)}"` +
`launchd_service_target()` + `launchctl_run` (which uses `/bin/launchctl` for the
system domain), with `MACPROVIDER_LAUNCHD_DOMAIN=system` set in the headless
watchdog plist. The RFC footnote read the GUI-only *standalone reference* copy
(`ops/macprovider-watchdog/watchdog.sh`), which the `watchdog-inline-drift`
check deliberately normalizes away — not the shipping copy. Editing the
standalone would be redundant and would break the drift check.

### Change
`install_headless_fleet.test.sh` already statically rejects any hardcoded `gui/`
and asserts the headless plist env + `enable system/live.malibu.provider`. This
adds the **runtime** assertion #1384's AC asked for: extract the deployed
watchdog's launchd adapter and prove target selection —
`system/live.malibu.provider` under `MACPROVIDER_LAUNCHD_DOMAIN=system`
(headless_fleet), `gui/<uid>/live.malibu.provider` otherwise (consumer_user).
Runs under `make test-dist`; no macOS-only dependency (Bash/Python/`id -u`).

Code-lane codex review: 0 C/H/M (one LOW — temp-file cleanup — fixed by using the
trapped `$TMP`).

Refs SPEC-020 R-4.14. Closes #1384.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "issue": "https://github.com/Augustas11/macprovider/issues/1384",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R005"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["DECISION_REQUIRED"],
  "tests": ["phase3-binary/dist/test/install_headless_fleet.test.sh"],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
