### PR TITLE
fix(release): stop comparing Pearl runtime version to CLI in pre-publication

### DIFF
--- a/.github/workflows/promote-acceptance-candidate.yml
+++ b/.github/workflows/promote-acceptance-candidate.yml
@@ -473,12 +473,9 @@ jobs:
           policy_file="$RUNNER_TEMP/release-staged-policy.env"
           bash scripts/release-staged-version-policy.sh "$TAG" > "$policy_file"
           source "$policy_file"
-          prepublication_recommendation_args=()
-          if [ "$MACPROVIDER_RELEASE_STAGED" = true ]; then
-            prepublication_recommendation_args=(
-              --expected-previous-recommendation "$MACPROVIDER_RELEASE_PREVIOUS_STABLE_VERSION"
-            )
-          fi
+          prepublication_recommendation_args=(
+            --expected-previous-recommendation "$MACPROVIDER_RELEASE_COORDINATOR_RECOMMENDATION"
+          )
           env -u GH_TOKEN -u RELEASE_POSTURE_TOKEN \
             python3 scripts/verify-live-coordinator-release-gate.py \
             --tag "$TAG" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1871,10 +1871,10 @@ jobs:
 
           # This is the final pre-publication gate: repeat every mutable
           # source, tag, repository-posture, numeric-ID, and asset assertion
-          # directly before changing draft=false. The coordinator may still
-          # advertise the previous stable CLI until this release is public.
-          # Pearl /healthz may already be a runtime-only patch ahead of that
-          # advertisement; it must not be older than the advertised CLI.
+          # directly before changing draft=false. CLI advertisement is the
+          # checked-in Pearl recommendation (previous stable while staged,
+          # candidate when already matching). Pearl /healthz.version is the
+          # coordinator runtime and is not compared to CLI semver.
           GITHUB_SHA="$commit" bash scripts/verify-release-source.sh \
             "$tag" "$commit" origin --require-existing
           GH_TOKEN="$RELEASE_POSTURE_TOKEN" \
@@ -1902,12 +1902,9 @@ jobs:
             policy_file="$RUNNER_TEMP/release-staged-policy.env"
             bash scripts/release-staged-version-policy.sh "$tag" > "$policy_file"
             source "$policy_file"
-            prepublication_recommendation_args=()
-            if [ "$MACPROVIDER_RELEASE_STAGED" = true ]; then
-              prepublication_recommendation_args=(
-                --expected-previous-recommendation "$MACPROVIDER_RELEASE_PREVIOUS_STABLE_VERSION"
-              )
-            fi
+            prepublication_recommendation_args=(
+              --expected-previous-recommendation "$MACPROVIDER_RELEASE_COORDINATOR_RECOMMENDATION"
+            )
             env -u GH_TOKEN -u RELEASE_POSTURE_TOKEN \
               python3 scripts/verify-live-coordinator-release-gate.py \
               --tag "$tag" \

--- a/scripts/test-acceptance-promotion.sh
+++ b/scripts/test-acceptance-promotion.sh
@@ -138,7 +138,7 @@ for requirement in (
     "--openssl \"$OPENSSL_BIN\"",
     "scripts/release-staged-version-policy.sh",
     "prepublication_recommendation_args",
-    "--expected-previous-recommendation \"$MACPROVIDER_RELEASE_PREVIOUS_STABLE_VERSION\"",
+    "--expected-previous-recommendation \"$MACPROVIDER_RELEASE_COORDINATOR_RECOMMENDATION\"",
 ):
     if requirement not in publish_step[pre_gate_label:]:
         raise SystemExit(f"promotion live coordinator gate omits: {requirement}")

