### PR TITLE
Fix SPEC-041 rejection auditing, rate limits, and replay safety

### DIFF
--- a/phase5-gateway/internal/router/relay_blind.go
+++ b/phase5-gateway/internal/router/relay_blind.go
@@ -616,7 +616,7 @@ func (s *Server) admitRelayBlindWalletMetadata(w http.ResponseWriter, r *http.Re
 
 func (s *Server) admitRelayBlindMetadataWrite(w http.ResponseWriter, r *http.Request, accountID string) bool {
 	limit := s.relayBlindMetadataRequestsPerMinute()
-	decision := s.relayBlindMetadataLimits.allow(accountID, limit, s.now())
+	decision := s.relayBlindMetadataLimits.allowPerMinute(accountID, limit, s.now())
 	if decision.Admitted {
 		return true
 	}

--- a/phase5-gateway/internal/router/relay_blind.go
+++ b/phase5-gateway/internal/router/relay_blind.go
@@ -157,18 +157,14 @@ func decodeRelayBlindRouteReservation(body []byte) (relayBlindRouteReservationRe
 
 func (s *Server) rejectRelayBlindEnvelopeIfRequired(w http.ResponseWriter, r *http.Request, body []byte, accountID string, walletSession *walletSessionAuth) bool {
 	probe, ok, malformed := parseRelayBlindEnvelopeProbe(body)
-	if !ok {
-		if malformed {
-			writeError(w, http.StatusBadRequest, "invalid_request_error", "relay_blind_envelope_invalid", "Relay-blind request envelope is malformed")
-			return true
-		}
+	if !ok && !malformed {
 		return false
 	}
 	if walletSession != nil && !s.admitRelayBlindWalletMetadata(w, r, walletSession, body) {
 		return true
 	}
 	if malformed || probe.Mode == "" {
-		writeError(w, http.StatusBadRequest, "invalid_request_error", "relay_blind_envelope_invalid", "Relay-blind request envelope is malformed")
+		s.rejectRelayBlindEnvelopePrecheck(w, r, accountID, walletSession, relayBlindEndpointFamilyFromRequest(r), body, http.StatusBadRequest, "relay_blind_envelope_invalid", "Relay-blind request envelope is malformed")
 		return true
 	}
 	if probe.Mode != "required" {
@@ -186,18 +182,21 @@ func (s *Server) rejectRelayBlindEnvelopeIfRequired(w http.ResponseWriter, r *ht
 	enforceEncryptedSizeLimit := s.cfg.Features.RelayBlindRequests.Enabled
 	env, err := s.validateRelayBlindRequestEnvelope(body, endpointFamily, enforceEncryptedSizeLimit)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid_request_error", "relay_blind_envelope_invalid", err.Error())
+		s.rejectRelayBlindEnvelopePrecheck(w, r, accountID, walletSession, endpointFamily, body, http.StatusBadRequest, "relay_blind_envelope_invalid", err.Error())
 		return true
 	}
-	if walletSession != nil && !writeRelayBlindWalletSessionPrecheck(w, walletSession.Session, env.Model, env.InputTokenUpperBound, env.MaxOutputTokens, env.ReservationTokenCap) {
-		return true
+	if walletSession != nil {
+		if status, code, message := relayBlindWalletSessionPrecheckError(walletSession.Session, env.Model, env.InputTokenUpperBound, env.MaxOutputTokens, env.ReservationTokenCap); code != "" {
+			s.rejectRelayBlindEnvelopePrecheck(w, r, accountID, walletSession, endpointFamily, body, status, code, message)
+			return true
+		}
 	}
 	if walletSession == nil && relayBlindTokenBoundsInvalid(env.InputTokenUpperBound, env.MaxOutputTokens, env.ReservationTokenCap, relayBlindMaxOutputTokensForRequest(s, r)) {
-		writeError(w, http.StatusBadRequest, "invalid_request_error", "relay_blind_envelope_invalid", "Invalid relay-blind request envelope")
+		s.rejectRelayBlindEnvelopePrecheck(w, r, accountID, walletSession, endpointFamily, body, http.StatusBadRequest, "relay_blind_envelope_invalid", "Invalid relay-blind request envelope")
 		return true
 	}
 	if !s.relayBlindEnvelopeFresh(env) {
-		writeError(w, http.StatusBadRequest, "invalid_request_error", "relay_blind_envelope_invalid", "Relay-blind request envelope timestamp is outside the accepted freshness window")
+		s.rejectRelayBlindEnvelopePrecheck(w, r, accountID, walletSession, endpointFamily, body, http.StatusBadRequest, "relay_blind_envelope_invalid", "Relay-blind request envelope timestamp is outside the accepted freshness window")
 		return true
 	}
 	walletSessionID := ""
@@ -311,7 +310,7 @@ func (s *Server) handleRelayBlindEndpointDisabledBody(w http.ResponseWriter, r *
 			if authn.WalletSession != nil && !s.admitRelayBlindWalletMetadata(w, r, authn.WalletSession, body) {
 				return
 			}
-			writeError(w, http.StatusBadRequest, "invalid_request_error", "relay_blind_envelope_invalid", "Relay-blind request envelope is malformed")
+			s.rejectRelayBlindEnvelopePrecheck(w, r, relayBlindAccountID(authn), authn.WalletSession, endpointFamily, body, http.StatusBadRequest, "relay_blind_envelope_invalid", "Relay-blind request envelope is malformed")
 			return
 		}
 		s.handleNotFound(w, r)
@@ -329,7 +328,7 @@ func (s *Server) handleRelayBlindEndpointDisabledBody(w http.ResponseWriter, r *
 		if authn.WalletSession != nil && !s.admitRelayBlindWalletMetadata(w, r, authn.WalletSession, body) {
 			return
 		}
-		writeError(w, http.StatusBadRequest, "invalid_request_error", "relay_blind_envelope_invalid", "Relay-blind request envelope is malformed")
+		s.rejectRelayBlindEnvelopePrecheck(w, r, relayBlindAccountID(authn), authn.WalletSession, endpointFamily, body, http.StatusBadRequest, "relay_blind_envelope_invalid", "Relay-blind request envelope is malformed")
 		return
 	}
 	authn, authed := s.authenticateAny(w, r)
@@ -350,7 +349,7 @@ func (s *Server) handleRelayBlindEndpointDisabledBody(w http.ResponseWriter, r *
 	}
 	if probe.Mode != "required" {
 		if probe.Mode == "" || malformed {
-			writeError(w, http.StatusBadRequest, "invalid_request_error", "relay_blind_envelope_invalid", "Relay-blind request envelope is malformed")
+			s.rejectRelayBlindEnvelopePrecheck(w, r, relayBlindAccountID(authn), authn.WalletSession, endpointFamily, body, http.StatusBadRequest, "relay_blind_envelope_invalid", "Relay-blind request envelope is malformed")
 			return
 		}
 		if authn.WalletSession == nil && !s.admitRelayBlindMetadataWrite(w, r, relayBlindAccountID(authn)) {
@@ -365,18 +364,21 @@ func (s *Server) handleRelayBlindEndpointDisabledBody(w http.ResponseWriter, r *
 	}
 	env, err := s.validateRelayBlindRequestEnvelope(body, endpointFamily, s.cfg.Features.RelayBlindRequests.Enabled)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid_request_error", "relay_blind_envelope_invalid", err.Error())
+		s.rejectRelayBlindEnvelopePrecheck(w, r, relayBlindAccountID(authn), authn.WalletSession, endpointFamily, body, http.StatusBadRequest, "relay_blind_envelope_invalid", err.Error())
 		return
 	}
-	if authn.WalletSession != nil && !writeRelayBlindWalletSessionPrecheck(w, authn.WalletSession.Session, env.Model, env.InputTokenUpperBound, env.MaxOutputTokens, env.ReservationTokenCap) {
-		return
+	if authn.WalletSession != nil {
+		if status, code, message := relayBlindWalletSessionPrecheckError(authn.WalletSession.Session, env.Model, env.InputTokenUpperBound, env.MaxOutputTokens, env.ReservationTokenCap); code != "" {
+			s.rejectRelayBlindEnvelopePrecheck(w, r, relayBlindAccountID(authn), authn.WalletSession, endpointFamily, body, status, code, message)
+			return
+		}
 	}
 	if authn.WalletSession == nil && relayBlindTokenBoundsInvalid(env.InputTokenUpperBound, env.MaxOutputTokens, env.ReservationTokenCap, relayBlindMaxOutputTokensForAuth(s, authn)) {
-		writeError(w, http.StatusBadRequest, "invalid_request_error", "relay_blind_envelope_invalid", "Invalid relay-blind request envelope")
+		s.rejectRelayBlindEnvelopePrecheck(w, r, relayBlindAccountID(authn), authn.WalletSession, endpointFamily, body, http.StatusBadRequest, "relay_blind_envelope_invalid", "Invalid relay-blind request envelope")
 		return
 	}
 	if !s.relayBlindEnvelopeFresh(env) {
-		writeError(w, http.StatusBadRequest, "invalid_request_error", "relay_blind_envelope_invalid", "Relay-blind request envelope timestamp is outside the accepted freshness window")
+		s.rejectRelayBlindEnvelopePrecheck(w, r, relayBlindAccountID(authn), authn.WalletSession, endpointFamily, body, http.StatusBadRequest, "relay_blind_envelope_invalid", "Relay-blind request envelope timestamp is outside the accepted freshness window")
 		return
 	}
 	walletSessionID := ""
@@ -736,13 +738,62 @@ func (s *Server) recordRelayBlindRequiredAudit(r *http.Request, accountID, walle
 	})
 }
 
-func writeRelayBlindWalletSessionPrecheck(w http.ResponseWriter, session storage.WalletSession, model string, inputTokenUpperBound, maxOutputTokens, reservationTokenCap int64) bool {
+// Wallet callers must complete signed metadata admission before reaching this path.
+func (s *Server) rejectRelayBlindEnvelopePrecheck(w http.ResponseWriter, r *http.Request, accountID string, walletSession *walletSessionAuth, endpointFamily string, body []byte, status int, code, message string) {
+	if walletSession == nil && !s.admitRelayBlindMetadataWrite(w, r, accountID) {
+		return
+	}
+	walletSessionID := ""
+	if walletSession != nil {
+		walletSessionID = walletSession.Session.SessionID
+	}
+	// Even partially decoded envelope fields are untrusted; persist only a digest
+	// and gateway-derived correlation, never the decoder error or raw identifiers.
+	digest := sha256.Sum256(body)
+	payload, err := json.Marshal(map[string]any{
+		"endpoint_family":        endpointFamily,
+		"mode_class":             "unvalidated",
+		"requested_privacy_mode": "relay_blind_required",
+		"effective_outcome":      "relay_blind_unavailable",
+		"wallet_session_id":      walletSessionID,
+		"envelope_digest":        hex.EncodeToString(digest[:]),
+		"reason_code":            code,
+	})
+	if err == nil {
+		err = s.store.InsertAuditEvent(r.Context(), storage.AuditEvent{
+			EventID: mustID("audit"), RequestID: requestID(r), AccountID: accountID,
+			Actor: "gateway", Type: "relay_blind_required_rejected", Payload: string(payload), CreatedAt: s.now().UTC(),
+		})
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "server_error", "internal_error", "Could not record relay-blind rejection audit")
+		return
+	}
+	errorType := "invalid_request_error"
+	if status == http.StatusForbidden {
+		errorType = "permission_error"
+	}
+	writeError(w, status, errorType, code, message)
+}
+
+func relayBlindWalletSessionPrecheckError(session storage.WalletSession, model string, inputTokenUpperBound, maxOutputTokens, reservationTokenCap int64) (int, string, string) {
 	if _, ok := walletModelAllowlist(session)[model]; !ok {
-		writeError(w, http.StatusForbidden, "permission_error", "wallet_session_model_not_allowed", "Wallet session does not allow this model")
-		return false
+		return http.StatusForbidden, "wallet_session_model_not_allowed", "Wallet session does not allow this model"
 	}
 	if relayBlindWalletSessionCapExceeded(session.PerRequestTokenCap, inputTokenUpperBound, maxOutputTokens, reservationTokenCap) {
-		writeError(w, http.StatusBadRequest, "invalid_request_error", "wallet_session_request_cap_exceeded", "Wallet-session per-request cap exceeded")
+		return http.StatusBadRequest, "wallet_session_request_cap_exceeded", "Wallet-session per-request cap exceeded"
+	}
+	return 0, "", ""
+}
+
+func writeRelayBlindWalletSessionPrecheck(w http.ResponseWriter, session storage.WalletSession, model string, inputTokenUpperBound, maxOutputTokens, reservationTokenCap int64) bool {
+	status, code, message := relayBlindWalletSessionPrecheckError(session, model, inputTokenUpperBound, maxOutputTokens, reservationTokenCap)
+	if code != "" {
+		errorType := "invalid_request_error"
+		if status == http.StatusForbidden {
+			errorType = "permission_error"
+		}
+		writeError(w, status, errorType, code, message)
 		return false
 	}
 	return true

--- a/phase5-gateway/internal/router/relay_blind.go
+++ b/phase5-gateway/internal/router/relay_blind.go
@@ -584,8 +584,9 @@ func (s *Server) admitRelayBlindWalletMetadata(w http.ResponseWriter, r *http.Re
 		return false
 	}
 	err = s.store.AdmitWalletSessionMetadata(r.Context(), storage.WalletSessionMetadataAdmissionRequest{
-		SessionID: sessionAuth.Session.SessionID,
-		AccountID: sessionAuth.Session.AccountID,
+		RelayBlindReplay: s.walletMetadataRelayReplayCandidate(r, sessionAuth.Session, rawBody),
+		SessionID:        sessionAuth.Session.SessionID,
+		AccountID:        sessionAuth.Session.AccountID,
 		Replay: storage.WalletSessionReplayMaterial{
 			SessionID:           sessionAuth.Session.SessionID,
 			RequestID:           requestID(r),
@@ -605,13 +606,49 @@ func (s *Server) admitRelayBlindWalletMetadata(w http.ResponseWriter, r *http.Re
 	if err == nil {
 		return true
 	}
+	reason := walletSessionAdmissionAuditReason(err)
+	if errors.Is(err, storage.ErrRelayBlindReplay) {
+		reason = "relay_blind_replay"
+	}
 	s.recordWalletSessionAudit(r.Context(), sessionAuth.Session.AccountID, sessionAuth.Session.SessionID, "wallet_session_rejected", "gateway", map[string]any{
 		"request_id":      requestID(r),
 		"canonical_route": walletCanonicalRouteForRequest(r),
-		"reason":          walletSessionAdmissionAuditReason(err),
+		"reason":          reason,
 	})
+	if errors.Is(err, storage.ErrRelayBlindReplay) {
+		writeError(w, http.StatusConflict, "invalid_request_error", "relay_blind_replay", "Relay-blind request envelope was already seen in the replay retention window")
+		return false
+	}
 	s.writeWalletAdmissionError(w, err, storage.WalletSessionAdmissionDecision{})
 	return false
+}
+
+func (s *Server) walletMetadataRelayReplayCandidate(r *http.Request, session storage.WalletSession, body []byte) *storage.RelayBlindReplayMaterial {
+	if r.Method != http.MethodPost {
+		return nil
+	}
+	// Disabled adapters have no endpoint context. Bind to the signed public route,
+	// and never interpret route-reservation metadata as an inference envelope.
+	var family string
+	switch walletCanonicalRouteForRequest(r) {
+	case "/v1/chat/completions":
+		family = "chat_completions"
+	case "/v1/responses":
+		family = "responses"
+	case "/v1/messages":
+		family = "messages"
+	default:
+		return nil
+	}
+	env, err := s.validateRelayBlindRequestEnvelope(body, family, s.cfg.Features.RelayBlindRequests.Enabled)
+	if err != nil || !s.relayBlindEnvelopeFresh(env) {
+		return nil
+	}
+	if _, allowed := walletModelAllowlist(session)[env.Model]; !allowed || relayBlindWalletSessionCapExceeded(session.PerRequestTokenCap, env.InputTokenUpperBound, env.MaxOutputTokens, env.ReservationTokenCap) {
+		return nil
+	}
+	replay := s.relayBlindReplayMaterial(session.AccountID, session.SessionID, env, body)
+	return &replay
 }
 
 func (s *Server) admitRelayBlindMetadataWrite(w http.ResponseWriter, r *http.Request, accountID string) bool {

--- a/phase5-gateway/internal/router/relay_blind_metadata_rate_test.go
+++ b/phase5-gateway/internal/router/relay_blind_metadata_rate_test.go
@@ -1,0 +1,117 @@
+package router
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-gateway/internal/config"
+)
+
+func TestRelayBlindMetadataRefillsPerMinute(t *testing.T) {
+	for _, family := range []string{"chat_completions", "responses", "messages"} {
+		for _, enabled := range []bool{false, true} {
+			for _, mode := range []string{"required", "opportunistic"} {
+				for _, limit := range []int{1, 2} {
+					t.Run(fmt.Sprintf("%s/enabled=%t/%s/limit=%d", family, enabled, mode, limit), func(t *testing.T) {
+						start := fixedNow()
+						now := start
+						dispatches := 0
+						h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+							cfg.Features.RelayBlindRequests.Enabled = enabled
+							cfg.Features.ResponsesAPIEnabled = enabled
+							cfg.Features.AnthropicMessagesEnabled = enabled
+							cfg.Features.RelayBlindRequests.MetadataRequestsPerMinute = limit
+						}, WithNow(func() time.Time { return now }), WithHTTPClient(&http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+							dispatches++
+							return responseWithBody(http.StatusOK, nil, `{}`), nil
+						})}))
+						accountID := "acct_relay_minute"
+						key := createAccountAndKey(t, store, cfg, accountID)
+						otherKey := createAccountAndKey(t, store, cfg, "acct_relay_minute_other")
+						path := "/v1/" + family
+						if family == "chat_completions" {
+							path = "/v1/chat/completions"
+						}
+						acceptedStatus, acceptedCode := http.StatusBadRequest, "relay_blind_downgrade_rejected"
+						auditType := "relay_blind_downgrade_rejected"
+						if mode == "required" {
+							auditType = "relay_blind_required_rejected"
+							acceptedStatus, acceptedCode = http.StatusBadRequest, "relay_blind_endpoint_unsupported"
+							if !enabled {
+								acceptedStatus, acceptedCode = http.StatusServiceUnavailable, "relay_blind_disabled"
+							} else if family == "chat_completions" {
+								acceptedStatus, acceptedCode = http.StatusServiceUnavailable, "relay_blind_required_unavailable"
+							}
+						}
+						sequence := 0
+						body := func() string {
+							sequence++
+							return validRelayBlindRequestEnvelope(t, map[string]any{
+								"endpoint_family": family, "mode": mode, "issued_at_unix": now.Unix(),
+								"request_id": fmt.Sprintf("req-%d", sequence), "request_replay_nonce": fmt.Sprintf("nonce-%d", sequence),
+								"buyer_ephemeral_public_key": fmt.Sprintf("key-%d", sequence), "ciphertext": fmt.Sprintf("ciphertext-%d", sequence),
+							})
+						}
+						send := func(key, body string, status int, code string, retryAfter int) {
+							t.Helper()
+							req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+							req.Header.Set("Authorization", "Bearer "+key)
+							resp := httptest.NewRecorder()
+							h.ServeHTTP(resp, req)
+							if resp.Code != status {
+								t.Fatalf("at %s status=%d want %d body=%s", now.Sub(start), resp.Code, status, resp.Body.String())
+							}
+							if family == "messages" {
+								assertAnthropicErrorCode(t, resp.Body.String(), code)
+							} else {
+								assertErrorCode(t, resp.Body.String(), code)
+							}
+							if retryAfter > 0 {
+								assertBodyRetryable(t, resp.Body.String(), true)
+								if got := resp.Header().Get("Retry-After"); got != strconv.Itoa(retryAfter) {
+									t.Errorf("Retry-After=%q want %d", got, retryAfter)
+								}
+							}
+						}
+						first := body()
+						send(key, first, acceptedStatus, acceptedCode, 0)
+						for i := 1; i < limit; i++ {
+							send(key, body(), acceptedStatus, acceptedCode, 0)
+						}
+						interval := time.Minute / time.Duration(limit)
+						send(key, body(), http.StatusTooManyRequests, "relay_blind_metadata_rate_limited", int(interval.Seconds()))
+						now = start.Add(time.Second)
+						if mode == "required" {
+							send(key, first, http.StatusConflict, "relay_blind_replay", 0)
+						}
+						send(key, body(), http.StatusTooManyRequests, "relay_blind_metadata_rate_limited", int(interval.Seconds())-1)
+						send(otherKey, body(), acceptedStatus, acceptedCode, 0)
+						now = start.Add(interval - time.Millisecond)
+						send(key, body(), http.StatusTooManyRequests, "relay_blind_metadata_rate_limited", 1)
+						now = start.Add(interval)
+						send(key, body(), acceptedStatus, acceptedCode, 0)
+						send(key, body(), http.StatusTooManyRequests, "relay_blind_metadata_rate_limited", int(interval.Seconds()))
+						now = start.Add(3 * time.Minute)
+						for i := 0; i < limit; i++ {
+							send(key, body(), acceptedStatus, acceptedCode, 0)
+						}
+						send(key, body(), http.StatusTooManyRequests, "relay_blind_metadata_rate_limited", int(interval.Seconds()))
+						if got, want := countAuditEvents(t, dbPath, auditType), 2*limit+2; got != want {
+							t.Fatalf("audit rows=%d want %d", got, want)
+						}
+						if dispatches != 0 {
+							t.Fatalf("dispatches=%d want 0", dispatches)
+						}
+						assertNoDailyUsage(t, store, accountID)
+						assertNoDailyUsage(t, store, "acct_relay_minute_other")
+					})
+				}
+			}
+		}
+	}
+}

--- a/phase5-gateway/internal/router/relay_blind_rejection_audit_test.go
+++ b/phase5-gateway/internal/router/relay_blind_rejection_audit_test.go
@@ -1,0 +1,214 @@
+package router
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-gateway/internal/config"
+)
+
+func TestRelayBlindPrecheckRejectionsAuditBoundedMetadata(t *testing.T) {
+	for _, family := range []string{"chat_completions", "responses", "messages"} {
+		for _, enabled := range []bool{false, true} {
+			for _, rejection := range []string{"malformed", "schema", "cap", "stale", "oversized identifier"} {
+				t.Run(fmt.Sprintf("%s/enabled=%t/%s", family, enabled, rejection), func(t *testing.T) {
+					dispatchCalls := 0
+					h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+						cfg.Features.RelayBlindRequests.Enabled = enabled
+						cfg.Features.ResponsesAPIEnabled = enabled
+						cfg.Features.AnthropicMessagesEnabled = enabled
+						cfg.Features.RelayBlindRequests.MetadataRequestsPerMinute = 1
+						cfg.Limits.MaxTokensPerRequest = 20
+					}, WithHTTPClient(&http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+						dispatchCalls++
+						return responseWithBody(http.StatusOK, nil, `{}`), nil
+					})}))
+					accountID := "acct_rejection_audit"
+					key := createAccountAndKey(t, store, cfg, accountID)
+					overrides := map[string]any{"endpoint_family": family}
+					switch rejection {
+					case "schema":
+						overrides["private-prompt-sentinel"] = "private-plaintext-sentinel"
+					case "cap":
+						overrides["max_output_tokens"] = 21
+						overrides["reservation_token_cap"] = 29
+					case "stale":
+						overrides["issued_at_unix"] = fixedNow().Add(-2 * time.Minute).Unix()
+					case "oversized identifier":
+						overrides["kid"] = strings.Repeat("private-identifier-sentinel", 100)
+					}
+					body := validRelayBlindRequestEnvelope(t, overrides)
+					if rejection == "malformed" {
+						body = `{"version":"relay-blind-request-v1","mode":"required","private-prompt-sentinel":`
+					}
+					path := "/v1/" + family
+					if family == "chat_completions" {
+						path = "/v1/chat/completions"
+					}
+					unauthenticated := httptest.NewRecorder()
+					h.ServeHTTP(unauthenticated, httptest.NewRequest(http.MethodPost, path, strings.NewReader(body)))
+					if unauthenticated.Code != http.StatusUnauthorized {
+						t.Fatalf("unauthenticated status=%d want 401", unauthenticated.Code)
+					}
+					if got := countAuditEvents(t, dbPath, "relay_blind_required_rejected"); got != 0 {
+						t.Fatalf("unauthenticated audits=%d want 0", got)
+					}
+					for attempt, wantStatus := range []int{http.StatusBadRequest, http.StatusTooManyRequests} {
+						req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+						req.Header.Set("Authorization", "Bearer "+key)
+						resp := httptest.NewRecorder()
+						h.ServeHTTP(resp, req)
+						if resp.Code != wantStatus {
+							t.Fatalf("attempt=%d status=%d want %d body=%s", attempt, resp.Code, wantStatus, resp.Body.String())
+						}
+						code := "relay_blind_envelope_invalid"
+						if attempt > 0 {
+							code = "relay_blind_metadata_rate_limited"
+						}
+						if family == "messages" {
+							assertAnthropicErrorCode(t, resp.Body.String(), code)
+						} else {
+							assertErrorCode(t, resp.Body.String(), code)
+						}
+						if got := countAuditEvents(t, dbPath, "relay_blind_required_rejected"); got != 1 {
+							t.Fatalf("attempt=%d rejection audits=%d want 1", attempt, got)
+						}
+					}
+					payload := relayBlindAuditPayload(t, dbPath, "relay_blind_required_rejected")
+					var fields map[string]any
+					if err := json.Unmarshal([]byte(payload), &fields); err != nil {
+						t.Fatal(err)
+					}
+					digest := sha256.Sum256([]byte(body))
+					want := map[string]any{
+						"endpoint_family": family, "mode_class": "unvalidated",
+						"requested_privacy_mode": "relay_blind_required", "effective_outcome": "relay_blind_unavailable",
+						"wallet_session_id": "", "envelope_digest": hex.EncodeToString(digest[:]),
+						"reason_code": "relay_blind_envelope_invalid",
+					}
+					if len(fields) != len(want) {
+						t.Fatalf("unexpected audit fields: %s", payload)
+					}
+					for key, value := range want {
+						if fields[key] != value {
+							t.Fatalf("audit[%s]=%v want %v", key, fields[key], value)
+						}
+					}
+					if dispatchCalls != 0 {
+						t.Fatalf("dispatches=%d want 0", dispatchCalls)
+					}
+					assertNoDailyUsage(t, store, accountID)
+				})
+			}
+		}
+	}
+}
+
+func TestRelayBlindWalletPrecheckAuditPreservesAdmission(t *testing.T) {
+	for _, family := range []string{"chat_completions", "responses", "messages"} {
+		for _, enabled := range []bool{false, true} {
+			for _, rejection := range []string{"malformed", "schema", "model", "cap", "stale"} {
+				t.Run(fmt.Sprintf("%s/enabled=%t/%s", family, enabled, rejection), func(t *testing.T) {
+					h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+						cfg.Public.BaseURL = "https://api.malibu.test"
+						cfg.Auth.WalletSessions.Enabled = true
+						cfg.Auth.WalletSessions.BearerHashKeys = map[string]string{"k1": strings.Repeat("b", 32)}
+						cfg.Auth.WalletSessions.CurrentBearerHashKeyID = "k1"
+						cfg.Auth.WalletSessions.WalletFingerprintSecret = strings.Repeat("f", 32)
+						cfg.Auth.WalletSessions.MetadataRequestsPerMinute = 1
+						cfg.Features.RelayBlindRequests.Enabled = enabled
+						cfg.Features.ResponsesAPIEnabled = enabled
+						cfg.Features.AnthropicMessagesEnabled = enabled
+					}, WithHTTPClient(walletModelsClient()))
+					accountID := "acct_wallet_precheck_audit"
+					key := createAccountAndKey(t, store, cfg, accountID)
+					wallet := registerWalletSessionViaAPIWithCaps(t, h, cfg, key, accountID, []string{"model-a"}, 100, 50)
+					overrides := map[string]any{"endpoint_family": family}
+					status, code := http.StatusBadRequest, "relay_blind_envelope_invalid"
+					switch rejection {
+					case "schema":
+						overrides["private-prompt-sentinel"] = "private-plaintext-sentinel"
+					case "model":
+						overrides["model"] = "model-b"
+						status, code = http.StatusForbidden, "wallet_session_model_not_allowed"
+					case "cap":
+						overrides["reservation_token_cap"] = 51
+						code = "wallet_session_request_cap_exceeded"
+					case "stale":
+						overrides["issued_at_unix"] = fixedNow().Add(-2 * time.Minute).Unix()
+					}
+					body := []byte(validRelayBlindRequestEnvelope(t, overrides))
+					if rejection == "malformed" {
+						body = []byte(`{"mode":"required"}`)
+					}
+					path := "/v1/" + family
+					if family == "chat_completions" {
+						path = "/v1/chat/completions"
+					}
+					outerID := "018f7b7b-7c35-4cf0-8d4e-3f0ab1c50928"
+					for _, attempt := range []struct {
+						id     string
+						status int
+						code   string
+					}{
+						{outerID, status, code},
+						{outerID, http.StatusConflict, "wallet_session_duplicate_request"},
+						{"018f7b7b-7c35-4cf0-8d4e-3f0ab1c50929", http.StatusTooManyRequests, "wallet_session_rate_limited"},
+					} {
+						resp := httptest.NewRecorder()
+						h.ServeHTTP(resp, signedWalletRequest(t, wallet, http.MethodPost, path, path, attempt.id, body))
+						if resp.Code != attempt.status {
+							t.Fatalf("status=%d want %d body=%s", resp.Code, attempt.status, resp.Body.String())
+						}
+						if family == "messages" {
+							assertAnthropicErrorCode(t, resp.Body.String(), attempt.code)
+						} else {
+							assertErrorCode(t, resp.Body.String(), attempt.code)
+						}
+						if got := countAuditEvents(t, dbPath, "relay_blind_required_rejected"); got != 1 {
+							t.Fatalf("audits=%d want 1", got)
+						}
+					}
+					var payload map[string]any
+					if err := json.Unmarshal([]byte(relayBlindAuditPayload(t, dbPath, "relay_blind_required_rejected")), &payload); err != nil {
+						t.Fatal(err)
+					}
+					if payload["wallet_session_id"] != wallet.SessionID || payload["reason_code"] != code {
+						t.Fatalf("audit correlation/reason=%v", payload)
+					}
+					assertNoDailyUsage(t, store, accountID)
+				})
+			}
+		}
+	}
+}
+
+func TestRelayBlindPrecheckAuditFailureFailsClosed(t *testing.T) {
+	for _, path := range []string{"/v1/chat/completions", "/v1/responses", "/v1/messages"} {
+		t.Run(path, func(t *testing.T) {
+			_, store, _, cfg := newTestHarness(t, fakeOAuth{}, WithHTTPClient(noopClient()))
+			key := createAccountAndKey(t, store, cfg, "acct_precheck_audit_failure")
+			h := New(cfg, relayBlindAuditFailStore{Store: store}, fakeOAuth{}, WithNow(fixedNow), WithHTTPClient(noopClient())).Handler()
+			req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(`{"mode":"required"}`))
+			req.Header.Set("Authorization", "Bearer "+key)
+			resp := httptest.NewRecorder()
+			h.ServeHTTP(resp, req)
+			if resp.Code != http.StatusInternalServerError {
+				t.Fatalf("status=%d want 500 body=%s", resp.Code, resp.Body.String())
+			}
+			if path == "/v1/messages" {
+				assertAnthropicErrorCode(t, resp.Body.String(), "internal_error")
+			} else {
+				assertErrorCode(t, resp.Body.String(), "internal_error")
+			}
+			assertNoDailyUsage(t, store, "acct_precheck_audit_failure")
+		})
+	}
+}

