### PR TITLE
Align BYOM E2E preflight oracle with non-earning offer eligibility

### DIFF
--- a/scripts/tests/test_byom_onboarding_oracle.py
+++ b/scripts/tests/test_byom_onboarding_oracle.py
@@ -1,0 +1,95 @@
+import copy
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    "byom_onboarding_e2e", ROOT / "test/e2e/byom/run-cli-onboarding-e2e.py"
+)
+HARNESS = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(HARNESS)
+
+
+class BYOMOnboardingOracleTests(unittest.TestCase):
+    def setUp(self):
+        self.document = {
+            "schema": "model_admission_offer_dry_run.v1",
+            "candidate_id": "byom_test_candidate",
+            "served_model_ref": HARNESS.SERVED_MODEL_REF,
+            "catalog_model_key": HARNESS.CATALOG_MODEL_KEY,
+            "would_submit": True,
+            "reason_code": "catalog_binding_unverified",
+            "likely_admission_state": "offerable",
+            "likely_admission_state_source": "local_default",
+            "warnings": ["evaluation_required", "catalog_match_unverified"],
+            "provider_guidance": {
+                "state_meaning_key": "byom.offer_dry_run.catalog_path_missing_trusted_binding",
+                "earning_path_class": "not_earning_yet_catalog_or_receipt_path_exists",
+                "transition_reason_code": "catalog_binding_unverified",
+                "next_action": "submit_offer",
+            },
+        }
+
+    def check(self, document, requests=None):
+        HARNESS.assert_catalog_offer_dry_run(
+            document, "byom_test_candidate", [] if requests is None else requests
+        )
+
+    def test_accepts_local_eligibility_without_submission(self):
+        self.check(self.document)
+
+    def test_rejects_stale_or_unsafe_top_level_oracles(self):
+        for field, value in (
+            ("schema", "model_admission_status.v1"),
+            ("candidate_id", "different_candidate"),
+            ("served_model_ref", "different_model"),
+            ("catalog_model_key", None),
+            ("would_submit", False),
+            ("would_submit", 1),
+            ("reason_code", "evaluation_required"),
+            ("likely_admission_state", "offer_submitted"),
+            ("likely_admission_state", "settlement_capable"),
+            ("likely_admission_state_source", "coordinator"),
+            ("warnings", []),
+            ("warnings", ["evaluation_required"]),
+            ("warnings", ["catalog_match_unverified"]),
+            ("warnings", "evaluation_required catalog_match_unverified"),
+        ):
+            with self.subTest(field=field, value=value):
+                document = copy.deepcopy(self.document)
+                document[field] = value
+                with self.assertRaises(HARNESS.HarnessFailure):
+                    self.check(document)
+
+    def test_rejects_premature_earning_and_action_guidance(self):
+        for field, value in (
+            ("state_meaning_key", "byom.admission.settlement_capable"),
+            ("earning_path_class", "settlement_capable"),
+            ("transition_reason_code", None),
+            ("next_action", "maintain_runtime"),
+        ):
+            with self.subTest(field=field):
+                document = copy.deepcopy(self.document)
+                document["provider_guidance"][field] = value
+                with self.assertRaises(HARNESS.HarnessFailure):
+                    self.check(document)
+
+    def test_rejects_missing_contract_fields(self):
+        for field in self.document:
+            with self.subTest(field=field):
+                document = copy.deepcopy(self.document)
+                del document[field]
+                with self.assertRaises(HARNESS.HarnessFailure):
+                    self.check(document)
+
+    def test_rejects_any_coordinator_contact(self):
+        for method in ("GET", "POST"):
+            with self.subTest(method=method):
+                with self.assertRaises(HARNESS.HarnessFailure):
+                    self.check(self.document, [{"method": method}])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/e2e/byom/run-cli-onboarding-e2e.py
+++ b/test/e2e/byom/run-cli-onboarding-e2e.py
@@ -328,6 +328,29 @@ def find_candidate(document):
     raise HarnessFailure("candidate not found in discovery output")
 
 
