### PR TITLE
fix(byom): operator guidance (F2/F5) + hermetic E2E harness (F8) (#1381)

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/BYOMDiscovery.swift
+++ b/phase3-binary/Sources/macprovider-cli/BYOMDiscovery.swift
@@ -1211,11 +1211,11 @@ enum BYOMModelAdmissionError: Error, Equatable, CustomStringConvertible {
         case .missingAdmissionIdentity(let providerID):
             return "provider admission signing identity is missing for \(providerID); start provider enrollment before offering BYOM models"
         case .candidateNotFound:
-            return "BYOM candidate was not found in local discovery"
+            return "BYOM candidate was not found in local discovery; target the offer by its served_model_ref (for example ollama:llama3.2:3b) rather than a candidate id. models offer provisions the local namespace and re-resolves a stable id, so an id copied from a first discover on a fresh namespace (a byom_unstable_… value) will no longer match"
         case .candidateUnstable:
-            return "BYOM candidate id is unstable; run models discover --json to initialize the local namespace"
+            return "BYOM candidate id is unstable; target the offer by its served_model_ref (for example ollama:llama3.2:3b) instead of the byom_unstable_… id. models offer provisions the local discovery namespace and resolves a stable id; re-running models discover alone will not, because discovery is read-only (SPEC-046-R001)"
         case .candidateNotOfferable:
-            return "BYOM candidate is not offerable; run models evaluate and models offer --dry-run --json before submitting"
+            return "BYOM candidate is not offerable; run models evaluate <ref> --json and pass the returned evaluation_digest_sha256 to models offer via --evaluation-digest-sha256. models evaluate does not persist state, so the evaluation_required warning clears only when you supply that digest; also resolve any blocking readiness warning"
         case .invalidEvaluationDigest:
             return "evaluation digest must be a 64-character lowercase SHA-256 hex value"
         case .invalidWithdrawalReason:
@@ -2849,6 +2849,36 @@ struct BYOMCatalogMatcher: Sendable {
     }
 }
 
+/// RAM detection for BYOM discovery's **advisory local-fit signal** only.
+///
+/// Production reads real hardware via `ModelFit.detectRAMGB()`. The
+/// hermetic BYOM E2E harness (`make test-byom-e2e`, #1381) drives the
+/// offer/economics flow with a fixed catalog fixture (`qwen3-8b`, ~16 GB
+/// estimate) that would report `does_not_fit` on a CI runner or an ordinary
+/// dev Mac and block the flow before the assertions under test. This override
+/// lets the harness supply a RAM value so the *fit logic still runs* (it is not
+/// bypassed) against a machine large enough for the fixture.
+///
+/// Deliberately scoped to BYOM discovery's local readiness signal, which is
+/// advisory QoS and — in v0.1 — cannot affect earning. It does NOT touch
+/// `ModelFit.detectRAMGB()` or autotune's global fit gating. A provider who set
+/// it in production could only mislead their own local BYOM readiness display
+/// (and risk OOMing their own machine); no money-path or coordinator decision
+/// consumes it.
+enum BYOMFitEnvironment {
+    static let overrideEnvVar = "MACPROVIDER_BYOM_E2E_DETECTED_RAM_GB"
+
+    static func detectedRAMGB(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Int {
+        if let raw = environment[overrideEnvVar]?.trimmingCharacters(in: .whitespaces),
+           let gb = Int(raw), gb > 0 {
+            return gb
+        }
+        return ModelFit.detectRAMGB()
+    }
+}
+
 struct BYOMMLXCacheDiscovery {
     private let cacheRoot: URL
     private let namespace: Data?
@@ -3099,7 +3129,7 @@ struct BYOMMLXCacheDiscovery {
     }
 
     private func fitState(modelID: String) -> String {
-        switch ModelFit.evaluate(modelID: modelID, ramGB: ModelFit.detectRAMGB()) {
+        switch ModelFit.evaluate(modelID: modelID, ramGB: BYOMFitEnvironment.detectedRAMGB()) {
         case .fits, .tight:
             return "fits"
         case .wontFit:
@@ -3254,7 +3284,7 @@ struct BYOMOllamaDiscovery: Sendable {
     }
 
     private func fitState(modelID: String) -> String {
-        switch ModelFit.evaluate(modelID: modelID, ramGB: ModelFit.detectRAMGB()) {
+        switch ModelFit.evaluate(modelID: modelID, ramGB: BYOMFitEnvironment.detectedRAMGB()) {
         case .fits, .tight:
             return "fits"
         case .wontFit:

--- a/phase3-binary/Tests/macprovider-cliTests/BYOMDiscoveryTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/BYOMDiscoveryTests.swift
@@ -5,6 +5,49 @@ import XCTest
 @testable import macprovider_cli
 
 final class BYOMDiscoveryTests: XCTestCase {
+    // #1381 F8 cause 2: the hermetic BYOM E2E harness supplies a RAM value so
+    // the fixture model's advisory local-fit signal does not report
+    // does_not_fit on CI/dev hardware. The override is honored only for a
+    // positive integer; anything else falls back to real detection.
+    func testBYOMFitEnvironmentHonorsScopedRAMOverride() {
+        XCTAssertEqual(
+            BYOMFitEnvironment.detectedRAMGB(environment: [BYOMFitEnvironment.overrideEnvVar: "64"]),
+            64
+        )
+        XCTAssertEqual(
+            BYOMFitEnvironment.detectedRAMGB(environment: [BYOMFitEnvironment.overrideEnvVar: " 48 "]),
+            48
+        )
+        let real = BYOMFitEnvironment.detectedRAMGB(environment: [:])
+        for invalid in ["0", "-4", "abc", ""] {
+            XCTAssertEqual(
+                BYOMFitEnvironment.detectedRAMGB(environment: [BYOMFitEnvironment.overrideEnvVar: invalid]),
+                real,
+                "invalid override \(invalid.debugDescription) should fall back to real detection"
+            )
+        }
+        XCTAssertEqual(BYOMFitEnvironment.detectedRAMGB(environment: [:]), real)
+    }
+
+    // #1381 F2/F5: operator-facing guidance must name the action that actually
+    // resolves the blocker, not a dead end.
+    func testBYOMModelAdmissionGuidancePointsToRecoveryActions() {
+        // F2: not-offerable names the digest input canSubmit requires.
+        XCTAssertTrue(
+            BYOMModelAdmissionError.candidateNotOfferable.description.contains("--evaluation-digest-sha256"),
+            "not-offerable guidance must name --evaluation-digest-sha256"
+        )
+        // F5: unstable / not-found point at the served_model_ref recovery target.
+        XCTAssertTrue(
+            BYOMModelAdmissionError.candidateUnstable.description.contains("served_model_ref"),
+            "unstable guidance must name served_model_ref"
+        )
+        XCTAssertTrue(
+            BYOMModelAdmissionError.candidateNotFound.description.contains("served_model_ref"),
+            "not-found guidance must name served_model_ref"
+        )
+    }
+
     func testDiscoverCommandEmitsClosedSchemaWithNullableAdvisoryFields() async throws {
         let root = try temporaryDirectory("byom-schema")
         let cache = root.appendingPathComponent("hf", isDirectory: true)

--- a/test/e2e/byom/run-cli-onboarding-e2e.py
+++ b/test/e2e/byom/run-cli-onboarding-e2e.py
@@ -377,6 +377,16 @@ def main():
         home.mkdir(mode=0o700)
         protected_root = temp_root / "protected-credentials"
         namespace = temp_root / "local-discovery.namespace"
+        # Seed the CLI-owned discovery salt before any command runs. `models
+        # discover` is read-only by SPEC-046-R001 and deliberately will not
+        # provision this salt itself; without it discovery emits byom_unstable_*
+        # ids carrying candidate_id_unstable (admission_state "local_only"), and
+        # the id changes again once `models evaluate` provisions the salt -- so
+        # discover and the dry-run would resolve different candidates. temp_root
+        # is an 0700 mkdtemp, so the CLI's private-parent and 0600-file checks
+        # both pass. (#1381 F8, cause 1)
+        namespace.write_bytes(secrets.token_bytes(32))
+        namespace.chmod(0o600)
         hf_cache = temp_root / "hf-cache"
         config = temp_root / "config.yaml"
         config.write_text(
@@ -396,6 +406,13 @@ def main():
             "MACPROVIDER_CONFIG": str(config),
             "MACPROVIDER_PROTECTED_CREDENTIAL_ROOT": str(protected_root),
             "MACPROVIDER_BYOM_ALLOW_INSECURE_LOOPBACK_COORDINATOR": "1",
+            # The catalog fixture (qwen3-8b, ~16 GB estimate) reports
+            # does_not_fit on CI runners and ordinary dev Macs, which would
+            # block the offer/economics flow this harness actually tests. Supply
+            # a RAM value so BYOM discovery's advisory local-fit signal treats
+            # the fixture as fitting; the fit logic still runs. Scoped to BYOM
+            # discovery only -- not autotune. (#1381 F8, cause 2)
+            "MACPROVIDER_BYOM_E2E_DETECTED_RAM_GB": "64",
         })
 
         common_discovery_args = [


### PR DESCRIPTION
Addresses #1381 findings **F2**, **F5**, and **F8** (from @SmtTheSE's BYOM v0.1 candidate E2E).

## F2 — offer-refusal guidance was a dead end (message-only)

`models offer` refused an `evaluation_required` candidate with "run models evaluate and models offer --dry-run --json before submitting." But `canSubmit` passes only when the evaluation digest is non-empty **or** the `evaluation_required` warning is absent — and `models evaluate` persists nothing, so that warning never clears. Following the message loops forever. The guidance now names the input that works: run `models evaluate <ref> --json` and pass its `evaluation_digest_sha256` via `--evaluation-digest-sha256`.

## F5 — unstable-id dead end (message-only)

A first `discover` on a fresh namespace returns a `byom_unstable_*` candidate id. `models offer` then **provisions the salt and re-discovers a stable id**, so the unstable id an operator copied no longer matches (`selectCandidate` matches `candidateID || servedModelRef || displayName`). The `candidateNotFound` / `candidateUnstable` guidance now tells the operator to target by `served_model_ref`, and that re-running `discover` alone won't help (discovery is read-only, SPEC-046-R001).

## F8 — `make test-byom-e2e` couldn't pass on `main`

Two independent causes:

- **Cause 1** — the harness set `--local-discovery-namespace-path` but never created the salt file, so `discover` emitted `byom_unstable_*` and the `offerable` assertion was unreachable. Seed the salt before any command runs (Steven's patch).
- **Cause 2** — the catalog fixture `qwen3-8b` (~16 GB estimate) reports `does_not_fit` on CI runners (~14 GB) and ordinary dev Macs, blocking the offer/economics flow the harness actually tests. A fixture swap is not viable: `catalogKey(for:)` matches the served-ref by lowercase equality against catalog `key`/`model_id`, `qwen3-8b` is the smallest **short-key** model, and the 3B model's only key is the org-prefixed `meta-llama/llama-3.2-3b-instruct` — an Ollama-style served name won't match it, so a swap would null `catalog_model_key` and break the `catalog_priced` assertions. Instead, add a **BYOM-discovery-scoped, hermetic-E2E-only** RAM override `MACPROVIDER_BYOM_E2E_DETECTED_RAM_GB` that the harness sets; the fit **logic still runs** against the supplied RAM. It is scoped to BYOM's advisory local-readiness signal — it does **not** touch `ModelFit.detectRAMGB()` or autotune's global fit gating, and no money-path or coordinator decision consumes BYOM `fitState` (v0.1 enables no earning). Worst case in production: a provider misleads their own local fit display / OOMs their own machine.

## Tests

`swift test` (BYOMDiscoveryTests): guidance-message assertions (F2/F5) + RAM-override fallback semantics (positive int honored; 0/negative/non-numeric/empty → real detection). Build + these tests green locally. `make test-byom-e2e` green must be confirmed on the Ollama-loopback + coordinator rig (a #1396 exit criterion; not runnable in per-PR CI, per the harness README).

## Audit

3-lane audit (code / security / architecture) via Claude subagents (codex at usage limit this round). **All three PASS — 0 CRITICAL / HIGH / MEDIUM.**

- **Security** grep-confirmed **no coordinator/gateway consumer of `fit_state`** — settlement is gated on cryptographic catalog material, so the override's blast radius is self-inflicted-only (own local display / own OOM). Salt uses a CSPRNG at 0600.
- **Architecture** confirmed the env-var seam is *required* (a Python→CLI subprocess boundary can't be crossed by in-process DI/test-initializers; an undocumented test-named env is lower-surface than a permanent CLI flag), verified the override is scoped to the two BYOM `fitState` sites (the 5 other `detectRAMGB` callers untouched), and independently **refuted the fixture-swap alternative** against the baked catalog.
- **Code** verified F2/F5 guidance is factually accurate against `canSubmit`/`selectCandidate`/`submitOffer` and that the salt seed satisfies `readNamespace`'s exact checks.

Carried (LOW/INFO follow-ups, non-blocking): (a) the RAM override isn't build-gated — a future hardening could fence it behind `MACPROVIDER_BYOM_ALLOW_INSECURE_LOOPBACK_COORDINATOR` (architecture deemed this no-action for this batch given the self-inflicted blast radius); (b) `candidateUnstable` is also reached on `namespacePermissionInvalid`, where a permissions fix is additionally needed — the message steers to `served_model_ref` (the primary recovery) but doesn't name that case; (c) the env read sits in a domain helper rather than composition-root injection (refactor quality).

## Context

Batches into the enriched **1.8.120** acceptance (#1396) alongside F1 (#1397, merged). Not a promotion by itself.

## Governance

`behavior_change: none` in the buyer/settlement/spec sense — operator-facing guidance text, a test harness, and a BYOM-only advisory-fit test seam. No spec, contract, schema, or money-path surface changes.

<!-- SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "none",
  "contract_change": "none",
  "specs": [],
  "requirements": [],
  "authority_domains": [],
  "arbitration": [],
  "tests": ["swift test --filter BYOMDiscoveryTests", "make test-byom-e2e (manual, real-runtime rig)"],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