--- a/phase5-gateway/internal/router/relay_blind_session_replay_test.go
+++ b/phase5-gateway/internal/router/relay_blind_session_replay_test.go
@@ -1,0 +1,141 @@
+package router
+
+import (
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRelayBlindWalletReplayBeforeTemporalThrottle(t *testing.T) {
+	for _, route := range []struct {
+		path, family    string
+		adaptersEnabled bool
+	}{
+		{"/v1/chat/completions", "chat_completions", false},
+		{"/v1/responses", "responses", false},
+		{"/v1/messages", "messages", false},
+		{"/v1/responses", "responses", true},
+		{"/v1/messages", "messages", true},
+	} {
+		for _, enabled := range []bool{false, true} {
+			for _, bound := range []string{"available", "rate", "rows", "bytes"} {
+				t.Run(route.family+"/"+map[bool]string{false: "disabled", true: "enabled"}[enabled]+"/"+bound, func(t *testing.T) {
+					dispatches := 0
+					baseClient := walletModelsClient()
+					client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+						if !strings.HasSuffix(r.URL.Path, "/poolz") {
+							dispatches++
+						}
+						return baseClient.Transport.RoundTrip(r)
+					})}
+					h, store, dbPath, cfg := newWalletSessionHarness(t, client)
+					cfg.Features.RelayBlindRequests.Enabled = enabled
+					cfg.Features.ResponsesAPIEnabled = route.adaptersEnabled
+					cfg.Features.AnthropicMessagesEnabled = route.adaptersEnabled
+					cfg.Auth.WalletSessions.MetadataRequestsPerMinute = 100
+					body := []byte(validRelayBlindRequestEnvelope(t, map[string]any{"endpoint_family": route.family}))
+					if bound != "available" {
+						cfg.Auth.WalletSessions.MetadataRequestsPerMinute = 1
+					}
+					if bound == "rows" {
+						cfg.Auth.WalletSessions.ReplayMaxRowsPerSession = 1
+					}
+					if bound == "bytes" {
+						cfg.Auth.WalletSessions.ReplayMaxBytesPerSession = int64(len(body))
+					}
+					h = New(cfg, store, fakeOAuth{}, WithNow(fixedNow), WithHTTPClient(client)).Handler()
+					accountID := "acct_wallet_relay_precedence"
+					key := createAccountAndKey(t, store, cfg, accountID)
+					wallet := registerWalletSessionViaAPI(t, h, cfg, key, accountID, []string{"model-a"})
+					send := func(id string, payload []byte) *httptest.ResponseRecorder {
+						response := httptest.NewRecorder()
+						h.ServeHTTP(response, signedWalletRequest(t, wallet, http.MethodPost, route.path, route.path, id, payload))
+						return response
+					}
+					firstID := "018f7b7b-7c35-4cf0-8d4e-3f0ab1c4a901"
+					first := send(firstID, body)
+					if first.Code < 400 || first.Code == http.StatusTooManyRequests {
+						t.Fatalf("first response=%d %s", first.Code, first.Body.String())
+					}
+					assertErrorCode(t, send(firstID, body).Body.String(), "wallet_session_duplicate_request")
+					assertErrorCode(t, send(firstID, append(append([]byte(nil), body...), ' ')).Body.String(), "wallet_session_replay_mismatch")
+					replayed := send("018f7b7b-7c35-4cf0-8d4e-3f0ab1c4a902", body)
+					want := "relay_blind_replay"
+					if bound == "rows" || bound == "bytes" {
+						want = "wallet_session_replay_capacity_exhausted"
+					}
+					if replayed.Code != http.StatusConflict {
+						t.Fatalf("replay status=%d want 409: %s", replayed.Code, replayed.Body.String())
+					}
+					assertErrorCode(t, replayed.Body.String(), want)
+					assertBodyRetryable(t, replayed.Body.String(), false)
+					db, err := sql.Open("sqlite", dbPath)
+					if err != nil {
+						t.Fatal(err)
+					}
+					defer db.Close()
+					var rows int
+					if err := db.QueryRow(`SELECT COUNT(*) FROM wallet_session_replays WHERE session_id = ?`, wallet.SessionID).Scan(&rows); err != nil {
+						t.Fatal(err)
+					}
+					wantRows := 1
+					if bound == "available" {
+						wantRows = 2
+					}
+					if rows != wantRows || dispatches != 0 {
+						t.Fatalf("metadata rows=%d want %d; dispatches=%d want 0", rows, wantRows, dispatches)
+					}
+					if bound == "rate" {
+						var audits int
+						if err := db.QueryRow(`SELECT COUNT(*) FROM audit_events WHERE event_type = 'wallet_session_rejected' AND json_extract(payload_json, '$.reason') = 'relay_blind_replay'`).Scan(&audits); err != nil || audits != 1 {
+							t.Fatalf("replay audits=%d want 1 err=%v", audits, err)
+						}
+					}
+					assertNoDailyUsage(t, store, accountID)
+				})
+			}
+		}
+	}
+}
+
+func TestRelayBlindWalletThrottleDoesNotClassifyInvalidOrFreshReplay(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		overrides map[string]any
+	}{
+		{"fresh", map[string]any{"request_id": "fresh-request", "request_replay_nonce": "fresh-nonce", "buyer_ephemeral_public_key": "fresh-key"}},
+		{"downgrade", map[string]any{"mode": "preferred"}},
+		{"unknown_field", map[string]any{"unexpected": "value"}},
+		{"stale", map[string]any{"issued_at_unix": fixedNow().Add(-2 * time.Minute).Unix()}},
+		{"wrong_route", map[string]any{"endpoint_family": "responses"}},
+		{"model_denied", map[string]any{"model": "model-b"}},
+		{"cap_exceeded", map[string]any{"reservation_token_cap": 51}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := walletModelsClient()
+			h, store, _, cfg := newWalletSessionHarness(t, client)
+			cfg.Features.RelayBlindRequests.Enabled = true
+			cfg.Auth.WalletSessions.MetadataRequestsPerMinute = 1
+			h = New(cfg, store, fakeOAuth{}, WithNow(fixedNow), WithHTTPClient(client)).Handler()
+			accountID := "acct_wallet_relay_controls"
+			key := createAccountAndKey(t, store, cfg, accountID)
+			wallet := registerWalletSessionViaAPI(t, h, cfg, key, accountID, []string{"model-a"})
+			send := func(id string, overrides map[string]any) *httptest.ResponseRecorder {
+				response := httptest.NewRecorder()
+				h.ServeHTTP(response, signedWalletRequest(t, wallet, http.MethodPost, "/v1/chat/completions", "/v1/chat/completions", id, []byte(validRelayBlindRequestEnvelope(t, overrides))))
+				return response
+			}
+			assertErrorCode(t, send("018f7b7b-7c35-4cf0-8d4e-3f0ab1c4a901", nil).Body.String(), "relay_blind_required_unavailable")
+			response := send("018f7b7b-7c35-4cf0-8d4e-3f0ab1c4a902", tc.overrides)
+			if response.Code != http.StatusTooManyRequests {
+				t.Fatalf("status=%d want 429 body=%s", response.Code, response.Body.String())
+			}
+			assertErrorCode(t, response.Body.String(), "wallet_session_rate_limited")
+			assertBodyRetryable(t, response.Body.String(), true)
+			assertNoDailyUsage(t, store, accountID)
+		})
+	}
+}

