### PR TITLE
Audit SPEC-041 envelope precheck rejections

### DIFF
--- a/phase5-gateway/internal/router/relay_blind.go
+++ b/phase5-gateway/internal/router/relay_blind.go
@@ -157,18 +157,14 @@ func decodeRelayBlindRouteReservation(body []byte) (relayBlindRouteReservationRe
 
 func (s *Server) rejectRelayBlindEnvelopeIfRequired(w http.ResponseWriter, r *http.Request, body []byte, accountID string, walletSession *walletSessionAuth) bool {
 	probe, ok, malformed := parseRelayBlindEnvelopeProbe(body)
-	if !ok {
-		if malformed {
-			writeError(w, http.StatusBadRequest, "invalid_request_error", "relay_blind_envelope_invalid", "Relay-blind request envelope is malformed")
-			return true
-		}
+	if !ok && !malformed {
 		return false
 	}
 	if walletSession != nil && !s.admitRelayBlindWalletMetadata(w, r, walletSession, body) {
 		return true
 	}
 	if malformed || probe.Mode == "" {
-		writeError(w, http.StatusBadRequest, "invalid_request_error", "relay_blind_envelope_invalid", "Relay-blind request envelope is malformed")
+		s.rejectRelayBlindEnvelopePrecheck(w, r, accountID, walletSession, relayBlindEndpointFamilyFromRequest(r), body, http.StatusBadRequest, "relay_blind_envelope_invalid", "Relay-blind request envelope is malformed")
 		return true
 	}
 	if probe.Mode != "required" {
@@ -186,18 +182,21 @@ func (s *Server) rejectRelayBlindEnvelopeIfRequired(w http.ResponseWriter, r *ht
 	enforceEncryptedSizeLimit := s.cfg.Features.RelayBlindRequests.Enabled
 	env, err := s.validateRelayBlindRequestEnvelope(body, endpointFamily, enforceEncryptedSizeLimit)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid_request_error", "relay_blind_envelope_invalid", err.Error())
+		s.rejectRelayBlindEnvelopePrecheck(w, r, accountID, walletSession, endpointFamily, body, http.StatusBadRequest, "relay_blind_envelope_invalid", err.Error())
 		return true
 	}
-	if walletSession != nil && !writeRelayBlindWalletSessionPrecheck(w, walletSession.Session, env.Model, env.InputTokenUpperBound, env.MaxOutputTokens, env.ReservationTokenCap) {
-		return true
+	if walletSession != nil {
+		if status, code, message := relayBlindWalletSessionPrecheckError(walletSession.Session, env.Model, env.InputTokenUpperBound, env.MaxOutputTokens, env.ReservationTokenCap); code != "" {
+			s.rejectRelayBlindEnvelopePrecheck(w, r, accountID, walletSession, endpointFamily, body, status, code, message)
+			return true
+		}
 	}
 	if walletSession == nil && relayBlindTokenBoundsInvalid(env.InputTokenUpperBound, env.MaxOutputTokens, env.ReservationTokenCap, relayBlindMaxOutputTokensForRequest(s, r)) {
-		writeError(w, http.StatusBadRequest, "invalid_request_error", "relay_blind_envelope_invalid", "Invalid relay-blind request envelope")
+		s.rejectRelayBlindEnvelopePrecheck(w, r, accountID, walletSession, endpointFamily, body, http.StatusBadRequest, "relay_blind_envelope_invalid", "Invalid relay-blind request envelope")
 		return true
 	}
 	if !s.relayBlindEnvelopeFresh(env) {
-		writeError(w, http.StatusBadRequest, "invalid_request_error", "relay_blind_envelope_invalid", "Relay-blind request envelope timestamp is outside the accepted freshness window")
+		s.rejectRelayBlindEnvelopePrecheck(w, r, accountID, walletSession, endpointFamily, body, http.StatusBadRequest, "relay_blind_envelope_invalid", "Relay-blind request envelope timestamp is outside the accepted freshness window")
 		return true
 	}
 	walletSessionID := ""
@@ -311,7 +310,7 @@ func (s *Server) handleRelayBlindEndpointDisabledBody(w http.ResponseWriter, r *
 			if authn.WalletSession != nil && !s.admitRelayBlindWalletMetadata(w, r, authn.WalletSession, body) {
 				return
 			}
-			writeError(w, http.StatusBadRequest, "invalid_request_error", "relay_blind_envelope_invalid", "Relay-blind request envelope is malformed")
+			s.rejectRelayBlindEnvelopePrecheck(w, r, relayBlindAccountID(authn), authn.WalletSession, endpointFamily, body, http.StatusBadRequest, "relay_blind_envelope_invalid", "Relay-blind request envelope is malformed")
 			return
 		}
 		s.handleNotFound(w, r)
@@ -329,7 +328,7 @@ func (s *Server) handleRelayBlindEndpointDisabledBody(w http.ResponseWriter, r *
 		if authn.WalletSession != nil && !s.admitRelayBlindWalletMetadata(w, r, authn.WalletSession, body) {
 			return
 		}
-		writeError(w, http.StatusBadRequest, "invalid_request_error", "relay_blind_envelope_invalid", "Relay-blind request envelope is malformed")
+		s.rejectRelayBlindEnvelopePrecheck(w, r, relayBlindAccountID(authn), authn.WalletSession, endpointFamily, body, http.StatusBadRequest, "relay_blind_envelope_invalid", "Relay-blind request envelope is malformed")
 		return
 	}
 	authn, authed := s.authenticateAny(w, r)
@@ -350,7 +349,7 @@ func (s *Server) handleRelayBlindEndpointDisabledBody(w http.ResponseWriter, r *
 	}
 	if probe.Mode != "required" {
 		if probe.Mode == "" || malformed {
-			writeError(w, http.StatusBadRequest, "invalid_request_error", "relay_blind_envelope_invalid", "Relay-blind request envelope is malformed")
+			s.rejectRelayBlindEnvelopePrecheck(w, r, relayBlindAccountID(authn), authn.WalletSession, endpointFamily, body, http.StatusBadRequest, "relay_blind_envelope_invalid", "Relay-blind request envelope is malformed")
 			return
 		}
 		if authn.WalletSession == nil && !s.admitRelayBlindMetadataWrite(w, r, relayBlindAccountID(authn)) {
@@ -365,18 +364,21 @@ func (s *Server) handleRelayBlindEndpointDisabledBody(w http.ResponseWriter, r *
 	}
 	env, err := s.validateRelayBlindRequestEnvelope(body, endpointFamily, s.cfg.Features.RelayBlindRequests.Enabled)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid_request_error", "relay_blind_envelope_invalid", err.Error())
+		s.rejectRelayBlindEnvelopePrecheck(w, r, relayBlindAccountID(authn), authn.WalletSession, endpointFamily, body, http.StatusBadRequest, "relay_blind_envelope_invalid", err.Error())
 		return
 	}
-	if authn.WalletSession != nil && !writeRelayBlindWalletSessionPrecheck(w, authn.WalletSession.Session, env.Model, env.InputTokenUpperBound, env.MaxOutputTokens, env.ReservationTokenCap) {
-		return
+	if authn.WalletSession != nil {
+		if status, code, message := relayBlindWalletSessionPrecheckError(authn.WalletSession.Session, env.Model, env.InputTokenUpperBound, env.MaxOutputTokens, env.ReservationTokenCap); code != "" {
+			s.rejectRelayBlindEnvelopePrecheck(w, r, relayBlindAccountID(authn), authn.WalletSession, endpointFamily, body, status, code, message)
+			return
+		}
 	}
 	if authn.WalletSession == nil && relayBlindTokenBoundsInvalid(env.InputTokenUpperBound, env.MaxOutputTokens, env.ReservationTokenCap, relayBlindMaxOutputTokensForAuth(s, authn)) {
-		writeError(w, http.StatusBadRequest, "invalid_request_error", "relay_blind_envelope_invalid", "Invalid relay-blind request envelope")
+		s.rejectRelayBlindEnvelopePrecheck(w, r, relayBlindAccountID(authn), authn.WalletSession, endpointFamily, body, http.StatusBadRequest, "relay_blind_envelope_invalid", "Invalid relay-blind request envelope")
 		return
 	}
 	if !s.relayBlindEnvelopeFresh(env) {
-		writeError(w, http.StatusBadRequest, "invalid_request_error", "relay_blind_envelope_invalid", "Relay-blind request envelope timestamp is outside the accepted freshness window")
+		s.rejectRelayBlindEnvelopePrecheck(w, r, relayBlindAccountID(authn), authn.WalletSession, endpointFamily, body, http.StatusBadRequest, "relay_blind_envelope_invalid", "Relay-blind request envelope timestamp is outside the accepted freshness window")
 		return
 	}
 	walletSessionID := ""
@@ -736,13 +738,62 @@ func (s *Server) recordRelayBlindRequiredAudit(r *http.Request, accountID, walle
 	})
 }
 
-func writeRelayBlindWalletSessionPrecheck(w http.ResponseWriter, session storage.WalletSession, model string, inputTokenUpperBound, maxOutputTokens, reservationTokenCap int64) bool {
+// Wallet callers must complete signed metadata admission before reaching this path.
+func (s *Server) rejectRelayBlindEnvelopePrecheck(w http.ResponseWriter, r *http.Request, accountID string, walletSession *walletSessionAuth, endpointFamily string, body []byte, status int, code, message string) {
+	if walletSession == nil && !s.admitRelayBlindMetadataWrite(w, r, accountID) {
+		return
+	}
+	walletSessionID := ""
+	if walletSession != nil {
+		walletSessionID = walletSession.Session.SessionID
+	}
+	// Even partially decoded envelope fields are untrusted; persist only a digest
+	// and gateway-derived correlation, never the decoder error or raw identifiers.
+	digest := sha256.Sum256(body)
+	payload, err := json.Marshal(map[string]any{
+		"endpoint_family":        endpointFamily,
+		"mode_class":             "unvalidated",
+		"requested_privacy_mode": "relay_blind_required",
+		"effective_outcome":      "relay_blind_unavailable",
+		"wallet_session_id":      walletSessionID,
+		"envelope_digest":        hex.EncodeToString(digest[:]),
+		"reason_code":            code,
+	})
+	if err == nil {
+		err = s.store.InsertAuditEvent(r.Context(), storage.AuditEvent{
+			EventID: mustID("audit"), RequestID: requestID(r), AccountID: accountID,
+			Actor: "gateway", Type: "relay_blind_required_rejected", Payload: string(payload), CreatedAt: s.now().UTC(),
+		})
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "server_error", "internal_error", "Could not record relay-blind rejection audit")
+		return
+	}
+	errorType := "invalid_request_error"
+	if status == http.StatusForbidden {
+		errorType = "permission_error"
+	}
+	writeError(w, status, errorType, code, message)
+}
+
+func relayBlindWalletSessionPrecheckError(session storage.WalletSession, model string, inputTokenUpperBound, maxOutputTokens, reservationTokenCap int64) (int, string, string) {
 	if _, ok := walletModelAllowlist(session)[model]; !ok {
-		writeError(w, http.StatusForbidden, "permission_error", "wallet_session_model_not_allowed", "Wallet session does not allow this model")
-		return false
+		return http.StatusForbidden, "wallet_session_model_not_allowed", "Wallet session does not allow this model"
 	}
 	if relayBlindWalletSessionCapExceeded(session.PerRequestTokenCap, inputTokenUpperBound, maxOutputTokens, reservationTokenCap) {
-		writeError(w, http.StatusBadRequest, "invalid_request_error", "wallet_session_request_cap_exceeded", "Wallet-session per-request cap exceeded")
+		return http.StatusBadRequest, "wallet_session_request_cap_exceeded", "Wallet-session per-request cap exceeded"
+	}
+	return 0, "", ""
+}
+
+func writeRelayBlindWalletSessionPrecheck(w http.ResponseWriter, session storage.WalletSession, model string, inputTokenUpperBound, maxOutputTokens, reservationTokenCap int64) bool {
+	status, code, message := relayBlindWalletSessionPrecheckError(session, model, inputTokenUpperBound, maxOutputTokens, reservationTokenCap)
+	if code != "" {
+		errorType := "invalid_request_error"
+		if status == http.StatusForbidden {
+			errorType = "permission_error"
+		}
+		writeError(w, status, errorType, code, message)
 		return false
 	}
 	return true

--- a/phase5-gateway/internal/router/relay_blind_rejection_audit_test.go
+++ b/phase5-gateway/internal/router/relay_blind_rejection_audit_test.go
@@ -1,0 +1,214 @@
+package router
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-gateway/internal/config"
+)
+
+func TestRelayBlindPrecheckRejectionsAuditBoundedMetadata(t *testing.T) {
+	for _, family := range []string{"chat_completions", "responses", "messages"} {
+		for _, enabled := range []bool{false, true} {
+			for _, rejection := range []string{"malformed", "schema", "cap", "stale", "oversized identifier"} {
+				t.Run(fmt.Sprintf("%s/enabled=%t/%s", family, enabled, rejection), func(t *testing.T) {
+					dispatchCalls := 0
+					h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+						cfg.Features.RelayBlindRequests.Enabled = enabled
+						cfg.Features.ResponsesAPIEnabled = enabled
+						cfg.Features.AnthropicMessagesEnabled = enabled
+						cfg.Features.RelayBlindRequests.MetadataRequestsPerMinute = 1
+						cfg.Limits.MaxTokensPerRequest = 20
+					}, WithHTTPClient(&http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+						dispatchCalls++
+						return responseWithBody(http.StatusOK, nil, `{}`), nil
+					})}))
+					accountID := "acct_rejection_audit"
+					key := createAccountAndKey(t, store, cfg, accountID)
+					overrides := map[string]any{"endpoint_family": family}
+					switch rejection {
+					case "schema":
+						overrides["private-prompt-sentinel"] = "private-plaintext-sentinel"
+					case "cap":
+						overrides["max_output_tokens"] = 21
+						overrides["reservation_token_cap"] = 29
+					case "stale":
+						overrides["issued_at_unix"] = fixedNow().Add(-2 * time.Minute).Unix()
+					case "oversized identifier":
+						overrides["kid"] = strings.Repeat("private-identifier-sentinel", 100)
+					}
+					body := validRelayBlindRequestEnvelope(t, overrides)
+					if rejection == "malformed" {
+						body = `{"version":"relay-blind-request-v1","mode":"required","private-prompt-sentinel":`
+					}
+					path := "/v1/" + family
+					if family == "chat_completions" {
+						path = "/v1/chat/completions"
+					}
+					unauthenticated := httptest.NewRecorder()
+					h.ServeHTTP(unauthenticated, httptest.NewRequest(http.MethodPost, path, strings.NewReader(body)))
+					if unauthenticated.Code != http.StatusUnauthorized {
+						t.Fatalf("unauthenticated status=%d want 401", unauthenticated.Code)
+					}
+					if got := countAuditEvents(t, dbPath, "relay_blind_required_rejected"); got != 0 {
+						t.Fatalf("unauthenticated audits=%d want 0", got)
+					}
+					for attempt, wantStatus := range []int{http.StatusBadRequest, http.StatusTooManyRequests} {
+						req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+						req.Header.Set("Authorization", "Bearer "+key)
+						resp := httptest.NewRecorder()
+						h.ServeHTTP(resp, req)
+						if resp.Code != wantStatus {
+							t.Fatalf("attempt=%d status=%d want %d body=%s", attempt, resp.Code, wantStatus, resp.Body.String())
+						}
+						code := "relay_blind_envelope_invalid"
+						if attempt > 0 {
+							code = "relay_blind_metadata_rate_limited"
+						}
+						if family == "messages" {
+							assertAnthropicErrorCode(t, resp.Body.String(), code)
+						} else {
+							assertErrorCode(t, resp.Body.String(), code)
+						}
+						if got := countAuditEvents(t, dbPath, "relay_blind_required_rejected"); got != 1 {
+							t.Fatalf("attempt=%d rejection audits=%d want 1", attempt, got)
+						}
+					}
+					payload := relayBlindAuditPayload(t, dbPath, "relay_blind_required_rejected")
+					var fields map[string]any
+					if err := json.Unmarshal([]byte(payload), &fields); err != nil {
+						t.Fatal(err)
+					}
+					digest := sha256.Sum256([]byte(body))
+					want := map[string]any{
+						"endpoint_family": family, "mode_class": "unvalidated",
+						"requested_privacy_mode": "relay_blind_required", "effective_outcome": "relay_blind_unavailable",
+						"wallet_session_id": "", "envelope_digest": hex.EncodeToString(digest[:]),
+						"reason_code": "relay_blind_envelope_invalid",
+					}
+					if len(fields) != len(want) {
+						t.Fatalf("unexpected audit fields: %s", payload)
+					}
+					for key, value := range want {
+						if fields[key] != value {
+							t.Fatalf("audit[%s]=%v want %v", key, fields[key], value)
+						}
+					}
+					if dispatchCalls != 0 {
+						t.Fatalf("dispatches=%d want 0", dispatchCalls)
+					}
+					assertNoDailyUsage(t, store, accountID)
+				})
+			}
+		}
+	}
+}
+
+func TestRelayBlindWalletPrecheckAuditPreservesAdmission(t *testing.T) {
+	for _, family := range []string{"chat_completions", "responses", "messages"} {
+		for _, enabled := range []bool{false, true} {
+			for _, rejection := range []string{"malformed", "schema", "model", "cap", "stale"} {
+				t.Run(fmt.Sprintf("%s/enabled=%t/%s", family, enabled, rejection), func(t *testing.T) {
+					h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+						cfg.Public.BaseURL = "https://api.malibu.test"
+						cfg.Auth.WalletSessions.Enabled = true
+						cfg.Auth.WalletSessions.BearerHashKeys = map[string]string{"k1": strings.Repeat("b", 32)}
+						cfg.Auth.WalletSessions.CurrentBearerHashKeyID = "k1"
+						cfg.Auth.WalletSessions.WalletFingerprintSecret = strings.Repeat("f", 32)
+						cfg.Auth.WalletSessions.MetadataRequestsPerMinute = 1
+						cfg.Features.RelayBlindRequests.Enabled = enabled
+						cfg.Features.ResponsesAPIEnabled = enabled
+						cfg.Features.AnthropicMessagesEnabled = enabled
+					}, WithHTTPClient(walletModelsClient()))
+					accountID := "acct_wallet_precheck_audit"
+					key := createAccountAndKey(t, store, cfg, accountID)
+					wallet := registerWalletSessionViaAPIWithCaps(t, h, cfg, key, accountID, []string{"model-a"}, 100, 50)
+					overrides := map[string]any{"endpoint_family": family}
+					status, code := http.StatusBadRequest, "relay_blind_envelope_invalid"
+					switch rejection {
+					case "schema":
+						overrides["private-prompt-sentinel"] = "private-plaintext-sentinel"
+					case "model":
+						overrides["model"] = "model-b"
+						status, code = http.StatusForbidden, "wallet_session_model_not_allowed"
+					case "cap":
+						overrides["reservation_token_cap"] = 51
+						code = "wallet_session_request_cap_exceeded"
+					case "stale":
+						overrides["issued_at_unix"] = fixedNow().Add(-2 * time.Minute).Unix()
+					}
+					body := []byte(validRelayBlindRequestEnvelope(t, overrides))
+					if rejection == "malformed" {
+						body = []byte(`{"mode":"required"}`)
+					}
+					path := "/v1/" + family
+					if family == "chat_completions" {
+						path = "/v1/chat/completions"
+					}
+					outerID := "018f7b7b-7c35-4cf0-8d4e-3f0ab1c50928"
+					for _, attempt := range []struct {
+						id     string
+						status int
+						code   string
+					}{
+						{outerID, status, code},
+						{outerID, http.StatusConflict, "wallet_session_duplicate_request"},
+						{"018f7b7b-7c35-4cf0-8d4e-3f0ab1c50929", http.StatusTooManyRequests, "wallet_session_rate_limited"},
+					} {
+						resp := httptest.NewRecorder()
+						h.ServeHTTP(resp, signedWalletRequest(t, wallet, http.MethodPost, path, path, attempt.id, body))
+						if resp.Code != attempt.status {
+							t.Fatalf("status=%d want %d body=%s", resp.Code, attempt.status, resp.Body.String())
+						}
+						if family == "messages" {
+							assertAnthropicErrorCode(t, resp.Body.String(), attempt.code)
+						} else {
+							assertErrorCode(t, resp.Body.String(), attempt.code)
+						}
+						if got := countAuditEvents(t, dbPath, "relay_blind_required_rejected"); got != 1 {
+							t.Fatalf("audits=%d want 1", got)
+						}
+					}
+					var payload map[string]any
+					if err := json.Unmarshal([]byte(relayBlindAuditPayload(t, dbPath, "relay_blind_required_rejected")), &payload); err != nil {
+						t.Fatal(err)
+					}
+					if payload["wallet_session_id"] != wallet.SessionID || payload["reason_code"] != code {
+						t.Fatalf("audit correlation/reason=%v", payload)
+					}
+					assertNoDailyUsage(t, store, accountID)
+				})
+			}
+		}
+	}
+}
+
+func TestRelayBlindPrecheckAuditFailureFailsClosed(t *testing.T) {
+	for _, path := range []string{"/v1/chat/completions", "/v1/responses", "/v1/messages"} {
+		t.Run(path, func(t *testing.T) {
+			_, store, _, cfg := newTestHarness(t, fakeOAuth{}, WithHTTPClient(noopClient()))
+			key := createAccountAndKey(t, store, cfg, "acct_precheck_audit_failure")
+			h := New(cfg, relayBlindAuditFailStore{Store: store}, fakeOAuth{}, WithNow(fixedNow), WithHTTPClient(noopClient())).Handler()
+			req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(`{"mode":"required"}`))
+			req.Header.Set("Authorization", "Bearer "+key)
+			resp := httptest.NewRecorder()
+			h.ServeHTTP(resp, req)
+			if resp.Code != http.StatusInternalServerError {
+				t.Fatalf("status=%d want 500 body=%s", resp.Code, resp.Body.String())
+			}
+			if path == "/v1/messages" {
+				assertAnthropicErrorCode(t, resp.Body.String(), "internal_error")
+			} else {
+				assertErrorCode(t, resp.Body.String(), "internal_error")
+			}
+			assertNoDailyUsage(t, store, "acct_precheck_audit_failure")
+		})
+	}
+}

