### PR TITLE
Revoke SPEC-047 admissions on heartbeat model drift

### DIFF
--- a/phase4-coordinator/internal/ws/model_admission.go
+++ b/phase4-coordinator/internal/ws/model_admission.go
@@ -59,6 +59,7 @@ type ModelAdmissionStore interface {
 	AppendModelAdmissionDecision(context.Context, ModelAdmissionEvent) (ModelAdmissionEvent, error)
 	LatestModelAdmissionStatus(context.Context, string, string) (ModelAdmissionEvent, bool, error)
 	LatestModelAdmissionRouteStatus(context.Context, string, string, string) (ModelAdmissionEvent, bool, error)
+	SettlementCapableModelAdmissionStatusesForServedModel(context.Context, string, string) ([]ModelAdmissionEvent, error)
 }
 
 type ModelAdmissionEvent struct {
@@ -270,6 +271,30 @@ func (s *memoryModelAdmissionStore) LatestModelAdmissionRouteStatus(_ context.Co
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return latestModelAdmissionRouteStatusFromEvents(s.events, providerID, servedModelRef, catalogModelKey)
+}
+
+func (s *memoryModelAdmissionStore) SettlementCapableModelAdmissionStatusesForServedModel(_ context.Context, providerID, servedModelRef string) ([]ModelAdmissionEvent, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	servedModelRef = strings.TrimSpace(servedModelRef)
+	seen := map[string]struct{}{}
+	events := make([]ModelAdmissionEvent, 0)
+	for i := len(s.events) - 1; i >= 0; i-- {
+		event := s.events[i]
+		if event.ProviderID != providerID || event.ServedModelRef != servedModelRef {
+			continue
+		}
+		key := event.ProviderID + "|" + event.CandidateID
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		latest := s.latest[key]
+		if ModelAdmissionSettlementStateCandidate(latest) {
+			events = append(events, latest)
+		}
+	}
+	return events, nil
 }
 
 type SQLiteModelAdmissionStore struct {
@@ -692,6 +717,38 @@ func (s *SQLiteModelAdmissionStore) LatestModelAdmissionRouteStatus(ctx context.
  LIMIT 1`), providerID, servedModelRef, catalogModelKey)
 }
 
+func (s *SQLiteModelAdmissionStore) SettlementCapableModelAdmissionStatusesForServedModel(ctx context.Context, providerID, servedModelRef string) ([]ModelAdmissionEvent, error) {
+	servedModelRef = strings.TrimSpace(servedModelRef)
+	rows, err := s.db.QueryContext(ctx, modelAdmissionEventSelect(`
+  FROM model_admission_events e
+  JOIN (
+       SELECT MAX(id) AS latest_id
+         FROM model_admission_events
+        WHERE provider_id = ? AND served_model_ref = ?
+        GROUP BY provider_id, candidate_id
+  ) latest ON latest.latest_id = e.id
+ WHERE e.state = 'settlement_capable'
+ ORDER BY e.id DESC`), providerID, servedModelRef)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var events []ModelAdmissionEvent
+	for rows.Next() {
+		event, err := scanModelAdmissionEventRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		if ModelAdmissionSettlementStateCandidate(event) {
+			events = append(events, event)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return events, nil
+}
+
 // latestModelAdmissionRouteStatusFromEvents mirrors the SQLite store's
 // `ORDER BY id DESC LIMIT 1` route-status semantics: it walks the append-ordered
 // event log from newest to oldest and returns the LAST-APPENDED event matching
@@ -723,10 +780,25 @@ type modelAdmissionQueryer interface {
 	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
+type modelAdmissionScanner interface {
+	Scan(...any) error
+}
+
 func scanModelAdmissionEvent(ctx context.Context, q modelAdmissionQueryer, query string, args ...any) (ModelAdmissionEvent, bool, error) {
+	event, err := scanModelAdmissionEventRow(q.QueryRowContext(ctx, query, args...))
+	if err == sql.ErrNoRows {
+		return ModelAdmissionEvent{}, false, nil
+	}
+	if err != nil {
+		return ModelAdmissionEvent{}, false, err
+	}
+	return event, true, nil
+}
+
+func scanModelAdmissionEventRow(row modelAdmissionScanner) (ModelAdmissionEvent, error) {
 	var event ModelAdmissionEvent
 	var createdAt string
-	err := q.QueryRowContext(ctx, query, args...).Scan(
+	err := row.Scan(
 		&event.CoordinatorEventID,
 		&event.Actor,
 		&event.ProviderID,
@@ -752,18 +824,15 @@ func scanModelAdmissionEvent(ctx context.Context, q modelAdmissionQueryer, query
 		&event.SignatureDigestSHA256,
 		&createdAt,
 	)
-	if err == sql.ErrNoRows {
-		return ModelAdmissionEvent{}, false, nil
-	}
 	if err != nil {
-		return ModelAdmissionEvent{}, false, err
+		return ModelAdmissionEvent{}, err
 	}
 	parsed, err := time.Parse(time.RFC3339Nano, createdAt)
 	if err != nil {
-		return ModelAdmissionEvent{}, false, err
+		return ModelAdmissionEvent{}, err
 	}
 	event.CreatedAt = parsed.UTC()
-	return event, true, nil
+	return event, nil
 }
 
 func modelAdmissionEventSelect(tail string) string {

--- a/phase4-coordinator/internal/ws/model_admission_test.go
+++ b/phase4-coordinator/internal/ws/model_admission_test.go
@@ -1206,6 +1206,52 @@ func TestModelAdmissionRouteStatusUsesAppendOrderAcrossStores(t *testing.T) {
 	})
 }
 
+func TestModelAdmissionSettlementCapableRouteSetIgnoresShadowingNonSettlementCandidates(t *testing.T) {
+	run := func(t *testing.T, store providerws.ModelAdmissionStore) {
+		catalogPriced, _ := modelAdmissionDecisionLifecycle(t, store, "shd")
+		settlement, found, err := store.LatestModelAdmissionStatus(context.Background(), catalogPriced.ProviderID, catalogPriced.CandidateID)
+		if err != nil || !found || settlement.State != "settlement_capable" {
+			t.Fatalf("latest settlement found=%v state=%q err=%v", found, settlement.State, err)
+		}
+		shadow := settlement
+		shadow.CandidateID = stableModelAdmissionCandidateID("t")
+		shadow.State = "offer_submitted"
+		shadow.RequestID = "request_shadow_shd"
+		shadow.Nonce = "nonce_shadow_shd"
+		shadow.PayloadDigestSHA256 = stringsOf("6", 64)
+		shadow.SignatureDigestSHA256 = stringsOf("7", 64)
+		shadow.CreatedAt = time.Unix(1800000050, 0).UTC()
+		if _, replay, err := store.AppendModelAdmissionOffer(context.Background(), shadow); err != nil || replay {
+			t.Fatalf("append shadow offer replay=%v err=%v", replay, err)
+		}
+
+		events, err := store.SettlementCapableModelAdmissionStatusesForServedModel(context.Background(), settlement.ProviderID, settlement.ServedModelRef)
+		if err != nil {
+			t.Fatalf("settlement-capable route set: %v", err)
+		}
+		if len(events) != 1 {
+			t.Fatalf("settlement-capable route set len=%d want 1: %+v", len(events), events)
+		}
+		if events[0].CandidateID != settlement.CandidateID || events[0].State != "settlement_capable" {
+			t.Fatalf("settlement-capable route set event = %+v", events[0])
+		}
+	}
+
+	t.Run("memory", func(t *testing.T) { run(t, providerws.NewMemoryModelAdmissionStore()) })
+	t.Run("sqlite", func(t *testing.T) {
+		db, err := auth.OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+		store, err := providerws.NewSQLiteModelAdmissionStore(db.DB())
+		if err != nil {
+			t.Fatal(err)
+		}
+		run(t, store)
+	})
+}
+
 func TestSQLiteModelAdmissionStorePersistsRouteStatusLookup(t *testing.T) {
 	db, err := auth.OpenStore(filepath.Join(t.TempDir(), "coordinator.db"))
 	if err != nil {

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -53,11 +53,12 @@ const (
 )
 
 const (
-	autotuneEvidenceLookupTimeout       = 2 * time.Second
-	admissionCeilingEventCooldown       = 5 * time.Minute
-	admissionCeilingEventStateTTL       = 24 * time.Hour
-	admissionCeilingEventStateMaxKeys   = 4096
-	admissionCeilingDiagnosticValueRune = 48
+	autotuneEvidenceLookupTimeout          = 2 * time.Second
+	modelAdmissionRuntimeRevocationTimeout = 2 * time.Second
+	admissionCeilingEventCooldown          = 5 * time.Minute
+	admissionCeilingEventStateTTL          = 24 * time.Hour
+	admissionCeilingEventStateMaxKeys      = 4096
+	admissionCeilingDiagnosticValueRune    = 48
 )
 
 type admissionCeilingEventRateState struct {
@@ -5131,6 +5132,7 @@ func (s *Server) handleHeartbeat(conn net.Conn, providerID, assignedID string, p
 	}
 	if heartbeatResult.ModelIDChanged {
 		s.observeAdmissionCeilingDrift(*entry, heartbeatResult.PriorModelID)
+		s.revokeSettlementAdmissionForHeartbeatModelDrift(*entry, heartbeatResult.PriorModelID)
 	}
 	s.applyAdmissionCeilingRouteExclusion(entry, "heartbeat")
 	s.rememberProviderSnapshotCoalesced(*entry)
@@ -5187,6 +5189,63 @@ func (s *Server) handleHeartbeat(conn net.Conn, providerID, assignedID string, p
 		// telemetry_drift.quarantine_missing_benchmark are set, in which case
 		// the verdict is Unknown and routing is untouched.
 		s.applyBenchmarkQuarantine(providerID, assignedID, entry.ModelID, verdict, telemetryGeneration)
+	}
+}
+
+func (s *Server) revokeSettlementAdmissionForHeartbeatModelDrift(provider pool.Provider, priorModelID string) {
+	if s == nil || s.modelAdmissions == nil {
+		return
+	}
+	priorModelID = strings.TrimSpace(priorModelID)
+	currentModelID := strings.TrimSpace(provider.ModelID)
+	if priorModelID == "" || currentModelID == "" || strings.EqualFold(priorModelID, currentModelID) {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), modelAdmissionRuntimeRevocationTimeout)
+	defer cancel()
+	currentAdmissions, err := s.modelAdmissions.SettlementCapableModelAdmissionStatusesForServedModel(ctx, provider.ProviderID, priorModelID)
+	if err != nil {
+		s.log.Warn().
+			Err(err).
+			Str("provider_id", provider.ProviderID).
+			Str("prior_model_id", priorModelID).
+			Msg("model admission runtime-drift lookup failed")
+		return
+	}
+	for _, current := range currentAdmissions {
+		revocation, drifted := ModelAdmissionRevocationForRuntimeDrift(current, ModelAdmissionPaidRoutingPredicate{
+			ProviderID:                        current.ProviderID,
+			CandidateID:                       current.CandidateID,
+			ServedModelRef:                    currentModelID,
+			CatalogModelKey:                   current.CatalogModelKey,
+			DiscoveryDigestSHA256:             current.DiscoveryDigestSHA256,
+			EvaluationDigestSHA256:            current.EvaluationDigestSHA256,
+			CatalogID:                         current.CatalogID,
+			CatalogBodyDigest:                 current.CatalogBodyDigest,
+			CatalogSignatureKeyID:             current.CatalogSignatureKeyID,
+			CatalogSignaturePubkeyFingerprint: current.CatalogSignaturePubkeyFingerprint,
+			ExpectedCatalogModelHash:          current.ExpectedCatalogModelHash,
+			ExpectedCatalogModelHashAlgorithm: current.ExpectedCatalogModelHashAlgorithm,
+		}, "runtime_identity_drift", s.now())
+		if !drifted {
+			continue
+		}
+		if _, err := s.modelAdmissions.AppendModelAdmissionDecision(ctx, revocation); err != nil {
+			s.log.Warn().
+				Err(err).
+				Str("provider_id", provider.ProviderID).
+				Str("candidate_id", current.CandidateID).
+				Str("prior_model_id", priorModelID).
+				Str("current_model_id", currentModelID).
+				Msg("model admission runtime-drift revocation failed")
+			continue
+		}
+		s.log.Warn().
+			Str("provider_id", provider.ProviderID).
+			Str("candidate_id", current.CandidateID).
+			Str("prior_model_id", priorModelID).
+			Str("current_model_id", currentModelID).
+			Msg("model admission revoked after heartbeat model drift")
 	}
 }
 

--- a/phase4-coordinator/internal/ws/server_test.go
+++ b/phase4-coordinator/internal/ws/server_test.go
@@ -1403,6 +1403,92 @@ func TestWarmupProbeTimeoutLeavesProviderRoutable(t *testing.T) {
 	})
 }
 
+func TestHeartbeatModelDriftRevokesSettlementCapableModelAdmission(t *testing.T) {
+	store := providerws.NewMemoryModelAdmissionStore()
+	priorModelID := validHello("m4-anon")["model_id"].(string)
+	offer := providerws.ModelAdmissionEvent{
+		ProviderID:               "m4-anon",
+		CandidateID:              stableModelAdmissionCandidateID("h"),
+		ServedModelRef:           priorModelID,
+		CatalogModelKey:          "qwen2-5-7b",
+		DiscoveryDigestSHA256:    stringsOf("a", 64),
+		EvaluationDigestSHA256:   stringsOf("b", 64),
+		RequestedDisclosureClass: "catalog_binding_requested",
+		ReasonCode:               "provider_offer_submitted",
+		RequestID:                "request_offer_heartbeat_model_drift",
+		Nonce:                    "nonce_offer_heartbeat_model_drift",
+		PayloadDigestSHA256:      stringsOf("c", 64),
+		SignatureDigestSHA256:    stringsOf("d", 64),
+		CreatedAt:                time.Unix(1800000020, 0).UTC(),
+	}
+	submitted, replay, err := store.AppendModelAdmissionOffer(context.Background(), offer)
+	if err != nil || replay {
+		t.Fatalf("append offer replay=%v err=%v", replay, err)
+	}
+	catalogPriced := withTrustedCatalogDecisionFields(submitted)
+	catalogPriced.State = "catalog_priced"
+	catalogPriced.ReasonCode = ""
+	catalogPriced.RequestID = "request_catalog_heartbeat_model_drift"
+	catalogPriced.Nonce = "nonce_catalog_heartbeat_model_drift"
+	catalogPriced.PayloadDigestSHA256 = stringsOf("e", 64)
+	catalogPriced.CreatedAt = time.Unix(1800000030, 0).UTC()
+	catalogPriced, err = store.AppendModelAdmissionDecision(context.Background(), catalogPriced)
+	if err != nil {
+		t.Fatalf("append catalog_priced: %v", err)
+	}
+	settlement := catalogPriced
+	settlement.State = "settlement_capable"
+	settlement.RequestID = "request_settlement_heartbeat_model_drift"
+	settlement.Nonce = "nonce_settlement_heartbeat_model_drift"
+	settlement.PayloadDigestSHA256 = stringsOf("f", 64)
+	settlement.CreatedAt = time.Unix(1800000040, 0).UTC()
+	if _, err := store.AppendModelAdmissionDecision(context.Background(), settlement); err != nil {
+		t.Fatalf("append settlement_capable: %v", err)
+	}
+	shadow := offer
+	shadow.CandidateID = stableModelAdmissionCandidateID("i")
+	shadow.RequestID = "request_shadow_heartbeat_model_drift"
+	shadow.Nonce = "nonce_shadow_heartbeat_model_drift"
+	shadow.PayloadDigestSHA256 = stringsOf("9", 64)
+	shadow.CreatedAt = time.Unix(1800000050, 0).UTC()
+	if _, replay, err := store.AppendModelAdmissionOffer(context.Background(), shadow); err != nil || replay {
+		t.Fatalf("append shadow offer replay=%v err=%v", replay, err)
+	}
+
+	h := newProviderHarnessWithServerOptions(t, nil, []providerws.Option{
+		providerws.WithModelAdmissionStore(store),
+	})
+	defer h.HTTP.Close()
+	conn, _, _, err := gobwas.Dial(context.Background(), wsURL(h.HTTP.URL))
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	assignedID := assertHelloAck(t, conn)
+
+	hb := heartbeat()
+	hb["model_id"] = "mlx-community/Qwen3-8B-Instruct-4bit"
+	if err := wsutil.WriteClientText(conn, mustJSON(hb)); err != nil {
+		t.Fatalf("write heartbeat: %v", err)
+	}
+	eventually(t, func() bool {
+		provider, ok := h.Registry.Resolve("m4-anon", assignedID)
+		if !ok || provider.ModelID != hb["model_id"] {
+			return false
+		}
+		latest, found, err := store.LatestModelAdmissionStatus(context.Background(), offer.ProviderID, offer.CandidateID)
+		return err == nil &&
+			found &&
+			latest.State == "revoked" &&
+			latest.PreviousState == "settlement_capable" &&
+			latest.ReasonCode == "runtime_identity_drift"
+	})
+	shadowLatest, found, err := store.LatestModelAdmissionStatus(context.Background(), shadow.ProviderID, shadow.CandidateID)
+	if err != nil || !found || shadowLatest.State != "offer_submitted" {
+		t.Fatalf("shadow candidate latest found=%v state=%q err=%v", found, shadowLatest.State, err)
+	}
+}
+
 // #1354: a zero-token completion records a negative fitness verdict but must not
 // change routing state (replaces TestWarmupGateRejectsZeroTokenCompletion).
 func TestWarmupProbeZeroTokenLeavesProviderRoutable(t *testing.T) {


### PR DESCRIPTION
## Summary

Connect SPEC-047 runtime model drift to the existing model-admission revocation state machine. When an authenticated provider heartbeat changes `model_id`, the coordinator now finds every latest per-candidate `settlement_capable` admission for the prior served model and appends coordinator `revoked` events with `runtime_identity_drift`.

## Behavior fixed

- Heartbeat-observed model changes now make previously settlement-capable BYOM admissions visibly revoked instead of leaving stale provider-facing settlement status.
- Revocation is scoped to latest per-candidate settlement-capable rows for the prior served model, so newer non-settlement candidates cannot shadow older settlement-capable candidates.
- Pending, withdrawn, revoked, and otherwise non-settlement candidates are not promoted or rewritten.
- No provider-authored admission binding fields were added; this remains coordinator-derived and revocation-only.

## Tests

- `go test ./internal/ws -run 'TestHeartbeatModelDriftRevokesSettlementCapableModelAdmission|TestModelAdmissionSettlementCapableRouteSetIgnoresShadowingNonSettlementCandidates|TestModelAdmissionRuntimeDriftRevocationRequiresSettlementState' -count=1`
- `go test ./internal/ws -count=1`
- `go test ./internal/buyer -run 'Test.*ModelAdmission|Test.*BYOM|Test.*RouteSnapshot' -count=1`
- `go vet ./internal/ws`
- `go test ./... -count=1` from `phase4-coordinator`
- `git diff --check`

## Review lanes

Astra review gate passed after the shadowing fix:

- Code review: 0 Critical / High / Medium / Low findings
- Security review: 0 Critical / High / Medium / Low findings
- Architecture/spec-boundary review: 0 Critical / High / Medium / Low findings

## Known gaps

- This does not implement provider-side BYOM discovery/evaluation or provider-side relay crypto.
- This does not capture or promote signed journey evidence.
- Runtime hash/adapter drift beyond heartbeat `model_id` changes remains separate SPEC-047 follow-up work.
- Live production SQLite contention under heartbeat storms and separate-process restart replay were not tested.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-047"],
  "requirements": ["SPEC-047-R006"],
  "authority_domains": ["network-model-admission"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "go test ./internal/ws -run 'TestHeartbeatModelDriftRevokesSettlementCapableModelAdmission|TestModelAdmissionSettlementCapableRouteSetIgnoresShadowingNonSettlementCandidates|TestModelAdmissionRuntimeDriftRevocationRequiresSettlementState' -count=1",
    "go test ./internal/ws -count=1",
    "go test ./internal/buyer -run 'Test.*ModelAdmission|Test.*BYOM|Test.*RouteSnapshot' -count=1",
    "go vet ./internal/ws",
    "go test ./... -count=1 from phase4-coordinator",
    "git diff --check"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END