--- a/phase5-gateway/internal/router/relay_blind_test.go
+++ b/phase5-gateway/internal/router/relay_blind_test.go
@@ -1486,8 +1486,8 @@ func TestRelayBlindDisabledFamilyPrechecksModelAndCapsBeforeReplayAudit(t *testi
 	}
 	assertErrorCode(t, resp.Body.String(), "relay_blind_envelope_invalid")
 	assertBodyRetryable(t, resp.Body.String(), false)
-	if got := countAuditEvents(t, dbPath, "relay_blind_required_rejected"); got != 0 {
-		t.Fatalf("required audit events=%d want 0", got)
+	if got := countAuditEvents(t, dbPath, "relay_blind_required_rejected"); got != 1 {
+		t.Fatalf("required audit events=%d want 1", got)
 	}
 	assertNoDailyUsage(t, store, "acct_relay_blind_disabled_family_cap")
 }
@@ -1519,8 +1519,8 @@ func TestRelayBlindDisabledFamilyWalletPrecheckStillRecordsWalletReplay(t *testi
 	}
 	assertErrorCode(t, resp.Body.String(), "wallet_session_model_not_allowed")
 	assertBodyRetryable(t, resp.Body.String(), false)
-	if got := countAuditEvents(t, dbPath, "relay_blind_required_rejected"); got != 0 {
-		t.Fatalf("required audit events=%d want 0", got)
+	if got := countAuditEvents(t, dbPath, "relay_blind_required_rejected"); got != 1 {
+		t.Fatalf("required audit events=%d want 1", got)
 	}
 
 	replay := httptest.NewRecorder()
@@ -1902,7 +1902,7 @@ type relayBlindAuditFailStore struct {
 }
 
 func (s relayBlindAuditFailStore) InsertAuditEvent(ctx context.Context, event storage.AuditEvent) error {
-	if event.Type == "relay_blind_downgrade_rejected" {
+	if event.Type == "relay_blind_downgrade_rejected" || event.Type == "relay_blind_required_rejected" {
 		return errors.New("audit insert failed")
 	}
 	return s.Store.InsertAuditEvent(ctx, event)

--- a/phase5-gateway/internal/router/request_rate_limiter.go
+++ b/phase5-gateway/internal/router/request_rate_limiter.go
@@ -36,6 +36,14 @@ func newRequestRateLimiter() *requestRateLimiter {
 }
 
 func (l *requestRateLimiter) allow(key string, limit int, now time.Time) requestRateDecision {
+	return l.allowWithRefillPeriod(key, limit, now, time.Second)
+}
+
+func (l *requestRateLimiter) allowPerMinute(key string, limit int, now time.Time) requestRateDecision {
+	return l.allowWithRefillPeriod(key, limit, now, time.Minute)
+}
+
+func (l *requestRateLimiter) allowWithRefillPeriod(key string, limit int, now time.Time, period time.Duration) requestRateDecision {
 	if limit <= 0 || key == "" {
 		return requestRateDecision{Admitted: true, Limit: limit}
 	}
@@ -49,14 +57,19 @@ func (l *requestRateLimiter) allow(key string, limit int, now time.Time) request
 		bucket = &requestRateBucket{tokens: capacity, last: now}
 		l.buckets[key] = bucket
 	}
-	if elapsed := now.Sub(bucket.last).Seconds(); elapsed > 0 {
-		bucket.tokens = math.Min(capacity, bucket.tokens+elapsed*capacity)
-		bucket.last = now
+	tokens := bucket.tokens
+	elapsed := math.Max(0, now.Sub(bucket.last).Seconds())
+	if elapsed > 0 {
+		tokens = math.Min(capacity, tokens+elapsed*capacity/period.Seconds())
 	}
 	bucket.lastSeen = now
 
-	if bucket.tokens >= 1 {
-		bucket.tokens--
+	if tokens >= 1 {
+		// Commit refill only on consumption so denied probes cannot accumulate rounding error.
+		bucket.tokens = tokens - 1
+		if now.After(bucket.last) {
+			bucket.last = now
+		}
 		return requestRateDecision{
 			Admitted:  true,
 			Limit:     limit,
@@ -64,7 +77,7 @@ func (l *requestRateLimiter) allow(key string, limit int, now time.Time) request
 		}
 	}
 
-	retryAfter := int(math.Ceil((1 - bucket.tokens) / capacity))
+	retryAfter := int(math.Ceil((1-bucket.tokens)*period.Seconds()/capacity - elapsed))
 	if retryAfter < 1 {
 		retryAfter = 1
 	}

--- a/phase5-gateway/internal/router/request_rate_limiter_test.go
+++ b/phase5-gateway/internal/router/request_rate_limiter_test.go
@@ -6,6 +6,60 @@ import (
 	"time"
 )
 
+func TestRequestRateLimiterPreservesPerSecondRefill(t *testing.T) {
+	limiter := newRequestRateLimiter()
+	start := time.Unix(1_700_000_000, 0)
+	for i, tc := range []struct {
+		elapsed time.Duration
+		admit   bool
+	}{
+		{0, true}, {0, true}, {0, false},
+		{499 * time.Millisecond, false}, {500 * time.Millisecond, true},
+		{500 * time.Millisecond, false}, {time.Second, true},
+	} {
+		got := limiter.allow("account", 2, start.Add(tc.elapsed))
+		if got.Admitted != tc.admit || (!tc.admit && got.RetryAfterSeconds != 1) {
+			t.Fatalf("step %d: decision=%+v want admitted=%t", i, got, tc.admit)
+		}
+	}
+}
+
+func TestRequestRateLimiterPerMinuteRefill(t *testing.T) {
+	for _, limit := range []int{1, 2, 120} {
+		t.Run(fmt.Sprint(limit), func(t *testing.T) {
+			limiter := newRequestRateLimiter()
+			start := time.Unix(1_700_000_000, 0)
+			for i := 0; i < limit; i++ {
+				if got := limiter.allowPerMinute("account", limit, start); !got.Admitted || got.Remaining != limit-i-1 {
+					t.Fatalf("burst %d: %+v", i, got)
+				}
+			}
+			interval := time.Minute / time.Duration(limit)
+			for elapsed := time.Second; elapsed < interval; elapsed += time.Second {
+				got := limiter.allowPerMinute("account", limit, start.Add(elapsed))
+				wantRetry := int((interval - elapsed + time.Second - 1) / time.Second)
+				if got.Admitted || got.RetryAfterSeconds != wantRetry {
+					t.Errorf("at %s: %+v want retry=%d", elapsed, got, wantRetry)
+				}
+			}
+			for i := 1; i < 100; i++ {
+				if got := limiter.allowPerMinute("account", limit, start.Add(interval*time.Duration(i)/100)); got.Admitted {
+					t.Fatalf("probe %d refilled early: %+v", i, got)
+				}
+			}
+			if got := limiter.allowPerMinute("account", limit, start.Add(interval-time.Millisecond)); got.Admitted || got.RetryAfterSeconds != 1 {
+				t.Fatalf("before refill: %+v", got)
+			}
+			if got := limiter.allowPerMinute("account", limit, start.Add(interval)); !got.Admitted || got.Remaining != 0 {
+				t.Fatalf("at refill: %+v", got)
+			}
+			if got := limiter.allowPerMinute("account", limit, start.Add(interval)); got.Admitted {
+				t.Fatalf("extra token after refill: %+v", got)
+			}
+		})
+	}
+}
+
 func TestRequestRateLimiterCapsDistinctBuckets(t *testing.T) {
 	limiter := newRequestRateLimiter()
 	now := time.Unix(1_700_000_000, 0)

--- a/phase5-gateway/internal/storage/sqlite/metadata_relay_replay_test.go
+++ b/phase5-gateway/internal/storage/sqlite/metadata_relay_replay_test.go
@@ -1,0 +1,365 @@
+package sqlite
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-gateway/internal/storage"
+)
+
+func TestWalletMetadataRelayReplayRetentionWithoutCleanup(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		offset time.Duration
+		want   error
+	}{
+		{"before_second", -time.Second, storage.ErrRelayBlindReplay},
+		{"before_nanosecond", -time.Nanosecond, storage.ErrRelayBlindReplay},
+		{"at", 0, storage.ErrRateLimit},
+		{"after_nanosecond", time.Nanosecond, storage.ErrRateLimit},
+		{"after_second", time.Second, storage.ErrRateLimit},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store, req, replay := metadataRelayReplayFixture(t)
+			recordMetadataRelayReplay(t, store, replay)
+			req.CreatedAt = replay.RetentionExpiresAt.Add(tc.offset)
+			// The candidate's clock and expiry must not replace admission time or stored retention.
+			replay.CreatedAt = fixedTime().Add(time.Hour)
+			if tc.offset >= 0 {
+				replay.CreatedAt = fixedTime().Add(-time.Hour)
+			}
+			replay.RetentionExpiresAt = req.CreatedAt.Add(time.Hour)
+			req.RelayBlindReplay = &replay
+			assertMetadataRelayReplayRejected(t, store, req, tc.want)
+			var rows int
+			if err := store.db.QueryRow(`SELECT COUNT(*) FROM relay_blind_replays`).Scan(&rows); err != nil {
+				t.Fatal(err)
+			}
+			if rows != 1 {
+				t.Fatalf("retained rows=%d want 1 without cleanup", rows)
+			}
+		})
+	}
+}
+
+func TestWalletMetadataRelayReplayFractionalExpiryAfterWholeSecond(t *testing.T) {
+	store, req, replay := metadataRelayReplayFixture(t)
+	req.CreatedAt = fixedTime().Add(10 * time.Second)
+	replay.RetentionExpiresAt = req.CreatedAt.Add(time.Nanosecond)
+	recordMetadataRelayReplay(t, store, replay)
+	req.RelayBlindReplay = &replay
+	assertMetadataRelayReplayRejected(t, store, req, storage.ErrRelayBlindReplay)
+}
+
+func TestWalletMetadataRelayReplayAnyRetainedMatchingRowWins(t *testing.T) {
+	for _, firstExpired := range []bool{true, false} {
+		t.Run(fmt.Sprintf("first_expired_%t", firstExpired), func(t *testing.T) {
+			store, req, first := metadataRelayReplayFixture(t)
+			second := first
+			second.RequestID = "second-inner-request"
+			second.RequestReplayNonceDigest = []byte("second-inner-nonce")
+			second.BuyerEphemeralPublicKeyDigest = []byte("second-inner-buyer-key")
+			second.EnvelopeDigest = []byte("second-inner-envelope")
+			second.RetentionExpiresAt = fixedTime().Add(20 * time.Second)
+			if !firstExpired {
+				first.RetentionExpiresAt, second.RetentionExpiresAt = second.RetentionExpiresAt, first.RetentionExpiresAt
+			}
+			recordMetadataRelayReplay(t, store, first)
+			recordMetadataRelayReplay(t, store, second)
+			req.CreatedAt = fixedTime().Add(11 * time.Second)
+			// This candidate matches the first request ID and the second nonce.
+			first.RequestReplayNonceDigest = second.RequestReplayNonceDigest
+			req.RelayBlindReplay = &first
+			assertMetadataRelayReplayRejected(t, store, req, storage.ErrRelayBlindReplay)
+		})
+	}
+}
+
+func TestWalletMetadataRelayReplayMatchesEachIdentity(t *testing.T) {
+	for _, identity := range []string{"request_id", "nonce", "buyer_key", "envelope"} {
+		t.Run(identity, func(t *testing.T) {
+			store, req, replay := metadataRelayReplayFixture(t)
+			recordMetadataRelayReplay(t, store, replay)
+			candidate := replay
+			candidate.RequestID = "fresh-inner-request"
+			candidate.RequestReplayNonceDigest = []byte("fresh-nonce")
+			candidate.BuyerEphemeralPublicKeyDigest = []byte("fresh-buyer-key")
+			candidate.EnvelopeDigest = []byte("fresh-envelope")
+			switch identity {
+			case "request_id":
+				candidate.RequestID = replay.RequestID
+			case "nonce":
+				candidate.RequestReplayNonceDigest = replay.RequestReplayNonceDigest
+			case "buyer_key":
+				candidate.BuyerEphemeralPublicKeyDigest = replay.BuyerEphemeralPublicKeyDigest
+			case "envelope":
+				candidate.EnvelopeDigest = replay.EnvelopeDigest
+			}
+			req.RelayBlindReplay = &candidate
+			assertMetadataRelayReplayRejected(t, store, req, storage.ErrRelayBlindReplay)
+		})
+	}
+}
+
+func TestWalletMetadataRelayReplayBindsAdmissionScope(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		storedAccount string
+		storedSession string
+		want          error
+	}{
+		{"candidate_cannot_override_scope", "acct_metadata_relay", "ws_metadata_relay", storage.ErrRelayBlindReplay},
+		{"other_account", "acct_other", "ws_metadata_relay", storage.ErrRateLimit},
+		{"other_session", "acct_metadata_relay", "ws_other", storage.ErrRateLimit},
+		{"api_key_scope", "acct_metadata_relay", "", storage.ErrRateLimit},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store, req, replay := metadataRelayReplayFixture(t)
+			replay.AccountID, replay.WalletSessionID = tc.storedAccount, tc.storedSession
+			recordMetadataRelayReplay(t, store, replay)
+			if tc.want == storage.ErrRelayBlindReplay {
+				replay.AccountID, replay.WalletSessionID = "acct_other", "ws_other"
+			}
+			req.RelayBlindReplay = &replay
+			originalScope := [2]string{replay.AccountID, replay.WalletSessionID}
+			assertMetadataRelayReplayRejected(t, store, req, tc.want)
+			if got := [2]string{replay.AccountID, replay.WalletSessionID}; got != originalScope {
+				t.Fatal("admission mutated caller-owned replay scope")
+			}
+		})
+	}
+}
+
+func TestWalletMetadataRelayReplayFreshAndAbsentCandidatesRemainRateLimited(t *testing.T) {
+	for _, present := range []bool{false, true} {
+		t.Run(fmt.Sprintf("candidate_%t", present), func(t *testing.T) {
+			store, req, replay := metadataRelayReplayFixture(t)
+			recordMetadataRelayReplay(t, store, replay)
+			if present {
+				replay.RequestID = "fresh-inner-request"
+				replay.RequestReplayNonceDigest = []byte("fresh-nonce")
+				replay.BuyerEphemeralPublicKeyDigest = []byte("fresh-buyer-key")
+				replay.EnvelopeDigest = []byte("fresh-envelope")
+				req.RelayBlindReplay = &replay
+			}
+			assertMetadataRelayReplayRejected(t, store, req, storage.ErrRateLimit)
+		})
+	}
+}
+
+func TestWalletMetadataRelayReplayOnlyClassifiesTemporalRejection(t *testing.T) {
+	for _, rateLimit := range []int{0, 2} {
+		t.Run(fmt.Sprintf("rate_limit_%d", rateLimit), func(t *testing.T) {
+			store, req, replay := metadataRelayReplayFixture(t)
+			recordMetadataRelayReplay(t, store, replay)
+			req.RateLimit = rateLimit
+			req.RelayBlindReplay = &replay
+			before := metadataRelayReplayState(t, store)
+			if err := store.AdmitWalletSessionMetadata(context.Background(), req); err != nil {
+				t.Fatalf("metadata admission with available rate budget: %v", err)
+			}
+			want := before
+			want[0]++
+			want[1]++
+			if got := metadataRelayReplayState(t, store); got != want {
+				t.Fatalf("state=%v want only one new metadata replay %v", got, want)
+			}
+		})
+	}
+}
+
+func TestWalletMetadataRelayReplayExistingGuardsKeepPrecedence(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		want error
+	}{
+		{"outer_duplicate", storage.ErrWalletSessionReplayDuplicate},
+		{"outer_mismatch", storage.ErrWalletSessionReplayMismatch},
+		{"hard_rows", storage.ErrWalletSessionReplayCapacity},
+		{"hard_bytes", storage.ErrWalletSessionReplayCapacity},
+		{"revoked_session", storage.ErrWalletSessionInactive},
+		{"expired_session", storage.ErrWalletSessionInactive},
+		{"inactive_account", storage.ErrWalletSessionInactive},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store, req, replay := metadataRelayReplayFixture(t)
+			recordMetadataRelayReplay(t, store, replay)
+			req.RelayBlindReplay = &replay
+			switch tc.name {
+			case "outer_duplicate", "outer_mismatch":
+				req.Replay.RequestID = "outer-seed"
+				req.MaxReplayRows, req.MaxReplayBytes = 1, 1
+				if tc.name == "outer_mismatch" {
+					req.Replay.RawBodyHash = []byte("different-body")
+				}
+			case "hard_rows":
+				req.MaxReplayRows = 1
+			case "hard_bytes":
+				req.MaxReplayBytes = 2*req.Replay.BodyBytes - 1
+			case "revoked_session":
+				if err := store.RevokeWalletSession(context.Background(), req.AccountID, req.SessionID, "test", "test", req.CreatedAt); err != nil {
+					t.Fatal(err)
+				}
+			case "expired_session":
+				if _, err := store.db.Exec(`UPDATE wallet_sessions SET expires_at = ? WHERE session_id = ?`, encodeTime(req.CreatedAt), req.SessionID); err != nil {
+					t.Fatal(err)
+				}
+			case "inactive_account":
+				if _, err := store.db.Exec(`UPDATE accounts SET status = 'blocked' WHERE account_id = ?`, req.AccountID); err != nil {
+					t.Fatal(err)
+				}
+			}
+			assertMetadataRelayReplayRejected(t, store, req, tc.want)
+		})
+	}
+}
+
+func TestWalletMetadataRelayReplayLookupErrorFailsClosed(t *testing.T) {
+	store, req, replay := metadataRelayReplayFixture(t)
+	recordMetadataRelayReplay(t, store, replay)
+	req.RelayBlindReplay = &replay
+	if _, err := store.db.Exec(`ALTER TABLE relay_blind_replays RENAME COLUMN retention_expires_at TO unavailable_retention_expires_at`); err != nil {
+		t.Fatal(err)
+	}
+	before := metadataRelayReplayState(t, store)
+	err := store.AdmitWalletSessionMetadata(context.Background(), req)
+	if err == nil || errors.Is(err, storage.ErrRateLimit) || errors.Is(err, storage.ErrRelayBlindReplay) || !strings.Contains(err.Error(), "retention_expires_at") {
+		t.Fatalf("lookup error=%v want storage error naming missing retention column", err)
+	}
+	if got := metadataRelayReplayState(t, store); got != before {
+		t.Fatalf("failed lookup changed state: before=%v after=%v", before, got)
+	}
+}
+
+func TestWalletMetadataRelayReplayCorruptRetentionFailsClosed(t *testing.T) {
+	store, req, replay := metadataRelayReplayFixture(t)
+	recordMetadataRelayReplay(t, store, replay)
+	req.RelayBlindReplay = &replay
+	if _, err := store.db.Exec(`UPDATE relay_blind_replays SET retention_expires_at = 'invalid-timestamp' WHERE request_id = ?`, replay.RequestID); err != nil {
+		t.Fatal(err)
+	}
+	before := metadataRelayReplayState(t, store)
+	err := store.AdmitWalletSessionMetadata(context.Background(), req)
+	if err == nil || errors.Is(err, storage.ErrRateLimit) || errors.Is(err, storage.ErrRelayBlindReplay) {
+		t.Fatalf("corrupt retention error=%v want storage error", err)
+	}
+	if got := metadataRelayReplayState(t, store); got != before {
+		t.Fatalf("corrupt retention lookup changed state: before=%v after=%v", before, got)
+	}
+}
+
+func TestWalletMetadataRelayReplayConcurrentRejectionsPreserveState(t *testing.T) {
+	store, req, replay := metadataRelayReplayFixture(t)
+	recordMetadataRelayReplay(t, store, replay)
+	req.RelayBlindReplay = &replay
+	if _, err := store.AdmitWalletSessionInference(context.Background(), walletAdmission(req.AccountID, req.SessionID, "reserved-before-rejections", 20)); err != nil {
+		t.Fatalf("seed inference reservation: %v", err)
+	}
+	before := metadataRelayReplayState(t, store)
+	const attempts = 16
+	start := make(chan struct{})
+	results := make(chan error, attempts)
+	var wg sync.WaitGroup
+	for i := 0; i < attempts; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			candidate := req
+			candidate.Replay.RequestID = fmt.Sprintf("concurrent-outer-%d", i)
+			<-start
+			results <- store.AdmitWalletSessionMetadata(context.Background(), candidate)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+	for err := range results {
+		if !errors.Is(err, storage.ErrRelayBlindReplay) {
+			t.Errorf("concurrent rejection=%v want ErrRelayBlindReplay", err)
+		}
+	}
+	if got := metadataRelayReplayState(t, store); got != before {
+		t.Fatalf("rejected lookups changed state: before=%v after=%v", before, got)
+	}
+	used, reserved, err := store.DailyUsage(context.Background(), req.AccountID, "2026-05-29")
+	if err != nil || used != 0 || reserved != 20 {
+		t.Fatalf("daily usage after rejection: used=%d reserved=%d err=%v want 0,20,nil", used, reserved, err)
+	}
+}
+
+func metadataRelayReplayFixture(t *testing.T) (*Store, storage.WalletSessionMetadataAdmissionRequest, storage.RelayBlindReplayMaterial) {
+	t.Helper()
+	store := newTestStore(t)
+	createWalletSession(t, store, "acct_metadata_relay", "ws_metadata_relay", 1000, 100)
+	req := storage.WalletSessionMetadataAdmissionRequest{
+		AccountID:      "acct_metadata_relay",
+		SessionID:      "ws_metadata_relay",
+		Replay:         walletReplay("ws_metadata_relay", "outer-seed", "POST", "/v1/chat/completions", []byte("outer-body"), 128, "192.0.2.1"),
+		WindowStart:    fixedTime().Add(-time.Minute),
+		RateLimit:      1,
+		MaxReplayRows:  100,
+		MaxReplayBytes: 100000,
+		CreatedAt:      fixedTime(),
+	}
+	if err := store.AdmitWalletSessionMetadata(context.Background(), req); err != nil {
+		t.Fatalf("seed metadata rate budget: %v", err)
+	}
+	req.Replay.RequestID = "outer-retry"
+	req.CreatedAt = fixedTime().Add(time.Second)
+	return store, req, storage.RelayBlindReplayMaterial{
+		AccountID:                     req.AccountID,
+		WalletSessionID:               req.SessionID,
+		RequestID:                     "inner-request",
+		RequestReplayNonceDigest:      []byte("inner-nonce"),
+		BuyerEphemeralPublicKeyDigest: []byte("inner-buyer-key"),
+		ProviderBindingDigest:         []byte("provider-binding"),
+		KIDDigest:                     []byte("kid"),
+		EnvelopeDigest:                []byte("inner-envelope"),
+		EnvelopeBytes:                 128,
+		RetentionExpiresAt:            fixedTime().Add(10 * time.Second),
+		CreatedAt:                     fixedTime(),
+	}
+}
+
+func recordMetadataRelayReplay(t *testing.T, store *Store, replay storage.RelayBlindReplayMaterial) {
+	t.Helper()
+	if err := store.RecordRelayBlindReplay(context.Background(), replay); err != nil {
+		t.Fatalf("seed inner replay: %v", err)
+	}
+}
+
+func assertMetadataRelayReplayRejected(t *testing.T, store *Store, req storage.WalletSessionMetadataAdmissionRequest, want error) {
+	t.Helper()
+	before := metadataRelayReplayState(t, store)
+	if err := store.AdmitWalletSessionMetadata(context.Background(), req); !errors.Is(err, want) {
+		t.Fatalf("metadata rejection=%v want %v", err, want)
+	}
+	if got := metadataRelayReplayState(t, store); got != before {
+		t.Fatalf("rejection changed state: before=%v after=%v", before, got)
+	}
+}
+
+func metadataRelayReplayState(t *testing.T, store *Store) [9]int64 {
+	t.Helper()
+	var state [9]int64
+	err := store.db.QueryRow(`SELECT
+		(SELECT COUNT(*) FROM wallet_session_replays),
+		(SELECT COUNT(*) FROM wallet_session_replays WHERE state = 'metadata_only'),
+		(SELECT COUNT(*) FROM relay_blind_replays),
+		(SELECT COUNT(*) FROM wallet_session_reservations),
+		(SELECT COALESCE(SUM(reserved_tokens), 0) FROM wallet_session_reservations),
+		(SELECT COUNT(*) FROM quota_reservations),
+		(SELECT COALESCE(SUM(reserved_tokens), 0) FROM quota_reservations),
+		(SELECT COUNT(*) FROM wallet_session_request_map),
+		(SELECT COUNT(*) FROM usage_events)`).Scan(
+		&state[0], &state[1], &state[2], &state[3], &state[4], &state[5], &state[6], &state[7], &state[8])
+	if err != nil {
+		t.Fatalf("read admission state: %v", err)
+	}
+	return state
+}

