### PR TITLE
fix(release): decouple coordinator binary version from CLI release in rollout gate

### DIFF
--- a/scripts/test-live-coordinator-release-gate.sh
+++ b/scripts/test-live-coordinator-release-gate.sh
@@ -220,11 +220,23 @@ if run_guard "$work/missing-sig" >"$work/missing-sig.out" 2>&1; then
 fi
 grep -q 'fixture coordinator response is missing for /v1/rate-card.sig' "$work/missing-sig.out"
 
-make_fixture "$work/stale-healthz" v1.8.68 v1.8.67
-if run_guard "$work/stale-healthz" >"$work/stale-healthz.out" 2>&1; then
-  fail "accepted a coordinator older than the shipped CLI release"
+# Post-publication: the coordinator's own /healthz binary version is an
+# independent Pearl-runtime artifact that shares the vX.Y.Z tag space with the
+# provider CLI but ships on its own cadence. A coordinator OLDER than the shipped
+# CLI release is accepted as long as it advertises the release
+# (recommended_binary_version == release); the coordinator does not need to be
+# rebuilt in lockstep with every CLI release.
+make_fixture "$work/older-coordinator-post" v1.8.68 v1.8.67
+run_guard "$work/older-coordinator-post" | grep -q 'ok: https://coordinator.fixture.invalid serves v1.8.68 feed set'
+
+# Pre-publication still guards against a coordinator that has regressed BELOW the
+# previously-advertised stable (a genuine coordinator rollback), independent of
+# the CLI release being staged.
+make_fixture "$work/older-than-previous-pre" v1.8.68 v1.8.66
+if run_guard_phase "$work/older-than-previous-pre" pre-publication >"$work/older-than-previous-pre.out" 2>&1; then
+  fail "pre-publication accepted a coordinator older than the previous stable"
 fi
-grep -q "/healthz version 'v1.8.67' is older than release 1.8.68" "$work/stale-healthz.out"
+grep -q "is older than previous stable 1.8.67" "$work/older-than-previous-pre.out"
 
 make_fixture "$work/missing-recommended" v1.8.68 v1.8.68 2026-07-30T12:00:00Z 2026-07-30T12:00:00Z streamvc-autotune-static-v4 __absent__
 if run_guard "$work/missing-recommended" >"$work/missing-recommended.out" 2>&1; then

--- a/scripts/verify-live-coordinator-release-gate.py
+++ b/scripts/verify-live-coordinator-release-gate.py
@@ -398,28 +398,38 @@ def main() -> int:
         # (Pearl deployed first). The branch below only constrains the case
         # where Pearl is still older than the CLI being published.
         if live_version < required_version:
-            previous_version = None
-            if (
-                args.publication_phase == "pre-publication"
-                and args.expected_previous_recommendation is not None
-            ):
-                previous_version = parse_advertised_version(
-                    args.expected_previous_recommendation,
-                    "expected previous recommendation",
-                )
-            if previous_version is None:
-                fail(
-                    f"/healthz version {healthz.get('version')!r} is older than "
-                    f"release {expected_version}"
-                )
-            if live_version < previous_version:
-                fail(
-                    f"/healthz version {healthz.get('version')!r} is older than "
-                    f"previous stable {args.expected_previous_recommendation}"
-                )
-            # previous_version <= live_version < required_version is allowed:
-            # Pearl runtime-only patches may advance /healthz without moving
-            # the advertised CLI recommendation.
+            # /healthz "version" is the Pearl-runtime coordinator's OWN binary
+            # version. The coordinator and the provider CLI share the vX.Y.Z tag
+            # space but ship on independent cadences, so the coordinator may
+            # legitimately be older than the CLI release it advertises. Post-
+            # publication correctness is enforced by the
+            # recommended_binary_version == release check below (the coordinator
+            # must advertise the released CLI), NOT by the coordinator's own
+            # binary version. Pre-publication still guards against a coordinator
+            # that has regressed below the previously-advertised stable.
+            if args.publication_phase == "pre-publication":
+                previous_version = None
+                if args.expected_previous_recommendation is not None:
+                    previous_version = parse_advertised_version(
+                        args.expected_previous_recommendation,
+                        "expected previous recommendation",
+                    )
+                if previous_version is None:
+                    fail(
+                        f"/healthz version {healthz.get('version')!r} is older than "
+                        f"release {expected_version}"
+                    )
+                if live_version < previous_version:
+                    fail(
+                        f"/healthz version {healthz.get('version')!r} is older than "
+                        f"previous stable {args.expected_previous_recommendation}"
+                    )
+                # previous_version <= live_version < required_version is allowed:
+                # Pearl runtime-only patches may advance /healthz without moving
+                # the advertised CLI recommendation.
+            # post-publication: the coordinator's binary version is decoupled
+            # from the CLI release version; the recommended_binary_version ==
+            # release check below is authoritative.
         recommended_value = healthz.get("recommended_binary_version")
         if (
             args.publication_phase == "pre-publication"


### PR DESCRIPTION
## What

`verify-live-coordinator-release-gate.py` failed the **post-publication** rollout gate whenever the live coordinator's own `/healthz` binary version was older than the provider-CLI release being rolled out — e.g. coordinator **v1.8.119** rolling out CLI **1.8.121** → `/healthz version 'v1.8.119' is older than release 1.8.121`.

## Why it's wrong

The Pearl-runtime **coordinator** and the **provider CLI** are independent artifacts that share the `vX.Y.Z` tag space but ship on **independent cadences**. The coordinator does not need to be rebuilt in lockstep with every CLI release (especially a packaging-only one).

- SPEC-034: *"independent Malibu/CLI marketing versions negotiate by capability, not equality."*
- SPEC-020: `recommended_binary_version` is operator-set and advertised regardless of the coordinator's own binary version.
- The check already allowed the coordinator to be **ahead** of a staged CLI (#1094) — it simply never handled the **behind** case post-publication.

## Fix

Gate the `/healthz`-version-older-than-release failure to **pre-publication only** (where it still guards against a coordinator regressed below the previously-advertised stable). Post-publication correctness is enforced by the existing **`recommended_binary_version == release`** check, which is authoritative.

Test updated: a coordinator older than the CLI release is now accepted post-publication; added a pre-publication regression that still rejects a coordinator older than the previous stable.

## Verification
- `scripts/test-live-coordinator-release-gate.sh` → PASS
- `scripts/test-acceptance-promotion.sh` → PASS
- 3-lane audit (code / security / architecture) to 0 C/H/M.

<!-- SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R001"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": ["scripts/test-live-coordinator-release-gate.sh", "scripts/test-acceptance-promotion.sh"],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END -->
