### PR TITLE
fix(malibu): hold Live through stale local status polls (#1422)

### DIFF
--- a/phase3-binary/app/Sources/Malibu/Agent/AgentSnapshot.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/AgentSnapshot.swift
@@ -1488,7 +1488,9 @@ enum AgentSnapshotPresenter {
         }
 
         let primaryDiagnostic = primaryDiagnosticFinding(s)
-        if let primaryDiagnostic, primaryDiagnostic.signatureID != .autoupdateInProgress {
+        if let primaryDiagnostic,
+           primaryDiagnostic.signatureID != .autoupdateInProgress,
+           !shouldHoldLiveThroughStaleServeUnresponsive(primaryDiagnostic, snapshot: s) {
             let context = diagnosticContext(primaryDiagnostic, snapshot: s)
             let meaning = ([publicS.detail ?? "Malibu found a provider issue that needs attention."] + context)
                 .joined(separator: " ")
@@ -2741,6 +2743,9 @@ enum AgentSnapshotPresenter {
                 safeNextAction: "Keep Malibu open. You do not need a new invite."
             )
         case .serveUnresponsive:
+            if shouldHoldLiveThroughStaleServeUnresponsive(finding, snapshot: s) {
+                return nil
+            }
             return PublicStatus(
                 title: serveUnresponsiveTitle(finding),
                 detail: serveUnresponsiveDetail(finding),
@@ -2799,6 +2804,7 @@ enum AgentSnapshotPresenter {
     private static func topDiagnosticFinding(_ s: AgentSnapshot) -> ProviderDiagnosticFinding? {
         s.diagnosticFindings
             .filter { canUseAsPrimaryDiagnosticStatus($0, snapshot: s) }
+            .filter { !shouldHoldLiveThroughStaleServeUnresponsive($0, snapshot: s) }
             .sorted(by: diagnosticPrecedes)
             .first
     }
@@ -2875,6 +2881,32 @@ enum AgentSnapshotPresenter {
         hasNetworkStateEvidence(finding)
             ? "Customer availability is interrupted"
             : "Provider status is unavailable"
+    }
+
+    /// #1338 ranked availability diagnostics ahead of ready copy. A stale local
+    /// status poll (`serve_unresponsive` from `/v1/status` with
+    /// `observation.id=` evidence and no `network_state=`) must not steal Live
+    /// while the display-retained observation is still `buyer_serving`.
+    /// Doctor/app-polling `serve_dead` findings and missing evidence stay primary.
+    private static func shouldHoldLiveThroughStaleServeUnresponsive(
+        _ finding: ProviderDiagnosticFinding,
+        snapshot s: AgentSnapshot,
+        at now: Date = Date()
+    ) -> Bool {
+        finding.signatureID == .serveUnresponsive
+            && finding.source == .status
+            && isStaleLocalPollServeUnresponsiveEvidence(finding)
+            && isNetworkReady(s, at: now)
+    }
+
+    private static func isStaleLocalPollServeUnresponsiveEvidence(
+        _ finding: ProviderDiagnosticFinding
+    ) -> Bool {
+        let prefix = "observation.id="
+        guard let evidence = finding.evidence, evidence.hasPrefix(prefix) else {
+            return false
+        }
+        return evidence.count > prefix.count
     }
 
     private static func serveUnresponsiveDetail(_ finding: ProviderDiagnosticFinding) -> String {

--- a/phase3-binary/app/Sources/Malibu/Agent/LocalStatusObservationPolicy.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/LocalStatusObservationPolicy.swift
@@ -25,6 +25,38 @@ enum LocalStatusObservationPolicy {
         max(Double(reportedValidForMS) / 1_000.0, displayRetentionSeconds)
     }
 
+    /// First local `/v1/health` or `/v1/status` miss must not wipe a trusted
+    /// observation while launchd still owns a pid. Invalidate only when the
+    /// service is gone or misses span the display retention window.
+    static func shouldInvalidateAfterLocalPollMiss(
+        missStartedAt: Date?,
+        now: Date = Date(),
+        launchdPID: Int?
+    ) -> Bool {
+        if launchdPID == nil { return true }
+        guard let missStartedAt else { return false }
+        return now.timeIntervalSince(missStartedAt) >= displayRetentionSeconds
+    }
+
+    /// A fetched `/v1/status` whose service identity does not match is a hard
+    /// fail. Only a missing HTTP response may hold through display retention.
+    static func shouldInvalidateAfterLocalStatusRefreshFailure(
+        fetchedStatus: Bool,
+        identityMatched: Bool,
+        missStartedAt: Date?,
+        now: Date = Date(),
+        launchdPID: Int?
+    ) -> Bool {
+        if fetchedStatus {
+            return !identityMatched
+        }
+        return shouldInvalidateAfterLocalPollMiss(
+            missStartedAt: missStartedAt,
+            now: now,
+            launchdPID: launchdPID
+        )
+    }
+
     /// Bounded diagnostic when public status demotes solely because the
     /// observation retention window elapsed (not a harder failure).
     static let observationExpiryDiagnostic = "public_status_transition cause=status_observation_expired"

--- a/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
+++ b/phase3-binary/app/Sources/Malibu/Agent/MalibuAgent.swift
@@ -46,6 +46,9 @@ final class MalibuAgent: ObservableObject {
     /// passes both the local readiness and service-identity checks.
     private var providerProjectionEligible = false
     private var lastRequestsRateSample: (total: Int, date: Date)?
+    /// First timestamp of the current local health/status miss streak.
+    /// Cleared on a successful `/v1/status` refresh.
+    private var localStatusMissStartedAt: Date?
     private var latestReleaseFetchedAt: Date?
     private var cliUpdateTask: Task<Void, Never>?
     private var providerSoftwareRepairTask: Task<Void, Never>?
@@ -745,14 +748,19 @@ final class MalibuAgent: ObservableObject {
         if !localReady {
             invalidateProviderProjectionFreshness()
         }
-        if let status = await InstalledProviderMonitor.fetchStatus(port: port),
-           let expectedProviderID = ProviderConfig.readProviderID(),
-           InstalledProviderMonitor.serviceIdentityMatches(
-               status,
-               expectedProviderID: expectedProviderID,
-               launchdPID: InstalledProviderMonitor.launchdServicePID(),
-               liveCodeMatches: ProviderCredentialHandoffRunner.validatedInstalledProcessMatches(pid:)
-           ) {
+        let status = await InstalledProviderMonitor.fetchStatus(port: port)
+        let expectedProviderID = ProviderConfig.readProviderID()
+        let identityMatched = status.map { fetched in
+            guard let expectedProviderID else { return false }
+            return InstalledProviderMonitor.serviceIdentityMatches(
+                fetched,
+                expectedProviderID: expectedProviderID,
+                launchdPID: InstalledProviderMonitor.launchdServicePID(),
+                liveCodeMatches: ProviderCredentialHandoffRunner.validatedInstalledProcessMatches(pid:)
+            )
+        } ?? false
+        if let status, let expectedProviderID, identityMatched {
+            localStatusMissStartedAt = nil
             snapshot.localProviderID = expectedProviderID
             snapshot.localStatusContractVersion = status.contractVersion
             snapshot.localStatusMinimumReaderVersion = status.minimumReaderVersion
@@ -844,15 +852,36 @@ final class MalibuAgent: ObservableObject {
                 snapshot.referralLastError = nil
                 finishReferralAction()
             }
-        } else {
-            // Never carry a prior authoritative serving verdict across a
-            // failed status/readiness refresh.
+        } else if LocalStatusObservationPolicy.shouldInvalidateAfterLocalStatusRefreshFailure(
+            fetchedStatus: status != nil,
+            identityMatched: identityMatched,
+            missStartedAt: localStatusMissStartedAt,
+            launchdPID: monitorsLaunchdProvider ? InstalledProviderMonitor.launchdServicePID() : nil
+        ) {
+            // Identity mismatch is a hard fail. A missing HTTP response may
+            // hold until launchd is gone or misses span display retention.
             snapshot.invalidateLocalStatusObservation()
             invalidateProviderProjectionFreshness()
+        } else {
+            noteLocalStatusPollMiss()
         }
         reconcileNetworkState(localReady: localReady)
         await refreshLatestReleaseIfNeeded()
         refreshDiagnosticFindings()
+    }
+
+    private func noteLocalStatusPollMiss(now: Date = Date()) {
+        if localStatusMissStartedAt == nil {
+            localStatusMissStartedAt = now
+        }
+    }
+
+    private func shouldInvalidateHeldLocalStatus(now: Date = Date()) -> Bool {
+        LocalStatusObservationPolicy.shouldInvalidateAfterLocalPollMiss(
+            missStartedAt: localStatusMissStartedAt,
+            now: now,
+            launchdPID: monitorsLaunchdProvider ? InstalledProviderMonitor.launchdServicePID() : nil
+        )
     }
 
     private func refreshCredentialDiagnosis() async {
@@ -1058,17 +1087,22 @@ final class MalibuAgent: ObservableObject {
                     await self.requestReferralStatusIfDue()
                 } else if self.monitorsLaunchdProvider {
                     await MainActor.run {
-                        self.snapshot.invalidateLocalStatusObservation()
-                        self.invalidateProviderProjectionFreshness()
-                        if let failure = self.diagnosedProviderFailure(includingLaunchdState: true) {
-                            self.providerStartFailure = failure
-                            self.snapshot.state = .error
-                            self.snapshot.lastError = failure
+                        if self.shouldInvalidateHeldLocalStatus() {
+                            self.snapshot.invalidateLocalStatusObservation()
+                            self.invalidateProviderProjectionFreshness()
+                            if let failure = self.diagnosedProviderFailure(includingLaunchdState: true) {
+                                self.providerStartFailure = failure
+                                self.snapshot.state = .error
+                                self.snapshot.lastError = failure
+                            } else {
+                                self.snapshot.state = .reconnecting
+                                self.snapshot.lastError = ProviderLogDiagnostics.timeoutMessage(
+                                    logHint: ProviderLogDiagnostics.logHint()
+                                )
+                            }
                         } else {
-                            self.snapshot.state = .reconnecting
-                            self.snapshot.lastError = ProviderLogDiagnostics.timeoutMessage(
-                                logHint: ProviderLogDiagnostics.logHint()
-                            )
+                            self.noteLocalStatusPollMiss()
+                            self.refreshDiagnosticFindings()
                         }
                     }
                 }

--- a/phase3-binary/app/Tests/MalibuTests/AgentSnapshotPresenterTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/AgentSnapshotPresenterTests.swift
@@ -912,6 +912,182 @@ final class AgentSnapshotPresenterTests: XCTestCase {
         )
     }
 
+    func testLocalPollMissHoldDoesNotInvalidateWhileLaunchdPidAliveInsideRetention() {
+        let origin = Date(timeIntervalSince1970: 1_800_000_000)
+        XCTAssertFalse(
+            LocalStatusObservationPolicy.shouldInvalidateAfterLocalPollMiss(
+                missStartedAt: nil,
+                now: origin,
+                launchdPID: 4242
+            )
+        )
+        XCTAssertFalse(
+            LocalStatusObservationPolicy.shouldInvalidateAfterLocalPollMiss(
+                missStartedAt: origin,
+                now: origin.addingTimeInterval(LocalStatusObservationPolicy.displayRetentionSeconds - 0.1),
+                launchdPID: 4242
+            )
+        )
+        XCTAssertTrue(
+            LocalStatusObservationPolicy.shouldInvalidateAfterLocalPollMiss(
+                missStartedAt: origin,
+                now: origin.addingTimeInterval(LocalStatusObservationPolicy.displayRetentionSeconds),
+                launchdPID: 4242
+            )
+        )
+        XCTAssertTrue(
+            LocalStatusObservationPolicy.shouldInvalidateAfterLocalPollMiss(
+                missStartedAt: nil,
+                now: origin,
+                launchdPID: nil
+            )
+        )
+    }
+
+    func testIdentityMismatchInvalidatesImmediatelyWhilePollMissMayHold() {
+        let origin = Date(timeIntervalSince1970: 1_800_000_000)
+        XCTAssertTrue(
+            LocalStatusObservationPolicy.shouldInvalidateAfterLocalStatusRefreshFailure(
+                fetchedStatus: true,
+                identityMatched: false,
+                missStartedAt: nil,
+                now: origin,
+                launchdPID: 4242
+            )
+        )
+        XCTAssertFalse(
+            LocalStatusObservationPolicy.shouldInvalidateAfterLocalStatusRefreshFailure(
+                fetchedStatus: false,
+                identityMatched: false,
+                missStartedAt: nil,
+                now: origin,
+                launchdPID: 4242
+            )
+        )
+        XCTAssertFalse(
+            LocalStatusObservationPolicy.shouldInvalidateAfterLocalStatusRefreshFailure(
+                fetchedStatus: false,
+                identityMatched: false,
+                missStartedAt: origin,
+                now: origin.addingTimeInterval(LocalStatusObservationPolicy.displayRetentionSeconds - 0.1),
+                launchdPID: 4242
+            )
+        )
+        XCTAssertTrue(
+            LocalStatusObservationPolicy.shouldInvalidateAfterLocalStatusRefreshFailure(
+                fetchedStatus: false,
+                identityMatched: false,
+                missStartedAt: origin,
+                now: origin.addingTimeInterval(LocalStatusObservationPolicy.displayRetentionSeconds),
+                launchdPID: 4242
+            )
+        )
+    }
+
+    func testStaleServeUnresponsiveDoesNotOverrideReadyPublicStatus() {
+        var snapshot = buyerServingObservationSnapshot(observedAt: Date().addingTimeInterval(-6))
+        snapshot.diagnosticFindings = [
+            ProviderDiagnosticFinding(
+                signatureID: .serveUnresponsive,
+                source: .status,
+                userMessage: "Provider local status is unavailable or stale.",
+                evidence: "observation.id=observation-a",
+                observedAt: Date()
+            )
+        ]
+
+        XCTAssertTrue(AgentSnapshotPresenter.isNetworkReady(snapshot))
+        XCTAssertEqual(AgentSnapshotPresenter.publicStatus(snapshot).title, "Provider is ready")
+        XCTAssertEqual(AgentSnapshotPresenter.consolidatedStatus(snapshot).phase, .live)
+        XCTAssertNotEqual(
+            AgentSnapshotPresenter.consolidatedStatus(snapshot).label,
+            "Provider status is unavailable"
+        )
+    }
+
+    func testStatusServeUnresponsiveWithoutObservationIDDoesNotHoldLive() {
+        var snapshot = buyerServingObservationSnapshot(observedAt: Date().addingTimeInterval(-6))
+        snapshot.diagnosticFindings = [
+            ProviderDiagnosticFinding(
+                signatureID: .serveUnresponsive,
+                source: .status,
+                userMessage: "Provider local status is unavailable or stale.",
+                evidence: nil,
+                observedAt: Date()
+            )
+        ]
+
+        XCTAssertTrue(AgentSnapshotPresenter.isNetworkReady(snapshot))
+        XCTAssertEqual(
+            AgentSnapshotPresenter.publicStatus(snapshot).title,
+            "Provider status is unavailable"
+        )
+        XCTAssertEqual(AgentSnapshotPresenter.consolidatedStatus(snapshot).phase, .needsAttention)
+    }
+
+    func testHeldStaleServeUnresponsiveDoesNotHideLowerRankedDiagnostic() {
+        var snapshot = buyerServingObservationSnapshot(observedAt: Date().addingTimeInterval(-6))
+        snapshot.diagnosticFindings = [
+            ProviderDiagnosticFinding(
+                signatureID: .serveUnresponsive,
+                source: .status,
+                userMessage: "Provider local status is unavailable or stale.",
+                evidence: "observation.id=observation-a",
+                observedAt: Date()
+            ),
+            ProviderDiagnosticFinding(
+                signatureID: .autoupdateDisabled,
+                source: .status,
+                userMessage: "Provider automatic updates are disabled.",
+                evidence: nil,
+                observedAt: Date()
+            ),
+        ]
+
+        XCTAssertTrue(AgentSnapshotPresenter.isNetworkReady(snapshot))
+        XCTAssertEqual(
+            AgentSnapshotPresenter.publicStatus(snapshot).title,
+            "Provider automatic updates are disabled"
+        )
+        XCTAssertEqual(AgentSnapshotPresenter.consolidatedStatus(snapshot).phase, .needsAttention)
+        XCTAssertEqual(
+            AgentSnapshotPresenter.consolidatedStatus(snapshot).label,
+            "Provider automatic updates are disabled"
+        )
+    }
+
+    func testDoctorServeDeadStillDrivesPublicStatusDuringDisplayRetention() {
+        var snapshot = buyerServingObservationSnapshot(observedAt: Date().addingTimeInterval(-6))
+        snapshot.diagnosticFindings = [
+            ProviderDiagnosticFinding(
+                signatureID: .serveUnresponsive,
+                source: .status,
+                userMessage: "Provider local status is unavailable or stale.",
+                evidence: "observation.id=observation-a",
+                observedAt: Date()
+            ),
+            ProviderDiagnosticFinding(
+                signatureID: .serveUnresponsive,
+                source: .doctorReport,
+                userMessage: "doctor report found serve dead",
+                evidence: "serve_dead=true",
+                observedAt: Date()
+            ),
+        ]
+
+        XCTAssertTrue(AgentSnapshotPresenter.isNetworkReady(snapshot))
+        XCTAssertFalse(snapshot.hasFreshContractValidatedStatusObservation())
+        XCTAssertEqual(
+            AgentSnapshotPresenter.publicStatus(snapshot).title,
+            "Provider status is unavailable"
+        )
+        XCTAssertEqual(AgentSnapshotPresenter.consolidatedStatus(snapshot).phase, .needsAttention)
+        XCTAssertEqual(
+            AgentSnapshotPresenter.consolidatedStatus(snapshot).label,
+            "Provider status is unavailable"
+        )
+    }
+
     @MainActor
     func testObservationExpiryDiagnosticEmitsOnPresentedServingToConnectedTransition() {
         PublicStatusTransitionDiagnostics.resetForTests()

--- a/phase3-binary/app/Tests/MalibuTests/RewardVerdictContractTests.swift
+++ b/phase3-binary/app/Tests/MalibuTests/RewardVerdictContractTests.swift
@@ -555,6 +555,55 @@ final class RewardVerdictContractTests: XCTestCase {
         interrupted.networkState = "not_buyer_serving"
         XCTAssertEqual(AgentSnapshotPresenter.consolidatedStatus(interrupted).phase, .needsAttention)
 
+        var stalePoll = trustedServing()
+        stalePoll.diagnosticFindings = [
+            diagnostic(
+                .serveUnresponsive,
+                message: "Provider local status is unavailable or stale.",
+                evidence: "observation.id=stale-observation"
+            )
+        ]
+        let stalePollStatus = AgentSnapshotPresenter.consolidatedStatus(stalePoll)
+        XCTAssertNotEqual(stalePollStatus.phase, .needsAttention)
+        XCTAssertNotEqual(stalePollStatus.label, "Provider status is unavailable")
+
+        var stalePollWithLowerRanked = trustedServing()
+        stalePollWithLowerRanked.diagnosticFindings = [
+            diagnostic(
+                .serveUnresponsive,
+                message: "Provider local status is unavailable or stale.",
+                evidence: "observation.id=stale-observation"
+            ),
+            diagnostic(
+                .autoupdateDisabled,
+                source: .status,
+                message: "Provider automatic updates are disabled."
+            ),
+        ]
+        let stalePollNextStatus = AgentSnapshotPresenter.consolidatedStatus(stalePollWithLowerRanked)
+        XCTAssertEqual(stalePollNextStatus.phase, .needsAttention)
+        XCTAssertEqual(stalePollNextStatus.label, "Provider automatic updates are disabled")
+
+        var doctorServeDead = trustedServing()
+        doctorServeDead.statusObservedAt = Date().addingTimeInterval(-6)
+        doctorServeDead.statusObservationValidForMS = 5_000
+        doctorServeDead.diagnosticFindings = [
+            diagnostic(
+                .serveUnresponsive,
+                message: "Provider local status is unavailable or stale.",
+                evidence: "observation.id=stale-observation"
+            ),
+            diagnostic(
+                .serveUnresponsive,
+                source: .doctorReport,
+                message: "doctor report found serve dead",
+                evidence: "serve_dead=true"
+            ),
+        ]
+        let doctorServeDeadStatus = AgentSnapshotPresenter.consolidatedStatus(doctorServeDead)
+        XCTAssertEqual(doctorServeDeadStatus.phase, .needsAttention)
+        XCTAssertEqual(doctorServeDeadStatus.label, "Provider status is unavailable")
+
         var autoupdate = trustedServing()
         autoupdate.diagnosticFindings = [
             diagnostic(.autoupdateInProgress, message: "Provider software update is in progress.")


### PR DESCRIPTION
## Summary
- Keep Malibu Live when a retained `buyer_serving` observation is still valid and the only diagnostic is a stale local `/v1/status` poll (`serve_unresponsive` with `observation.id=` evidence).
- First `/v1/health` or `/v1/status` miss no longer wipes that observation while launchd still has a pid; identity mismatch and launchd pid loss still invalidate immediately.
- Doctor/app-polling `serve_dead` and lower-ranked diagnostics still drive public status. This ships in combined CLI+Malibu **v1.8.122**; Pearl must recommend 122 after publish, not 121.

## Tests
- `xcodebuild -scheme Malibu -destination platform=macOS -only-testing:MalibuTests/AgentSnapshotPresenterTests -only-testing:MalibuTests/RewardVerdictContractTests test` (114 tests, 0 failures)
- 3-lane Codex audit of the landing diff: 0 CRITICAL / 0 HIGH / 0 MEDIUM
- Carried LOW: independent `Date()` near retention boundary; empty `observation.id=` string sibling test

## Follow-up
- Stage v1.8.122, combined `release.yml`, then Pearl overlay `target_id` + `latest_binary_version` = 1.8.122. Keep 117 and 121 in `accepted_ids`. Do not leave recommend on 121.

Closes #1422

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "issue": "https://github.com/Augustas11/macprovider/issues/1422",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": [
    "SPEC-025",
    "SPEC-035"
  ],
  "requirements": [
    "SPEC-035-R011"
  ],
  "authority_domains": [
    "native-app-lifecycle",
    "provider-connection-diagnostics",
    "provider-console"
  ],
  "arbitration": [
    "CODE_BUG"
  ],
  "tests": [
    "xcodebuild -scheme Malibu -destination platform=macOS -only-testing:MalibuTests/AgentSnapshotPresenterTests -only-testing:MalibuTests/RewardVerdictContractTests test",
    "AgentSnapshotPresenterTests Live-hold stale-poll and doctor serve_dead regressions",
    "RewardVerdictContractTests stale-poll does not steal Live",
    "3-lane Codex audit 0 C/H/M"
  ],
  "journeys": [
    "not-required"
  ]
}
SPEC-GOVERNANCE-DECLARATION-END

Made with [Cursor](https://cursor.com)