--- a/phase5-gateway/internal/storage/sqlite/relay_replay_retention_test.go
+++ b/phase5-gateway/internal/storage/sqlite/relay_replay_retention_test.go
@@ -1,0 +1,212 @@
+package sqlite
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-gateway/internal/storage"
+)
+
+func TestRelayReplayRetentionPrecision(t *testing.T) {
+	for _, method := range []string{"seen", "record"} {
+		for _, tc := range []struct {
+			name                    string
+			expiryOffset, nowOffset time.Duration
+		}{
+			{"fraction_live_at_whole_second", time.Nanosecond, 0},
+			{"whole_expired_after_nanosecond", 0, time.Nanosecond},
+			{"fraction_live_at_shorter_precision", 100000001 * time.Nanosecond, 100 * time.Millisecond},
+			{"fraction_expired_at_longer_precision", 100 * time.Millisecond, 100000001 * time.Nanosecond},
+			{"exact_whole_boundary", 0, 0},
+			{"exact_fraction_boundary", time.Nanosecond, time.Nanosecond},
+			{"earlier_second", -time.Nanosecond, 0},
+			{"later_second", time.Second, 0},
+		} {
+			t.Run(method+"/"+tc.name, func(t *testing.T) {
+				store := newTestStore(t)
+				boundary := fixedTime().Add(time.Minute)
+				replay := retentionReplay("original", boundary.Add(tc.expiryOffset))
+				if err := store.RecordRelayBlindReplay(context.Background(), replay); err != nil {
+					t.Fatal(err)
+				}
+				replay.CreatedAt = boundary.Add(tc.nowOffset)
+				live := replay.RetentionExpiresAt.After(replay.CreatedAt)
+				if method == "seen" {
+					seen, err := store.RelayBlindReplaySeen(context.Background(), replay)
+					if err != nil || seen != live {
+						t.Fatalf("seen=%v err=%v want live=%v", seen, err, live)
+					}
+				} else {
+					replay.RetentionExpiresAt = replay.CreatedAt.Add(time.Minute)
+					err := store.RecordRelayBlindReplay(context.Background(), replay)
+					if (live && !errors.Is(err, storage.ErrRelayBlindReplay)) || (!live && err != nil) {
+						t.Fatalf("record err=%v live=%v", err, live)
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestRelayReplayRetentionCapacityDoesNotDiscardLiveRow(t *testing.T) {
+	store := newTestStore(t)
+	boundary := fixedTime().Add(time.Minute)
+	original := retentionReplay("original", boundary.Add(time.Nanosecond))
+	if err := store.RecordRelayBlindReplay(context.Background(), original); err != nil {
+		t.Fatal(err)
+	}
+	unique := retentionReplay("unique", boundary.Add(time.Minute))
+	unique.CreatedAt = boundary
+	unique.MaxReplayRows = 1
+	if err := store.RecordRelayBlindReplay(context.Background(), unique); !errors.Is(err, storage.ErrRateLimit) {
+		t.Fatalf("live row capacity err=%v want ErrRateLimit", err)
+	}
+	unique.CreatedAt = boundary.Add(time.Nanosecond)
+	if err := store.RecordRelayBlindReplay(context.Background(), unique); err != nil {
+		t.Fatalf("expired capacity was not reclaimed: %v", err)
+	}
+}
+
+func retentionReplay(id string, expiry time.Time) storage.RelayBlindReplayMaterial {
+	return storage.RelayBlindReplayMaterial{
+		AccountID: "retention-account", RequestID: id,
+		RequestReplayNonceDigest:      []byte("nonce-" + id),
+		BuyerEphemeralPublicKeyDigest: []byte("buyer-" + id),
+		ProviderBindingDigest:         []byte("binding"), KIDDigest: []byte("kid"),
+		EnvelopeDigest: []byte("envelope-" + id), EnvelopeBytes: 128,
+		RetentionExpiresAt: expiry, CreatedAt: fixedTime(),
+	}
+}
+
+func TestRelayReplayRetentionAllFractionalPrecisions(t *testing.T) {
+	store := newTestStore(t)
+	boundary := fixedTime().Add(time.Minute)
+	var expiries []time.Time
+	for _, second := range []int{-1, 0, 1} {
+		for _, nanos := range []int{0, 1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 100000001, 123456789, 999999999} {
+			expiries = append(expiries, boundary.Add(time.Duration(second)*time.Second+time.Duration(nanos)))
+		}
+	}
+	for i, expiry := range expiries {
+		replay := retentionReplay(fmt.Sprint(i), expiry)
+		replay.AccountID = fmt.Sprintf("account-%d", i%2)
+		replay.WalletSessionID = fmt.Sprintf("session-%d", i%3)
+		if err := store.RecordRelayBlindReplay(context.Background(), replay); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, now := range expiries {
+		t.Run(encodeTime(now), func(t *testing.T) {
+			tx, err := store.beginImmediate(context.Background())
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer tx.Rollback()
+			if err := deleteExpiredRelayBlindReplaysTx(context.Background(), tx, now.In(time.FixedZone("offset", 8*60*60))); err != nil {
+				t.Fatal(err)
+			}
+			rows, err := tx.QueryContext(context.Background(), `SELECT request_id FROM relay_blind_replays`)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer rows.Close()
+			retained := make(map[string]bool)
+			for rows.Next() {
+				var id string
+				if err := rows.Scan(&id); err != nil {
+					t.Fatal(err)
+				}
+				retained[id] = true
+			}
+			if err := rows.Err(); err != nil {
+				t.Fatal(err)
+			}
+			for i, expiry := range expiries {
+				if got, want := retained[fmt.Sprint(i)], expiry.After(now); got != want {
+					t.Errorf("expiry=%s retained=%v want %v", encodeTime(expiry), got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestRelayReplayRetentionUsesExpiryIndex(t *testing.T) {
+	store := newTestStore(t)
+	rows, err := store.db.Query("EXPLAIN QUERY PLAN "+deleteExpiredRelayBlindReplaysSQL,
+		encodeTime(fixedTime()), fixedTime().Format("2006-01-02T15:04:05.000000000"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	indexed := false
+	for rows.Next() {
+		var id, parent, unused int
+		var detail string
+		if err := rows.Scan(&id, &parent, &unused, &detail); err != nil {
+			t.Fatal(err)
+		}
+		indexed = indexed || strings.Contains(detail, "USING INDEX idx_relay_blind_replay_expires (retention_expires_at<?)")
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if !indexed {
+		t.Fatal("cleanup did not use the expiry index range")
+	}
+}
+
+func TestRelayReplayRetentionSurvivesReopen(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "replay.db")
+	store, err := Open(ctx, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	boundary := fixedTime().Add(time.Minute)
+	replay := retentionReplay("persisted", boundary.Add(time.Nanosecond).In(time.FixedZone("offset", -5*60*60)))
+	if err := store.RecordRelayBlindReplay(ctx, replay); err != nil {
+		store.Close()
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := Open(ctx, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reopened.Close()
+	replay.CreatedAt = boundary
+	if seen, err := reopened.RelayBlindReplaySeen(ctx, replay); err != nil || !seen {
+		t.Fatalf("live persisted replay seen=%v err=%v", seen, err)
+	}
+	replay.CreatedAt = boundary.Add(time.Nanosecond)
+	if seen, err := reopened.RelayBlindReplaySeen(ctx, replay); err != nil || seen {
+		t.Fatalf("expired persisted replay seen=%v err=%v", seen, err)
+	}
+}
+
+func TestRelayReplayRetentionCleanupRollsBackWithRecord(t *testing.T) {
+	store := newTestStore(t)
+	boundary := fixedTime().Add(time.Minute)
+	if err := store.RecordRelayBlindReplay(context.Background(), retentionReplay("original", boundary)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.Exec(`CREATE TRIGGER fail_replay_insert BEFORE INSERT ON relay_blind_replays BEGIN SELECT RAISE(ABORT, 'test insert failure'); END`); err != nil {
+		t.Fatal(err)
+	}
+	replay := retentionReplay("fresh", boundary.Add(time.Minute))
+	replay.CreatedAt = boundary.Add(time.Nanosecond)
+	if err := store.RecordRelayBlindReplay(context.Background(), replay); err == nil || !strings.Contains(err.Error(), "test insert failure") {
+		t.Fatalf("record error=%v want injected insert failure", err)
+	}
+	var id string
+	if err := store.db.QueryRow(`SELECT request_id FROM relay_blind_replays`).Scan(&id); err != nil || id != "original" {
+		t.Fatalf("cleanup was not rolled back: id=%s err=%v", id, err)
+	}
+}

--- a/phase5-gateway/internal/storage/sqlite/store.go
+++ b/phase5-gateway/internal/storage/sqlite/store.go
@@ -2187,7 +2187,7 @@ func (s *Store) RecordRelayBlindReplay(ctx context.Context, replay storage.Relay
 	if replay.RetentionExpiresAt.IsZero() || !replay.RetentionExpiresAt.After(now) {
 		return storage.ErrRelayBlindReplay
 	}
-	if _, err := tx.ExecContext(ctx, `DELETE FROM relay_blind_replays WHERE retention_expires_at <= ?`, encodeTime(now)); err != nil {
+	if err := deleteExpiredRelayBlindReplaysTx(ctx, tx, now); err != nil {
 		return err
 	}
 	seen, err := relayBlindReplaySeenTx(ctx, tx, replay)
@@ -2238,7 +2238,7 @@ func (s *Store) RelayBlindReplaySeen(ctx context.Context, replay storage.RelayBl
 		replay.CreatedAt = time.Now().UTC()
 	}
 	now := replay.CreatedAt.UTC()
-	if _, err := tx.ExecContext(ctx, `DELETE FROM relay_blind_replays WHERE retention_expires_at <= ?`, encodeTime(now)); err != nil {
+	if err := deleteExpiredRelayBlindReplaysTx(ctx, tx, now); err != nil {
 		return false, err
 	}
 	seen, err := relayBlindReplaySeenTx(ctx, tx, replay)
@@ -2278,6 +2278,18 @@ func retainedRelayBlindReplaySeenTx(ctx context.Context, tx *immediateTx, replay
 		seen = seen || expiry.After(now)
 	}
 	return seen, rows.Err()
+}
+
+const deleteExpiredRelayBlindReplaysSQL = `DELETE FROM relay_blind_replays
+	WHERE retention_expires_at <= ? AND rtrim(retention_expires_at, 'Z') <= ?`
+
+func deleteExpiredRelayBlindReplaysTx(ctx context.Context, tx *immediateTx, now time.Time) error {
+	// Stored expiries are UTC RFC3339Nano ending in Z. The whole-second bound
+	// uses the expiry index; stripping Z and using a fixed-nine-digit cutoff
+	// orders variable fractional precision correctly, including exact expiry.
+	_, err := tx.ExecContext(ctx, deleteExpiredRelayBlindReplaysSQL,
+		encodeTime(now.Truncate(time.Second)), now.UTC().Format("2006-01-02T15:04:05.000000000"))
+	return err
 }
 
 func relayBlindReplaySeenTx(ctx context.Context, tx *immediateTx, replay storage.RelayBlindReplayMaterial) (bool, error) {

--- a/phase5-gateway/internal/storage/sqlite/store.go
+++ b/phase5-gateway/internal/storage/sqlite/store.go
@@ -2154,6 +2154,17 @@ func (s *Store) AdmitWalletSessionMetadata(ctx context.Context, req storage.Wall
 			return err
 		}
 		if count >= req.RateLimit {
+			if req.RelayBlindReplay != nil {
+				replay := *req.RelayBlindReplay
+				replay.AccountID, replay.WalletSessionID = req.AccountID, req.SessionID
+				seen, err := retainedRelayBlindReplaySeenTx(ctx, tx, replay, now)
+				if err != nil {
+					return err
+				}
+				if seen {
+					return storage.ErrRelayBlindReplay
+				}
+			}
 			return storage.ErrRateLimit
 		}
 	}
@@ -2238,6 +2249,35 @@ func (s *Store) RelayBlindReplaySeen(ctx context.Context, replay storage.RelayBl
 		return false, err
 	}
 	return seen, nil
+}
+
+// The four scoped unique replay identities bound the result set. Parse expiry
+// instead of sorting RFC3339Nano text, whose fractional precision can vary.
+func retainedRelayBlindReplaySeenTx(ctx context.Context, tx *immediateTx, replay storage.RelayBlindReplayMaterial, now time.Time) (bool, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT retention_expires_at FROM relay_blind_replays
+		WHERE account_id = ? AND wallet_session_id = ?
+			AND (request_id = ? OR request_replay_nonce_digest = ?
+				OR buyer_ephemeral_public_key_digest = ? OR envelope_digest = ?)`,
+		replay.AccountID, replay.WalletSessionID, replay.RequestID, replay.RequestReplayNonceDigest,
+		replay.BuyerEphemeralPublicKeyDigest, replay.EnvelopeDigest)
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+	seen := false
+	for rows.Next() {
+		var rawExpiry string
+		if err := rows.Scan(&rawExpiry); err != nil {
+			return false, err
+		}
+		expiry, err := time.Parse(time.RFC3339Nano, rawExpiry)
+		if err != nil {
+			return false, errors.New("invalid relay-blind replay retention timestamp")
+		}
+		seen = seen || expiry.After(now)
+	}
+	return seen, rows.Err()
 }
 
 func relayBlindReplaySeenTx(ctx context.Context, tx *immediateTx, replay storage.RelayBlindReplayMaterial) (bool, error) {

--- a/phase5-gateway/internal/storage/types.go
+++ b/phase5-gateway/internal/storage/types.go
@@ -333,6 +333,10 @@ type WalletSessionMetadataAdmissionRequest struct {
 	MaxReplayRows  int
 	MaxReplayBytes int64
 	CreatedAt      time.Time
+
+	// Validated, fresh required envelope; only classifies a temporal rejection.
+	// Admission's account/session and time remain authoritative for the lookup.
+	RelayBlindReplay *RelayBlindReplayMaterial
 }
 
 type WalletSessionDispatchArm struct {


### PR DESCRIPTION
## Outcome

Consolidate #1411, #1412, #1413, and #1415 into one SPEC-041 gateway rejection-safety review. This replaces those four PRs; it does not add another independent implementation slice. The audit remains in #1408 and SPEC-045 budget safety remains in #1407.

The four original Lore commits are preserved by cherry-pick from fresh `origin/main` at `0d87cd35`. The only conflict was adjacent SQLite helper insertion; both helpers are retained unchanged. Historical per-commit `Not-tested` and follow-up notes describe their original slices, not the combined validation below.

## Behavior

- Audit authenticated malformed/schema/cap/model/freshness rejections with fixed bounded classifications and an envelope digest. Never persist raw input, decoder errors, or unvalidated identities; audit insertion failure rejects before dispatch or quota use.
- Apply the configured relay metadata refill per minute, preserving an initial N-token burst, per-second plaintext admission, separate buckets, and Retry-After seconds.
- Under temporal wallet metadata throttling, return permanent inner-envelope replay rejection for retained valid material. Preserve authenticated scope, outer duplicate/mismatch, inactive-state, and permanent hard-cap precedence inside the existing transaction.
- Preserve SQLite replay protection through exact fractional-second expiry, retaining indexed cleanup, duplicate-before-capacity ordering, and transaction rollback.

## Verification

- Combined final branch: `go test -race ./... -count=1` in `phase5-gateway` passed all seven test-bearing packages (router 95.370s; SQLite 14.877s).
- Combined focused run: `go test -race ./internal/router ./internal/storage/sqlite -run 'Test.*(RelayBlind|RelayReplayRetention|WalletMetadata|WalletSession|RequestRateLimiter)' -count=1` passed (router 26.585s; SQLite 6.833s).
- Independent `gpt-6-astra` / `ultra` code, security, and architecture review lanes examined the complete combined 11-file diff: each returned 0 Critical, 0 High, 0 Medium, 0 Low findings; architecture CLEAR.
- `go vet ./...` passed.
- `python3 scripts/check_spec_governance.py --base-ref origin/main`, `jq empty specs/AUTHORITY.json specs/CONFORMANCE.json`, `python3 scripts/gen_spec_index.py --check`, and `git diff --check origin/main..HEAD` passed.
- Original regression-first failures and individual-slice test results are preserved in the linked superseded PRs. New combined validation does not claim a fresh production journey.

## Boundaries

No provider-side cryptography, usable encrypted inference, conformance promotion, signed journey evidence, deployment, or production-readiness claim. SPEC-015 receipts and SPEC-022 settlement authority are unchanged. Authentication/outer-admission failures and existing replay-audit persistence policy are not generalized by this patch.

The relay token bucket remains process-local with existing restart/eviction semantics. Cleanup relies on the existing sole writer's UTC RFC3339Nano timestamp contract; manually corrupted/offset-bearing rows are outside it. Reopen and concurrent local operations are covered, but separate-process crash recovery and live signed gateway journeys were not run.

## Governance

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-040", "SPEC-041"],
  "requirements": ["SPEC-040-R005", "SPEC-041-R004", "SPEC-041-R005", "SPEC-041-R007", "SPEC-041-R008"],
  "authority_domains": ["wallet-buyer-session", "relay-blind-request-encryption"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "phase5-gateway/internal/router/relay_blind_rejection_audit_test.go",
    "phase5-gateway/internal/router/relay_blind_metadata_rate_test.go",
    "phase5-gateway/internal/router/request_rate_limiter_test.go",
    "phase5-gateway/internal/router/relay_blind_session_replay_test.go",
    "phase5-gateway/internal/storage/sqlite/metadata_relay_replay_test.go",
    "phase5-gateway/internal/storage/sqlite/relay_replay_retention_test.go"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END
