### PR TITLE
fix(autotune): bound candidate-log filename to NAME_MAX (#1397)

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/CandidateProviderRunner.swift
+++ b/phase3-binary/Sources/macprovider-cli/CandidateProviderRunner.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Darwin
 import Foundation
 import MacProviderCore
@@ -464,7 +465,43 @@ final class CandidateProviderRunner {
         // 8 chars of a UUID gives ~32 bits of disambiguation per second.
         let timestamp = Int(Date().timeIntervalSince1970)
         let suffix = UUID().uuidString.prefix(8)
-        return directory.appendingPathComponent("\(safeModelName(model))-\(port)-\(timestamp)-\(suffix).log")
+        return directory.appendingPathComponent("\(boundedLogModelComponent(model))-\(port)-\(timestamp)-\(suffix).log")
+    }
+
+    /// Upper bound, in bytes, on the model component of a candidate log
+    /// filename. The remaining `-<port>-<timestamp>-<uuid8>.log` suffix is
+    /// ~31 bytes, so a 160-byte model component keeps the whole name well
+    /// under the 255-byte POSIX `NAME_MAX`.
+    static let maxLogModelComponentBytes = 160
+
+    /// Filesystem-safe, length-bounded rendering of `model` for a log
+    /// filename. Autotune passes a fully-qualified model identity that
+    /// flattens the absolute artifact path plus two SHA-256 digests; on a Mac
+    /// whose (Apple-ID-derived) username is long, the verbatim `safeModelName`
+    /// form overran `NAME_MAX` and the `.atomic` log write failed with a Cocoa
+    /// "file name is invalid" error — aborting `autotune --recommend --apply`
+    /// and blocking provider onboarding (#1397). Short identities are used
+    /// verbatim; long ones keep a readable prefix and append a stable short
+    /// digest of the full identity so distinct models never collide.
+    static func boundedLogModelComponent(_ model: String) -> String {
+        let safe = safeModelName(model)
+        guard safe.utf8.count > maxLogModelComponentBytes else { return safe }
+        let digest = SHA256.hash(data: Data(model.utf8))
+            .prefix(8)
+            .map { String(format: "%02x", $0) }
+            .joined()
+        let prefixBudget = maxLogModelComponentBytes - 1 - digest.count
+        // Append whole UTF-8 scalars until the next would exceed the byte
+        // budget; never split a multi-byte sequence.
+        var prefix = ""
+        var used = 0
+        for scalar in safe.unicodeScalars {
+            let width = String(scalar).utf8.count
+            if used + width > prefixBudget { break }
+            prefix.unicodeScalars.append(scalar)
+            used += width
+        }
+        return "\(prefix)-\(digest)"
     }
 
     private static func makeCandidateConfigRoot() throws -> URL {

--- a/phase3-binary/Tests/macprovider-cliTests/CandidateProviderRunnerTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/CandidateProviderRunnerTests.swift
@@ -300,6 +300,44 @@ final class CandidateProviderRunnerTests: XCTestCase {
         XCTAssertNotEqual(urlA.lastPathComponent, urlB.lastPathComponent)
     }
 
+    /// #1397 regression: autotune passes a fully-qualified model identity
+    /// (flattened absolute artifact path + two SHA-256 digests). On a Mac with
+    /// a long (Apple-ID-derived) username the verbatim filename exceeded
+    /// `NAME_MAX` and the `.atomic` log write failed, aborting
+    /// `autotune --recommend --apply` and blocking onboarding. The filename
+    /// MUST stay under NAME_MAX regardless of identity length.
+    func testLogFileURLStaysUnderNameMaxForLongModelIdentity() throws {
+        let longHome = "/Users/a-twenty-eight-char-username-x/Library/Application Support/macprovider/models"
+        let model = "\(longHome)/mlx-community/Llama-3.2-3B-Instruct-4bit/"
+            + String(repeating: "7f0dc925", count: 5)   // 40-char commit-sha stand-in
+            + "/"
+            + String(repeating: "e7e5bff4", count: 8)   // 64-char artifact-sha stand-in
+        let url = CandidateProviderRunner.logFileURLForTesting(model: model, port: 18_080)
+        let nameBytes = Data(url.lastPathComponent.utf8).count
+        XCTAssertLessThanOrEqual(
+            nameBytes, 255,
+            "log filename is \(nameBytes)B, over NAME_MAX for a long model identity"
+        )
+        XCTAssertTrue(url.lastPathComponent.hasSuffix(".log"))
+    }
+
+    /// Distinct long model identities that share a prefix MUST still produce
+    /// distinct bounded components — the appended digest disambiguates.
+    func testBoundedLogModelComponentDisambiguatesLongIdentities() {
+        let base = String(repeating: "mlx-community-model-", count: 20) // exceeds the byte budget
+        let a = CandidateProviderRunner.boundedLogModelComponent(base + "alpha")
+        let b = CandidateProviderRunner.boundedLogModelComponent(base + "beta")
+        XCTAssertLessThanOrEqual(Data(a.utf8).count, CandidateProviderRunner.maxLogModelComponentBytes)
+        XCTAssertLessThanOrEqual(Data(b.utf8).count, CandidateProviderRunner.maxLogModelComponentBytes)
+        XCTAssertNotEqual(a, b, "distinct long identities collided after length-bounding")
+    }
+
+    /// A short model identity is passed through verbatim (no digest suffix),
+    /// preserving the existing readable filenames.
+    func testBoundedLogModelComponentPassesShortIdentityVerbatim() {
+        XCTAssertEqual(CandidateProviderRunner.boundedLogModelComponent("mlx/test-model"), "mlx-test-model")
+    }
+
     func testServeArgumentsRejectInvalidKnobs() throws {
         XCTAssertThrowsError(
             try CandidateProviderRunner.serveArguments(


### PR DESCRIPTION
Fixes #1397.

## What

`CandidateProviderRunner.logFileURL` embedded `safeModelName(model)` verbatim, and `safeModelName` only sanitizes characters — it never bounds length. During `autotune --recommend --apply` the model identity is a fully-qualified string that flattens the absolute model-artifact path plus **two** SHA-256 digests. On a Mac whose (Apple-ID-derived) username is long (~28 chars is ordinary), the flattened `$HOME` path pushed the filename to **258 bytes against the 255-byte POSIX `NAME_MAX`**, so the `.atomic` log write threw a Cocoa "file name is invalid" error and aborted `--apply`.

Because `--apply` is the **only** source of `model_artifact_sha256`, and `serve` refuses to join a coordinator without it, **provider onboarding could not complete at all** on ordinary consumer Macs — the error named no cause and suggested no fix. CI never saw it because a runner named `runner` (6 chars) clears the limit.

## Fix

Add `boundedLogModelComponent(model)`:
- short identities pass through verbatim (existing readable filenames preserved);
- long ones keep a **byte-bounded** readable prefix (appending whole UTF-8 scalars only — never splitting a multibyte sequence) and append a stable **16-hex SHA-256 digest of the full identity**, so distinct models never collide.

`maxLogModelComponentBytes = 160`; the fixed `-<port>-<timestamp>-<uuid8>.log` suffix is ~31 bytes, keeping the whole filename comfortably under `NAME_MAX`. Only the log-**filename** derivation changes — `model_artifact_sha256` itself is untouched.

## Tests

- `testLogFileURLStaysUnderNameMaxForLongModelIdentity` — pathological long identity (flattened long-`$HOME` path + 40- and 64-char digest stand-ins) yields a filename ≤ 255 bytes.
- `testBoundedLogModelComponentDisambiguatesLongIdentities` — two long identities sharing a prefix stay distinct after bounding.
- `testBoundedLogModelComponentPassesShortIdentityVerbatim` — short identity unchanged.
- Existing `testLogFileURLsDoNotCollideWithinOneSecond` still passes (no regression).

`swift build` + these tests green locally.

## Audit

3-lane audit (code / security / architecture) — **0 CRITICAL / HIGH / MEDIUM across all three lanes (PASS)**. Run via Claude subagents this round because codex was at its usage limit. Highlights: security confirmed the digest is over the *full* identity (truncation can't induce collisions) and path traversal is neutralized by `safeModelName`; architecture swept for sibling filename sites and found **none unfixed** (DecodeBench `.prefix(80)`, DurableModelArtifactStore separate dir levels, ProviderStatsStore provider-ID-keyed — all already bounded).

Carried (LOW/INFO, non-blocking, follow-ups):
- **LOW** — front-truncation keeps the path *head*, so the readable prefix is largely nominal for long identities; the digest is the real disambiguator. Consider slicing the readable portion from the model tail in a follow-up.
- **INFO** — a truncated prefix ending on `-` yields a cosmetic `--<digest>`; harmless.
- **INFO** — a shared `FilenameComponent.bounded(...)` helper could later unify `safeModelName`, `sanitizeProviderID`, `decodeBenchSanitizeFilenameComponent`, and `escapedComponent` (larger refactor, out of scope).

## Context

Found in the BYOM v0.1 candidate E2E (#1381, @SmtTheSE) as finding **F1**. **Not BYOM-specific** — this is the autotune onboarding path shared by all providers. Pre-existing (present in deployed 1.8.117); does not block the auto-update of already-onboarded nodes (they reuse the persisted `model_artifact_sha256`), but blocks fresh onboarding on long-username Macs. Batches into the enriched 1.8.120 acceptance (#1396).

## Governance

`behavior_change: none` in the buyer/settlement/spec sense — this changes only a local log filename derivation on the provider onboarding path; no spec, contract, schema, or money-path surface changes.

<!-- SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "none",
  "contract_change": "none",
  "specs": [],
  "requirements": [],
  "authority_domains": [],
  "arbitration": [],
  "tests": ["swift test --filter CandidateProviderRunnerTests"],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
