### PR TITLE
ops(coordinator): bump staged latest_binary_version 1.8.117->1.8.121

### DIFF
--- a/phase4-coordinator/coordinator.yaml.example
+++ b/phase4-coordinator/coordinator.yaml.example
@@ -189,7 +189,7 @@ autotune:
 # legacy cohort (DECISION_CRITERIA Entry 161). `required_binary_version` is a
 # hard admission floor, not an autoupdate target, and is unaffected by the gate.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.117"
+  latest_binary_version: "1.8.121"
   required_binary_version: ""
 
 auth:

--- a/phase4-coordinator/dist/coordinator.yaml
+++ b/phase4-coordinator/dist/coordinator.yaml
@@ -389,5 +389,5 @@ providers:
 # reconnecting and tells its operator to upgrade, and one without it
 # reconnect-loops.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.117"
+  latest_binary_version: "1.8.121"
   required_binary_version: "1.8.33"

--- a/phase4-coordinator/dist/coordinator.yaml.example
+++ b/phase4-coordinator/dist/coordinator.yaml.example
@@ -422,7 +422,7 @@ malibu_emission:
 # routing. Keys match model_id case-insensitively; values must be bare
 # numeric versions or the coordinator refuses to start.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.117"
+  latest_binary_version: "1.8.121"
   # required_binary_version: "1.7.0"
   # per_model_required_binary_version:
   #   "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit": "1.8.60"


### PR DESCRIPTION
## What

Bump the checked-in coordinator staged advertised-version `latest_binary_version` from **1.8.117 → 1.8.121** in all three configs:
- `phase4-coordinator/dist/coordinator.yaml`
- `phase4-coordinator/coordinator.yaml.example`
- `phase4-coordinator/dist/coordinator.yaml.example`

`required_binary_version` floor is unchanged.

## Why

The v1.8.122 acceptance-candidate promotion failed at its **pre-publication live-coordinator feed gate**:

```
[verify-live-coordinator-release-gate] ERROR: /healthz recommended_binary_version '1.8.121'
  does not match expected previous stable 1.8.117
```

`scripts/release-staged-version-policy.sh` derives previous-stable from these configs. Git still said 1.8.117 while live Pearl already recommends 1.8.121 (same class as #1406). `1.8.121 < 1.8.122` keeps the staged-release invariant.

## Tests

- `bash scripts/release-staged-version-policy.sh v1.8.122` → PREVIOUS_STABLE=1.8.121, staged=true
- `bash scripts/test-coordinator-advertised-version-test.sh`
- 3-lane Codex audit: 0 CRITICAL / 0 HIGH / 0 MEDIUM

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R001"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": ["scripts/release-staged-version-policy.sh v1.8.122", "scripts/test-coordinator-advertised-version-test.sh", "3-lane Codex audit 0 C/H/M"],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END
