### PR TITLE
governance(SPEC-010-R002): demote to pending after sendHeartbeat selector drift

### DIFF
--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -1621,7 +1621,7 @@
     {
       "requirement_id": "SPEC-010-R002",
       "spec_id": "SPEC-010",
-      "state": "conformant",
+      "state": "pending",
       "implementation": [
         "phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift:authInitialMessage",
         "phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift:sendHeartbeat",
@@ -1635,21 +1635,13 @@
       "journeys": [
         "JOURNEY-PROVIDER-PREBETA-ADMISSION"
       ],
-      "evidence": [
-        {
-          "artifact": "commit:6a2278f4f678abcc91361d0d6f008649e63b6fc3",
-          "source": null,
-          "captured_at": "2026-07-27",
-          "expires_at": "2026-10-27"
-        },
-        {
-          "artifact": "sha256:288348caef7f3c92f3028cbc34cb92b5697e14d8b85c5f329f4d7145ddb1253a",
-          "source": "journeys/evidence/provider-prebeta-admission-air5-qwen-20260727T042339Z.journey-result.signed.json",
-          "captured_at": "2026-07-27",
-          "expires_at": "2026-10-27"
-        }
-      ],
-      "gap": null
+      "evidence": [],
+      "gap": {
+        "verdict": "DECISION_REQUIRED",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/614",
+        "rationale": "Commit evidence 6a2278f4f678abcc91361d0d6f008649e63b6fc3 no longer matches the current CoordinatorClient.swift:sendHeartbeat declaration fragment (the heartbeat path has since gained F5 supervisor telemetry, warm-swap runtime identity, and catalog wire model id handling), so the consumed 2026-07-27 signed JOURNEY-PROVIDER-PREBETA-ADMISSION envelope no longer pins the code it attested and this row cannot stay conformant. Implementation, test, and journey mappings remain as local coverage only. Restore conformant only after a fresh signed JOURNEY-PROVIDER-PREBETA-ADMISSION promotion produced by the protected main workflow .github/workflows/promote-signed-provider-prebeta-journey.yml, whose repository.commit rematches every live mapped implementation and test selector fragment for this row, including sendHeartbeat."
+      }
     },
     {
       "requirement_id": "SPEC-010-R003",

--- a/specs/README.md
+++ b/specs/README.md
@@ -18,7 +18,7 @@ it can no longer drift. Do not hand-edit the table; edit each spec's
 | SPEC-007 | Internal Operator Protocol Explorer | 0.5.1 | normative | pending | pending corpus migration | [SPEC-007-explorer.md](SPEC-007-explorer.md) |
 | SPEC-008 | Tier-2 Trust Layer | 0.6.1 | normative | pending | pending: 1 | [SPEC-008-tier2.md](SPEC-008-tier2.md) |
 | SPEC-009 | MacProvider Console v2 | 0.1 | normative | pending | pending corpus migration | [SPEC-009-console-v2.md](SPEC-009-console-v2.md) |
-| SPEC-010 | Provider Model Catalog | 1.6 | normative | pending | conformant: 5, pending: 1 | [SPEC-010-model-catalog.md](SPEC-010-model-catalog.md) |
+| SPEC-010 | Provider Model Catalog | 1.6 | normative | pending | conformant: 4, pending: 2 | [SPEC-010-model-catalog.md](SPEC-010-model-catalog.md) |
 | SPEC-011 | Operator-Pushed Warm Swap | 0.5 | normative | pending | pending corpus migration | [SPEC-011-operator-pushed-warm-swap.md](SPEC-011-operator-pushed-warm-swap.md) |
 | SPEC-012 | Coordinator Demand-Pull Model Swap and Buyer Cold-Model Visibility | 0.3 | draft | pending | pending corpus migration | [SPEC-012-coordinator-demand-pull.md](SPEC-012-coordinator-demand-pull.md) |
 | SPEC-013 | `malibu-cli autotune` subcommand | 0.3.1 | normative | pending | pending corpus migration | [SPEC-013-cli-autotune.md](SPEC-013-cli-autotune.md) |


### PR DESCRIPTION
## What

Demote `SPEC-010-R002` in `specs/CONFORMANCE.json` from `conformant` to `pending` with an owned `DECISION_REQUIRED` gap, and regenerate `specs/README.md`.

## Why

`scripts/check_spec_governance.py` requires that, for every `conformant` row, each mapped selector fragment be byte-identical between the row's commit evidence and HEAD. `SPEC-010-R002` pins commit `6a2278f4f678abcc91361d0d6f008649e63b6fc3`, and its mapping
`phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift:sendHeartbeat` has since drifted (F5 supervisor telemetry, warm-swap runtime identity, catalog wire model id). `spec-index` was therefore red with:

```
error: specs/CONFORMANCE.json.requirements[6]: commit evidence 6a2278f4f678abcc91361d0d6f008649e63b6fc3 does not match current mapped selector fragment 'sendHeartbeat' in 'phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift'
```

The consumed 2026-07-27 signed `JOURNEY-PROVIDER-PREBETA-ADMISSION` envelope is still date-valid until 2026-10-27, but it no longer pins the code it attested. Signed `repository.commit` must equal the commit evidence, so the SHA cannot be bumped without a fresh signed journey, and recapture runs only through the protected main workflow `.github/workflows/promote-signed-provider-prebeta-journey.yml`. The honest, mergeable ledger fix is to withdraw the conformance claim.

## What changed

Follows the existing `SPEC-043-R001` expired-evidence pattern in the same file:

- `state`: `conformant` -> `pending`
- `evidence`: cleared to `[]`
- `gap`: added `DECISION_REQUIRED`, owner `@Augustas11`, issue #614, with the restore path
- `implementation`, `tests`, `journeys`: unchanged (local coverage retained)
- `specs/README.md`: regenerated by `scripts/gen_spec_index.py` (SPEC-010 now `conformant: 4, pending: 2`)

No other requirement is touched. No Swift or Go code changed. No `expires_at` extended.

## Why not retarget the selector

Verified with `check_spec_governance._commit_mapping_selector_matches_current` against commit `6a2278f4` and HEAD: of the six R002 mappings, only `sendHeartbeat` fails. The other still-matching selectors in that Swift file are `sendHeartbeatForTest` (a thin wrapper that delegates to the same mutable implementation) and `coordinatorWireModelID` (`model_id` aliasing, not R002). Neither emits the typed `model_hash` + `model_hash_algorithm` pair this requirement governs, so retargeting to either would preserve a green row while dropping the behavioral binding.

## Verification

- `python3 scripts/check_spec_governance.py --base-ref origin/main` — the `sendHeartbeat` selector error is gone. The four remaining errors are the pre-existing `SPEC-016-R002` expiry (2026-09-05), which also fail on clean `origin/main` and are out of scope here.
- `python3 scripts/gen_spec_index.py --check` — `ok: spec index is up to date`
- `python3 -m unittest scripts.tests.test_spec_governance scripts.tests.test_spec_pr_declaration` — 61 tests, 1 failure, which is the same pre-existing `SPEC-016-R002` real-corpus expiry failure present on `origin/main`.

## Audit

Three Codex lanes over the full diff — code review, security review, architecture review: **0 CRITICAL, 0 HIGH, 0 MEDIUM**. Carried notes are INFO/LOW: the unrelated `SPEC-016-R002` expiry, and a systemic observation that declaration-wide fragment pinning will keep producing this class of churn when a narrow contract maps to a broad function.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "none",
  "contract_change": "yes",
  "specs": ["SPEC-010"],
  "requirements": ["SPEC-010-R002"],
  "authority_domains": ["model-catalog-identity"],
  "arbitration": ["DECISION_REQUIRED"],
  "tests": ["scripts/tests/test_spec_governance.py", "scripts/tests/test_spec_pr_declaration.py"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/614"
}
SPEC-GOVERNANCE-DECLARATION-END
