### PR TITLE
Fix SPEC-041 metadata refill time units

### DIFF
--- a/phase5-gateway/internal/router/relay_blind.go
+++ b/phase5-gateway/internal/router/relay_blind.go
@@ -614,7 +614,7 @@ func (s *Server) admitRelayBlindWalletMetadata(w http.ResponseWriter, r *http.Re
 
 func (s *Server) admitRelayBlindMetadataWrite(w http.ResponseWriter, r *http.Request, accountID string) bool {
 	limit := s.relayBlindMetadataRequestsPerMinute()
-	decision := s.relayBlindMetadataLimits.allow(accountID, limit, s.now())
+	decision := s.relayBlindMetadataLimits.allowPerMinute(accountID, limit, s.now())
 	if decision.Admitted {
 		return true
 	}

--- a/phase5-gateway/internal/router/relay_blind_metadata_rate_test.go
+++ b/phase5-gateway/internal/router/relay_blind_metadata_rate_test.go
@@ -1,0 +1,117 @@
+package router
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-gateway/internal/config"
+)
+
+func TestRelayBlindMetadataRefillsPerMinute(t *testing.T) {
+	for _, family := range []string{"chat_completions", "responses", "messages"} {
+		for _, enabled := range []bool{false, true} {
+			for _, mode := range []string{"required", "opportunistic"} {
+				for _, limit := range []int{1, 2} {
+					t.Run(fmt.Sprintf("%s/enabled=%t/%s/limit=%d", family, enabled, mode, limit), func(t *testing.T) {
+						start := fixedNow()
+						now := start
+						dispatches := 0
+						h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+							cfg.Features.RelayBlindRequests.Enabled = enabled
+							cfg.Features.ResponsesAPIEnabled = enabled
+							cfg.Features.AnthropicMessagesEnabled = enabled
+							cfg.Features.RelayBlindRequests.MetadataRequestsPerMinute = limit
+						}, WithNow(func() time.Time { return now }), WithHTTPClient(&http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+							dispatches++
+							return responseWithBody(http.StatusOK, nil, `{}`), nil
+						})}))
+						accountID := "acct_relay_minute"
+						key := createAccountAndKey(t, store, cfg, accountID)
+						otherKey := createAccountAndKey(t, store, cfg, "acct_relay_minute_other")
+						path := "/v1/" + family
+						if family == "chat_completions" {
+							path = "/v1/chat/completions"
+						}
+						acceptedStatus, acceptedCode := http.StatusBadRequest, "relay_blind_downgrade_rejected"
+						auditType := "relay_blind_downgrade_rejected"
+						if mode == "required" {
+							auditType = "relay_blind_required_rejected"
+							acceptedStatus, acceptedCode = http.StatusBadRequest, "relay_blind_endpoint_unsupported"
+							if !enabled {
+								acceptedStatus, acceptedCode = http.StatusServiceUnavailable, "relay_blind_disabled"
+							} else if family == "chat_completions" {
+								acceptedStatus, acceptedCode = http.StatusServiceUnavailable, "relay_blind_required_unavailable"
+							}
+						}
+						sequence := 0
+						body := func() string {
+							sequence++
+							return validRelayBlindRequestEnvelope(t, map[string]any{
+								"endpoint_family": family, "mode": mode, "issued_at_unix": now.Unix(),
+								"request_id": fmt.Sprintf("req-%d", sequence), "request_replay_nonce": fmt.Sprintf("nonce-%d", sequence),
+								"buyer_ephemeral_public_key": fmt.Sprintf("key-%d", sequence), "ciphertext": fmt.Sprintf("ciphertext-%d", sequence),
+							})
+						}
+						send := func(key, body string, status int, code string, retryAfter int) {
+							t.Helper()
+							req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+							req.Header.Set("Authorization", "Bearer "+key)
+							resp := httptest.NewRecorder()
+							h.ServeHTTP(resp, req)
+							if resp.Code != status {
+								t.Fatalf("at %s status=%d want %d body=%s", now.Sub(start), resp.Code, status, resp.Body.String())
+							}
+							if family == "messages" {
+								assertAnthropicErrorCode(t, resp.Body.String(), code)
+							} else {
+								assertErrorCode(t, resp.Body.String(), code)
+							}
+							if retryAfter > 0 {
+								assertBodyRetryable(t, resp.Body.String(), true)
+								if got := resp.Header().Get("Retry-After"); got != strconv.Itoa(retryAfter) {
+									t.Errorf("Retry-After=%q want %d", got, retryAfter)
+								}
+							}
+						}
+						first := body()
+						send(key, first, acceptedStatus, acceptedCode, 0)
+						for i := 1; i < limit; i++ {
+							send(key, body(), acceptedStatus, acceptedCode, 0)
+						}
+						interval := time.Minute / time.Duration(limit)
+						send(key, body(), http.StatusTooManyRequests, "relay_blind_metadata_rate_limited", int(interval.Seconds()))
+						now = start.Add(time.Second)
+						if mode == "required" {
+							send(key, first, http.StatusConflict, "relay_blind_replay", 0)
+						}
+						send(key, body(), http.StatusTooManyRequests, "relay_blind_metadata_rate_limited", int(interval.Seconds())-1)
+						send(otherKey, body(), acceptedStatus, acceptedCode, 0)
+						now = start.Add(interval - time.Millisecond)
+						send(key, body(), http.StatusTooManyRequests, "relay_blind_metadata_rate_limited", 1)
+						now = start.Add(interval)
+						send(key, body(), acceptedStatus, acceptedCode, 0)
+						send(key, body(), http.StatusTooManyRequests, "relay_blind_metadata_rate_limited", int(interval.Seconds()))
+						now = start.Add(3 * time.Minute)
+						for i := 0; i < limit; i++ {
+							send(key, body(), acceptedStatus, acceptedCode, 0)
+						}
+						send(key, body(), http.StatusTooManyRequests, "relay_blind_metadata_rate_limited", int(interval.Seconds()))
+						if got, want := countAuditEvents(t, dbPath, auditType), 2*limit+2; got != want {
+							t.Fatalf("audit rows=%d want %d", got, want)
+						}
+						if dispatches != 0 {
+							t.Fatalf("dispatches=%d want 0", dispatches)
+						}
+						assertNoDailyUsage(t, store, accountID)
+						assertNoDailyUsage(t, store, "acct_relay_minute_other")
+					})
+				}
+			}
+		}
+	}
+}

