### PR TITLE
fix(install): warn when COORDINATOR_HOST is set but ignored

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,6 +191,7 @@ test-dist:
 	bash phase3-binary/dist/test/install_bundled_repair.test.sh
 	bash phase3-binary/dist/test/install_headless_fleet.test.sh
 	bash phase3-binary/dist/test/install_port_validation.test.sh
+	bash phase3-binary/dist/test/install_coordinator_url.test.sh
 	bash phase3-binary/dist/test/install_prefix.test.sh
 	bash phase3-binary/dist/test/uninstall_path_safety.test.sh
 	bash scripts/test-watchdog-inline-drift.sh

--- a/ops/macprovider-watchdog/README.md
+++ b/ops/macprovider-watchdog/README.md
@@ -47,7 +47,7 @@ operator without any hardcoded provider id.
 |---|---|
 | `watchdog.sh` | The poll script source (installed as `macprovider-health-monitor`). Idempotent; safe to invoke repeatedly. |
 | `live.malibu.provider-watchdog.template.plist` | LaunchAgent template; substituted by `install.sh`. |
-| `install.sh` | Idempotent installer. Invoked by both the main `get.malibu.tech/install.sh` flow and by an operator running this directory by hand. |
+| `install.sh` | Idempotent standalone watchdog installer (`ops/macprovider-watchdog/install.sh`). The public provider installer inlines the watchdog; it does not invoke this file. |
 | `uninstall.sh` | Removes the LaunchAgent and the `~/.local/share/macprovider-watchdog` directory. |
 
 ## Operator runbook
@@ -105,7 +105,17 @@ remains the process owner.
 
 ## Environment overrides (advanced)
 
-Both `install.sh` and `watchdog.sh` accept env overrides for testing:
+`ops/macprovider-watchdog/install.sh` and `watchdog.sh` accept env
+overrides for testing. These apply **only** to the standalone watchdog
+installer and the watchdog process. They are **not** read by the public
+provider installer (`phase3-binary/dist/install.sh` /
+`get.malibu.tech/install.sh`).
+
+To point a **provider install** at staging or a self-hosted coordinator,
+set `MACPROVIDER_COORDINATOR_URL` (for example
+`wss://127.0.0.1:18445/ws/provider`). `MACPROVIDER_COORDINATOR_HOST` does
+not change that installer's coordinator URL; the public installer derives
+the watchdog host from the chosen URL.
 
 | Variable | Default |
 |---|---|
@@ -118,5 +128,6 @@ Both `install.sh` and `watchdog.sh` accept env overrides for testing:
 | `MACPROVIDER_WATCHDOG_KICK_GRACE_SECONDS` | `300` |
 | `MACPROVIDER_LAUNCHCTL` | `launchctl` |
 
-These let an operator point the watchdog at a staging coordinator or
-verify the install path before rolling to production.
+These let an operator point the **standalone watchdog** at a staging
+coordinator or verify the watchdog install path before rolling to
+production.

--- a/ops/macprovider-watchdog/install.sh
+++ b/ops/macprovider-watchdog/install.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # Standalone installer for the macprovider-watchdog LaunchAgent.
 #
-# This script is also invoked by the main installer
-# (phase3-binary/dist/install.sh) — it MUST be idempotent so a
-# re-install does not double-load the LaunchAgent or leak the
+# The public provider installer (phase3-binary/dist/install.sh) inlines the
+# watchdog via write_watchdog_script(); it does not invoke this file. This
+# script is for operators re-installing the watchdog by hand. It MUST be
+# idempotent so a re-install does not double-load the LaunchAgent or leak the
 # previous plist.
 
 set -euo pipefail

--- a/phase3-binary/dist/install.sh
+++ b/phase3-binary/dist/install.sh
@@ -1204,6 +1204,9 @@ Environment overrides:
   MACPROVIDER_ACCEPTANCE_RUN_ATTEMPT
                                  exact positive GitHub Actions run attempt
   MACPROVIDER_COORDINATOR_URL    coordinator WebSocket URL