--- a/scripts/test-live-coordinator-release-gate.sh
+++ b/scripts/test-live-coordinator-release-gate.sh
@@ -178,15 +178,18 @@ run_guard_phase() {
   local directory="$1"
   local phase="$2"
   local previous="${3:-1.8.67}"
-  python3 "$guard" \
+  set -- python3 "$guard" \
     --tag v1.8.68 \
     --pearl-release-json "$directory/pearl-release.json" \
     --trusted-keys "$directory/trusted-keys.json" \
     --coordinator-url https://coordinator.fixture.invalid \
     --coordinator-dir "$directory/live" \
     --now 2026-07-30T12:05:00Z \
-    ${phase:+--expected-previous-recommendation "$previous"} \
     --publication-phase "$phase"
+  if [[ "$phase" == "pre-publication" && "$previous" != "__omit__" ]]; then
+    set -- "$@" --expected-previous-recommendation "$previous"
+  fi
+  "$@"
 }
 
 make_fixture "$work/ok"
@@ -229,14 +232,14 @@ grep -q 'fixture coordinator response is missing for /v1/rate-card.sig' "$work/m
 make_fixture "$work/older-coordinator-post" v1.8.68 v1.8.67
 run_guard "$work/older-coordinator-post" | grep -q 'ok: https://coordinator.fixture.invalid serves v1.8.68 feed set'
 
-# Pre-publication still guards against a coordinator that has regressed BELOW the
-# previously-advertised stable (a genuine coordinator rollback), independent of
-# the CLI release being staged.
-make_fixture "$work/older-than-previous-pre" v1.8.68 v1.8.66
-if run_guard_phase "$work/older-than-previous-pre" pre-publication >"$work/older-than-previous-pre.out" 2>&1; then
-  fail "pre-publication accepted a coordinator older than the previous stable"
+# Pre-publication: Pearl runtime binary may be older than the previous advertised
+# CLI. The CLI pin is recommended_binary_version, not /healthz version.
+make_fixture "$work/older-than-previous-pre" v1.8.68 v1.8.66 2026-07-30T12:00:00Z 2026-07-30T12:00:00Z streamvc-autotune-static-v4 1.8.67
+if ! run_guard_phase "$work/older-than-previous-pre" pre-publication >"$work/older-than-previous-pre.out" 2>&1; then
+  fail "pre-publication rejected an older Pearl runtime that still advertises the previous CLI"
 fi
-grep -q "is older than previous stable 1.8.67" "$work/older-than-previous-pre.out"
+grep -q 'healthz_version=v1.8.66 recommended_binary_version=1.8.67 publication_phase=pre-publication' \
+  "$work/older-than-previous-pre.out"
 
 make_fixture "$work/missing-recommended" v1.8.68 v1.8.68 2026-07-30T12:00:00Z 2026-07-30T12:00:00Z streamvc-autotune-static-v4 __absent__
 if run_guard "$work/missing-recommended" >"$work/missing-recommended.out" 2>&1; then
@@ -246,7 +249,7 @@ grep -q '/healthz recommended_binary_version is missing or not a version string'
 if run_guard_phase "$work/missing-recommended" pre-publication >"$work/missing-recommended-pre.out" 2>&1; then
   fail "pre-publication gate accepted a coordinator without the previous recommendation"
 fi
-grep -q 'recommended_binary_version is missing or not the expected previous stable version' \
+grep -q 'recommended_binary_version is missing or not the expected pre-publication recommendation' \
   "$work/missing-recommended-pre.out"
 
 make_fixture "$work/previous-recommended" v1.8.68 v1.8.68 2026-07-30T12:00:00Z 2026-07-30T12:00:00Z streamvc-autotune-static-v4 1.8.67
@@ -264,10 +267,10 @@ grep -q 'healthz_version=v1.8.67 recommended_binary_version=1.8.67 publication_p
   "$work/previous-healthz-and-recommended.out"
 
 make_fixture "$work/too-old-prepublication-healthz" v1.8.68 v1.8.66 2026-07-30T12:00:00Z 2026-07-30T12:00:00Z streamvc-autotune-static-v4 1.8.67
