### PR TITLE
Preserve SPEC-041 replay precedence under wallet throttling

### DIFF
--- a/phase5-gateway/internal/router/relay_blind.go
+++ b/phase5-gateway/internal/router/relay_blind.go
@@ -582,8 +582,9 @@ func (s *Server) admitRelayBlindWalletMetadata(w http.ResponseWriter, r *http.Re
 		return false
 	}
 	err = s.store.AdmitWalletSessionMetadata(r.Context(), storage.WalletSessionMetadataAdmissionRequest{
-		SessionID: sessionAuth.Session.SessionID,
-		AccountID: sessionAuth.Session.AccountID,
+		RelayBlindReplay: s.walletMetadataRelayReplayCandidate(r, sessionAuth.Session, rawBody),
+		SessionID:        sessionAuth.Session.SessionID,
+		AccountID:        sessionAuth.Session.AccountID,
 		Replay: storage.WalletSessionReplayMaterial{
 			SessionID:           sessionAuth.Session.SessionID,
 			RequestID:           requestID(r),
@@ -603,13 +604,49 @@ func (s *Server) admitRelayBlindWalletMetadata(w http.ResponseWriter, r *http.Re
 	if err == nil {
 		return true
 	}
+	reason := walletSessionAdmissionAuditReason(err)
+	if errors.Is(err, storage.ErrRelayBlindReplay) {
+		reason = "relay_blind_replay"
+	}
 	s.recordWalletSessionAudit(r.Context(), sessionAuth.Session.AccountID, sessionAuth.Session.SessionID, "wallet_session_rejected", "gateway", map[string]any{
 		"request_id":      requestID(r),
 		"canonical_route": walletCanonicalRouteForRequest(r),
-		"reason":          walletSessionAdmissionAuditReason(err),
+		"reason":          reason,
 	})
+	if errors.Is(err, storage.ErrRelayBlindReplay) {
+		writeError(w, http.StatusConflict, "invalid_request_error", "relay_blind_replay", "Relay-blind request envelope was already seen in the replay retention window")
+		return false
+	}
 	s.writeWalletAdmissionError(w, err, storage.WalletSessionAdmissionDecision{})
 	return false
+}
+
+func (s *Server) walletMetadataRelayReplayCandidate(r *http.Request, session storage.WalletSession, body []byte) *storage.RelayBlindReplayMaterial {
+	if r.Method != http.MethodPost {
+		return nil
+	}
+	// Disabled adapters have no endpoint context. Bind to the signed public route,
+	// and never interpret route-reservation metadata as an inference envelope.
+	var family string
+	switch walletCanonicalRouteForRequest(r) {
+	case "/v1/chat/completions":
+		family = "chat_completions"
+	case "/v1/responses":
+		family = "responses"
+	case "/v1/messages":
+		family = "messages"
+	default:
+		return nil
+	}
+	env, err := s.validateRelayBlindRequestEnvelope(body, family, s.cfg.Features.RelayBlindRequests.Enabled)
+	if err != nil || !s.relayBlindEnvelopeFresh(env) {
+		return nil
+	}
+	if _, allowed := walletModelAllowlist(session)[env.Model]; !allowed || relayBlindWalletSessionCapExceeded(session.PerRequestTokenCap, env.InputTokenUpperBound, env.MaxOutputTokens, env.ReservationTokenCap) {
+		return nil
+	}
+	replay := s.relayBlindReplayMaterial(session.AccountID, session.SessionID, env, body)
+	return &replay
 }
 
 func (s *Server) admitRelayBlindMetadataWrite(w http.ResponseWriter, r *http.Request, accountID string) bool {

--- a/phase5-gateway/internal/router/relay_blind_session_replay_test.go
+++ b/phase5-gateway/internal/router/relay_blind_session_replay_test.go
@@ -1,0 +1,141 @@
+package router
+
+import (
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRelayBlindWalletReplayBeforeTemporalThrottle(t *testing.T) {
+	for _, route := range []struct {
+		path, family    string
+		adaptersEnabled bool
+	}{
+		{"/v1/chat/completions", "chat_completions", false},
+		{"/v1/responses", "responses", false},
+		{"/v1/messages", "messages", false},
+		{"/v1/responses", "responses", true},
+		{"/v1/messages", "messages", true},
+	} {
+		for _, enabled := range []bool{false, true} {
+			for _, bound := range []string{"available", "rate", "rows", "bytes"} {
+				t.Run(route.family+"/"+map[bool]string{false: "disabled", true: "enabled"}[enabled]+"/"+bound, func(t *testing.T) {
+					dispatches := 0
+					baseClient := walletModelsClient()
+					client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+						if !strings.HasSuffix(r.URL.Path, "/poolz") {
+							dispatches++
+						}
+						return baseClient.Transport.RoundTrip(r)
+					})}
+					h, store, dbPath, cfg := newWalletSessionHarness(t, client)
+					cfg.Features.RelayBlindRequests.Enabled = enabled
+					cfg.Features.ResponsesAPIEnabled = route.adaptersEnabled
+					cfg.Features.AnthropicMessagesEnabled = route.adaptersEnabled
+					cfg.Auth.WalletSessions.MetadataRequestsPerMinute = 100
+					body := []byte(validRelayBlindRequestEnvelope(t, map[string]any{"endpoint_family": route.family}))
+					if bound != "available" {
+						cfg.Auth.WalletSessions.MetadataRequestsPerMinute = 1
+					}
+					if bound == "rows" {
+						cfg.Auth.WalletSessions.ReplayMaxRowsPerSession = 1
+					}
+					if bound == "bytes" {
+						cfg.Auth.WalletSessions.ReplayMaxBytesPerSession = int64(len(body))
+					}
+					h = New(cfg, store, fakeOAuth{}, WithNow(fixedNow), WithHTTPClient(client)).Handler()
+					accountID := "acct_wallet_relay_precedence"
+					key := createAccountAndKey(t, store, cfg, accountID)
+					wallet := registerWalletSessionViaAPI(t, h, cfg, key, accountID, []string{"model-a"})
+					send := func(id string, payload []byte) *httptest.ResponseRecorder {
+						response := httptest.NewRecorder()
+						h.ServeHTTP(response, signedWalletRequest(t, wallet, http.MethodPost, route.path, route.path, id, payload))
+						return response
+					}
+					firstID := "018f7b7b-7c35-4cf0-8d4e-3f0ab1c4a901"
+					first := send(firstID, body)
+					if first.Code < 400 || first.Code == http.StatusTooManyRequests {
+						t.Fatalf("first response=%d %s", first.Code, first.Body.String())
+					}
+					assertErrorCode(t, send(firstID, body).Body.String(), "wallet_session_duplicate_request")
+					assertErrorCode(t, send(firstID, append(append([]byte(nil), body...), ' ')).Body.String(), "wallet_session_replay_mismatch")
+					replayed := send("018f7b7b-7c35-4cf0-8d4e-3f0ab1c4a902", body)
+					want := "relay_blind_replay"
+					if bound == "rows" || bound == "bytes" {
+						want = "wallet_session_replay_capacity_exhausted"
+					}
+					if replayed.Code != http.StatusConflict {
+						t.Fatalf("replay status=%d want 409: %s", replayed.Code, replayed.Body.String())
+					}
+					assertErrorCode(t, replayed.Body.String(), want)
+					assertBodyRetryable(t, replayed.Body.String(), false)
+					db, err := sql.Open("sqlite", dbPath)
+					if err != nil {
+						t.Fatal(err)
+					}
+					defer db.Close()
+					var rows int
+					if err := db.QueryRow(`SELECT COUNT(*) FROM wallet_session_replays WHERE session_id = ?`, wallet.SessionID).Scan(&rows); err != nil {
+						t.Fatal(err)
+					}
+					wantRows := 1
+					if bound == "available" {
+						wantRows = 2
+					}
+					if rows != wantRows || dispatches != 0 {
+						t.Fatalf("metadata rows=%d want %d; dispatches=%d want 0", rows, wantRows, dispatches)
+					}
+					if bound == "rate" {
+						var audits int
+						if err := db.QueryRow(`SELECT COUNT(*) FROM audit_events WHERE event_type = 'wallet_session_rejected' AND json_extract(payload_json, '$.reason') = 'relay_blind_replay'`).Scan(&audits); err != nil || audits != 1 {
+							t.Fatalf("replay audits=%d want 1 err=%v", audits, err)
+						}
+					}
+					assertNoDailyUsage(t, store, accountID)
+				})
+			}
+		}
+	}
+}
+
+func TestRelayBlindWalletThrottleDoesNotClassifyInvalidOrFreshReplay(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		overrides map[string]any
+	}{
+		{"fresh", map[string]any{"request_id": "fresh-request", "request_replay_nonce": "fresh-nonce", "buyer_ephemeral_public_key": "fresh-key"}},
+		{"downgrade", map[string]any{"mode": "preferred"}},
+		{"unknown_field", map[string]any{"unexpected": "value"}},
+		{"stale", map[string]any{"issued_at_unix": fixedNow().Add(-2 * time.Minute).Unix()}},
+		{"wrong_route", map[string]any{"endpoint_family": "responses"}},
+		{"model_denied", map[string]any{"model": "model-b"}},
+		{"cap_exceeded", map[string]any{"reservation_token_cap": 51}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := walletModelsClient()
+			h, store, _, cfg := newWalletSessionHarness(t, client)
+			cfg.Features.RelayBlindRequests.Enabled = true
+			cfg.Auth.WalletSessions.MetadataRequestsPerMinute = 1
+			h = New(cfg, store, fakeOAuth{}, WithNow(fixedNow), WithHTTPClient(client)).Handler()
+			accountID := "acct_wallet_relay_controls"
+			key := createAccountAndKey(t, store, cfg, accountID)
+			wallet := registerWalletSessionViaAPI(t, h, cfg, key, accountID, []string{"model-a"})
+			send := func(id string, overrides map[string]any) *httptest.ResponseRecorder {
+				response := httptest.NewRecorder()
+				h.ServeHTTP(response, signedWalletRequest(t, wallet, http.MethodPost, "/v1/chat/completions", "/v1/chat/completions", id, []byte(validRelayBlindRequestEnvelope(t, overrides))))
+				return response
+			}
+			assertErrorCode(t, send("018f7b7b-7c35-4cf0-8d4e-3f0ab1c4a901", nil).Body.String(), "relay_blind_required_unavailable")
+			response := send("018f7b7b-7c35-4cf0-8d4e-3f0ab1c4a902", tc.overrides)
+			if response.Code != http.StatusTooManyRequests {
+				t.Fatalf("status=%d want 429 body=%s", response.Code, response.Body.String())
+			}
+			assertErrorCode(t, response.Body.String(), "wallet_session_rate_limited")
+			assertBodyRetryable(t, response.Body.String(), true)
+			assertNoDailyUsage(t, store, accountID)
+		})
+	}
+}

