### PR TITLE
Preserve SPEC-041 replay retention at fractional-second boundaries

### DIFF
--- a/phase5-gateway/internal/storage/sqlite/relay_replay_retention_test.go
+++ b/phase5-gateway/internal/storage/sqlite/relay_replay_retention_test.go
@@ -1,0 +1,212 @@
+package sqlite
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-gateway/internal/storage"
+)
+
+func TestRelayReplayRetentionPrecision(t *testing.T) {
+	for _, method := range []string{"seen", "record"} {
+		for _, tc := range []struct {
+			name                    string
+			expiryOffset, nowOffset time.Duration
+		}{
+			{"fraction_live_at_whole_second", time.Nanosecond, 0},
+			{"whole_expired_after_nanosecond", 0, time.Nanosecond},
+			{"fraction_live_at_shorter_precision", 100000001 * time.Nanosecond, 100 * time.Millisecond},
+			{"fraction_expired_at_longer_precision", 100 * time.Millisecond, 100000001 * time.Nanosecond},
+			{"exact_whole_boundary", 0, 0},
+			{"exact_fraction_boundary", time.Nanosecond, time.Nanosecond},
+			{"earlier_second", -time.Nanosecond, 0},
+			{"later_second", time.Second, 0},
+		} {
+			t.Run(method+"/"+tc.name, func(t *testing.T) {
+				store := newTestStore(t)
+				boundary := fixedTime().Add(time.Minute)
+				replay := retentionReplay("original", boundary.Add(tc.expiryOffset))
+				if err := store.RecordRelayBlindReplay(context.Background(), replay); err != nil {
+					t.Fatal(err)
+				}
+				replay.CreatedAt = boundary.Add(tc.nowOffset)
+				live := replay.RetentionExpiresAt.After(replay.CreatedAt)
+				if method == "seen" {
+					seen, err := store.RelayBlindReplaySeen(context.Background(), replay)
+					if err != nil || seen != live {
+						t.Fatalf("seen=%v err=%v want live=%v", seen, err, live)
+					}
+				} else {
+					replay.RetentionExpiresAt = replay.CreatedAt.Add(time.Minute)
+					err := store.RecordRelayBlindReplay(context.Background(), replay)
+					if (live && !errors.Is(err, storage.ErrRelayBlindReplay)) || (!live && err != nil) {
+						t.Fatalf("record err=%v live=%v", err, live)
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestRelayReplayRetentionCapacityDoesNotDiscardLiveRow(t *testing.T) {
+	store := newTestStore(t)
+	boundary := fixedTime().Add(time.Minute)
+	original := retentionReplay("original", boundary.Add(time.Nanosecond))
+	if err := store.RecordRelayBlindReplay(context.Background(), original); err != nil {
+		t.Fatal(err)
+	}
+	unique := retentionReplay("unique", boundary.Add(time.Minute))
+	unique.CreatedAt = boundary
+	unique.MaxReplayRows = 1
+	if err := store.RecordRelayBlindReplay(context.Background(), unique); !errors.Is(err, storage.ErrRateLimit) {
+		t.Fatalf("live row capacity err=%v want ErrRateLimit", err)
+	}
+	unique.CreatedAt = boundary.Add(time.Nanosecond)
+	if err := store.RecordRelayBlindReplay(context.Background(), unique); err != nil {
+		t.Fatalf("expired capacity was not reclaimed: %v", err)
+	}
+}
+
+func retentionReplay(id string, expiry time.Time) storage.RelayBlindReplayMaterial {
+	return storage.RelayBlindReplayMaterial{
+		AccountID: "retention-account", RequestID: id,
+		RequestReplayNonceDigest:      []byte("nonce-" + id),
+		BuyerEphemeralPublicKeyDigest: []byte("buyer-" + id),
+		ProviderBindingDigest:         []byte("binding"), KIDDigest: []byte("kid"),
+		EnvelopeDigest: []byte("envelope-" + id), EnvelopeBytes: 128,
+		RetentionExpiresAt: expiry, CreatedAt: fixedTime(),
+	}
+}
+
+func TestRelayReplayRetentionAllFractionalPrecisions(t *testing.T) {
+	store := newTestStore(t)
+	boundary := fixedTime().Add(time.Minute)
+	var expiries []time.Time
+	for _, second := range []int{-1, 0, 1} {
+		for _, nanos := range []int{0, 1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 100000001, 123456789, 999999999} {
+			expiries = append(expiries, boundary.Add(time.Duration(second)*time.Second+time.Duration(nanos)))
+		}
+	}
+	for i, expiry := range expiries {
+		replay := retentionReplay(fmt.Sprint(i), expiry)
+		replay.AccountID = fmt.Sprintf("account-%d", i%2)
+		replay.WalletSessionID = fmt.Sprintf("session-%d", i%3)
+		if err := store.RecordRelayBlindReplay(context.Background(), replay); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, now := range expiries {
+		t.Run(encodeTime(now), func(t *testing.T) {
+			tx, err := store.beginImmediate(context.Background())
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer tx.Rollback()
+			if err := deleteExpiredRelayBlindReplaysTx(context.Background(), tx, now.In(time.FixedZone("offset", 8*60*60))); err != nil {
+				t.Fatal(err)
+			}
+			rows, err := tx.QueryContext(context.Background(), `SELECT request_id FROM relay_blind_replays`)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer rows.Close()
+			retained := make(map[string]bool)
+			for rows.Next() {
+				var id string
+				if err := rows.Scan(&id); err != nil {
+					t.Fatal(err)
+				}
+				retained[id] = true
+			}
+			if err := rows.Err(); err != nil {
+				t.Fatal(err)
+			}
+			for i, expiry := range expiries {
+				if got, want := retained[fmt.Sprint(i)], expiry.After(now); got != want {
+					t.Errorf("expiry=%s retained=%v want %v", encodeTime(expiry), got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestRelayReplayRetentionUsesExpiryIndex(t *testing.T) {
+	store := newTestStore(t)
+	rows, err := store.db.Query("EXPLAIN QUERY PLAN "+deleteExpiredRelayBlindReplaysSQL,
+		encodeTime(fixedTime()), fixedTime().Format("2006-01-02T15:04:05.000000000"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	indexed := false
+	for rows.Next() {
+		var id, parent, unused int
+		var detail string
+		if err := rows.Scan(&id, &parent, &unused, &detail); err != nil {
+			t.Fatal(err)
+		}
+		indexed = indexed || strings.Contains(detail, "USING INDEX idx_relay_blind_replay_expires (retention_expires_at<?)")
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if !indexed {
+		t.Fatal("cleanup did not use the expiry index range")
+	}
+}
+
+func TestRelayReplayRetentionSurvivesReopen(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "replay.db")
+	store, err := Open(ctx, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	boundary := fixedTime().Add(time.Minute)
+	replay := retentionReplay("persisted", boundary.Add(time.Nanosecond).In(time.FixedZone("offset", -5*60*60)))
+	if err := store.RecordRelayBlindReplay(ctx, replay); err != nil {
+		store.Close()
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := Open(ctx, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reopened.Close()
+	replay.CreatedAt = boundary
+	if seen, err := reopened.RelayBlindReplaySeen(ctx, replay); err != nil || !seen {
+		t.Fatalf("live persisted replay seen=%v err=%v", seen, err)
+	}
+	replay.CreatedAt = boundary.Add(time.Nanosecond)
+	if seen, err := reopened.RelayBlindReplaySeen(ctx, replay); err != nil || seen {
+		t.Fatalf("expired persisted replay seen=%v err=%v", seen, err)
+	}
+}
+
+func TestRelayReplayRetentionCleanupRollsBackWithRecord(t *testing.T) {
+	store := newTestStore(t)
+	boundary := fixedTime().Add(time.Minute)
+	if err := store.RecordRelayBlindReplay(context.Background(), retentionReplay("original", boundary)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.Exec(`CREATE TRIGGER fail_replay_insert BEFORE INSERT ON relay_blind_replays BEGIN SELECT RAISE(ABORT, 'test insert failure'); END`); err != nil {
+		t.Fatal(err)
+	}
+	replay := retentionReplay("fresh", boundary.Add(time.Minute))
+	replay.CreatedAt = boundary.Add(time.Nanosecond)
+	if err := store.RecordRelayBlindReplay(context.Background(), replay); err == nil || !strings.Contains(err.Error(), "test insert failure") {
+		t.Fatalf("record error=%v want injected insert failure", err)
+	}
+	var id string
+	if err := store.db.QueryRow(`SELECT request_id FROM relay_blind_replays`).Scan(&id); err != nil || id != "original" {
+		t.Fatalf("cleanup was not rolled back: id=%s err=%v", id, err)
+	}
+}

--- a/phase5-gateway/internal/storage/sqlite/store.go
+++ b/phase5-gateway/internal/storage/sqlite/store.go
@@ -2176,7 +2176,7 @@ func (s *Store) RecordRelayBlindReplay(ctx context.Context, replay storage.Relay
 	if replay.RetentionExpiresAt.IsZero() || !replay.RetentionExpiresAt.After(now) {
 		return storage.ErrRelayBlindReplay
 	}
-	if _, err := tx.ExecContext(ctx, `DELETE FROM relay_blind_replays WHERE retention_expires_at <= ?`, encodeTime(now)); err != nil {
+	if err := deleteExpiredRelayBlindReplaysTx(ctx, tx, now); err != nil {
 		return err
 	}
 	seen, err := relayBlindReplaySeenTx(ctx, tx, replay)
@@ -2227,7 +2227,7 @@ func (s *Store) RelayBlindReplaySeen(ctx context.Context, replay storage.RelayBl
 		replay.CreatedAt = time.Now().UTC()
 	}
 	now := replay.CreatedAt.UTC()
-	if _, err := tx.ExecContext(ctx, `DELETE FROM relay_blind_replays WHERE retention_expires_at <= ?`, encodeTime(now)); err != nil {
+	if err := deleteExpiredRelayBlindReplaysTx(ctx, tx, now); err != nil {
 		return false, err
 	}
 	seen, err := relayBlindReplaySeenTx(ctx, tx, replay)
@@ -2238,6 +2238,18 @@ func (s *Store) RelayBlindReplaySeen(ctx context.Context, replay storage.RelayBl
 		return false, err
 	}
 	return seen, nil
+}
+
+const deleteExpiredRelayBlindReplaysSQL = `DELETE FROM relay_blind_replays
+	WHERE retention_expires_at <= ? AND rtrim(retention_expires_at, 'Z') <= ?`
+
+func deleteExpiredRelayBlindReplaysTx(ctx context.Context, tx *immediateTx, now time.Time) error {
+	// Stored expiries are UTC RFC3339Nano ending in Z. The whole-second bound
+	// uses the expiry index; stripping Z and using a fixed-nine-digit cutoff
+	// orders variable fractional precision correctly, including exact expiry.
+	_, err := tx.ExecContext(ctx, deleteExpiredRelayBlindReplaysSQL,
+		encodeTime(now.Truncate(time.Second)), now.UTC().Format("2006-01-02T15:04:05.000000000"))
+	return err
 }
 
 func relayBlindReplaySeenTx(ctx context.Context, tx *immediateTx, replay storage.RelayBlindReplayMaterial) (bool, error) {


### PR DESCRIPTION
## Summary

Fix SPEC-041 SQLite replay cleanup at fractional-second retention boundaries. Direct RFC3339Nano string ordering could delete a live entry early, allowing the same envelope to be recorded again, or keep an expired entry too long.

- Use one shared cleanup predicate for `RecordRelayBlindReplay` and `RelayBlindReplaySeen` within their existing immediate transactions.
- Keep the indexed whole-second candidate bound, then compare the stored UTC timestamp without its terminal Z against a fixed-nine-digit UTC cutoff.
- Support existing persisted whole-second and variable-fraction timestamps without migration or changing the writer format.
- Preserve duplicate-before-capacity ordering, exact-expiry reclamation, and rollback behavior. No routing, quota, receipt, or settlement changes.

This is the separate cleanup follow-up identified in #1413. It starts from fresh main and does not include that PR's wallet-throttle changes.

## Validation

- Regression first: baseline failed eight precision cases across both public methods and one live-row capacity case; all pass with the fix.
- `go test -race ./internal/storage/sqlite -run '^TestRelayReplayRetention' -count=1`: passed (3.391s).
- Tests include 1,521 timestamp comparisons across all fractional precisions, timezone normalization, indexed query-plan assertion, database reopen, and cleanup rollback after injected insert failure.
- `go test -race ./... -count=1`: passed across all seven test-bearing gateway packages (router 79.998s, SQLite 12.680s); storage interface package has no tests.
- `go vet ./...`, SPEC governance validation, JSON parsing, generated-index check, and `git diff --check`: passed.
- Astra Ultra code/security/architecture review of the full two-file diff: each 0 Critical / High / Medium / Low findings; architecture CLEAR.
- PR governance declaration validated before publication.

## Boundaries

The predicate relies on the existing sole writer's UTC RFC3339Nano format. Manually corrupted or offset-bearing SQL values are outside that storage contract. Reopening is tested in-process; a separate-process crash test and live signed gateway journey were not run.

No conformance status, authority, production readiness, provider-side crypto, or signed journey evidence is promoted or changed.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-041"],
  "requirements": ["SPEC-041-R005", "SPEC-041-R007", "SPEC-041-R008"],
  "authority_domains": ["relay-blind-request-encryption"],
  "arbitration": ["CODE_BUG"],
  "tests": ["phase5-gateway/internal/storage/sqlite/relay_replay_retention_test.go"],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END
