### PR TITLE
test(f5): isolate MACPROVIDER_WATCHDOG_STATE_DIR in heartbeat golden-frame test (#1386 fast-follow)

### DIFF
--- a/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift
@@ -2665,6 +2665,27 @@ final class CoordinatorClientTests: XCTestCase {
     }
 
     func testHeartbeatDisabledModeOmitsBothFields() async throws {
+        // RFC-001 §7 / F5: make the golden-frame check hermetic. sendHeartbeat reads
+        // SupervisorBeaconReader.lastWireObject() at the default beacon path
+        // (MACPROVIDER_WATCHDOG_STATE_DIR, else ~/.local/share/macprovider-watchdog/state),
+        // so on a dev Mac running a live watchdog a real supervisor-beacon.json would make
+        // the heartbeat carry last_supervisor_event and break the exact-frame equality.
+        // Point the reader at an empty temp dir for this test so the omitted-beacon
+        // assertion is isolated, not dependent on ambient absence.
+        let beaconStateDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("f5-hermetic-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: beaconStateDir, withIntermediateDirectories: true)
+        let priorBeaconStateDir = ProcessInfo.processInfo.environment["MACPROVIDER_WATCHDOG_STATE_DIR"]
+        setenv("MACPROVIDER_WATCHDOG_STATE_DIR", beaconStateDir.path, 1)
+        defer {
+            if let priorBeaconStateDir {
+                setenv("MACPROVIDER_WATCHDOG_STATE_DIR", priorBeaconStateDir, 1)
+            } else {
+                unsetenv("MACPROVIDER_WATCHDOG_STATE_DIR")
+            }
+            try? FileManager.default.removeItem(at: beaconStateDir)
+        }
+
         let recorder = CoordinatorFrameRecorder()
         let capacity = ProviderCapacity(maxContextOverride: 20_000, maxConcurrencyOverride: 1)
         let status = ProviderStatus(


### PR DESCRIPTION
## Test-hermeticity fast-follow for F5 (#1386 / PR #1393)

`testHeartbeatDisabledModeOmitsBothFields` asserts the exact heartbeat frame. F5's
`sendHeartbeat` reads `SupervisorBeaconReader.lastWireObject()` at the default beacon
path (`MACPROVIDER_WATCHDOG_STATE_DIR`, else `~/.local/share/macprovider-watchdog/state`),
so the omitted-`last_supervisor_event` assertion previously depended on the AMBIENT
absence of a real beacon — a dev Mac running a live watchdog would flake it.

This points `MACPROVIDER_WATCHDOG_STATE_DIR` at a fresh empty temp dir for the test's
duration (restored via `defer`, incl. the unset-when-previously-absent branch), making
the assertion hermetic. Test-only; no production code changes; the existing
`XCTAssertNil(last_supervisor_event)` gate and exact-frame equality are retained
unchanged (strengthened, not weakened).

Verified: compiles; heartbeat golden + `last_supervisor_event`-nil assertions pass;
`setenv` is reflected in `ProcessInfo.processInfo.environment` so `beaconURL()` honors
the override; clean-env CI is the authoritative swift verification.

Note: the advisory `spec-index / check` is red on `main` (and thus on this PR) for the
known SPEC-010-R002 signed-journey re-sign (operator-gated fast-follow) and unrelated
SPEC-016-R002 date-expiry — neither is introduced by this diff.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "issue": "https://github.com/Augustas11/macprovider/issues/1386",
  "specs": ["SPEC-001", "SPEC-025"],
  "requirements": ["SPEC-020-R005"],
  "authority_domains": ["provider-wire-protocol"],
  "arbitration": ["DECISION_REQUIRED"],
  "tests": ["phase3-binary/Tests/macprovider-cliTests/CoordinatorClientTests.swift::testHeartbeatDisabledModeOmitsBothFields"],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
