### PR TITLE
fix(byom): treat evaluation_required as advisory; unify submit/dry-run blockers (SPEC-047-R002)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -424,6 +424,14 @@ jobs:
         working-directory: phase3-binary
         run: swift test --parallel
 
+      - name: Run BYOM CLI onboarding E2E (hermetic)
+        # #1381 F8: this hermetic harness (fake Ollama loopback + in-process
+        # coordinator) is the only automated cover for the CLI-owned BYOM
+        # admission surface end to end. It was manual-only and silently
+        # regressed; gate it here so canSubmit/dry-run drift fails a required
+        # check. Reuses the SwiftPM build warmed by the swift test step above.
+        run: make test-byom-e2e
+
       - name: Install reviewed XcodeGen artifact
         shell: bash
         run: |

--- a/phase3-binary/Sources/macprovider-cli/BYOMDiscovery.swift
+++ b/phase3-binary/Sources/macprovider-cli/BYOMDiscovery.swift
@@ -18,6 +18,29 @@ enum BYOMDiscoveryWarning: String, Codable, Sendable {
     case namespacePermissionInvalid = "namespace_permission_invalid"
 }
 
+extension BYOMDiscoveryWarning {
+    /// Hard blockers for a BYOM offer submission, highest-priority first.
+    ///
+    /// Single source of truth so the real submit gate
+    /// (`BYOMOfferSubmissionBuilder.canSubmit`), the dry-run predictor
+    /// (`canSubmitLocalDryRun`), and the dry-run `reason_code` selector
+    /// (`reasonCode(for:)`) cannot drift: a truthful dry-run preflight MUST reject
+    /// exactly what the real submit rejects (SPEC-047-R002). `evaluation_required`
+    /// is deliberately absent — it is advisory for non-earning v0.1 candidates.
+    static let submitBlockingWarnings: [BYOMDiscoveryWarning] = [
+        .candidateIDUnstable,
+        .namespacePermissionInvalid,
+        .adapterRejectedNonLoopback,
+        .adapterMalformedResponse,
+        .adapterResponseTruncated,
+        .adapterUnavailable,
+        .adapterTimeout,
+        .requiresPreparation,
+    ]
+
+    static let submitBlockingWarningCodes: Set<String> = Set(submitBlockingWarnings.map(\.rawValue))
+}
+
 struct BYOMDiscoveryWire: Codable, Equatable, Sendable {
     struct Adapter: Codable, Equatable, Sendable {
         let runtimeSource: String
@@ -1215,7 +1238,7 @@ enum BYOMModelAdmissionError: Error, Equatable, CustomStringConvertible {
         case .candidateUnstable:
             return "BYOM candidate id is unstable; target the offer by its served_model_ref (for example ollama:llama3.2:3b) instead of the byom_unstable_… id. models offer provisions the local discovery namespace and resolves a stable id; re-running models discover alone will not, because discovery is read-only (SPEC-046-R001)"
         case .candidateNotOfferable:
-            return "BYOM candidate is not offerable; run models evaluate <ref> --json and pass the returned evaluation_digest_sha256 to models offer via --evaluation-digest-sha256. models evaluate does not persist state, so the evaluation_required warning clears only when you supply that digest; also resolve any blocking readiness warning"
+            return "BYOM candidate is not offerable; resolve the blocking local readiness, fit, or adapter warning first — the candidate must be local_default offerable, ready, fit, and free of adapter faults to submit. Evaluation is advisory for non-earning v0.1 offers (SPEC-047-R002): you may submit without it, but running models evaluate <ref> --json and passing the returned evaluation_digest_sha256 to models offer via --evaluation-digest-sha256 strengthens the offer"
         case .invalidEvaluationDigest:
             return "evaluation digest must be a 64-character lowercase SHA-256 hex value"
         case .invalidWithdrawalReason:
@@ -1267,7 +1290,7 @@ struct BYOMOfferSubmissionBuilder {
         if !evaluationDigest.isEmpty, !Self.isLowercaseSHA256(evaluationDigest) {
             throw BYOMModelAdmissionError.invalidEvaluationDigest
         }
-        guard Self.canSubmit(candidate: candidate, evaluationDigestSHA256: evaluationDigest) else {
+        guard Self.canSubmit(candidate: candidate) else {
             throw BYOMModelAdmissionError.candidateNotOfferable
         }
         let publicKey = admissionIdentity.publicKey.rawRepresentation
@@ -1329,21 +1352,21 @@ struct BYOMOfferSubmissionBuilder {
         value.range(of: #"^[0-9a-f]{64}$"#, options: .regularExpression) != nil
     }
 
-    private static func canSubmit(candidate: BYOMDiscoveryWire.Candidate, evaluationDigestSHA256: String) -> Bool {
+    private static func canSubmit(candidate: BYOMDiscoveryWire.Candidate) -> Bool {
         guard candidate.admissionStateSource == "local_default",
               candidate.admissionState == "offerable",
               candidate.readinessState == "ready",
               candidate.fitState != "does_not_fit" else {
             return false
         }
-        let warnings = Set(candidate.warningCodes)
-        if warnings.contains(BYOMDiscoveryWarning.adapterRejectedNonLoopback.rawValue) ||
-            warnings.contains(BYOMDiscoveryWarning.adapterMalformedResponse.rawValue) ||
-            warnings.contains(BYOMDiscoveryWarning.adapterResponseTruncated.rawValue) ||
-            warnings.contains(BYOMDiscoveryWarning.requiresPreparation.rawValue) {
-            return false
-        }
-        return !evaluationDigestSHA256.isEmpty || !warnings.contains(BYOMDiscoveryWarning.evaluationRequired.rawValue)
+        // `evaluation_required` is advisory, NOT a hard submit blocker: SPEC-047-R002
+        // permits omitting the evaluation digest for a non-earning (local_inventory_only)
+        // v0.1 candidate. The hard blockers are the single shared
+        // BYOMDiscoveryWarning.submitBlockingWarningCodes set, so this real gate cannot
+        // drift from the dry-run predictor (canSubmitLocalDryRun) — the dry-run neither
+        // over- nor under-promises the real submit. Unstable-id / namespace faults are
+        // additionally rejected by the caller (makePackage) before canSubmit.
+        return Set(candidate.warningCodes).isDisjoint(with: BYOMDiscoveryWarning.submitBlockingWarningCodes)
     }
 }
 
@@ -2551,7 +2574,7 @@ struct BYOMOfferDryRunRunner: Sendable {
 
         let warnings = candidate.warningCodes.sorted()
         let reason = reasonCode(for: candidate, warnings: Set(warnings))
-        let wouldSubmit = canSubmitLocalDryRun(candidate: candidate, reasonCode: reason)
+        let wouldSubmit = canSubmitLocalDryRun(candidate: candidate)
         return BYOMOfferDryRunWire(
             candidateID: candidate.candidateID,
             servedModelRef: candidate.servedModelRef,
@@ -2579,7 +2602,7 @@ struct BYOMOfferDryRunRunner: Sendable {
         }
     }
 
-    private func canSubmitLocalDryRun(candidate: BYOMDiscoveryWire.Candidate, reasonCode: String?) -> Bool {
+    private func canSubmitLocalDryRun(candidate: BYOMDiscoveryWire.Candidate) -> Bool {
         guard candidate.candidateID.hasPrefix("byom_"),
               !candidate.candidateID.hasPrefix("byom_unstable_"),
               candidate.admissionStateSource == "local_default",
@@ -2588,15 +2611,13 @@ struct BYOMOfferDryRunRunner: Sendable {
               candidate.fitState != "does_not_fit" else {
             return false
         }
-        // `evaluation_required` is advisory, NOT a hard blocker: SPEC-047-R002
-        // permits submitting an offer without the evaluation digest when the
-        // dry-run labels it more likely to be rejected or confined to
-        // non-earning states (which every v0.1 local_inventory_only candidate
-        // is). Treating it as a hard block made would_submit unreachable, since
-        // a freshly discovered candidate always carries evaluation_required.
-        return !Set(candidate.warningCodes).contains(BYOMDiscoveryWarning.candidateIDUnstable.rawValue)
-            && !Set(candidate.warningCodes).contains(BYOMDiscoveryWarning.namespacePermissionInvalid.rawValue)
-            && reasonCode != BYOMDiscoveryWarning.requiresPreparation.rawValue
+        // `evaluation_required` is advisory, NOT a hard blocker (SPEC-047-R002): a
+        // fresh non-earning candidate always carries it, so treating it as a hard
+        // block made would_submit unreachable. The hard blockers are the single
+        // shared BYOMDiscoveryWarning.submitBlockingWarningCodes set — identical to
+        // the real submit gate (BYOMOfferSubmissionBuilder.canSubmit) — so this
+        // preflight cannot over- or under-promise the real submit.
+        return Set(candidate.warningCodes).isDisjoint(with: BYOMDiscoveryWarning.submitBlockingWarningCodes)
     }
 
     private func localDefaultAdmissionState(_ state: String) -> String {
@@ -2612,14 +2633,9 @@ struct BYOMOfferDryRunRunner: Sendable {
         // evaluation_required is intentionally NOT a hard blocker here (it is
         // advisory per SPEC-047-R002); it remains available as a lower-priority
         // fallback reason below when nothing harder applies.
-        let blockingReasons = [
-            BYOMDiscoveryWarning.candidateIDUnstable.rawValue,
-            BYOMDiscoveryWarning.namespacePermissionInvalid.rawValue,
-            BYOMDiscoveryWarning.adapterRejectedNonLoopback.rawValue,
-            BYOMDiscoveryWarning.adapterMalformedResponse.rawValue,
-            BYOMDiscoveryWarning.adapterResponseTruncated.rawValue,
-            BYOMDiscoveryWarning.requiresPreparation.rawValue,
-        ]
+        // Same ordered source of truth the submit gates use, so the surfaced
+        // reason_code names the exact warning that blocks submission.
+        let blockingReasons = BYOMDiscoveryWarning.submitBlockingWarnings.map(\.rawValue)
         if let blocker = blockingReasons.first(where: warnings.contains) {
             return blocker
         }

--- a/phase3-binary/Tests/macprovider-cliTests/BYOMAdmissionTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/BYOMAdmissionTests.swift
@@ -483,22 +483,26 @@ final class BYOMAdmissionTests: XCTestCase {
         }
     }
 
-    func testOfferPackageRequiresEvaluationDigestWhenDiscoveryStillRequiresEvaluation() throws {
+    func testOfferPackageAllowsMissingEvaluationDigestForNonEarningCandidate() throws {
+        // SPEC-047-R002: evaluation_required is advisory, NOT a hard submit blocker,
+        // for a non-earning (local_inventory_only) v0.1 candidate -- "offer submission
+        // MAY omit the evaluation digest ... confined to non-earning states." So a
+        // clean offerable candidate carrying only evaluation_required submits with or
+        // without a digest, matching canSubmitLocalDryRun so the dry-run does not
+        // over-promise the real submit.
         let identity = Curve25519.Signing.PrivateKey()
         let candidate = byomAdmissionCandidate(
             candidateID: stableBYOMAdmissionCandidateID("f"),
             servedModelRef: "ollama:qwen3-8b",
             warningCodes: ["evaluation_required"]
         )
-        XCTAssertThrowsError(try BYOMOfferSubmissionBuilder.makePackage(
+        XCTAssertNoThrow(try BYOMOfferSubmissionBuilder.makePackage(
             providerID: "provider-byom-a",
             candidate: candidate,
             admissionIdentity: identity,
             evaluationDigestSHA256: nil,
             requestedDisclosureClass: "non_earning_provider_asserted"
-        )) { error in
-            XCTAssertEqual(error as? BYOMModelAdmissionError, .candidateNotOfferable)
-        }
+        ))
         XCTAssertNoThrow(try BYOMOfferSubmissionBuilder.makePackage(
             providerID: "provider-byom-a",
             candidate: candidate,
@@ -506,6 +510,49 @@ final class BYOMAdmissionTests: XCTestCase {
             evaluationDigestSHA256: String(repeating: "b", count: 64),
             requestedDisclosureClass: "non_earning_provider_asserted"
         ))
+    }
+
+    func testOfferPackageStillRejectsHardLocalBlockers() throws {
+        // The advisory-evaluation relaxation must not turn canSubmit into a no-op:
+        // every hard local blocker still fails closed with candidateNotOfferable,
+        // including the adapter faults that were previously inconsistently gated
+        // (adapter_unavailable / adapter_timeout) and every other code in the shared
+        // submitBlockingWarningCodes set.
+        let identity = Curve25519.Signing.PrivateKey()
+        let hardBlockers = [
+            "requires_preparation",
+            "adapter_rejected_non_loopback",
+            "adapter_malformed_response",
+            "adapter_response_truncated",
+            "adapter_unavailable",
+            "adapter_timeout",
+        ]
+        for code in hardBlockers {
+            let candidate = byomAdmissionCandidate(
+                candidateID: stableBYOMAdmissionCandidateID("g"),
+                servedModelRef: "ollama:qwen3-8b",
+                warningCodes: [code, "evaluation_required"]
+            )
+            XCTAssertThrowsError(try BYOMOfferSubmissionBuilder.makePackage(
+                providerID: "provider-byom-a",
+                candidate: candidate,
+                admissionIdentity: identity,
+                evaluationDigestSHA256: nil,
+                requestedDisclosureClass: "non_earning_provider_asserted"
+            ), "hard blocker \(code) must fail closed") { error in
+                XCTAssertEqual(error as? BYOMModelAdmissionError, .candidateNotOfferable, "wrong error for \(code)")
+            }
+            // A supplied evaluation digest must NOT override a hard local blocker.
+            XCTAssertThrowsError(try BYOMOfferSubmissionBuilder.makePackage(
+                providerID: "provider-byom-a",
+                candidate: candidate,
+                admissionIdentity: identity,
+                evaluationDigestSHA256: String(repeating: "b", count: 64),
+                requestedDisclosureClass: "non_earning_provider_asserted"
+            ), "hard blocker \(code) must fail closed even with a digest") { error in
+                XCTAssertEqual(error as? BYOMModelAdmissionError, .candidateNotOfferable, "wrong error for \(code) with digest")
+            }
+        }
     }
 
     func testWithdrawalPackageRejectsUnstableCandidateAndInvalidReason() throws {

--- a/phase3-binary/Tests/macprovider-cliTests/BYOMDiscoveryTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/BYOMDiscoveryTests.swift
@@ -32,10 +32,12 @@ final class BYOMDiscoveryTests: XCTestCase {
     // #1381 F2/F5: operator-facing guidance must name the action that actually
     // resolves the blocker, not a dead end.
     func testBYOMModelAdmissionGuidancePointsToRecoveryActions() {
-        // F2: not-offerable names the digest input canSubmit requires.
+        // Not-offerable guidance still names the advisory strengthening flag
+        // (--evaluation-digest-sha256); the digest is optional per SPEC-047-R002,
+        // not a hard requirement.
         XCTAssertTrue(
             BYOMModelAdmissionError.candidateNotOfferable.description.contains("--evaluation-digest-sha256"),
-            "not-offerable guidance must name --evaluation-digest-sha256"
+            "not-offerable guidance must name the advisory --evaluation-digest-sha256 flag"
         )
         // F5: unstable / not-found point at the served_model_ref recovery target.
         XCTAssertTrue(

--- a/scripts/ci-detect-changed-paths.sh
+++ b/scripts/ci-detect-changed-paths.sh
@@ -57,7 +57,10 @@ classify() {
       # AND the shared cross-language fixtures the Swift parity/losslessness/
       # settlement suites read from other modules. Keep this list in sync with
       # the Swift tests under phase3-binary/Tests and phase3-binary/app/Tests.
+      # test/e2e/byom/* is the hermetic BYOM CLI onboarding harness the Swift
+      # job runs via `make test-byom-e2e`; a harness-only edit must still gate.
       phase3-binary/*|scripts/*|Makefile|.gitattributes|.github/workflows/ci.yml|\
+      test/e2e/byom/*|\
       phase7-verify/testdata/*|phase4-coordinator/test/jcs_fixtures/*|testdata/*)
         swift=true
         matched_swift=$((matched_swift + 1)) ;;

--- a/scripts/tests/test-ci-detect-changed-paths.sh
+++ b/scripts/tests/test-ci-detect-changed-paths.sh
@@ -107,6 +107,15 @@ setup_external_fixture_testdata() {
 }
 assert_detect "root testdata fixture" setup_external_fixture_testdata true true
 
+# The hermetic BYOM CLI onboarding harness is run by the Swift job via
+# `make test-byom-e2e`; a harness-only edit must still gate the Swift job.
+setup_byom_e2e_harness() {
+  mkdir -p test/e2e/byom; echo x >test/e2e/byom/run-cli-onboarding-e2e.py
+  commit_all base >/dev/null; git rev-parse HEAD
+  echo y >test/e2e/byom/run-cli-onboarding-e2e.py; commit_all change >/dev/null
+}
+assert_detect "byom e2e harness (run swift)" setup_byom_e2e_harness true true
+
 # A normal coordinator .go change must NOT drag in swift (savings preserved).
 setup_coordinator_go() {
   mkdir -p phase4-coordinator/internal; echo x >phase4-coordinator/internal/ws.go

--- a/test/e2e/byom/run-cli-onboarding-e2e.py
+++ b/test/e2e/byom/run-cli-onboarding-e2e.py
@@ -468,8 +468,16 @@ def main():
         ))
         assert_true(dry_run.get("schema") == "model_admission_offer_dry_run.v1", "wrong dry-run schema")
         assert_true(dry_run.get("candidate_id") == candidate_id, "dry-run resolved a different candidate")
-        assert_true(dry_run.get("would_submit") is False, "dry-run unexpectedly submits without evaluation digest")
-        assert_true(dry_run.get("reason_code") == "evaluation_required", "dry-run did not explain evaluation gate")
+        # SPEC-047-R002: a non-earning (local_inventory_only) v0.1 candidate MAY be
+        # submitted without the evaluation digest, so the dry-run reports would_submit
+        # true. It must match the real submit gate (canSubmit) and may not over-promise.
+        assert_true(dry_run.get("would_submit") is True, "clean non-earning candidate should dry-run as submittable (evaluation_required is advisory, SPEC-047-R002)")
+        # The top advisory reason for a provider-asserted candidate is the unverified
+        # catalog binding (SPEC-047-R003: a provider-asserted catalog_model_key is never
+        # sufficient), which outranks evaluation_required. Both remain surfaced: the
+        # honest reason_code plus evaluation_required in the advisory warnings.
+        assert_true(dry_run.get("reason_code") == "catalog_binding_unverified", "dry-run did not surface the unverified catalog binding as the top advisory reason")
+        assert_true("evaluation_required" in (dry_run.get("warnings") or []), "dry-run dropped the advisory evaluation warning")
         assert_true(coordinator.state["requests"] == [], "dry-run contacted coordinator")
 
         offer = parse_json_output(run_cli(


### PR DESCRIPTION
## Summary

The provider CLI had two predicates deciding whether a BYOM offer can be submitted, and they disagreed on `evaluation_required`:

- `canSubmitLocalDryRun` (dry-run predictor) treated it as **advisory** → `would_submit: true`.
- `canSubmit` (the real offer-submit gate) treated it as a **hard block** unless an evaluation digest was supplied.

PR #1399 changed only the dry-run side, so the dry-run **over-promised**: it told the provider `would_submit: true` for a candidate the real `models offer` (without a digest) would refuse with `candidateNotOfferable`. This is a provider-facing truthfulness gap and it was the cause of the red `make test-byom-e2e` on `main`.

**SPEC-047-R002 is authoritative:** *"Offer submission MAY omit the evaluation digest only when the dry-run response explicitly labels the offer as more likely to be rejected or confined to non-earning states."* Every v0.1 `local_inventory_only` candidate is non-earning, so the digest is optional — `canSubmit` was the surface out of conformance.

## What changed

- **Single source of truth** `BYOMDiscoveryWarning.submitBlockingWarnings` (ordered) / `.submitBlockingWarningCodes` (Set). `canSubmit`, `canSubmitLocalDryRun`, and `reasonCode(for:)` all derive from it, so the dry-run can never again over- or under-promise the real submit. `evaluation_required` is deliberately absent.
- The shared set **adds `adapter_unavailable` + `adapter_timeout`**, which `canSubmit` previously failed to block and on which the dry-run diverged — both now fail closed. (Found by the code-review audit lane.)
- `canSubmit` drops its now-unused `evaluationDigestSHA256` parameter.
- `candidateNotOfferable` guidance leads with the real hard blockers; the digest is framed as an advisory strengthening step (still names `--evaluation-digest-sha256`).
- Tests: allow a missing digest for a non-earning candidate; table-test every hard blocker (incl. the two new adapter codes) failing closed **with and without** a digest; the E2E harness asserts `would_submit: true` + honest `reason_code: catalog_binding_unverified` (SPEC-047-R003) with `evaluation_required` still surfaced in `warnings`.
- **CI:** wire the previously manual-only `make test-byom-e2e` into the `phase3-binary` swift-tests job, and extend the change detector (`ci-detect-changed-paths.sh`) + its parity test to gate on `test/e2e/byom/*`, so this harness cannot silently regress again. (It was manual-only, which is why the drift went unnoticed for a day.)

## Testing
- Swift: `BYOMAdmissionTests` 21/0, `BYOMDiscoveryTests` 25/0, `BYOMOfferDryRunTests` 8/0
- `make test-byom-e2e`: **PASS** (was RED on `main`)
- Detector parity suite: all scenarios pass, incl. the new BYOM harness case

## Audit
Three lanes (code / security / architecture) via codex over the full fix diff: **0 CRITICAL, 0 HIGH, 0 MEDIUM.** Carried LOW (documented): a future signed promotion journey (SPEC-047-R008) should include one non-earning offer where the dry-run reports `would_submit: true`, `evaluation_required` stays in warnings, and the signed offer omits the digest — coverable by existing journey categories, no new state required.

Refs #1381

<!-- SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-047"],
  "requirements": ["SPEC-047-R002", "SPEC-047-R003"],
  "authority_domains": ["network-model-admission"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "phase3-binary/Tests/macprovider-cliTests/BYOMAdmissionTests.swift:testOfferPackageAllowsMissingEvaluationDigestForNonEarningCandidate",
    "phase3-binary/Tests/macprovider-cliTests/BYOMAdmissionTests.swift:testOfferPackageStillRejectsHardLocalBlockers",
    "test/e2e/byom/run-cli-onboarding-e2e.py"
  ],
  "journeys": ["not-required"],
  "issue": "https://github.com/Augustas11/macprovider/issues/1381"
}
SPEC-GOVERNANCE-DECLARATION-END -->