-if run_guard_phase "$work/too-old-prepublication-healthz" pre-publication >"$work/too-old-prepublication-healthz.out" 2>&1; then
-  fail "pre-publication gate accepted a coordinator older than the previous stable version"
+if ! run_guard_phase "$work/too-old-prepublication-healthz" pre-publication >"$work/too-old-prepublication-healthz.out" 2>&1; then
+  fail "pre-publication gate rejected a Pearl runtime older than the previous advertised CLI"
 fi
-grep -q "/healthz version 'v1.8.66' is older than previous stable 1.8.67" \
+grep -q 'healthz_version=v1.8.66 recommended_binary_version=1.8.67 publication_phase=pre-publication' \
   "$work/too-old-prepublication-healthz.out"
 
 make_fixture "$work/pearl-runtime-ahead" v1.8.68 v1.8.67 2026-07-30T12:00:00Z 2026-07-30T12:00:00Z streamvc-autotune-static-v4 1.8.66
@@ -282,8 +285,35 @@ if run_guard_phase "$work/pearl-runtime-ahead-wrong-recommendation" pre-publicat
   >"$work/pearl-runtime-ahead-wrong-recommendation.out" 2>&1; then
   fail "pre-publication gate accepted a Pearl-ahead healthz that also moved the advertised CLI"
 fi
-grep -q "/healthz recommended_binary_version '1.8.67' does not match expected previous stable 1.8.66" \
+grep -q "/healthz recommended_binary_version '1.8.67' does not match expected pre-publication recommendation 1.8.66" \
   "$work/pearl-runtime-ahead-wrong-recommendation.out"
+
+# Non-staged pre-publication: if --expected-previous-recommendation is omitted,
+# the CLI pin is the candidate/release version. Pearl runtime may still be
+# older than that candidate.
+make_fixture "$work/unstaged-older-runtime" v1.8.68 v1.8.66 2026-07-30T12:00:00Z 2026-07-30T12:00:00Z streamvc-autotune-static-v4 1.8.68
+if ! run_guard_phase "$work/unstaged-older-runtime" pre-publication __omit__ \
+  >"$work/unstaged-older-runtime.out" 2>&1; then
+  fail "non-staged pre-publication rejected an older Pearl runtime advertising the candidate"
+fi
+grep -q 'healthz_version=v1.8.66 recommended_binary_version=1.8.68 publication_phase=pre-publication' \
+  "$work/unstaged-older-runtime.out"
+
+make_fixture "$work/unstaged-missing-recommended" v1.8.68 v1.8.68 2026-07-30T12:00:00Z 2026-07-30T12:00:00Z streamvc-autotune-static-v4 __absent__
+if run_guard_phase "$work/unstaged-missing-recommended" pre-publication __omit__ \
+  >"$work/unstaged-missing-recommended.out" 2>&1; then
+  fail "non-staged pre-publication accepted a coordinator without recommended_binary_version"
+fi
+grep -q 'recommended_binary_version is missing or not the expected pre-publication recommendation' \
+  "$work/unstaged-missing-recommended.out"
+
+make_fixture "$work/unstaged-stale-recommended" v1.8.68 v1.8.69 2026-07-30T12:00:00Z 2026-07-30T12:00:00Z streamvc-autotune-static-v4 1.8.67
+if run_guard_phase "$work/unstaged-stale-recommended" pre-publication __omit__ \
+  >"$work/unstaged-stale-recommended.out" 2>&1; then
+  fail "non-staged pre-publication accepted a coordinator that still advertised the previous CLI"
+fi
+grep -q "/healthz recommended_binary_version '1.8.67' does not match expected pre-publication recommendation 1.8.68" \
+  "$work/unstaged-stale-recommended.out"
 
 make_fixture "$work/malformed-recommended" v1.8.68 v1.8.68 2026-07-30T12:00:00Z 2026-07-30T12:00:00Z streamvc-autotune-static-v4 latest
 if run_guard "$work/malformed-recommended" >"$work/malformed-recommended.out" 2>&1; then
