### PR TITLE
fix(release): bundle MLX Metal resources into acceptance-candidate Malibu.app

### DIFF
--- a/scripts/sign-acceptance-candidate.sh
+++ b/scripts/sign-acceptance-candidate.sh
@@ -223,6 +223,41 @@ cmp "$cli_work/compatibility-set.json" "$app/Contents/Resources/compatibility-se
 rm -rf "$app/Contents/Resources/compatibility-set-local" "$app/Contents/Resources/catalog-release"
 cp -R "$cli_work/compatibility-set-local" "$app/Contents/Resources/compatibility-set-local"
 cp -R "$cli_work/catalog-release" "$app/Contents/Resources/catalog-release"
+# Malibu.app's bundled macprovider-cli loads MLX Metal kernels and SwiftPM
+# resources from files adjacent to it in Contents/MacOS, exactly like the
+# standalone tarball payload assembled below. Copy them in before the app is
+# signed/notarized/stapled so they are sealed into the shipped bundle; without
+# them the app-bundled CLI cannot run MLX Metal inference.
+[[ -f "$cli_work/mlx.metallib" && ! -L "$cli_work/mlx.metallib" ]] ||
+  die "provider payload lacks mlx.metallib for the Malibu.app bundle"
+install -m 0644 "$cli_work/mlx.metallib" "$app/Contents/MacOS/mlx.metallib"
+app_resource_bundle_count=0
+for provider_bundle in mlx-swift_Cmlx.bundle swift-nio_NIOPosix.bundle; do
+  if [[ -d "$cli_work/$provider_bundle" && ! -L "$cli_work/$provider_bundle" ]]; then
+    rm -rf "$app/Contents/MacOS/$provider_bundle"
+    cp -R "$cli_work/$provider_bundle" "$app/Contents/MacOS/$provider_bundle"
+    app_resource_bundle_count=$((app_resource_bundle_count + 1))
+  fi
+done
+[[ "$app_resource_bundle_count" -gt 0 ]] ||
+  die "Malibu.app payload lacks a SwiftPM resource bundle"
+# Sign the copied MLX Metal library and every nested SwiftPM resource bundle
+# with the Developer ID identity BEFORE the outer app sign, matching release.yml.
+# The outer app sign is non-deep (to preserve the already-signed embedded CLI
+# bytes), so these nested payloads must carry their own signatures or
+# `codesign --verify --strict --deep` and Apple notarization reject the app.
+codesign --force \
+  --timestamp \
+  --keychain "$keychain" \
+  --sign "$signing_identity" \
+  "$app/Contents/MacOS/mlx.metallib"
+while IFS= read -r -d '' nested_bundle; do
+  codesign --force \
+    --timestamp \
+    --keychain "$keychain" \
+    --sign "$signing_identity" \
+    "$nested_bundle"
+done < <(find "$app/Contents/MacOS" -mindepth 1 -maxdepth 1 -type d -name '*.bundle' -print0)
 embedded_cli_sha256="$(shasum -a 256 "$app/Contents/MacOS/macprovider-cli" | awk '{print $1}')"
 codesign --force \
   --options runtime \
@@ -246,6 +281,11 @@ rm -f "$app_notary"
 xcrun stapler staple "$app"
 xcrun stapler validate "$app"
 spctl -a -vvv -t exec "$app"
+# Fail closed if the shipped app bundle is missing the adjacent MLX Metal
+# library the bundled CLI needs (mirrors verify-tier2-provider-release.sh so a
+# packaging regression can never reach a published DMG again).
+[[ -f "$app/Contents/MacOS/mlx.metallib" ]] ||
+  die "signed Malibu.app lacks adjacent mlx.metallib for the bundled macprovider-cli"
 
 mkdir "$output_dir"
 provider_asset="$output_dir/macprovider-cli-${tag}-darwin-arm64.tar.gz"

--- a/scripts/test-acceptance-candidate-security.sh
+++ b/scripts/test-acceptance-candidate-security.sh
@@ -220,6 +220,27 @@ for value in (
 ):
     if value not in signer:
         raise SystemExit(f"acceptance Malibu.app omits bundled repair payload: {value}")
