### PR TITLE
ops(coordinator): bump staged latest_binary_version 1.8.105->1.8.117

### DIFF
--- a/phase4-coordinator/coordinator.yaml.example
+++ b/phase4-coordinator/coordinator.yaml.example
@@ -189,7 +189,7 @@ autotune:
 # legacy cohort (DECISION_CRITERIA Entry 161). `required_binary_version` is a
 # hard admission floor, not an autoupdate target, and is unaffected by the gate.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.105"
+  latest_binary_version: "1.8.117"
   required_binary_version: ""
 
 auth:

--- a/phase4-coordinator/dist/coordinator.yaml
+++ b/phase4-coordinator/dist/coordinator.yaml
@@ -389,5 +389,5 @@ providers:
 # reconnecting and tells its operator to upgrade, and one without it
 # reconnect-loops.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.105"
+  latest_binary_version: "1.8.117"
   required_binary_version: "1.8.33"

--- a/phase4-coordinator/dist/coordinator.yaml.example
+++ b/phase4-coordinator/dist/coordinator.yaml.example
@@ -422,7 +422,7 @@ malibu_emission:
 # routing. Keys match model_id case-insensitively; values must be bare
 # numeric versions or the coordinator refuses to start.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.105"
+  latest_binary_version: "1.8.117"
   # required_binary_version: "1.7.0"
   # per_model_required_binary_version:
   #   "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit": "1.8.60"


### PR DESCRIPTION
## What

Bump the checked-in coordinator staged advertised-version `latest_binary_version` from **1.8.105 → 1.8.117** in all three configs:
- `phase4-coordinator/dist/coordinator.yaml`
- `phase4-coordinator/coordinator.yaml.example`
- `phase4-coordinator/dist/coordinator.yaml.example`

`required_binary_version` floor is unchanged.

## Why

The 1.8.120 acceptance-candidate promotion fails at its **pre-publication live-coordinator feed gate**:

```
[verify-live-coordinator-release-gate] ERROR: /healthz recommended_binary_version '1.8.117'
  does not match expected previous stable 1.8.105
```

`scripts/release-staged-version-policy.sh` derives the staged previous-stable from these configs' `latest_binary_version`. That value drifted to `1.8.105` while the fleet advanced to `1.8.117` out-of-band (Pearl-side recommendation bumps for 1.8.106–1.8.117 never touched the checked-in configs). The gate then demands the live coordinator (`coordinator.malibu.tech`, which correctly serves `recommended_binary_version: 1.8.117`) still advertise the stale `1.8.105`, and fails.

`1.8.117` is the true current stable — it matches both the live coordinator and the last published stable GitHub release (`v1.8.117`). `1.8.117 < 1.8.120` preserves the staged-release invariant (checked-in config holds the *previous* stable until 1.8.120 is public).

## Verification

- `scripts/release-staged-version-policy.sh v1.8.120` → `MACPROVIDER_RELEASE_PREVIOUS_STABLE_VERSION='1.8.117'`, staged=true ✅
- `scripts/test-live-coordinator-release-gate.sh` → PASS ✅
- `scripts/test-release-security-posture.sh` → PASS ✅
- `make test-dist` → all pass except `coord_deploy_tier2_migration_gate.test.sh`, which fails identically on clean `origin/main` due to the `/private/tmp` worktree ownership/mode (env-only, not this change) — passes on CI workspace perms.

Config value only; no runtime/schema/executable change.

<!-- SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R001"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": ["scripts/test-live-coordinator-release-gate.sh", "scripts/test-release-security-posture.sh"],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END -->