@@ -556,7 +586,7 @@ def require_stable_gate(
         "--openssl \"$OPENSSL_BIN\"",
         "scripts/release-staged-version-policy.sh",
         "prepublication_recommendation_args",
-        "--expected-previous-recommendation \"$MACPROVIDER_RELEASE_PREVIOUS_STABLE_VERSION\"",
+        "--expected-previous-recommendation \"$MACPROVIDER_RELEASE_COORDINATOR_RECOMMENDATION\"",
         "env -u GH_TOKEN -u RELEASE_POSTURE_TOKEN",
     ):
         if required not in publish[pre_gate_label:]:

--- a/scripts/verify-live-coordinator-release-gate.py
+++ b/scripts/verify-live-coordinator-release-gate.py
@@ -311,14 +311,18 @@ def main() -> int:
         choices=("pre-publication", "post-publication"),
         default="post-publication",
         help=(
-            "pre-publication verifies release-bound feed bytes without requiring "
-            "the live recommendation; post-publication requires exact recommendation "
-            "equality (default)"
+            "pre-publication verifies release-bound feed bytes and that Pearl still "
+            "advertises the expected CLI pin; post-publication requires exact "
+            "recommendation equality with the published release (default)"
         ),
     )
     parser.add_argument(
         "--expected-previous-recommendation",
-        help="pre-publication recommendation that must remain live until publication",
+        help=(
+            "CLI version Pearl must advertise during pre-publication. Staged "
+            "releases pass the previous stable; non-staged releases pass the "
+            "candidate. If omitted, the gate requires the candidate/release version."
+        ),
     )
     parser.add_argument(
         "--now",
@@ -392,88 +396,49 @@ def main() -> int:
             fail("/healthz response is not a JSON object")
         if healthz.get("status") != "ok":
             fail(f"/healthz status is {healthz.get('status')!r}, expected 'ok'")
-        live_version = parse_semver(healthz.get("version"), "/healthz version")
+        # /healthz "version" is the Pearl-runtime coordinator's own binary.
+        # Coordinator and provider CLI share the vX.Y.Z tag space but ship on
+        # independent cadences, so this value is identity only — never compared
+        # to a CLI release or previous-stable pin.
+        parse_semver(healthz.get("version"), "/healthz version")
         required_version = parse_semver(expected_version, "release version")
-        # Pre-publication /healthz may already be at or above the candidate
-        # (Pearl deployed first). The branch below only constrains the case
-        # where Pearl is still older than the CLI being published.
-        if live_version < required_version:
-            # /healthz "version" is the Pearl-runtime coordinator's OWN binary
-            # version. The coordinator and the provider CLI share the vX.Y.Z tag
-            # space but ship on independent cadences, so the coordinator may
-            # legitimately be older than the CLI release it advertises. Post-
-            # publication correctness is enforced by the
-            # recommended_binary_version == release check below (the coordinator
-            # must advertise the released CLI), NOT by the coordinator's own
-            # binary version. Pre-publication still guards against a coordinator
-            # that has regressed below the previously-advertised stable.
-            if args.publication_phase == "pre-publication":
-                previous_version = None
-                if args.expected_previous_recommendation is not None:
-                    previous_version = parse_advertised_version(
-                        args.expected_previous_recommendation,
-                        "expected previous recommendation",
-                    )
-                if previous_version is None:
-                    fail(
-                        f"/healthz version {healthz.get('version')!r} is older than "
-                        f"release {expected_version}"
-                    )
-                if live_version < previous_version:
-                    fail(
-                        f"/healthz version {healthz.get('version')!r} is older than "
-                        f"previous stable {args.expected_previous_recommendation}"
-                    )
-                # previous_version <= live_version < required_version is allowed:
-                # Pearl runtime-only patches may advance /healthz without moving
-                # the advertised CLI recommendation.
-            # post-publication: the coordinator's binary version is decoupled
-            # from the CLI release version; the recommended_binary_version ==
-            # release check below is authoritative.
         recommended_value = healthz.get("recommended_binary_version")
-        if (
-            args.publication_phase == "pre-publication"
-            and args.expected_previous_recommendation is not None
-            and recommended_value is None
-        ):
-            fail("/healthz recommended_binary_version is missing or not the expected previous stable version")
-        if recommended_value is None and args.publication_phase == "post-publication":
+        expected_recommendation = args.expected_previous_recommendation
+        if args.publication_phase == "pre-publication":
+            if expected_recommendation is None:
+                expected_recommendation = expected_version
+            if recommended_value is None:
+                fail(
+                    "/healthz recommended_binary_version is missing or not the "
+                    "expected pre-publication recommendation"
+                )
+        elif recommended_value is None:
             fail("/healthz recommended_binary_version is missing or not a version string")
-        if recommended_value is not None:
-            recommended_version = parse_advertised_version(
-                recommended_value,
-                "/healthz recommended_binary_version",
+        recommended_version = parse_advertised_version(
+            recommended_value,
+            "/healthz recommended_binary_version",
+        )
+        if args.publication_phase == "post-publication" and (
+            recommended_version != required_version
+            or recommended_value != expected_version
+        ):
+            fail(
+                f"/healthz recommended_binary_version {recommended_value!r} "
+                f"does not match release {expected_version}"
             )
-            if (
-                args.publication_phase == "post-publication"
-                and (
-                    recommended_version != required_version
-                    or recommended_value != expected_version
-                )
-            ):
-                fail(
-                    f"/healthz recommended_binary_version {recommended_value!r} "
-                    f"does not match release {expected_version}"
-                )
-            if (
-                args.publication_phase == "pre-publication"
-                and args.expected_previous_recommendation is not None
-                and (
-                    recommended_value != args.expected_previous_recommendation
-                    or recommended_version
-                    != parse_advertised_version(
-                        args.expected_previous_recommendation,
-                        "expected previous recommendation",
-                    )
-                )
-            ):
-                fail(
-                    f"/healthz recommended_binary_version {recommended_value!r} "
-                    f"does not match expected previous stable "
-                    f"{args.expected_previous_recommendation}"
-                )
-        else:
-            recommended_value = "<not advertised>"
+        if args.publication_phase == "pre-publication" and (
+            recommended_value != expected_recommendation
+            or recommended_version
+            != parse_advertised_version(
+                expected_recommendation,
+                "expected pre-publication recommendation",
+            )
+        ):
+            fail(
+                f"/healthz recommended_binary_version {recommended_value!r} "
+                f"does not match expected pre-publication recommendation "
+                f"{expected_recommendation}"
+            )
 
         print(
             "[verify-live-coordinator-release-gate] ok: "


### PR DESCRIPTION
## What

#1419 decoupled **post-publication** `/healthz.version` from provider-CLI tags. **Pre-publication** still mixed Pearl runtime identity with advertised CLI semver:

- staged: fail if `/healthz.version` < previous advertised CLI (`v1.8.119` vs `1.8.121` blocked v1.8.122 promote)
- non-staged: fail if `/healthz.version` < the candidate, and `recommended_binary_version` was optional

## Fix

Pre-publication treats `/healthz.version` as Pearl runtime identity only (still parsed as `vX.Y.Z`). CLI advertisement is `recommended_binary_version` against the checked-in coordinator recommendation (`MACPROVIDER_RELEASE_COORDINATOR_RECOMMENDATION`: previous stable while staged, candidate when already matching). Missing recommendation now fails closed in both staged and non-staged pre-publication.

## Verification
- `/bin/bash scripts/test-live-coordinator-release-gate.sh` → PASS (macOS Bash 3.2.57)
- `bash scripts/test-acceptance-promotion.sh` → PASS
- 3-lane Codex audit (code / security / architecture) → 0 CRITICAL / 0 HIGH / 0 MEDIUM. Carried LOW: flag name `--expected-previous-recommendation` now also means the non-staged candidate pin.

<!-- SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R001"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": ["scripts/test-live-coordinator-release-gate.sh", "scripts/test-acceptance-promotion.sh"],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END -->

Made with [Cursor](https://cursor.com)