+# The bundled CLI loads MLX Metal kernels and SwiftPM resources from files
+# adjacent to it in Contents/MacOS; the app must ship them like the tarball or
+# app-installed providers cannot run Metal inference (regression that shipped a
+# metallib-less Malibu.app in v1.8.120).
+for value in (
+    'install -m 0644 "$cli_work/mlx.metallib" "$app/Contents/MacOS/mlx.metallib"',
+    'cp -R "$cli_work/$provider_bundle" "$app/Contents/MacOS/$provider_bundle"',
+):
+    if value not in signer:
+        raise SystemExit(f"acceptance Malibu.app omits adjacent MLX Metal resource: {value}")
+# The nested MLX Metal library and SwiftPM resource bundles must be signed with
+# the Developer ID identity BEFORE the non-deep outer app sign, or
+# `codesign --verify --strict --deep` and Apple notarization reject the app
+# (the copied payloads are otherwise unsigned nested bundles). mlx.metallib
+# appears three times once signed: install, codesign, post-staple assertion.
+if signer.count('"$app/Contents/MacOS/mlx.metallib"') < 3:
+    raise SystemExit("acceptance signer must codesign the copied mlx.metallib before the outer app sign")
+if 'find "$app/Contents/MacOS" -mindepth 1 -maxdepth 1 -type d -name \'*.bundle\' -print0' not in signer:
+    raise SystemExit("acceptance signer must codesign every nested SwiftPM resource bundle before the outer app sign")
+if 'die "signed Malibu.app lacks adjacent mlx.metallib' not in signer:
+    raise SystemExit("acceptance signer must fail closed when the signed app lacks the adjacent MLX Metal library")
 for value in (
     'keychain="acceptance-signing-${run_id}-${run_attempt}-${keychain_nonce}.keychain"',
     'acceptance_keychain_capture_default || die',


### PR DESCRIPTION
## What

The acceptance-candidate signer (`scripts/sign-acceptance-candidate.sh`) assembled `Malibu.app` with only `macprovider-cli` + catalog payloads in `Contents/MacOS`, never the adjacent `mlx.metallib` and SwiftPM resource bundles (`mlx-swift_Cmlx.bundle`, `swift-nio_NIOPosix.bundle`) that the standalone tarball payload already ships. The app-bundled CLI loads MLX Metal kernels from files adjacent to it, so an **app-installed** provider on a build cut through this flow could not run Metal inference.

- **v1.8.117** was cut via `release.yml` (which does copy these, guarded by `test-release-security-posture.sh`) → unaffected.
- **v1.8.120** was the first cut through `acceptance-candidate → promote` → shipped a metallib-less `Malibu.app`. Caught by the post-publication `verify-tier2-provider-release` gate **before any fleet rollout** (coordinator still recommends 1.8.117).

## Fix

- Copy `mlx.metallib` + the two SwiftPM bundles from `$cli_work` into `Malibu.app/Contents/MacOS`, then **codesign the metallib and every nested `*.bundle`** with the Developer ID identity **before** the non-deep outer app sign (mirroring `release.yml:954-963`). This is required: the shipped v1.8.117 nested bundles each carry their own `Contents/_CodeSignature`, and the non-deep outer sign does not add them — without explicit nested signing, `codesign --verify --strict --deep` and Apple notarization would reject the app.
- Fail closed after stapling if `mlx.metallib` is absent.
- Add a source guard in `test-acceptance-candidate-security.sh` so the acceptance-candidate app-assembly path is covered (previously only `release.yml` was guarded — the gap that let this ship).

## Verification

- `scripts/test-acceptance-candidate-security.sh` (new guard) → PASS; proven to FAIL when the sign-script copy is reverted.
- `scripts/test-tier2-provider-release.sh`, `test-release-security-posture.sh`, `test-compatibility-set-manifest.sh`, `test-malibu-independent-release.sh` → PASS.
- 3-lane audit (code / security / architecture) to 0 C/H/M.

Release/packaging path; no runtime code or schema change. A new version will be cut through the full flow to supersede the broken v1.8.120 DMG (immutable public release — not patched in place).

<!-- SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R001"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": ["scripts/test-acceptance-candidate-security.sh", "scripts/test-tier2-provider-release.sh", "scripts/test-release-security-posture.sh"],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END -->
