### PR TITLE
specs(SPEC-016-R002): demote to pending after signed payout-address journey evidence expired

### DIFF
--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -4890,7 +4890,7 @@
     {
       "requirement_id": "SPEC-016-R002",
       "spec_id": "SPEC-016",
-      "state": "conformant",
+      "state": "pending",
       "implementation": [
         "phase4-coordinator/internal/payout/addresses.go:AddressesService",
         "phase4-coordinator/internal/payout/addresses.go:ServePayoutChallenge",
@@ -4925,21 +4925,13 @@
       "journeys": [
         "JOURNEY-SPEC-016-PAYOUT-ADDRESS-REGISTRATION"
       ],
-      "evidence": [
-        {
-          "artifact": "commit:57d9813957b1421199b59e5b3f09488f7c9644cd",
-          "source": null,
-          "captured_at": "2026-08-05",
-          "expires_at": "2026-09-05"
-        },
-        {
-          "artifact": "sha256:cce4916a7a89b4edccb350b53cb6c1d48bb0a0e0d4479446d63634d4c8f8c90d",
-          "source": "journeys/evidence/spec016-r002-payout-address-20260805T054857Z.journey-result.signed.json",
-          "captured_at": "2026-08-05",
-          "expires_at": "2026-09-05"
-        }
-      ],
-      "gap": null
+      "evidence": [],
+      "gap": {
+        "verdict": "DECISION_REQUIRED",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/614",
+        "rationale": "The previously consumed signed SPEC-016-R002 journey evidence (spec016-r002-payout-address-20260805T054857Z) expired on 2026-09-05, so this row is no longer claimed conformant. Implementation and journey mappings remain as local coverage only. Restore conformant only after a fresh signed JOURNEY-SPEC-016-PAYOUT-ADDRESS-REGISTRATION envelope is produced by the protected promote-signed-payout-journey.yml workflow on main and consumed into CONFORMANCE."
+      }
     },
     {
       "requirement_id": "SPEC-016-R003",

--- a/specs/README.md
+++ b/specs/README.md
@@ -24,7 +24,7 @@ it can no longer drift. Do not hand-edit the table; edit each spec's
 | SPEC-013 | `malibu-cli autotune` subcommand | 0.3.1 | normative | pending | pending corpus migration | [SPEC-013-cli-autotune.md](SPEC-013-cli-autotune.md) |
 | SPEC-014 | Provider Portal (seller-facing web surface) | 0.10 | draft | pending | pending: 2 | [SPEC-014-provider-portal.md](SPEC-014-provider-portal.md) |
 | SPEC-015 | Verifiable inference receipts | 0.4.6 | normative | complete | conformant: 1, pending: 4 | [SPEC-015-receipts.md](SPEC-015-receipts.md) |
-| SPEC-016 | Provider payout pipeline (USDC on Base) | 0.1.26 | draft | pending | conformant: 1, pending: 10 | [SPEC-016-payout-pipeline.md](SPEC-016-payout-pipeline.md) |
+| SPEC-016 | Provider payout pipeline (USDC on Base) | 0.1.26 | draft | pending | pending: 11 | [SPEC-016-payout-pipeline.md](SPEC-016-payout-pipeline.md) |
 | SPEC-017 | Network Stats API | 0.2.0 | normative | pending | pending: 1 | [SPEC-017-network-stats-api.md](SPEC-017-network-stats-api.md) |
 | SPEC-018 | Agentic tool calling (provider-side response synthesis) | 0.2.7 | normative | pending | conformant: 1, pending: 1 | [SPEC-018-agentic-tool-calling.md](SPEC-018-agentic-tool-calling.md) |
 | SPEC-019 | Structured output (`response_format: json_schema`) | 0.2.5 | normative | pending | pending corpus migration | [SPEC-019-structured-output.md](SPEC-019-structured-output.md) |


### PR DESCRIPTION
## Why

`spec-index / check` is red on `main`. `SPEC-016-R002` (provider payout-address
registration — SPEC-016 §3 / FR-P1: challenge GET, EIP-712 proof-of-possession
POST, anti-replay, cooling-off, rotation) was still claimed `conformant` on
signed journey evidence that expired **2026-09-05**:

```
specs/CONFORMANCE.json.requirements[144].evidence[0]: evidence expired on 2026-09-05
specs/CONFORMANCE.json.requirements[144].evidence[1]: evidence expired on 2026-09-05
SPEC-016-R002.evidence[1].source.signed.expires_at: signed journey-result expired on 2026-09-05
SPEC-016-R002: sensitive conformant requirement requires valid signed journey-result evidence
```

The `payout-lifecycle` authority domain sets `requires_signed_journey_result:
true`, so a sensitive conformant requirement must be backed by a **current**
signed journey-result. Per `specs/PROCESS.md`, expired evidence fails validation
rather than silently downgrading, so the claim has to be withdrawn explicitly.

## What changed

One requirement row in `specs/CONFORMANCE.json`, following the
`SPEC-043-R001`/`SPEC-043-R002` expired-evidence demotion precedent already in
the same file:

- `state`: `conformant` → `pending`
- `evidence`: the two expired records → `[]`
- `gap`: `null` → `DECISION_REQUIRED`, owner `@Augustas11`, issue #614, with the
  recapture condition in the rationale
- `implementation`, `tests`, and `journeys` arrays are retained unchanged as
  local coverage only

`specs/README.md` is the generated spec index, regenerated by
`scripts/gen_spec_index.py`; the SPEC-016 row becomes `pending: 11`.

Deliberately **not** done:

- `expires_at` was not extended on the old artifacts — that would be a fake
  recapture.
- The tracked historical artifacts
  `journeys/evidence/spec016-r002-payout-address-20260805T054857Z.*` are left in
  place.
- No payout Go handler, test, or workflow was touched.
- The protected signing workflow was not dispatched as a substitute for this
  demotion.

`SPEC-016` is `draft` / `implementation_status: partial` /
`production_status: not-deployed`, so demoting R002 does not trip the
"all owned requirements must be conformant" rule.

## Restoring conformant

Requires a fresh signed `JOURNEY-SPEC-016-PAYOUT-ADDRESS-REGISTRATION` envelope
produced by the protected `.github/workflows/promote-signed-payout-journey.yml`
workflow (`workflow_dispatch` on `main`, `production-release` environment,
`promotion_confirmed=true`, source SHA equal to `origin/main`) and consumed into
CONFORMANCE. That path is not mergeable as a PR, which is why this demotion
lands first.

## Verification

```
python3 scripts/check_spec_governance.py --base-ref origin/main
```

All four `SPEC-016-R002` errors are gone. One pre-existing, unrelated error
remains and is **also present on `origin/main` at `7d1ce3c4`** (out of scope,
owned by a separate change):

```
specs/CONFORMANCE.json.requirements[6]: commit evidence 6a2278f4... does not match
current mapped selector fragment 'sendHeartbeat' in
'phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift'
```

```
python3 scripts/gen_spec_index.py --check   -> ok: spec index is up to date
python3 -m unittest scripts.tests.test_spec_governance scripts.tests.test_spec_pr_declaration
```

The one unittest failure asserts a clean whole-repo governance run and fails
identically on `origin/main` for the same `sendHeartbeat` reason; it is not
introduced here.

## Audit

Three lanes over the full diff — code review, security review, architecture
review. Gate met: **0 CRITICAL, 0 HIGH, 0 MEDIUM.**

- Code review: APPROVE, 0 findings, 1 INFO (the pre-existing `sendHeartbeat`
  error).
- Security review: 0 C/H/M/LOW, 2 INFO. Confirmed the demotion is the
  integrity-preserving action, no control or trust claim is weakened, and the
  validator rejects re-promotion to `conformant` with empty evidence.
- Architecture review: PASS, 0 C/H/M, 1 LOW — suggested `UNKNOWN` instead of
  `DECISION_REQUIRED`. Carried as LOW: `DECISION_REQUIRED` matches the SPEC-043
  expired-evidence precedent for the identical situation, and the row is
  nonconformant, owned, issue-linked, and has a concrete recovery condition
  either way.

<!-- SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "none",
  "contract_change": "yes",
  "specs": ["SPEC-016"],
  "requirements": ["SPEC-016-R002"],
  "authority_domains": ["payout-lifecycle"],
  "arbitration": ["DECISION_REQUIRED"],
  "issue": "https://github.com/Augustas11/macprovider/issues/614",
  "tests": ["python3 scripts/check_spec_governance.py --base-ref origin/main", "python3 scripts/gen_spec_index.py --check", "python3 -m unittest scripts.tests.test_spec_governance scripts.tests.test_spec_pr_declaration"],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END -->
