### PR TITLE
Fix SPEC-045 ambiguous-send budget exposure

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift
@@ -719,6 +719,7 @@ final class ConsumeUpstreamCancellationHandle: @unchecked Sendable {
 
 enum ConsumeUpstreamForwardError: Error {
     case preDispatchUnavailable
+    case possiblyDispatchedUnavailable
     case dispatchedUnavailable
 }
 
@@ -742,6 +743,7 @@ struct ConsumeUpstreamTimeouts: Sendable {
 private struct ConsumeUpstreamFailureClassification {
     let status: HTTPResponseStatus
     let forwardedUpstream: Bool
+    let mayHaveDispatched: Bool
 }
 
 private final class ConsumeChunkedBodyDecoder: @unchecked Sendable {
@@ -1350,7 +1352,7 @@ final class ConsumePinnedUpstreamClient: ConsumeUpstreamClient, @unchecked Senda
             }
             deadline.schedule(nanoseconds: timeoutNanoseconds) {
                 connection.cancel()
-                finish(.failure(ConsumeUpstreamForwardError.preDispatchUnavailable))
+                finish(.failure(ConsumeUpstreamForwardError.possiblyDispatchedUnavailable))
             }
             connection.send(content: data, completion: .contentProcessed { error in
                 if let error {
@@ -1363,7 +1365,9 @@ final class ConsumePinnedUpstreamClient: ConsumeUpstreamClient, @unchecked Senda
     }
 
     private static func classifySendFailure(_ error: Error) -> ConsumeUpstreamForwardError {
-        .preDispatchUnavailable
+        // After submitting content, neither an error nor cancellation proves that
+        // no bytes were sent. Retain exposure without claiming confirmed forwarding.
+        .possiblyDispatchedUnavailable
     }
 
     static func sendFailureClassificationForTesting(_ error: Error) -> ConsumeUpstreamForwardError {
@@ -5656,7 +5660,7 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
                             estimate: estimate.amount
                         )
                         return
-                    } else if failure.forwardedUpstream {
+                    } else if failure.mayHaveDispatched {
                         try ledger.hold(
                             runID: self.runtime.launchID,
                             reservationID: reservationID,
@@ -5873,7 +5877,7 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
                             settledAmount: estimate.amount,
                             reason: "settled_to_admission_estimate"
                         )
-                    } else if failure.forwardedUpstream {
+                    } else if failure.mayHaveDispatched {
                         try ledger.settle(
                             runID: self.runtime.launchID,
                             reservationID: reservationID,
@@ -6022,18 +6026,28 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
         if case ConsumeUpstreamForwardError.preDispatchUnavailable = error {
             return ConsumeUpstreamFailureClassification(
                 status: .serviceUnavailable,
-                forwardedUpstream: false
+                forwardedUpstream: false,
+                mayHaveDispatched: false
+            )
+        }
+        if case ConsumeUpstreamForwardError.possiblyDispatchedUnavailable = error {
+            return ConsumeUpstreamFailureClassification(
+                status: .serviceUnavailable,
+                forwardedUpstream: false,
+                mayHaveDispatched: true
             )
         }
         if case ConsumeUpstreamForwardError.dispatchedUnavailable = error {
             return ConsumeUpstreamFailureClassification(
                 status: HTTPResponseStatus(statusCode: 502),
-                forwardedUpstream: true
+                forwardedUpstream: true,
+                mayHaveDispatched: true
             )
         }
         return ConsumeUpstreamFailureClassification(
             status: .serviceUnavailable,
-            forwardedUpstream: false
+            forwardedUpstream: false,
+            mayHaveDispatched: false
         )
     }
 

--- a/phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift
@@ -3,6 +3,7 @@ import Darwin
 import Dispatch
 import Foundation
 import MacProviderCore
+import Network
 import NIOCore
 import NIOEmbedded
 import NIOHTTP1
@@ -1648,12 +1649,33 @@ final class ConsumeCommandTests: XCTestCase {
         XCTAssertEqual(resourceSnapshot.upstreamSocketDescriptors, 0)
     }
 
-    func testPhase3DSendFailureIsPreDispatch() throws {
-        let classification = ConsumePinnedUpstreamClient.sendFailureClassificationForTesting(
-            ConsumeUpstreamForwardError.dispatchedUnavailable
-        )
-        guard case .preDispatchUnavailable = classification else {
-            return XCTFail("send failure must not be treated as forwarded upstream")
+    func testPhase3DSendFailuresAreAmbiguous() throws {
+        let errors: [Error] = [
+            NWError.posix(.ECONNRESET),
+            NWError.posix(.ETIMEDOUT),
+            NWError.posix(.ECANCELED),
+            CancellationError(),
+            ConsumeUpstreamForwardError.preDispatchUnavailable,
+            ConsumeUpstreamForwardError.possiblyDispatchedUnavailable,
+            ConsumeUpstreamForwardError.dispatchedUnavailable,
+        ]
+        for error in errors {
+            let classification = ConsumePinnedUpstreamClient.sendFailureClassificationForTesting(error)
+            guard case .possiblyDispatchedUnavailable = classification else {
+                return XCTFail("send failure must retain exposure without claiming confirmed forwarding")
+            }
+        }
+    }
+
+    func testPhase3DAmbiguousSendFailureHoldsReservationAcrossRestart() throws {
+        for code in [POSIXErrorCode.ECONNRESET, .ETIMEDOUT, .ECANCELED] {
+            try assertAmbiguousSendPreservesExposure(streaming: false, error: NWError.posix(code))
+        }
+    }
+
+    func testPhase3GAmbiguousSendFailureAccountsEstimateAcrossRestart() throws {
+        for code in [POSIXErrorCode.ECONNRESET, .ETIMEDOUT, .ECANCELED] {
+            try assertAmbiguousSendPreservesExposure(streaming: true, error: NWError.posix(code))
         }
     }
 
@@ -5695,6 +5717,122 @@ final class ConsumeCommandTests: XCTestCase {
     private func localError(from body: String) throws -> [String: Any] {
         let object = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(body.utf8)) as? [String: Any])
         return try XCTUnwrap(object["error"] as? [String: Any])
+    }
+
+    private func assertAmbiguousSendPreservesExposure(streaming: Bool, error: Error) throws {
+        let token = try ConsumeLocalToken.generate()
+        let home = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let ledgerURL = home.appendingPathComponent("budget.jsonl")
+        let trustedRateCard = phase3CTrustedRateCard(
+            promptRatePerMtok: 1_000_000,
+            completionRatePerMtok: 2_000_000,
+            usdPerMillionCredits: 1.0
+        )
+        let body = streaming
+            ? #"{"model":"llama-test","messages":[],"max_tokens":10,"stream":true}"#
+            : #"{"model":"llama-test","messages":[],"max_tokens":10}"#
+        let expected = try ConsumePricedExposureEstimator.estimate(
+            bodyByteCount: Data(body.utf8).count,
+            request: StrictJSONParser.parse(body),
+            match: XCTUnwrap(trustedRateCard.match(model: "llama-test")),
+            projection: trustedRateCard.projection
+        ).amount
+        let failure = ConsumePinnedUpstreamClient.sendFailureClassificationForTesting(error)
+        let recorder = ConsumeUpstreamRequestRecorder()
+        let counter = ConsumeEndpointRequestCounter()
+        let upstreamClient = ConsumeStubUpstreamClient { request, eventLoop in
+            recorder.append(request)
+            return eventLoop.makeFailedFuture(failure)
+        }
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+        let head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers)
+
+        func assertExposure(_ ledger: ConsumeBudgetLedger) throws {
+            let summary = try ledger.summary()
+            XCTAssertEqual(summary.reserved.rawValue, 0)
+            XCTAssertEqual(summary.held.rawValue, streaming ? 0 : expected.rawValue)
+            XCTAssertEqual(summary.settled.rawValue, streaming ? expected.rawValue : 0)
+            XCTAssertEqual(summary.released.rawValue, 0)
+            XCTAssertEqual(summary.heldReservationCount, streaming ? 0 : 1)
+            XCTAssertEqual(try summary.committedExposure(), expected)
+        }
+
+        // End the runtime and ledger lifetimes before reopening the same locked file.
+        do {
+            let ledger = try ConsumeBudgetLedger.open(ledgerPath: ledgerURL.path, homeDirectory: home, startupDirectory: home)
+            let budget = ConsumeBudgetConfig(
+                mode: .budget(expected),
+                maxRequestMicroUSD: nil,
+                allowUnpriced: false,
+                ledger: ledger,
+                ledgerPathClass: ledger.pathClass
+            )
+            let runtime = consumeRuntime(
+                token: token,
+                credentialStatus: .environmentLoaded,
+                credentialCustody: consumeCredentialCustody("buyer-token"),
+                budget: budget,
+                trustedPricing: .available(trustedRateCard),
+                upstreamClient: upstreamClient,
+                now: { ConsumeCommandTests.phase3CTestNow },
+                requestCounter: counter
+            )
+            let failed = try response(from: runtime, head: head, body: Data(body.utf8))
+            XCTAssertEqual(failed.status, .serviceUnavailable)
+            XCTAssertEqual(try localError(from: failed.body)["code"] as? String, "local_upstream_unavailable")
+            XCTAssertFalse(try localForwardedFlag(from: failed.body))
+            XCTAssertEqual(recorder.snapshot().count, 1)
+            XCTAssertEqual(recorder.snapshot().first?.streaming, streaming)
+            try assertExposure(ledger)
+
+            let persisted = try Data(contentsOf: ledgerURL)
+            let rows = try persisted.split(separator: 0x0a).map {
+                try XCTUnwrap(JSONSerialization.jsonObject(with: Data($0)) as? [String: Any])
+            }
+            XCTAssertEqual(rows.count, 2)
+            let reserved = try XCTUnwrap(rows.first)
+            let terminal = try XCTUnwrap(rows.last)
+            XCTAssertEqual(reserved["state"] as? String, "reserved")
+            XCTAssertEqual(terminal["state"] as? String, streaming ? "settled" : "held")
+            XCTAssertEqual(terminal["reason"] as? String, streaming ? "settled_to_admission_estimate" : "upstream_proxy_failed")
+            XCTAssertEqual(terminal["admission_estimate_micro_usd"] as? String, "\(expected.rawValue)")
+            XCTAssertEqual(terminal["reservation_id"] as? String, try XCTUnwrap(reserved["reservation_id"] as? String))
+            XCTAssertEqual(terminal["run_id"] as? String, runtime.launchID)
+            if streaming {
+                XCTAssertEqual(terminal["settled_exposure_micro_usd"] as? String, "\(expected.rawValue)")
+            } else {
+                XCTAssertNil(terminal["settled_exposure_micro_usd"])
+            }
+
+            let denied = try response(from: runtime, head: head, body: Data(body.utf8))
+            XCTAssertEqual(denied.status, .paymentRequired)
+            XCTAssertEqual(try localError(from: denied.body)["code"] as? String, "local_budget_exceeded")
+            XCTAssertFalse(try localForwardedFlag(from: denied.body))
+            XCTAssertEqual(recorder.snapshot().count, 1)
+            XCTAssertEqual(try Data(contentsOf: ledgerURL), persisted)
+            let resources = counter.resourceSnapshot()
+            XCTAssertEqual(resources.responseSpoolBytes, 0)
+            XCTAssertEqual(resources.upstreamWorkerTasks, 0)
+            XCTAssertEqual(resources.upstreamSocketDescriptors, 0)
+            XCTAssertEqual(resources.openStreamingResponses, 0)
+        }
+
+        let reopened = try ConsumeBudgetLedger.open(ledgerPath: ledgerURL.path, homeDirectory: home, startupDirectory: home)
+        let persisted = try Data(contentsOf: ledgerURL)
+        try reopened.markHeldReservationsForRestart(excludingRunID: "next-launch")
+        try assertExposure(reopened)
+        let admission = try reopened.reservePricedEstimateForForwarding(
+            runID: "next-launch",
+            budget: expected,
+            estimate: expected,
+            maxRequest: nil
+        )
+        guard case .budgetExceeded = admission else {
+            return XCTFail("ambiguous send exposure must still consume budget after restart")
+        }
+        XCTAssertEqual(try Data(contentsOf: ledgerURL), persisted)
     }
 
     private func localForwardedFlag(from body: String) throws -> Bool {

--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -6819,7 +6819,7 @@
     {
       "requirement_id": "SPEC-045-R002",
       "spec_id": "SPEC-045",
-      "state": "conformant",
+      "state": "pending",
       "implementation": [
         "phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift:final class ConsumeLocalHandler",
         "phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift:private func validatePreAuthBoundsAndFraming",
@@ -6851,7 +6851,12 @@
           "expires_at": "2027-08-24"
         }
       ],
-      "gap": null
+      "gap": {
+        "verdict": "UNKNOWN",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/927",
+        "rationale": "The ambiguous-send budget safety fix changes the mapped local handler beyond the historical dc63ecec candidate. Existing evidence is retained as historical provenance only; full requirement conformance requires refreshed matching commit and signed journey evidence."
+      }
     },
     {
       "requirement_id": "SPEC-045-R003",
@@ -6927,7 +6932,7 @@
     {
       "requirement_id": "SPEC-045-R005",
       "spec_id": "SPEC-045",
-      "state": "conformant",
+      "state": "pending",
       "implementation": [
         "phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift:final class ConsumeBudgetLedger",
         "phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift:struct ConsumeBudgetStatusCommand",
@@ -6940,7 +6945,9 @@
         "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase3BudgetedUnpricedRequestIsHeldUntilRelease",
         "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase3LedgerRejectsMalformedJSONAndUnsupportedTransitions",
         "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase3LedgerRejectsRunIDAndAmountMutation",
-        "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase3GStreamingResponseRelaysAfterDoneAndSettlesUsage"
+        "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase3GStreamingResponseRelaysAfterDoneAndSettlesUsage",
+        "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase3DAmbiguousSendFailureHoldsReservationAcrossRestart",
+        "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase3GAmbiguousSendFailureAccountsEstimateAcrossRestart"
       ],
       "journeys": [
         "JOURNEY-LOCAL-CONSUMER-ENDPOINT"
@@ -6959,7 +6966,12 @@
           "expires_at": "2027-08-24"
         }
       ],
-      "gap": null
+      "gap": {
+        "verdict": "UNKNOWN",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/927",
+        "rationale": "Ambiguous-send failures now retain local exposure rather than settling to zero. The mapped settlement implementation has changed beyond the historical dc63ecec candidate; local regression coverage does not replace refreshed matching commit and signed restart/recovery journey evidence."
+      }
     },
     {
       "requirement_id": "SPEC-045-R006",
@@ -6999,7 +7011,7 @@
     {
       "requirement_id": "SPEC-045-R007",
       "spec_id": "SPEC-045",
-      "state": "conformant",
+      "state": "pending",
       "implementation": [
         "phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift:private func writeLocalError",
         "phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift:private static func classifyUpstreamFailure",
@@ -7011,7 +7023,8 @@
         "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase3GStreamingUpstreamErrorResponseIsPreservedAndSettlesEstimate",
         "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase3FInvalidCompressedUpstreamResponseWithLedgerWriteFailureKeepsForwardedProvenance",
         "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase4FakeGatewayRedirectStatusIsPreservedWithoutLocationOrSecondDispatch",
-        "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase3GCompressedStreamingResponseFailsBeforeLocalSuccessAndSettlesEstimate"
+        "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase3GCompressedStreamingResponseFailsBeforeLocalSuccessAndSettlesEstimate",
+        "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase3DSendFailuresAreAmbiguous"
       ],
       "journeys": [
         "JOURNEY-LOCAL-CONSUMER-ENDPOINT"
@@ -7030,12 +7043,17 @@
           "expires_at": "2027-08-24"
         }
       ],
-      "gap": null
+      "gap": {
+        "verdict": "UNKNOWN",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/927",
+        "rationale": "The transport classifier now separates uncertain send exposure from confirmed forwarded_upstream provenance. This changes the mapped classifier beyond the historical dc63ecec candidate; existing evidence remains historical and full conformance requires refreshed matching commit and signed journey evidence."
+      }
     },
     {
       "requirement_id": "SPEC-045-R008",
       "spec_id": "SPEC-045",
-      "state": "conformant",
+      "state": "pending",
       "implementation": [
         "phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift:final class ConsumeLocalHandler",
         "phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift:final class ConsumePinnedUpstreamClient",
@@ -7047,7 +7065,10 @@
         "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase4FakeGatewayStreamingSDKPayloadEmitsOpenAICompatibleSSE",
         "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase4FakeGatewayRedirectStatusIsPreservedWithoutLocationOrSecondDispatch",
         "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase4PinnedUpstreamGeneratedHeadersAreClosedAndSanitized",
-        "scripts/test-signed-local-consumer-endpoint-journey-workflow.sh:required_workflow = ["
+        "scripts/test-signed-local-consumer-endpoint-journey-workflow.sh:required_workflow = [",
+        "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase3DSendFailuresAreAmbiguous",
+        "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase3DAmbiguousSendFailureHoldsReservationAcrossRestart",
+        "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase3GAmbiguousSendFailureAccountsEstimateAcrossRestart"
       ],
       "journeys": [
         "JOURNEY-LOCAL-CONSUMER-ENDPOINT"
@@ -7066,7 +7087,12 @@
           "expires_at": "2027-08-24"
         }
       ],
-      "gap": null
+      "gap": {
+        "verdict": "UNKNOWN",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/927",
+        "rationale": "The mapped pinned upstream client and local handler changed for ambiguous-send budget safety after the historical dc63ecec candidate. New local negative tests cover exposure retention, denial, and ledger reopen, but the unchanged signed journey does not attest this implementation; refreshed matching commit and signed journey evidence remain required."
+      }
     },
     {
       "requirement_id": "SPEC-046-R001",

--- a/specs/README.md
+++ b/specs/README.md
@@ -53,7 +53,7 @@ it can no longer drift. Do not hand-edit the table; edit each spec's
 | SPEC-042 | Pool Control Plane and Trusted-Pool Manifest | 0.0.30 | draft | complete | pending: 12 | [SPEC-042-pool-control-plane.md](SPEC-042-pool-control-plane.md) |
 | SPEC-043 | Trusted Pool Creator Onboarding MVP | 0.1.0 | normative | complete | pending: 12 | [SPEC-043-trusted-pool-creator-onboarding.md](SPEC-043-trusted-pool-creator-onboarding.md) |
 | SPEC-044 | Malibu Model Catalog Economics | 0.1.1 | draft | complete | pending: 12 | [SPEC-044-malibu-model-catalog-economics.md](SPEC-044-malibu-model-catalog-economics.md) |
-| SPEC-045 | Local Consumer Endpoint Mode | 0.1.0 | draft | complete | conformant: 8 | [SPEC-045-local-consumer-endpoint-mode.md](SPEC-045-local-consumer-endpoint-mode.md) |
+| SPEC-045 | Local Consumer Endpoint Mode | 0.1.0 | draft | complete | conformant: 4, pending: 4 | [SPEC-045-local-consumer-endpoint-mode.md](SPEC-045-local-consumer-endpoint-mode.md) |
 | SPEC-046 | Provider BYOM Discovery | 0.1.1 | draft | complete | pending: 8 | [SPEC-046-provider-byom-discovery.md](SPEC-046-provider-byom-discovery.md) |
 | SPEC-047 | Network Model Admission | 0.1.2 | draft | complete | pending: 8 | [SPEC-047-network-model-admission.md](SPEC-047-network-model-admission.md) |
 <!-- AUTOGEN:spec-index END -->


### PR DESCRIPTION
## Summary

Prevent ambiguous `NWConnection.send` failures from restoring potentially spent local consumer budget. This is a bounded SPEC-045 safety correction, not full SPEC-045 implementation or production promotion.

- Separate possible dispatch from confirmed forwarding. Send errors, cancellation, and send deadlines retain conservative exposure without claiming confirmed `forwarded_upstream` provenance.
- Hold non-streaming reservations and settle streaming reservations to the full admission estimate. Proven pre-dispatch failures still settle to zero; confirmed-dispatch handling is unchanged.
- Add reset, timeout, and cancellation regressions covering both modes, durable ledger rows, denial of a subsequent over-budget request, and ledger reopen. Replace the existing unsafe send-classification expectation.
- Leave upstream billing/settlement authority, SPEC-041/046/047, signed artifacts, and deployment status unchanged.

Related to #927. This PR does not close the broader local consumer endpoint implementation work.

## Changed Files

| File | Change |
| --- | --- |
| `phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift` | Add an ambiguous-send state and use internal possible-dispatch exposure, rather than the public forwarding flag, for ledger decisions. |
| `phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift` | Replace the unsafe expectation and add ledger-level failure, budget-denial, and reopen regressions. |
| `specs/CONFORMANCE.json` | Demote four affected SPEC-045 rows, record owned evidence gaps, and map the new tests. |
| `specs/README.md` | Regenerate the index to show four conformant and four pending SPEC-045 requirements. |

## Conformance And Evidence

Demote **SPEC-045-R002, R005, R007, and R008** from `conformant` to `pending`. Their mapped implementation selectors change in this fix, so the historical `dc63ecec` candidate and its signed journey cannot attest the new implementation under `specs/PROCESS.md` selector-equality rules.

The original defect is a `CODE_BUG`; the post-fix full-requirement evidence gaps are `UNKNOWN`, owned by `@Augustas11` under #927. Historical commit and journey evidence is retained unchanged and explicitly described as historical. No signed journey was created, refreshed, or promoted. The other four SPEC-045 requirement states and aggregate lifecycle/deployment states are unchanged.

The declaration below uses `contract_change: yes` because `CONFORMANCE.json` changed; the normative SPEC-045 text and authority manifest are unchanged. R004 is included as the conservative-admission behavior exercised by the fix, not as an additional metadata demotion.

## Verification

Original reviewed implementation: `60357ba84ab1174ea9adc65514ebf0f75080b36d`, rebased without code/test changes as `a6cdd2de7d859f6fef957ddace95b0e7332c4c7a` onto `afe6b12e`. Test output remains available locally under `phase3-binary/.build/spec045-send-targeted.log`, `phase3-binary/.build/spec045-consume-suite.log`, and `phase3-binary/.build/spec045-pr-verification.log`; these are not signed journey evidence.

- Before the runtime fix, `swift test --jobs 4 --filter 'ConsumeCommandTests.testPhase3[DG]AmbiguousSendFailure'` reproduced the defect: two tests failed with 75 assertions, including zero exposure, a second forwarding attempt, and lost accounting after reopen.
- After the fix, `swift test --jobs 4 --filter 'ConsumeCommandTests.testPhase3[DG](AmbiguousSendFailure|SendFailuresAreAmbiguous|PreDispatchTransportFailure|DispatchedTransportFailure)'`: **5 tests passed, 0 failures**.
- `swift test --skip-build --filter 'ConsumeCommandTests|ConsumeTrustedPricingTests|ConsumeConformanceJourneyTests'`: **135 tests passed, 0 failures** (126 consume, 7 pricing, 2 journey-fixture tests). These are not a live gateway journey.
- After rebasing, `swift test --jobs 4 --filter 'ConsumeCommandTests|ConsumeTrustedPricingTests|ConsumeConformanceJourneyTests'`: **135 tests passed, 0 failures**, with a fresh build.
- `PYTHONDONTWRITEBYTECODE=1 python3 scripts/check_spec_governance.py --base-ref origin/main`: **passed** again against `afe6b12e` during PR preparation.
- `jq empty specs/AUTHORITY.json specs/CONFORMANCE.json`: **passed**.
- `PYTHONDONTWRITEBYTECODE=1 python3 scripts/gen_spec_index.py --check` and `--lint`: **passed**.
- `git diff --check` and `git diff origin/main...HEAD --check`: **passed**.
- A structured manifest comparison verified that only the four affected SPEC-045 rows changed, with all evidence arrays, journey arrays, and aggregate spec states preserved.
- Subsequent [full Swift CI](https://github.com/Augustas11/macprovider/actions/runs/34082780737/job/101621142600) passed: unfiltered `swift test --parallel` completed all **2,620 XCTest entries**, and `xcodebuild test -project Malibu.xcodeproj -scheme Malibu -configuration Debug -destination 'platform=macOS'` passed **564 tests, 0 failures**. This supersedes the initial full-suite verification gap; it is not signed journey evidence.

Swift commands ran from `phase3-binary`; other commands ran from the task worktree root. Existing compiler warnings were not addressed by this scoped fix.

## Review Lanes

All three independent final-diff lanes used `gpt-6-astra` with Ultra reasoning:

| Lane | Result |
| --- | --- |
| Code | Approved; 0 Critical, High, Medium, or Low findings. |
| Security | Approved; 0 Critical, High, Medium, or Low findings. |
| Architecture/spec boundary | CLEAR; 0 Critical, High, Medium, or Low findings. |

## Known Gaps

- Live `NWConnection` callback, cancellation, and deadline races were not induced; tests inject failures through the production classifier and a stub transport.
- Restart coverage reopens the durable ledger in-process, not across a separate-process restart or crash.
- Full Swift suites were not rerun locally; the complete SwiftPM and Malibu app suites subsequently passed in CI as recorded above.
- A refreshed signed staging/production gateway journey remains required before promoting the affected requirements.
- The PR remains blocked by [coordinator CI](https://github.com/Augustas11/macprovider/actions/runs/34082780737/job/101621118545): unchanged `TestJourneyTrustedPoolCreatorMVPCandidate` exceeded the 25 ms pool-timing p99 threshold twice (67.187432 ms, then 30.70402 ms on fresh samples). The underlying cause is unresolved, not assumed flaky. No coordinator files or CI definitions changed in this PR; no check was bypassed.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": ["SPEC-045"],
  "requirements": [
    "SPEC-045-R002",
    "SPEC-045-R004",
    "SPEC-045-R005",
    "SPEC-045-R007",
    "SPEC-045-R008"
  ],
  "authority_domains": ["local-consumer-endpoint"],
  "arbitration": ["CODE_BUG", "UNKNOWN"],
  "tests": [
    "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase3DSendFailuresAreAmbiguous",
    "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase3DAmbiguousSendFailureHoldsReservationAcrossRestart",
    "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase3GAmbiguousSendFailureAccountsEstimateAcrossRestart",
    "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase3DPreDispatchTransportFailureSettlesReservationToZero",
    "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase3DDispatchedTransportFailureHoldsReservation"
  ],
  "journeys": ["JOURNEY-LOCAL-CONSUMER-ENDPOINT"],
  "issue": "https://github.com/Augustas11/macprovider/issues/927"
}
SPEC-GOVERNANCE-DECLARATION-END