--- a/phase5-gateway/internal/router/request_rate_limiter.go
+++ b/phase5-gateway/internal/router/request_rate_limiter.go
@@ -36,6 +36,14 @@ func newRequestRateLimiter() *requestRateLimiter {
 }
 
 func (l *requestRateLimiter) allow(key string, limit int, now time.Time) requestRateDecision {
+	return l.allowWithRefillPeriod(key, limit, now, time.Second)
+}
+
+func (l *requestRateLimiter) allowPerMinute(key string, limit int, now time.Time) requestRateDecision {
+	return l.allowWithRefillPeriod(key, limit, now, time.Minute)
+}
+
+func (l *requestRateLimiter) allowWithRefillPeriod(key string, limit int, now time.Time, period time.Duration) requestRateDecision {
 	if limit <= 0 || key == "" {
 		return requestRateDecision{Admitted: true, Limit: limit}
 	}
@@ -49,14 +57,19 @@ func (l *requestRateLimiter) allow(key string, limit int, now time.Time) request
 		bucket = &requestRateBucket{tokens: capacity, last: now}
 		l.buckets[key] = bucket
 	}
-	if elapsed := now.Sub(bucket.last).Seconds(); elapsed > 0 {
-		bucket.tokens = math.Min(capacity, bucket.tokens+elapsed*capacity)
-		bucket.last = now
+	tokens := bucket.tokens
+	elapsed := math.Max(0, now.Sub(bucket.last).Seconds())
+	if elapsed > 0 {
+		tokens = math.Min(capacity, tokens+elapsed*capacity/period.Seconds())
 	}
 	bucket.lastSeen = now
 
-	if bucket.tokens >= 1 {
-		bucket.tokens--
+	if tokens >= 1 {
+		// Commit refill only on consumption so denied probes cannot accumulate rounding error.
+		bucket.tokens = tokens - 1
+		if now.After(bucket.last) {
+			bucket.last = now
+		}
 		return requestRateDecision{
 			Admitted:  true,
 			Limit:     limit,
@@ -64,7 +77,7 @@ func (l *requestRateLimiter) allow(key string, limit int, now time.Time) request
 		}
 	}
 
-	retryAfter := int(math.Ceil((1 - bucket.tokens) / capacity))
+	retryAfter := int(math.Ceil((1-bucket.tokens)*period.Seconds()/capacity - elapsed))
 	if retryAfter < 1 {
 		retryAfter = 1
 	}

--- a/phase5-gateway/internal/router/request_rate_limiter_test.go
+++ b/phase5-gateway/internal/router/request_rate_limiter_test.go
@@ -6,6 +6,60 @@ import (
 	"time"
 )
 
+func TestRequestRateLimiterPreservesPerSecondRefill(t *testing.T) {
+	limiter := newRequestRateLimiter()
+	start := time.Unix(1_700_000_000, 0)
+	for i, tc := range []struct {
+		elapsed time.Duration
+		admit   bool
+	}{
+		{0, true}, {0, true}, {0, false},
+		{499 * time.Millisecond, false}, {500 * time.Millisecond, true},
+		{500 * time.Millisecond, false}, {time.Second, true},
+	} {
+		got := limiter.allow("account", 2, start.Add(tc.elapsed))
+		if got.Admitted != tc.admit || (!tc.admit && got.RetryAfterSeconds != 1) {
+			t.Fatalf("step %d: decision=%+v want admitted=%t", i, got, tc.admit)
+		}
+	}
+}
+
+func TestRequestRateLimiterPerMinuteRefill(t *testing.T) {
+	for _, limit := range []int{1, 2, 120} {
+		t.Run(fmt.Sprint(limit), func(t *testing.T) {
+			limiter := newRequestRateLimiter()
+			start := time.Unix(1_700_000_000, 0)
+			for i := 0; i < limit; i++ {
+				if got := limiter.allowPerMinute("account", limit, start); !got.Admitted || got.Remaining != limit-i-1 {
+					t.Fatalf("burst %d: %+v", i, got)
+				}
+			}
+			interval := time.Minute / time.Duration(limit)
+			for elapsed := time.Second; elapsed < interval; elapsed += time.Second {
+				got := limiter.allowPerMinute("account", limit, start.Add(elapsed))
+				wantRetry := int((interval - elapsed + time.Second - 1) / time.Second)
+				if got.Admitted || got.RetryAfterSeconds != wantRetry {
+					t.Errorf("at %s: %+v want retry=%d", elapsed, got, wantRetry)
+				}
+			}
+			for i := 1; i < 100; i++ {
+				if got := limiter.allowPerMinute("account", limit, start.Add(interval*time.Duration(i)/100)); got.Admitted {
+					t.Fatalf("probe %d refilled early: %+v", i, got)
+				}
+			}
+			if got := limiter.allowPerMinute("account", limit, start.Add(interval-time.Millisecond)); got.Admitted || got.RetryAfterSeconds != 1 {
+				t.Fatalf("before refill: %+v", got)
+			}
+			if got := limiter.allowPerMinute("account", limit, start.Add(interval)); !got.Admitted || got.Remaining != 0 {
+				t.Fatalf("at refill: %+v", got)
+			}
+			if got := limiter.allowPerMinute("account", limit, start.Add(interval)); got.Admitted {
+				t.Fatalf("extra token after refill: %+v", got)
+			}
+		})
+	}
+}
+
 func TestRequestRateLimiterCapsDistinctBuckets(t *testing.T) {
 	limiter := newRequestRateLimiter()
 	now := time.Unix(1_700_000_000, 0)


### PR DESCRIPTION
## Summary

Fix the SPEC-041 metadata rate time-unit defect found while reviewing [#1411](https://github.com/Augustas11/macprovider/pull/1411). This is an independent branch from `origin/main` at `62dd0798`, not stacked on that PR.

`MetadataRequestsPerMinute` previously fed a per-second token refill, allowing approximately 60 times the configured sustained metadata rate. Relay metadata now uses an explicit per-minute entry point; plaintext account admission retains its per-second entry point and separate bucket instance.

The existing token-bucket contract is retained: capacity N permits an initial N-token burst, followed by N/minute refill. This is not a hard rolling-window N-request ceiling. Both paths calculate `Retry-After` in seconds. Denied probes calculate available refill without committing fractional balance, avoiding accumulated rounding at the admission boundary; retry countdown is calculated from the last consumed deficit to avoid one-second overstatements.

Changed files:

- `phase5-gateway/internal/router/relay_blind.go`: select minute-based metadata refill.
- `phase5-gateway/internal/router/request_rate_limiter.go`: explicit time-unit wrappers and stable refill/countdown calculation.
- `phase5-gateway/internal/router/request_rate_limiter_test.go`: plaintext per-second control; minute limits 1, 2, and 120; frequent probes, exact refill boundaries, and integer-second countdowns.
- `phase5-gateway/internal/router/relay_blind_metadata_rate_test.go`: 24 HTTP cases across required/downgrade requests, three endpoint families, enabled/disabled features, and limits 1/2. Checks burst exhaustion, one-second denial, refill boundaries, idle burst cap, account isolation, API-key replay precedence, audit counts, and no dispatch/usage.

## Verification

Gateway commands ran from `phase5-gateway`:

- Regression first: `go test ./internal/router -run 'TestRelayBlindMetadataRefillsPerMinute|TestRequestRateLimiterPreservesPerSecondRefill' -count=1` failed all 24 HTTP cases on the original implementation: premature refill at one second and incorrect `Retry-After`. The plaintext control passed.
- Integer-second countdown regressions also failed before the review follow-up fix, including limit 1 at 59 seconds and limit 2 at 10 seconds.
- Final `go test ./internal/router -run 'TestRelayBlind|TestRequestRateLimiter' -race -count=1`: PASS, 12.769s.
- Final `go test ./... -race -count=1`: PASS, all seven tested gateway packages; router 82.234s, SQLite 11.061s.
- `go vet ./...`: PASS.
- Root `PYTHONDONTWRITEBYTECODE=1 python3 scripts/check_spec_governance.py --base-ref origin/main`: PASS against `62dd0798`.
- Root `jq empty specs/AUTHORITY.json specs/CONFORMANCE.json`, `PYTHONDONTWRITEBYTECODE=1 python3 scripts/gen_spec_index.py --check`, and `git diff --check`: PASS.

The first governance run used the old worktree after another session advanced the shared `origin/main` reference and reported an upstream SPEC-003 requirement missing from the old tree. Refreshing this isolated branch to `62dd0798` resolved that stale-base comparison; no governance files were edited by this task.

Final independent `gpt-6-astra` / `ultra` code, security, and architecture/spec-boundary reviews: 0 Critical, 0 High, 0 Medium, 0 Low; architecture CLEAR. The code lane's initial Low retry-countdown finding was fixed and re-reviewed.

## Boundaries And Remaining Gaps

No wallet-session admission, replay ordering, quota/settlement, provider crypto, schema, conformance status, signed evidence, or production behavior is promoted or changed. SPEC-041 rows remain pending. This does not fix the separately reproduced wallet metadata-before-inner-replay precedence issue.

The limiter remains process-local and bounded by the existing bucket cache; restart, eviction, and distributed enforcement semantics are unchanged. No live gateway or signed physical journey was captured. The local assertions do not establish complete SPEC-041 conformance. Existing precheck audit omissions are handled separately by #1411.

## Governance

`CODE_BUG` applies to the configuration/refill unit mismatch. R004 covers metadata admission ceilings, R005 is exercised only as an unchanged API-key replay-precedence boundary, R007 covers typed retry behavior, and R008 covers local negative tests. `not-required` means no new signed journey is needed to submit this unpromoted local fix, not that physical evidence is unnecessary for future conformance promotion.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-041"],
  "requirements": ["SPEC-041-R004", "SPEC-041-R005", "SPEC-041-R007", "SPEC-041-R008"],
  "authority_domains": ["relay-blind-request-encryption"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "phase5-gateway/internal/router/relay_blind_metadata_rate_test.go#TestRelayBlindMetadataRefillsPerMinute",
    "phase5-gateway/internal/router/request_rate_limiter_test.go#TestRequestRateLimiterPreservesPerSecondRefill",
    "phase5-gateway/internal/router/request_rate_limiter_test.go#TestRequestRateLimiterPerMinuteRefill"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END
