### PR TITLE
ops(coordinator): bump live latest_binary_version 1.8.121->1.8.122

### DIFF
--- a/phase4-coordinator/coordinator.yaml.example
+++ b/phase4-coordinator/coordinator.yaml.example
@@ -189,7 +189,7 @@ autotune:
 # legacy cohort (DECISION_CRITERIA Entry 161). `required_binary_version` is a
 # hard admission floor, not an autoupdate target, and is unaffected by the gate.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.121"
+  latest_binary_version: "1.8.122"
   required_binary_version: ""
 
 auth:

--- a/phase4-coordinator/dist/coordinator.yaml
+++ b/phase4-coordinator/dist/coordinator.yaml
@@ -389,5 +389,5 @@ providers:
 # reconnecting and tells its operator to upgrade, and one without it
 # reconnect-loops.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.121"
+  latest_binary_version: "1.8.122"
   required_binary_version: "1.8.33"

--- a/phase4-coordinator/dist/coordinator.yaml.example
+++ b/phase4-coordinator/dist/coordinator.yaml.example
@@ -422,7 +422,7 @@ malibu_emission:
 # routing. Keys match model_id case-insensitively; values must be bare
 # numeric versions or the coordinator refuses to start.
 coordinator_advertised_version:
-  latest_binary_version: "1.8.121"
+  latest_binary_version: "1.8.122"
   # required_binary_version: "1.7.0"
   # per_model_required_binary_version:
   #   "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit": "1.8.60"


### PR DESCRIPTION
## What

Bump checked-in coordinator latest_binary_version 1.8.121 to 1.8.122 in:
- phase4-coordinator/dist/coordinator.yaml
- phase4-coordinator/coordinator.yaml.example
- phase4-coordinator/dist/coordinator.yaml.example

required_binary_version is unchanged.

## Why

v1.8.122 is public immutable and live Pearl already advertises 1.8.122. Git must match live (same class as #1406 / #1427) so the next staged CLI cut derives the correct previous-stable pin.

## Tests
- bash scripts/release-staged-version-policy.sh v1.8.122
- bash scripts/test-coordinator-advertised-version-test.sh
- 3-lane Codex audit: 0 CRITICAL / 0 HIGH / 0 MEDIUM

<!-- SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R001"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": ["scripts/test-coordinator-advertised-version-test.sh", "scripts/release-staged-version-policy.sh"],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END -->