--- a/phase5-gateway/internal/storage/sqlite/metadata_relay_replay_test.go
+++ b/phase5-gateway/internal/storage/sqlite/metadata_relay_replay_test.go
@@ -1,0 +1,365 @@
+package sqlite
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-gateway/internal/storage"
+)
+
+func TestWalletMetadataRelayReplayRetentionWithoutCleanup(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		offset time.Duration
+		want   error
+	}{
+		{"before_second", -time.Second, storage.ErrRelayBlindReplay},
+		{"before_nanosecond", -time.Nanosecond, storage.ErrRelayBlindReplay},
+		{"at", 0, storage.ErrRateLimit},
+		{"after_nanosecond", time.Nanosecond, storage.ErrRateLimit},
+		{"after_second", time.Second, storage.ErrRateLimit},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store, req, replay := metadataRelayReplayFixture(t)
+			recordMetadataRelayReplay(t, store, replay)
+			req.CreatedAt = replay.RetentionExpiresAt.Add(tc.offset)
+			// The candidate's clock and expiry must not replace admission time or stored retention.
+			replay.CreatedAt = fixedTime().Add(time.Hour)
+			if tc.offset >= 0 {
+				replay.CreatedAt = fixedTime().Add(-time.Hour)
+			}
+			replay.RetentionExpiresAt = req.CreatedAt.Add(time.Hour)
+			req.RelayBlindReplay = &replay
+			assertMetadataRelayReplayRejected(t, store, req, tc.want)
+			var rows int
+			if err := store.db.QueryRow(`SELECT COUNT(*) FROM relay_blind_replays`).Scan(&rows); err != nil {
+				t.Fatal(err)
+			}
+			if rows != 1 {
+				t.Fatalf("retained rows=%d want 1 without cleanup", rows)
+			}
+		})
+	}
+}
+
+func TestWalletMetadataRelayReplayFractionalExpiryAfterWholeSecond(t *testing.T) {
+	store, req, replay := metadataRelayReplayFixture(t)
+	req.CreatedAt = fixedTime().Add(10 * time.Second)
+	replay.RetentionExpiresAt = req.CreatedAt.Add(time.Nanosecond)
+	recordMetadataRelayReplay(t, store, replay)
+	req.RelayBlindReplay = &replay
+	assertMetadataRelayReplayRejected(t, store, req, storage.ErrRelayBlindReplay)
+}
+
+func TestWalletMetadataRelayReplayAnyRetainedMatchingRowWins(t *testing.T) {
+	for _, firstExpired := range []bool{true, false} {
+		t.Run(fmt.Sprintf("first_expired_%t", firstExpired), func(t *testing.T) {
+			store, req, first := metadataRelayReplayFixture(t)
+			second := first
+			second.RequestID = "second-inner-request"
+			second.RequestReplayNonceDigest = []byte("second-inner-nonce")
+			second.BuyerEphemeralPublicKeyDigest = []byte("second-inner-buyer-key")
+			second.EnvelopeDigest = []byte("second-inner-envelope")
+			second.RetentionExpiresAt = fixedTime().Add(20 * time.Second)
+			if !firstExpired {
+				first.RetentionExpiresAt, second.RetentionExpiresAt = second.RetentionExpiresAt, first.RetentionExpiresAt
+			}
+			recordMetadataRelayReplay(t, store, first)
+			recordMetadataRelayReplay(t, store, second)
+			req.CreatedAt = fixedTime().Add(11 * time.Second)
+			// This candidate matches the first request ID and the second nonce.
+			first.RequestReplayNonceDigest = second.RequestReplayNonceDigest
+			req.RelayBlindReplay = &first
+			assertMetadataRelayReplayRejected(t, store, req, storage.ErrRelayBlindReplay)
+		})
+	}
+}
+
+func TestWalletMetadataRelayReplayMatchesEachIdentity(t *testing.T) {
+	for _, identity := range []string{"request_id", "nonce", "buyer_key", "envelope"} {
+		t.Run(identity, func(t *testing.T) {
+			store, req, replay := metadataRelayReplayFixture(t)
+			recordMetadataRelayReplay(t, store, replay)
+			candidate := replay
+			candidate.RequestID = "fresh-inner-request"
+			candidate.RequestReplayNonceDigest = []byte("fresh-nonce")
+			candidate.BuyerEphemeralPublicKeyDigest = []byte("fresh-buyer-key")
+			candidate.EnvelopeDigest = []byte("fresh-envelope")
+			switch identity {
+			case "request_id":
+				candidate.RequestID = replay.RequestID
+			case "nonce":
+				candidate.RequestReplayNonceDigest = replay.RequestReplayNonceDigest
+			case "buyer_key":
+				candidate.BuyerEphemeralPublicKeyDigest = replay.BuyerEphemeralPublicKeyDigest
+			case "envelope":
+				candidate.EnvelopeDigest = replay.EnvelopeDigest
+			}
+			req.RelayBlindReplay = &candidate
+			assertMetadataRelayReplayRejected(t, store, req, storage.ErrRelayBlindReplay)
+		})
+	}
+}
+
+func TestWalletMetadataRelayReplayBindsAdmissionScope(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		storedAccount string
+		storedSession string
+		want          error
+	}{
+		{"candidate_cannot_override_scope", "acct_metadata_relay", "ws_metadata_relay", storage.ErrRelayBlindReplay},
+		{"other_account", "acct_other", "ws_metadata_relay", storage.ErrRateLimit},
+		{"other_session", "acct_metadata_relay", "ws_other", storage.ErrRateLimit},
+		{"api_key_scope", "acct_metadata_relay", "", storage.ErrRateLimit},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store, req, replay := metadataRelayReplayFixture(t)
+			replay.AccountID, replay.WalletSessionID = tc.storedAccount, tc.storedSession
+			recordMetadataRelayReplay(t, store, replay)
+			if tc.want == storage.ErrRelayBlindReplay {
+				replay.AccountID, replay.WalletSessionID = "acct_other", "ws_other"
+			}
+			req.RelayBlindReplay = &replay
+			originalScope := [2]string{replay.AccountID, replay.WalletSessionID}
+			assertMetadataRelayReplayRejected(t, store, req, tc.want)
+			if got := [2]string{replay.AccountID, replay.WalletSessionID}; got != originalScope {
+				t.Fatal("admission mutated caller-owned replay scope")
+			}
+		})
+	}
+}
+
+func TestWalletMetadataRelayReplayFreshAndAbsentCandidatesRemainRateLimited(t *testing.T) {
+	for _, present := range []bool{false, true} {
+		t.Run(fmt.Sprintf("candidate_%t", present), func(t *testing.T) {
+			store, req, replay := metadataRelayReplayFixture(t)
+			recordMetadataRelayReplay(t, store, replay)
+			if present {
+				replay.RequestID = "fresh-inner-request"
+				replay.RequestReplayNonceDigest = []byte("fresh-nonce")
+				replay.BuyerEphemeralPublicKeyDigest = []byte("fresh-buyer-key")
+				replay.EnvelopeDigest = []byte("fresh-envelope")
+				req.RelayBlindReplay = &replay
+			}
+			assertMetadataRelayReplayRejected(t, store, req, storage.ErrRateLimit)
+		})
+	}
+}
+
+func TestWalletMetadataRelayReplayOnlyClassifiesTemporalRejection(t *testing.T) {
+	for _, rateLimit := range []int{0, 2} {
+		t.Run(fmt.Sprintf("rate_limit_%d", rateLimit), func(t *testing.T) {
+			store, req, replay := metadataRelayReplayFixture(t)
+			recordMetadataRelayReplay(t, store, replay)
+			req.RateLimit = rateLimit
+			req.RelayBlindReplay = &replay
+			before := metadataRelayReplayState(t, store)
+			if err := store.AdmitWalletSessionMetadata(context.Background(), req); err != nil {
+				t.Fatalf("metadata admission with available rate budget: %v", err)
+			}
+			want := before
+			want[0]++
+			want[1]++
+			if got := metadataRelayReplayState(t, store); got != want {
+				t.Fatalf("state=%v want only one new metadata replay %v", got, want)
+			}
+		})
+	}
+}
+
+func TestWalletMetadataRelayReplayExistingGuardsKeepPrecedence(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		want error
+	}{
+		{"outer_duplicate", storage.ErrWalletSessionReplayDuplicate},
+		{"outer_mismatch", storage.ErrWalletSessionReplayMismatch},
+		{"hard_rows", storage.ErrWalletSessionReplayCapacity},
+		{"hard_bytes", storage.ErrWalletSessionReplayCapacity},
+		{"revoked_session", storage.ErrWalletSessionInactive},
+		{"expired_session", storage.ErrWalletSessionInactive},
+		{"inactive_account", storage.ErrWalletSessionInactive},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store, req, replay := metadataRelayReplayFixture(t)
+			recordMetadataRelayReplay(t, store, replay)
+			req.RelayBlindReplay = &replay
+			switch tc.name {
+			case "outer_duplicate", "outer_mismatch":
+				req.Replay.RequestID = "outer-seed"
+				req.MaxReplayRows, req.MaxReplayBytes = 1, 1
+				if tc.name == "outer_mismatch" {
+					req.Replay.RawBodyHash = []byte("different-body")
+				}
+			case "hard_rows":
+				req.MaxReplayRows = 1
+			case "hard_bytes":
+				req.MaxReplayBytes = 2*req.Replay.BodyBytes - 1
+			case "revoked_session":
+				if err := store.RevokeWalletSession(context.Background(), req.AccountID, req.SessionID, "test", "test", req.CreatedAt); err != nil {
+					t.Fatal(err)
+				}
+			case "expired_session":
+				if _, err := store.db.Exec(`UPDATE wallet_sessions SET expires_at = ? WHERE session_id = ?`, encodeTime(req.CreatedAt), req.SessionID); err != nil {
+					t.Fatal(err)
+				}
+			case "inactive_account":
+				if _, err := store.db.Exec(`UPDATE accounts SET status = 'blocked' WHERE account_id = ?`, req.AccountID); err != nil {
+					t.Fatal(err)
+				}
+			}
+			assertMetadataRelayReplayRejected(t, store, req, tc.want)
+		})
+	}
+}
+
+func TestWalletMetadataRelayReplayLookupErrorFailsClosed(t *testing.T) {
+	store, req, replay := metadataRelayReplayFixture(t)
+	recordMetadataRelayReplay(t, store, replay)
+	req.RelayBlindReplay = &replay
+	if _, err := store.db.Exec(`ALTER TABLE relay_blind_replays RENAME COLUMN retention_expires_at TO unavailable_retention_expires_at`); err != nil {
+		t.Fatal(err)
+	}
+	before := metadataRelayReplayState(t, store)
+	err := store.AdmitWalletSessionMetadata(context.Background(), req)
+	if err == nil || errors.Is(err, storage.ErrRateLimit) || errors.Is(err, storage.ErrRelayBlindReplay) || !strings.Contains(err.Error(), "retention_expires_at") {
+		t.Fatalf("lookup error=%v want storage error naming missing retention column", err)
+	}
+	if got := metadataRelayReplayState(t, store); got != before {
+		t.Fatalf("failed lookup changed state: before=%v after=%v", before, got)
+	}
+}
+
+func TestWalletMetadataRelayReplayCorruptRetentionFailsClosed(t *testing.T) {
+	store, req, replay := metadataRelayReplayFixture(t)
+	recordMetadataRelayReplay(t, store, replay)
+	req.RelayBlindReplay = &replay
+	if _, err := store.db.Exec(`UPDATE relay_blind_replays SET retention_expires_at = 'invalid-timestamp' WHERE request_id = ?`, replay.RequestID); err != nil {
+		t.Fatal(err)
+	}
+	before := metadataRelayReplayState(t, store)
+	err := store.AdmitWalletSessionMetadata(context.Background(), req)
+	if err == nil || errors.Is(err, storage.ErrRateLimit) || errors.Is(err, storage.ErrRelayBlindReplay) {
+		t.Fatalf("corrupt retention error=%v want storage error", err)
+	}
+	if got := metadataRelayReplayState(t, store); got != before {
+		t.Fatalf("corrupt retention lookup changed state: before=%v after=%v", before, got)
+	}
+}
+
+func TestWalletMetadataRelayReplayConcurrentRejectionsPreserveState(t *testing.T) {
+	store, req, replay := metadataRelayReplayFixture(t)
+	recordMetadataRelayReplay(t, store, replay)
+	req.RelayBlindReplay = &replay
+	if _, err := store.AdmitWalletSessionInference(context.Background(), walletAdmission(req.AccountID, req.SessionID, "reserved-before-rejections", 20)); err != nil {
+		t.Fatalf("seed inference reservation: %v", err)
+	}
+	before := metadataRelayReplayState(t, store)
+	const attempts = 16
+	start := make(chan struct{})
+	results := make(chan error, attempts)
+	var wg sync.WaitGroup
+	for i := 0; i < attempts; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			candidate := req
+			candidate.Replay.RequestID = fmt.Sprintf("concurrent-outer-%d", i)
+			<-start
+			results <- store.AdmitWalletSessionMetadata(context.Background(), candidate)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+	for err := range results {
+		if !errors.Is(err, storage.ErrRelayBlindReplay) {
+			t.Errorf("concurrent rejection=%v want ErrRelayBlindReplay", err)
+		}
+	}
+	if got := metadataRelayReplayState(t, store); got != before {
+		t.Fatalf("rejected lookups changed state: before=%v after=%v", before, got)
+	}
+	used, reserved, err := store.DailyUsage(context.Background(), req.AccountID, "2026-05-29")
+	if err != nil || used != 0 || reserved != 20 {
+		t.Fatalf("daily usage after rejection: used=%d reserved=%d err=%v want 0,20,nil", used, reserved, err)
+	}
+}
+
+func metadataRelayReplayFixture(t *testing.T) (*Store, storage.WalletSessionMetadataAdmissionRequest, storage.RelayBlindReplayMaterial) {
+	t.Helper()
+	store := newTestStore(t)
+	createWalletSession(t, store, "acct_metadata_relay", "ws_metadata_relay", 1000, 100)
+	req := storage.WalletSessionMetadataAdmissionRequest{
+		AccountID:      "acct_metadata_relay",
+		SessionID:      "ws_metadata_relay",
+		Replay:         walletReplay("ws_metadata_relay", "outer-seed", "POST", "/v1/chat/completions", []byte("outer-body"), 128, "192.0.2.1"),
+		WindowStart:    fixedTime().Add(-time.Minute),
+		RateLimit:      1,
+		MaxReplayRows:  100,
+		MaxReplayBytes: 100000,
+		CreatedAt:      fixedTime(),
+	}
+	if err := store.AdmitWalletSessionMetadata(context.Background(), req); err != nil {
+		t.Fatalf("seed metadata rate budget: %v", err)
+	}
+	req.Replay.RequestID = "outer-retry"
+	req.CreatedAt = fixedTime().Add(time.Second)
+	return store, req, storage.RelayBlindReplayMaterial{
+		AccountID:                     req.AccountID,
+		WalletSessionID:               req.SessionID,
+		RequestID:                     "inner-request",
+		RequestReplayNonceDigest:      []byte("inner-nonce"),
+		BuyerEphemeralPublicKeyDigest: []byte("inner-buyer-key"),
+		ProviderBindingDigest:         []byte("provider-binding"),
+		KIDDigest:                     []byte("kid"),
+		EnvelopeDigest:                []byte("inner-envelope"),
+		EnvelopeBytes:                 128,
+		RetentionExpiresAt:            fixedTime().Add(10 * time.Second),
+		CreatedAt:                     fixedTime(),
+	}
+}
+
+func recordMetadataRelayReplay(t *testing.T, store *Store, replay storage.RelayBlindReplayMaterial) {
+	t.Helper()
+	if err := store.RecordRelayBlindReplay(context.Background(), replay); err != nil {
+		t.Fatalf("seed inner replay: %v", err)
+	}
+}
+
+func assertMetadataRelayReplayRejected(t *testing.T, store *Store, req storage.WalletSessionMetadataAdmissionRequest, want error) {
+	t.Helper()
+	before := metadataRelayReplayState(t, store)
+	if err := store.AdmitWalletSessionMetadata(context.Background(), req); !errors.Is(err, want) {
+		t.Fatalf("metadata rejection=%v want %v", err, want)
+	}
+	if got := metadataRelayReplayState(t, store); got != before {
+		t.Fatalf("rejection changed state: before=%v after=%v", before, got)
+	}
+}
+
+func metadataRelayReplayState(t *testing.T, store *Store) [9]int64 {
+	t.Helper()
+	var state [9]int64
+	err := store.db.QueryRow(`SELECT
+		(SELECT COUNT(*) FROM wallet_session_replays),
+		(SELECT COUNT(*) FROM wallet_session_replays WHERE state = 'metadata_only'),
+		(SELECT COUNT(*) FROM relay_blind_replays),
+		(SELECT COUNT(*) FROM wallet_session_reservations),
+		(SELECT COALESCE(SUM(reserved_tokens), 0) FROM wallet_session_reservations),
+		(SELECT COUNT(*) FROM quota_reservations),
+		(SELECT COALESCE(SUM(reserved_tokens), 0) FROM quota_reservations),
+		(SELECT COUNT(*) FROM wallet_session_request_map),
+		(SELECT COUNT(*) FROM usage_events)`).Scan(
+		&state[0], &state[1], &state[2], &state[3], &state[4], &state[5], &state[6], &state[7], &state[8])
+	if err != nil {
+		t.Fatalf("read admission state: %v", err)
+	}
+	return state
+}