+def assert_catalog_offer_dry_run(document, candidate_id, coordinator_requests):
+    assert_true(document.get("schema") == "model_admission_offer_dry_run.v1", "wrong dry-run schema")
+    assert_true(document.get("candidate_id") == candidate_id, "dry-run resolved a different candidate")
+    assert_true(document.get("served_model_ref") == SERVED_MODEL_REF, "dry-run changed served model")
+    assert_true(document.get("catalog_model_key") == CATALOG_MODEL_KEY, "dry-run changed catalog key")
+    # SPEC-047-R002 makes evaluation advisory for explicitly non-earning offers.
+    # would_submit is local eligibility, not proof of submission or admission.
+    assert_true(document.get("would_submit") is True, "offerable fixture was blocked by dry-run")
+    assert_true(document.get("reason_code") == "catalog_binding_unverified", "dry-run lost unverified binding reason")
+    assert_true(document.get("likely_admission_state") == "offerable", "dry-run promoted local admission state")
+    assert_true(document.get("likely_admission_state_source") == "local_default", "dry-run claimed coordinator authority")
+    warnings = document.get("warnings")
+    assert_true(isinstance(warnings, list), "dry-run warnings missing")
+    assert_true("evaluation_required" in warnings, "dry-run lost advisory evaluation warning")
+    assert_true("catalog_match_unverified" in warnings, "dry-run lost unverified catalog warning")
+    guidance = document.get("provider_guidance") or {}
+    assert_true(guidance.get("state_meaning_key") == "byom.offer_dry_run.catalog_path_missing_trusted_binding", "dry-run overstated catalog binding")
+    assert_true(guidance.get("earning_path_class") == "not_earning_yet_catalog_or_receipt_path_exists", "dry-run overstated earning eligibility")
+    assert_true(guidance.get("transition_reason_code") == "catalog_binding_unverified", "dry-run guidance lost binding reason")
+    assert_true(guidance.get("next_action") == "submit_offer", "dry-run lost explicit submission step")
+    assert_true(coordinator_requests == [], "dry-run contacted coordinator")
+
+
 def assert_null_money(row):
     null_fields = [
         "prompt_rate_usd_per_million_tokens",
@@ -466,11 +489,7 @@ def main():
             env,
             root,
         ))
-        assert_true(dry_run.get("schema") == "model_admission_offer_dry_run.v1", "wrong dry-run schema")
-        assert_true(dry_run.get("candidate_id") == candidate_id, "dry-run resolved a different candidate")
-        assert_true(dry_run.get("would_submit") is False, "dry-run unexpectedly submits without evaluation digest")
-        assert_true(dry_run.get("reason_code") == "evaluation_required", "dry-run did not explain evaluation gate")
-        assert_true(coordinator.state["requests"] == [], "dry-run contacted coordinator")
+        assert_catalog_offer_dry_run(dry_run, candidate_id, coordinator.state["requests"])
 
         offer = parse_json_output(run_cli(
             cli,


### PR DESCRIPTION
## Summary

Repair the stale dry-run oracle in the local BYOM onboarding E2E harness. Its stable, ready, catalog-matched 64-GB fixture is locally `offerable`: the CLI correctly reports `would_submit: true` with `catalog_binding_unverified`, not an evaluation hard block. SPEC-047-R002 permits omitted evaluation evidence only with explicit non-earning disclosure; dry-run still never submits.

- Assert matching candidate/model/catalog identity, local-default `offerable` state, advisory evaluation and unverified-catalog warnings, missing-trusted-binding guidance, and explicit non-earning classification.
- Retain zero recorded coordinator admission requests through dry-run; do not confuse local eligibility with submission or network admission.
- Add negative tests rejecting stale expectations, coordinator-sourced/network states, earning overclaims, missing fields, and any coordinator contact.

Only the Python harness and its oracle tests change. CLI runtime, admission behavior, specs, conformance mappings, dependency pins, and signed artifacts are unchanged.

## Validation

- Baseline real-CLI E2E reproduced `dry-run unexpectedly submits without evaluation digest`.
- `swift build --force-resolved-versions --product macprovider-cli`: passed. Automatic lockfile pruning from the initial harness build was restored; no dependency change is included.
- Real CLI with hermetic loopback runtime/coordinator fixtures: complete onboarding E2E passed through discover, evaluate, dry-run, offer, status, economics, and withdrawal (six coordinator requests after dry-run).
- `swift test --force-resolved-versions --filter 'BYOM(Discovery|Evaluation|OfferDryRun|Admission)Tests'`: 66 tests, zero failures.
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts.tests.test_byom_onboarding_oracle scripts.tests.test_byom_contract_lock`: 10 tests passed, including table-driven negative cases.
- Governance, JSON parsing, generated-index and diff checks passed.
- Astra Ultra code/security/architecture review: each 0 Critical / High / Medium / Low; architecture CLEAR. PR declaration validated before publication.

## Remaining Gaps

SPEC-046 redacted-versus-absent diagnostics remain unresolved. The complete follow-up needs normative warning-code semantics that distinguish withheld optional labels and omitted model records without sending a display sentinel as an advisory capability in signed offers or changing admission blocking.

This local fixture is not a real coordinator acceptance test or signed journey. Its coordinator recorder observes supported admission routes, so zero recorded requests is not proof of arbitrary network isolation; strengthening that independent boundary is outside this stale-oracle correction. It does not cover the complete MLX/opaque/failure journey matrix. Full Swift suite and live production journeys were not run. This PR does not promote production readiness, conformance, or evidence status and creates no signed journey artifacts.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-046", "SPEC-047"],
  "requirements": ["SPEC-046-R003", "SPEC-046-R008", "SPEC-047-R002", "SPEC-047-R008"],
  "authority_domains": ["provider-byom-discovery", "network-model-admission"],
  "arbitration": ["CODE_BUG"],
  "tests": ["test/e2e/byom/run-cli-onboarding-e2e.py", "scripts/tests/test_byom_onboarding_oracle.py", "phase3-binary/Tests/macprovider-cliTests/BYOMOfferDryRunTests.swift"],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END