+                                 (staging/self-hosted override)
+  MACPROVIDER_COORDINATOR_HOST   watchdog-only; ignored by this installer.
+                                 Use MACPROVIDER_COORDINATOR_URL instead.
   MACPROVIDER_PORT               local HTTP port
   MACPROVIDER_INSTALL_DIR        support dir for binary + bundles
   MACPROVIDER_RELEASE_FORMAT     auto, pkg, or tar (default: auto)
@@ -9289,6 +9292,30 @@ choose_coordinator_url() {
   printf "%s" "${value:-$COORDINATOR_URL_DEFAULT}"
 }
 
+# Host portion of a coordinator WebSocket URL, including an optional :port
+# (self-hosted coordinators). Same derivation the watchdog plist uses.
+coordinator_host_from_url() {
+  printf "%s" "$1" | sed -E 's#^wss?://##; s#/.*##'
+}
+
+# MACPROVIDER_COORDINATOR_HOST is a watchdog knob, not an installer input.
+# Warn when it is set and disagrees with the URL this installer will use.
+warn_if_coordinator_host_ignored() {
+  coordinator_url="$1"
+  host_override="${MACPROVIDER_COORDINATOR_HOST:-}"
+  if [ -z "$host_override" ]; then
+    return 0
+  fi
+  derived="$(coordinator_host_from_url "$coordinator_url")"
+  if [ "$host_override" = "$derived" ]; then
+    return 0
+  fi
+  # Collapse CR/LF so a hostile HOST cannot forge extra installer log lines.
+  safe_host="$(printf "%s" "$host_override" | tr '\n\r' '  ')"
+  safe_url="$(printf "%s" "$coordinator_url" | tr '\n\r' '  ')"
+  log "WARNING: MACPROVIDER_COORDINATOR_HOST=$safe_host is ignored by this installer (watchdog-only). Using coordinator URL $safe_url. Set MACPROVIDER_COORDINATOR_URL to point at a staging or self-hosted coordinator."
+}
+
 validate_inputs() {
   model="$1"
   provider_id="$2"
@@ -12101,7 +12128,7 @@ render_watchdog_plist() {
   config_path="$(xml_escape "$CONFIG_PATH")"
   binary_path="$(xml_escape "$INSTALL_DIR/macprovider-cli")"
   protected_credential_root="$(xml_escape "$CONFIG_DIR/protected-credentials")"
-  coord_host="$(xml_escape "$(printf "%s" "$1" | sed -E 's#^wss?://##; s#/.*##')")"
+  coord_host="$(xml_escape "$(coordinator_host_from_url "$1")")"
   credential_store="keychain"
   watchdog_search_path="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
   launchctl_environment_entry=""
@@ -13696,6 +13723,7 @@ main() {
   coordinator_url="$(choose_coordinator_url)"
   coordinator_base="$(coordinator_http_base "$coordinator_url")"
   validate_inputs "$model" "$provider_id" "$coordinator_url"
+  warn_if_coordinator_host_ignored "$coordinator_url"
   log "Model selection: signed catalog recommendation after release verification"
   log "Provider ID: $provider_id"
   log "Coordinator: $coordinator_url"

--- a/phase3-binary/dist/test/install_coordinator_url.test.sh
+++ b/phase3-binary/dist/test/install_coordinator_url.test.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Issue #1401: MACPROVIDER_COORDINATOR_HOST is ignored by the public installer.
+#
+# choose_coordinator_url honors only MACPROVIDER_COORDINATOR_URL (or the
+# production default / prompt). HOST is a watchdog knob. When HOST is set and
+# disagrees with the chosen URL, the installer must warn and still use the URL.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+INSTALL_SH="$REPO_ROOT/phase3-binary/dist/install.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+[ -f "$INSTALL_SH" ] || fail "missing installer: $INSTALL_SH"
+
+python3 - "$INSTALL_SH" > "$TMP/fn.sh" <<'PY'
+import sys
+
+names = {
+    "die",
+    "reject_newlines",
+    "choose_coordinator_url",
+    "coordinator_host_from_url",
+    "warn_if_coordinator_host_ignored",
+    "coordinator_http_base",
+    "validate_inputs",
+    "usage",
+}
+lines = open(sys.argv[1], encoding="utf-8").read().splitlines()
+i = 0
+extracted = set()
+while i < len(lines):
+    name = lines[i].split("()", 1)[0].strip() if "()" in lines[i] else ""
+    if name not in names or name in extracted:
+        i += 1
+        continue
+    depth = 0
+    while i < len(lines):
+        line = lines[i]
+        print(line)
+        depth += line.count("{") - line.count("}")
+        i += 1
+        if depth == 0:
+            extracted.add(name)
+            break
+missing = names - extracted
+if missing:
+    raise SystemExit(f"could not extract: {sorted(missing)}")
+PY
+
+cat > "$TMP/harness.sh" <<'HARNESS'
+set -euo pipefail
+COORDINATOR_URL_DEFAULT="wss://coordinator.malibu.tech/ws/provider"
+COORDINATOR_BASE_DEFAULT="https://coordinator.malibu.tech"
+NO_PROMPT=0
+log() { printf "[macprovider-install] %s\n" "$*"; }
+HARNESS
+cat "$TMP/fn.sh" >> "$TMP/harness.sh"
+
+# shellcheck disable=SC1090
+source "$TMP/harness.sh"
+
+PROD_URL="$COORDINATOR_URL_DEFAULT"
+STAGING_URL="wss://127.0.0.1:18445/ws/provider"
+STAGING_HOST="127.0.0.1:18445"
+
+# 1) NO_PROMPT with no URL uses production.
+NO_PROMPT=1
+unset MACPROVIDER_COORDINATOR_URL || true
+got="$(choose_coordinator_url)"
+[ "$got" = "$PROD_URL" ] || fail "NO_PROMPT default: got [$got]"
+
+# 2) MACPROVIDER_COORDINATOR_URL wins, including host:port.
+MACPROVIDER_COORDINATOR_URL="$STAGING_URL"
+got="$(choose_coordinator_url)"
+[ "$got" = "$STAGING_URL" ] || fail "URL override: got [$got]"
+unset MACPROVIDER_COORDINATOR_URL
+
+# 3) Interactive empty Enter uses the production default and still shows it.
+NO_PROMPT=0
+read_line() { REPLY=""; }
+got="$(choose_coordinator_url 2>"$TMP/prompt.err")"
+[ "$got" = "$PROD_URL" ] || fail "empty prompt default: got [$got]"
+grep -Fq "Coordinator URL [default: $PROD_URL]" "$TMP/prompt.err" \
+  || fail "prompt must show production default"
+unset -f read_line
+
+# 4) choose_coordinator_url does not read HOST.
+NO_PROMPT=1
+MACPROVIDER_COORDINATOR_HOST="staging.example.test"
+got="$(choose_coordinator_url)"
+[ "$got" = "$PROD_URL" ] || fail "HOST must not change URL: got [$got]"
+
+# 5) HOST mismatch warns; URL is unchanged.
+warn="$(warn_if_coordinator_host_ignored "$PROD_URL")"
+printf "%s\n" "$warn" | grep -Fq "WARNING: MACPROVIDER_COORDINATOR_HOST=staging.example.test is ignored by this installer" \
+  || fail "missing HOST-ignored warning: [$warn]"
+printf "%s\n" "$warn" | grep -Fq "Set MACPROVIDER_COORDINATOR_URL" \
+  || fail "warning must name MACPROVIDER_COORDINATOR_URL: [$warn]"
+
+# 6) Matching HOST is silent (derived watchdog host agrees).
+MACPROVIDER_COORDINATOR_HOST="coordinator.malibu.tech"
+warn="$(warn_if_coordinator_host_ignored "$PROD_URL")"
+[ -z "$warn" ] || fail "matching HOST should be silent: [$warn]"
+
+# 7) Empty HOST is silent.
+unset MACPROVIDER_COORDINATOR_HOST
+warn="$(warn_if_coordinator_host_ignored "$PROD_URL")"
+[ -z "$warn" ] || fail "empty HOST should be silent: [$warn]"
+
+# 7b) Newline in HOST cannot forge a second log line.
+MACPROVIDER_COORDINATOR_HOST="$(printf 'staging.example.test\nCoordinator: wss://evil.example/ws/provider')"
+warn="$(warn_if_coordinator_host_ignored "$PROD_URL")"
+line_count="$(printf "%s\n" "$warn" | wc -l | tr -d ' ')"
+[ "$line_count" = "1" ] || fail "newline HOST forged extra log lines: [$warn]"
+printf "%s\n" "$warn" | grep -Fq "WARNING: MACPROVIDER_COORDINATOR_HOST=staging.example.test Coordinator: wss://evil.example/ws/provider is ignored" \
+  || fail "newline HOST was not collapsed into one warning: [$warn]"
+unset MACPROVIDER_COORDINATOR_HOST
+
+# 8) host:port derivation matches watchdog plist grammar.
+[ "$(coordinator_host_from_url "$STAGING_URL")" = "$STAGING_HOST" ] \
+  || fail "host:port derivation"
+[ "$(coordinator_host_from_url "$PROD_URL")" = "coordinator.malibu.tech" ] \
+  || fail "production host derivation"
+MACPROVIDER_COORDINATOR_HOST="$STAGING_HOST"
+warn="$(warn_if_coordinator_host_ignored "$STAGING_URL")"
+[ -z "$warn" ] || fail "matching staging HOST should be silent: [$warn]"
+unset MACPROVIDER_COORDINATOR_HOST
+
+# 9) HTTPS base follows a non-prod wss URL rather than falling back to prod.
+[ "$(coordinator_http_base "$PROD_URL")" = "$COORDINATOR_BASE_DEFAULT" ] \
+  || fail "prod http base"
+[ "$(coordinator_http_base "$STAGING_URL")" = "https://127.0.0.1:18445" ] \
+  || fail "staging http base"
+
+# 10) Non-wss URL fails closed. die() calls exit, so this must be a subshell.
+set +e
+(
+  validate_inputs "mlx-community/Qwen3-8B-4bit" "mp-test" "https://coordinator.malibu.tech"
+) >"$TMP/validate.out" 2>"$TMP/validate.err"
+validate_rc=$?
+set -e
+[ "$validate_rc" -ne 0 ] || fail "non-wss URL should die"
+grep -Fq "coordinator URL must start with wss://" "$TMP/validate.err" \
+  || fail "non-wss die message"
+
+# 11) usage() names the URL override and scopes HOST as watchdog-only.
+help="$(usage)"
+printf "%s\n" "$help" | grep -Fq "MACPROVIDER_COORDINATOR_URL" \
+  || fail "usage missing COORDINATOR_URL"
+printf "%s\n" "$help" | grep -Fq "watchdog-only; ignored by this installer" \
+  || fail "usage missing HOST ignored note"
+
+echo "PASS: installer coordinator URL selection ignores MACPROVIDER_COORDINATOR_HOST"

--- a/phase3-binary/dist/test/install_headless_fleet.test.sh
+++ b/phase3-binary/dist/test/install_headless_fleet.test.sh
@@ -42,6 +42,7 @@ names = [
     "read_config_provider_token_line",
     "scrub_config_provider_token",
     "render_plist",
+    "coordinator_host_from_url",
     "render_watchdog_plist",
     "install_plist",
     "install_watchdog",

--- a/phase3-binary/dist/test/install_launchd_migration.test.sh
+++ b/phase3-binary/dist/test/install_launchd_migration.test.sh
@@ -22,6 +22,7 @@ names = [
     "reclaim_launchd_service",
     "reclaim_legacy_launchd_service",
     "render_plist",
+    "coordinator_host_from_url",
     "render_watchdog_plist",
     "install_plist",
     "install_watchdog",
@@ -253,6 +254,9 @@ HOME="$TMP/home" \
     [ "$LAUNCHD_INSTALLED" -eq 1 ]
     install_watchdog "https://coordinator.example"
     [ "$WATCHDOG_INSTALLED" -eq 1 ]
+    expected_host="$(coordinator_host_from_url "https://coordinator.example")"
+    grep -A1 MACPROVIDER_COORDINATOR_HOST "$WATCHDOG_PLIST_PATH" \
+      | grep -qF "<string>$expected_host</string>"
   '
 grep -F 'enable gui/' "$TMP/launchd.log" | grep -F 'live.malibu.provider' >/dev/null
 grep -F 'bootstrap gui/' "$TMP/launchd.log" | grep -F 'live.malibu.provider.plist' >/dev/null

--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -62,7 +62,7 @@
     {
       "spec_id": "SPEC-003",
       "title": "Open Onboarding: Distribution, Lifecycle & Onboarding UX",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "path": "specs/SPEC-003-open-onboarding.md",
       "status": "normative",
       "owner": "@Augustas11",
@@ -5450,6 +5450,29 @@
         "owner": "@Augustas11",
         "issue": "https://github.com/Augustas11/macprovider/issues/926",
         "rationale": "The repo now contains the Malibu-domain hosted agent onboarding skill source, discovery index, and drift validator; the requirement remains pending until the public get.malibu.tech route is published and byte-compared against the repo artifact."
+      }
+    },
+    {
+      "requirement_id": "SPEC-003-R002",
+      "spec_id": "SPEC-003",
+      "state": "pending",
+      "implementation": [
+        "phase3-binary/dist/install.sh:choose_coordinator_url",
+        "phase3-binary/dist/install.sh:warn_if_coordinator_host_ignored",
+        "phase3-binary/dist/install.sh:coordinator_host_from_url",
+        "phase3-binary/dist/install.sh:usage"
+      ],
+      "tests": [
+        "phase3-binary/dist/test/install_coordinator_url.test.sh:MACPROVIDER_COORDINATOR_HOST is ignored by the public installer",
+        "Makefile:test-dist"
+      ],
+      "journeys": [],
+      "evidence": [],
+      "gap": {
+        "verdict": "CODE_BUG",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/1401",
+        "rationale": "Repo installer now warns when MACPROVIDER_COORDINATOR_HOST disagrees with the chosen URL and documents HOST as watchdog-only. Requirement remains pending until the curl-channel get.malibu.tech/install.sh is republished from a release that includes this warning."
       }
     },
     {

--- a/specs/README.md
+++ b/specs/README.md
@@ -11,7 +11,7 @@ it can no longer drift. Do not hand-edit the table; edit each spec's
 |---|---|---|---|---|---|---|
 | SPEC-001 | Phase 3 Binary: Mac Provider Inference CLI | 1.9.6 | normative | pending | pending: 1 | [SPEC-001-phase3-binary.md](SPEC-001-phase3-binary.md) |
 | SPEC-002 | Phase 4 Coordinator: Mac Provider Request Router | 1.6.0 | normative | pending | pending: 2 | [SPEC-002-coordinator.md](SPEC-002-coordinator.md) |
-| SPEC-003 | Open Onboarding: Distribution, Lifecycle & Onboarding UX | 0.11.1 | normative | pending | pending: 1 | [SPEC-003-open-onboarding.md](SPEC-003-open-onboarding.md) |
+| SPEC-003 | Open Onboarding: Distribution, Lifecycle & Onboarding UX | 0.11.2 | normative | pending | pending: 2 | [SPEC-003-open-onboarding.md](SPEC-003-open-onboarding.md) |
 | SPEC-004 | Smart Router | 0.3.4 | normative | pending | pending corpus migration | [SPEC-004-smart-router.md](SPEC-004-smart-router.md) |
 | SPEC-005 | Billing, Settlement, and Provider Rewards | 0.6.4 | normative | complete | conformant: 3, pending: 6 | [SPEC-005-billing.md](SPEC-005-billing.md) |
 | SPEC-006 | Buyer API Gateway: Mac Provider's first public buyer surface | 0.9.21 | normative | complete | conformant: 3, pending: 6 | [SPEC-006-buyer-api.md](SPEC-006-buyer-api.md) |

--- a/specs/SPEC-003-open-onboarding.md
+++ b/specs/SPEC-003-open-onboarding.md
@@ -1,6 +1,17 @@
 # SPEC-003 — Open Onboarding: Distribution, Lifecycle & Onboarding UX
 
-**Version:** 0.11.1 (2026-08-16, hosted agent onboarding skill)
+**Version:** 0.11.2 (2026-09-07, installer coordinator host override scoping)
+
+**Change log v0.11.2:** Clarifies that `MACPROVIDER_COORDINATOR_HOST` is
+watchdog-only and is not an installer coordinator override. The public
+installer (`phase3-binary/dist/install.sh`) selects the coordinator from
+`MACPROVIDER_COORDINATOR_URL`, the interactive prompt, or the production
+default. When `MACPROVIDER_COORDINATOR_HOST` is set and disagrees with the
+host of the chosen URL, the installer MUST warn and continue with that URL.
+`MACPROVIDER_NO_PROMPT=1` without a URL still uses the production default
+(GUI onboarding and unattended production installs). Closes the
+documentation-scoping footgun in issue #1401 without creating a second
+coordinator authority.
 
 **Change log v0.11.1:** Adds FR-C1b and AC-6 for the hosted
 agent-readable onboarding skill requested in issue #926. The canonical public
@@ -447,6 +458,14 @@ that:
 | `MACPROVIDER_INSTALL_DIR` | Override `~/macprovider` support directory |
 | `MACPROVIDER_NO_LAUNCHD` | Skip launchd prompt (no plist) |
 | `MACPROVIDER_NO_PROMPT` | Non-interactive mode (uses all defaults) |
+
+`MACPROVIDER_COORDINATOR_HOST` is a watchdog-only override consumed by
+`ops/macprovider-watchdog/install.sh` and the watchdog LaunchAgent. The
+public installer does not read it. Staging and self-hosted installs MUST
+set `MACPROVIDER_COORDINATOR_URL`. If `MACPROVIDER_COORDINATOR_HOST` is
+set and disagrees with the host of the chosen coordinator URL, the
+installer MUST warn and continue with that URL. `MACPROVIDER_NO_PROMPT=1`
+without `MACPROVIDER_COORDINATOR_URL` uses the production default.
 
 **FR-C3. malibu-cli update subcommand.**
 `malibu-cli update` performs an atomic self-update:


### PR DESCRIPTION
## Summary
- `install.sh` still selects the coordinator from `MACPROVIDER_COORDINATOR_URL`, the prompt, or the production default. `MACPROVIDER_COORDINATOR_HOST` remains watchdog-only.
- Warn (do not fail closed) when HOST is set and disagrees with the chosen URL, and collapse CR/LF so a hostile HOST cannot forge extra installer log lines.
- Scope watchdog docs/SPEC-003 so staging operators use `MACPROVIDER_COORDINATOR_URL`. `NO_PROMPT=1` without a URL still defaults to production (Malibu.app onboarding).

Closes #1401.

## Test plan
- [x] `bash phase3-binary/dist/test/install_coordinator_url.test.sh`
- [x] `bash phase3-binary/dist/test/install_launchd_migration.test.sh`
- [x] `bash phase3-binary/dist/test/install_headless_fleet.test.sh`
- [x] `python3 scripts/check_spec_governance.py`
- [ ] CI `ci-required` green
- [ ] antfleet-ops approval

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": ["SPEC-003"],
  "requirements": ["SPEC-003-R002"],
  "authority_domains": ["provider-onboarding-identity"],
  "arbitration": ["CODE_BUG"],
  "tests": ["phase3-binary/dist/test/install_coordinator_url.test.sh"],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/1401"
}
SPEC-GOVERNANCE-DECLARATION-END

Made with [Cursor](https://cursor.com)