--- a/phase5-gateway/internal/router/relay_blind_test.go
+++ b/phase5-gateway/internal/router/relay_blind_test.go
@@ -1486,8 +1486,8 @@ func TestRelayBlindDisabledFamilyPrechecksModelAndCapsBeforeReplayAudit(t *testi
 	}
 	assertErrorCode(t, resp.Body.String(), "relay_blind_envelope_invalid")
 	assertBodyRetryable(t, resp.Body.String(), false)
-	if got := countAuditEvents(t, dbPath, "relay_blind_required_rejected"); got != 0 {
-		t.Fatalf("required audit events=%d want 0", got)
+	if got := countAuditEvents(t, dbPath, "relay_blind_required_rejected"); got != 1 {
+		t.Fatalf("required audit events=%d want 1", got)
 	}
 	assertNoDailyUsage(t, store, "acct_relay_blind_disabled_family_cap")
 }
@@ -1519,8 +1519,8 @@ func TestRelayBlindDisabledFamilyWalletPrecheckStillRecordsWalletReplay(t *testi
 	}
 	assertErrorCode(t, resp.Body.String(), "wallet_session_model_not_allowed")
 	assertBodyRetryable(t, resp.Body.String(), false)
-	if got := countAuditEvents(t, dbPath, "relay_blind_required_rejected"); got != 0 {
-		t.Fatalf("required audit events=%d want 0", got)
+	if got := countAuditEvents(t, dbPath, "relay_blind_required_rejected"); got != 1 {
+		t.Fatalf("required audit events=%d want 1", got)
 	}
 
 	replay := httptest.NewRecorder()
@@ -1902,7 +1902,7 @@ type relayBlindAuditFailStore struct {
 }
 
 func (s relayBlindAuditFailStore) InsertAuditEvent(ctx context.Context, event storage.AuditEvent) error {
-	if event.Type == "relay_blind_downgrade_rejected" {
+	if event.Type == "relay_blind_downgrade_rejected" || event.Type == "relay_blind_required_rejected" {
 		return errors.New("audit insert failed")
 	}
 	return s.Store.InsertAuditEvent(ctx, event)


### PR DESCRIPTION
## Summary

Follow-up to the conformance truth audit in [#1408](https://github.com/Augustas11/macprovider/pull/1408). This independent branch starts from `afe6b12e` on `origin/main`; it does not stack on the audit or SPEC-045 fix PR.

Authenticated malformed/schema-invalid envelopes, account/demo token-cap failures, wallet model/cap failures, and stale timestamps previously returned before writing a privacy rejection audit. Record a bounded precheck rejection event on these paths across chat completions and enabled/disabled Responses and Messages adapters.

- Persist only a fixed seven-field payload: gateway endpoint classification, `mode_class: unvalidated`, requested privacy/effective rejection classifications, authenticated wallet-session correlation, SHA-256 envelope digest, and a constant reason code. Do not persist raw bodies, decoder errors, or unvalidated model/provider/key identifiers.
- Retain signed wallet metadata admission before audit writes. API-key/demo writes use the existing relay metadata bucket; exhausted admission does not create another rejection event.
- Audit insertion failure returns a generic HTTP 500 before dispatch or quota reservation. Otherwise existing precheck error codes/statuses remain, subject to metadata throttling.
- Keep wallet precheck conditions shared with route reservations without changing those reservations' behavior. Preserve the existing conformance-mapped test selector.

Changed files:

- `phase5-gateway/internal/router/relay_blind.go`
- `phase5-gateway/internal/router/relay_blind_test.go`
- `phase5-gateway/internal/router/relay_blind_rejection_audit_test.go`

## Verification

Commands below ran in `phase5-gateway` unless indicated otherwise.

- Regression first: `go test ./internal/router -run 'TestRelayBlindPrecheck|TestRelayBlindDisabledFamilyPrechecksModelAndCapsAreAudited|TestRelayBlindDisabledFamilyWalletPrecheckStillRecordsWalletReplay' -count=1` failed before the runtime fix: 30 missing-audit cases, three missing audit-failure cases, and two previously unsafe zero-audit expectations. The temporary test name was subsequently restored to its conformance-mapped name.
- Final `go test ./internal/router -run 'TestRelayBlind' -race -count=1`: PASS, 16.776s. New coverage includes 30 API-key cases, 30 signed-wallet cases, and three audit-storage-failure cases, plus existing relay tests. API-key cases also verify unauthenticated requests produce no rejection audit; both matrices verify metadata admission bounds audit row creation.
- `go test ./... -race -count=1`: PASS across all seven tested gateway packages; router 87.607s, SQLite 12.194s. This full run used the final runtime code, before the last test-only wallet-matrix expansion and selector-name restoration; the final targeted run above includes those changes.
- `go vet ./...`: PASS.
- Root `PYTHONDONTWRITEBYTECODE=1 python3 scripts/check_spec_governance.py --base-ref origin/main`: PASS.
- Root `jq empty specs/AUTHORITY.json specs/CONFORMANCE.json`: PASS.
- Root `PYTHONDONTWRITEBYTECODE=1 python3 scripts/gen_spec_index.py --check`: PASS, 47 canonical specs and generated index current.
- Root `git diff --check`: PASS.

Independent `gpt-6-astra` / `ultra` code, security, and architecture/spec-boundary review lanes examined the complete final diff: 0 Critical, 0 High, 0 Medium, and 0 Low introduced findings; architecture CLEAR. The security lane also independently ran the three new test groups successfully. These results approve this bounded patch, not the unresolved baseline findings.

## Explicit Limits And Remaining Findings

- This is precheck rejection auditing, not complete coverage of every required-mode rejection. Authentication failures, outer admission failures, replay rejection, and metadata/storage limits retain their existing handling. Failed audit storage cannot provide a durable audit event.
- The API-key/demo relay metadata bucket has an existing units mismatch: `MetadataRequestsPerMinute` is passed to a limiter that refills per second. This patch preserves that implementation; fixed-time tests prove burst exhaustion, not correct per-minute sustained enforcement. Correcting the time unit with clock-advancing regressions is a separate bounded follow-up.
- A separate scratch HTTP regression reproduced the existing wallet/inner-replay precedence gap: with a fresh valid outer request ID and repeated inner envelope, an exhausted wallet metadata rate returns retryable `wallet_session_rate_limited`; exhausted wallet replay rows return `wallet_session_replay_capacity_exhausted`. With capacity available, the response is permanent `relay_blind_replay`. Same-outer duplicates preserve `wallet_session_duplicate_request`, with no dispatch or usage in all cases. That deliberately failing diagnostic is not committed here. A separate SPEC-040/041 slice must preserve atomic session-state checks and outer duplicate/mismatch semantics.
- Provider-side relay-blind crypto, successful encrypted journeys, and production behavior remain unverified. No deployment, release, signed journey capture, secret use, or production-readiness claim is made.
- SPEC-045 is handled separately in [#1407](https://github.com/Augustas11/macprovider/pull/1407). SPEC-046/047 findings remain outside this diff. SPEC-015 receipts, SPEC-022 verified settlement, billing, payout, and coordinator authority are unchanged.
- PRs #1407 and #1408 currently have a coordinator CI blocker in unchanged `TestJourneyTrustedPoolCreatorMVPCandidate`: repeated pool-timing p99/statistical threshold failures. The cause is unresolved, not assumed flaky. No required check has been bypassed or PR merged.

## Governance

This fixes `CODE_BUG` precheck audit omissions under SPEC-041-R007 while preserving R004 admission boundaries and exercising R008 local negative tests. All SPEC-041 conformance rows remain pending. Canonical specs, authority/conformance manifests, generated indexes, and signed evidence are unchanged. Local tests do not establish physical conformance; `not-required` below applies only to this unpromoted local fix, not future conformance promotion.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-041"],
  "requirements": ["SPEC-041-R004", "SPEC-041-R007", "SPEC-041-R008"],
  "authority_domains": ["relay-blind-request-encryption", "wallet-buyer-session"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "phase5-gateway/internal/router/relay_blind_rejection_audit_test.go#TestRelayBlindPrecheckRejectionsAuditBoundedMetadata",
    "phase5-gateway/internal/router/relay_blind_rejection_audit_test.go#TestRelayBlindWalletPrecheckAuditPreservesAdmission",
    "phase5-gateway/internal/router/relay_blind_rejection_audit_test.go#TestRelayBlindPrecheckAuditFailureFailsClosed",
    "phase5-gateway/internal/router/relay_blind_test.go#TestRelayBlindDisabledFamilyPrechecksModelAndCapsBeforeReplayAudit",
    "phase5-gateway/internal/router/relay_blind_test.go#TestRelayBlindDisabledFamilyWalletPrecheckStillRecordsWalletReplay"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END