--- a/phase5-gateway/internal/storage/sqlite/store.go
+++ b/phase5-gateway/internal/storage/sqlite/store.go
@@ -2154,6 +2154,17 @@ func (s *Store) AdmitWalletSessionMetadata(ctx context.Context, req storage.Wall
 			return err
 		}
 		if count >= req.RateLimit {
+			if req.RelayBlindReplay != nil {
+				replay := *req.RelayBlindReplay
+				replay.AccountID, replay.WalletSessionID = req.AccountID, req.SessionID
+				seen, err := retainedRelayBlindReplaySeenTx(ctx, tx, replay, now)
+				if err != nil {
+					return err
+				}
+				if seen {
+					return storage.ErrRelayBlindReplay
+				}
+			}
 			return storage.ErrRateLimit
 		}
 	}
@@ -2238,6 +2249,35 @@ func (s *Store) RelayBlindReplaySeen(ctx context.Context, replay storage.RelayBl
 		return false, err
 	}
 	return seen, nil
+}
+
+// The four scoped unique replay identities bound the result set. Parse expiry
+// instead of sorting RFC3339Nano text, whose fractional precision can vary.
+func retainedRelayBlindReplaySeenTx(ctx context.Context, tx *immediateTx, replay storage.RelayBlindReplayMaterial, now time.Time) (bool, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT retention_expires_at FROM relay_blind_replays
+		WHERE account_id = ? AND wallet_session_id = ?
+			AND (request_id = ? OR request_replay_nonce_digest = ?
+				OR buyer_ephemeral_public_key_digest = ? OR envelope_digest = ?)`,
+		replay.AccountID, replay.WalletSessionID, replay.RequestID, replay.RequestReplayNonceDigest,
+		replay.BuyerEphemeralPublicKeyDigest, replay.EnvelopeDigest)
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+	seen := false
+	for rows.Next() {
+		var rawExpiry string
+		if err := rows.Scan(&rawExpiry); err != nil {
+			return false, err
+		}
+		expiry, err := time.Parse(time.RFC3339Nano, rawExpiry)
+		if err != nil {
+			return false, errors.New("invalid relay-blind replay retention timestamp")
+		}
+		seen = seen || expiry.After(now)
+	}
+	return seen, rows.Err()
 }
 
 func relayBlindReplaySeenTx(ctx context.Context, tx *immediateTx, replay storage.RelayBlindReplayMaterial) (bool, error) {

--- a/phase5-gateway/internal/storage/types.go
+++ b/phase5-gateway/internal/storage/types.go
@@ -333,6 +333,10 @@ type WalletSessionMetadataAdmissionRequest struct {
 	MaxReplayRows  int
 	MaxReplayBytes int64
 	CreatedAt      time.Time
+
+	// Validated, fresh required envelope; only classifies a temporal rejection.
+	// Admission's account/session and time remain authoritative for the lookup.
+	RelayBlindReplay *RelayBlindReplayMaterial
 }
 
 type WalletSessionDispatchArm struct {


### PR DESCRIPTION
## Summary

Recognize retained SPEC-041 inner-envelope replay before returning a retryable wallet metadata temporal throttle. A fresh signed outer request carrying previously seen valid, fresh required-mode material now returns permanent `409 relay_blind_replay`, not retryable `429 wallet_session_rate_limited`.

- Perform the lookup only in the exhausted temporal-rate branch of the existing serialized wallet metadata transaction. Bind account/session/time to that admission and filter expired replay rows without cleanup writes.
- Preserve inactive-account/session checks, SPEC-040 outer duplicate/mismatch errors, and permanent wallet row/byte capacity errors. Fresh or invalid envelopes remain throttled normally.
- Keep rejection audits bounded and classify the new rejection as `relay_blind_replay`. Rejected replay creates no metadata/replay row, reservation, inference dispatch, or usage charge.
- Cover chat completions, Responses, and Messages with relay-blind mode enabled and disabled.

This is independent of #1411 (precheck audit completeness) and #1412 (API-key minute-rate units); no changes from those branches are included.

## Validation

- Regression first: six temporal-throttle cases failed on the baseline with retryable 429; the other 18 precedence controls passed.
- Router regressions: all 40 route/configuration/bounds cases and seven invalid/fresh controls passed, including enabled and disabled adapters.
- `go test -race ./internal/router ./internal/storage/sqlite -run 'Test.*(RelayBlind|WalletMetadata|WalletSession)' -count=1`: passed (router 16.731s, SQLite 4.486s).
- `go test -race ./internal/storage/sqlite -run '^TestWalletMetadataRelayReplay' -count=1`: final storage tests passed (4.133s), including nanosecond expiry, mixed live/expired matches, corrupt retention, scope isolation, and concurrent no-write rejections.
- Astra Ultra code/security/architecture final-diff lanes: each 0 Critical / High / Medium / Low; architecture CLEAR.
- `go test -race ./... -count=1`: final full gateway suite passed, seven test-bearing packages (router 85.153s, SQLite 12.624s); storage interface package has no tests.
- `go vet ./...`, SPEC governance validation, JSON parsing, generated-index check, and `git diff --check`: passed. PR governance declaration validated before publication.
- After test-only filename renames required by local secret preflight, `go test -race ./internal/router ./internal/storage/sqlite -run 'Test.*(RelayBlindWallet|WalletMetadataRelayReplay)' -count=1` passed (router 7.340s, SQLite 4.238s). No hook bypass used.

## Boundaries And Gaps

SPEC-040 permanent hard-cap and outer-request error precedence remains unchanged. The SPEC-041 detected-replay specialization applies only to validated, fresh, required encrypted inference envelopes and temporary wallet throttling.

No provider-side crypto, settlement/receipt semantics, routing capability, production readiness, conformance status, or signed evidence is promoted. No fresh signed gateway journey or live production test was performed. Separate-process crash/restart behavior is not newly tested in this slice. Existing gateway rejection audit persistence policy is unchanged.

Follow-up identified during review: the older replay cleanup queries compare variable-precision timestamp strings. This PR does not change those queries; its new read-only retained lookup parses timestamps and has nanosecond-boundary coverage. Audit and fix cleanup retention ordering in a separate regression-first slice.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-040", "SPEC-041"],
  "requirements": ["SPEC-040-R005", "SPEC-041-R004", "SPEC-041-R005", "SPEC-041-R007", "SPEC-041-R008"],
  "authority_domains": ["wallet-buyer-session", "relay-blind-request-encryption"],
  "arbitration": ["CODE_BUG"],
  "tests": ["phase5-gateway/internal/router/relay_blind_session_replay_test.go", "phase5-gateway/internal/storage/sqlite/metadata_relay_replay_test.go"],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END
