### PR TITLE
Fix security audit F01-F03: admission, receipt authority, and OAuth custody

### DIFF
--- a/audits/security-high-fixes-2026-09-08.md
+++ b/audits/security-high-fixes-2026-09-08.md
@@ -96,6 +96,14 @@ High or Medium findings. Review-discovered observe outage recovery, retry
 starvation, incomplete snapshot scope and unlogged-current scope gaps were fixed
 and re-reviewed. The LOW drain-bound note and test limitations below remain.
 
+## PR Publication Follow-Up
+
+PR #1431 rebased the fix onto `58fcd226078438d4c10fa5204496812f9f0f53a7`
+without changing its patch bytes. CI correctly rejected stale historical selector
+evidence for SPEC-006-R003, SPEC-022-R005 and SPEC-022-R008. These mappings are
+demoted to pending, retaining historical evidence; issue #1433 tracks a separately
+authorized evidence refresh before re-promotion. No signed journey was created.
+
 ## Rollout and Residual Risks
 
 - Deploy the coordinator completeness signal first; older coordinator responses

--- a/audits/security-high-fixes-2026-09-08.md
+++ b/audits/security-high-fixes-2026-09-08.md
@@ -1,0 +1,120 @@
+# Security High Findings: Implementation Verification
+
+Base: `b63ccb465fa9ae6fab2084e45e703103efe40a9e` (fetched `origin/main`).
+Branch: `codex/security-high-fixes-2026-09-08`.
+Scope: F01-F04 from the 2026-09-07 security boundary audit. This record captures
+implementation verification before PR publication. No deployment, production
+credentials, or signed journey operation was performed.
+
+## Changes
+
+- F01: reject duplicate and case-colliding schema-owned JSON fields before
+  translation, reservation, or dispatch; preserve extension and user schemas.
+- F02: retain coordinator receipt authority despite missing trailers or facade
+  validation errors. Persist generation-bound local usage for observe recovery;
+  require complete request-scoped mode authority, including current-attempt
+  membership and snapshot/verdict coverage. Persist fair retry order across
+  gateway restarts. An initial coordinator attempt ID, persisted with the
+  candidate, fences the lookup and must be echoed after membership validation;
+  an earlier logged retry cannot substitute for a current unlogged attempt.
+- F03: exchange a hashed, single-use issuance intent for an in-memory API key;
+  transactionally store only the key hash and consume the intent. Schema 12
+  invalidates legacy plaintext handoffs and stores settlement recovery state.
+- F04: production fix already merged as
+  `fc32dad7bfe80320e2203e3090fa2a71e620d579`. Added streaming/nonstreaming
+  pre-dispatch release regressions. No production Swift change was needed.
+
+## Verification
+
+Commands run from the named package in this worktree unless otherwise stated.
+
+| Package | Command | Result |
+| --- | --- | --- |
+| Gateway | `go test -race -count=1 -timeout 5m ./...` | Exit 0; router 122.092s, SQLite 18.903s; all packages passed before final headerless-hold compatibility tightening |
+| Gateway | `go test -count=1 -timeout 5m ./...` | Final source: exit 0; router 29.894s, SQLite 3.378s; all packages passed |
+| Gateway | `go vet ./...` | Exit 0 |
+| Coordinator | `go test -count=1 -timeout 3m ./internal/billing ./internal/buyer` | Exit 0; billing 12.548s, buyer 9.144s |
+| Coordinator | `go vet ./internal/billing ./internal/buyer` | Exit 0 |
+| Swift | `swift test --scratch-path /tmp/macprovider-security-high-fixes-20260908-cli-swift-build --disable-automatic-resolution --filter ConsumeCommandTests` | 127 tests passed, zero failures |
+| Worktree | `git diff --check` | Exit 0 |
+
+Final recovery/scheduling additions also passed:
+`go test ./internal/storage/sqlite ./internal/router -run 'TestSettlementFallback|TestObserveFallback|TestSPEC022GatewaySettlementReconcile|TestWalletSessionSettlementReconcile|TestSecurity' -race -count=1`
+(SQLite 2.215s, router 14.199s). This includes 101 unavailable candidates with a
+batch limit of 100, later observe/enforce holds, a fixed clock and two database
+reopens, plus monotonic/generation-bound retry markers and wallet local usage.
+Current-attempt identity survives restart and wallet recovery; absent or wrong
+echoes cannot authorize observe/enforce debit or refund.
+Headerless candidates retain an immutable empty binding across restart and do
+not enter an unbound lookup or debit path, even if a prior enforce result exists.
+
+Coordinator focused race command (exit 0, 5.490s):
+
+```sh
+go test -race -count=1 -timeout 3m ./internal/billing -run '^(TestRequestSettlementFinality|TestAggregateExternalRequestFinality|TestSPEC022NonStreamingVerifiedReceiptCreatesBuyerFinalityAndProviderPayout|TestSPEC022StreamingVerifiedReceiptCreatesBuyerFinalityAndProviderPayout)'
+```
+
+Final coordinator current-attempt binding race command (exit 0; billing 2.097s,
+buyer 1.873s):
+
+```sh
+go test -race -count=1 -timeout 2m ./internal/billing ./internal/buyer -run '^(TestRequestSettlementFinalityBound|TestSettlementInternalRequestHeaderIsCoordinatorOwnedBeforeStreamEOF|TestSettlementFinalityRequiredInternalRequestQueryFailsClosed)'
+```
+
+The buyer test checks the coordinator-owned header before HTTP EOF/request-log
+creation, rejects substitution by buyer/provider headers, and covers fresh and
+idempotency-key requests. Bound lookup tests cover the unlogged current attempt,
+later mapping, missing verdicts, mixed mode and account/external/generation fences.
+
+Selected integration command (exit 0, 27.051s):
+
+```sh
+go test -race -count=1 -timeout 5m -run '^(TestSpec022V04StreamingSettlementReconcilerE2E|TestInternalBearerWrongTokenRejected|TestInternalBearerNoAuthRejected|TestInternalBearerServiceTokenAccepted|TestInternalBearerOperatorKeyRejectedPostCutover|TestStickyHeaderForwardedToCoordinator|TestGatewayGitHubOAuthDisabledRoutesReturn404)$' .
+```
+
+The full coordinator billing race run was **not green**:
+`go test -race -count=1 -timeout 3m ./internal/billing` failed after 77.443s at
+`TestAdminRateLimitBucketConsumesFailures`. An isolated race rerun with
+`-timeout 90s -run '^TestAdminRateLimitBucketConsumesFailures$'` also failed
+(41.657s). Its 600 calls took 41.32s (about 14.5 requests/second), below the
+configured 60-token/second refill rate, and produced no rate-limit responses.
+This unchanged admin-limiter test does not execute the modified finality path.
+No unrelated test was edited.
+
+One later gateway full race run failed the unchanged
+`TestPoolRejectionTimingFloor_EnforcedAndUniform` (router 156.149s): p95 difference
+15.735042ms exceeded its 15ms bound. The isolated command
+`go test -race -count=1 -timeout 1m ./internal/router -run '^TestPoolRejectionTimingFloor_EnforcedAndUniform$'`
+passed in 4.244s. Its timing assertion was not relaxed.
+
+## Review Gate
+
+Independent code, security and architecture lanes reviewed the complete combined
+tracked/untracked fix against the base SHA, including current-attempt binding and
+empty-binding compatibility closure. All three reported zero introduced Critical,
+High or Medium findings. Review-discovered observe outage recovery, retry
+starvation, incomplete snapshot scope and unlogged-current scope gaps were fixed
+and re-reviewed. The LOW drain-bound note and test limitations below remain.
+
+## Rollout and Residual Risks
+
+- Deploy the coordinator completeness signal first; older coordinator responses
+  intentionally leave missing-trailer recovery held. See gateway README.
+- Stop old gateway binaries before schema 12 migration. Legacy OAuth handoffs
+  must restart. Historical database pages/WAL/backups are not erased, and existing
+  API keys are not automatically revoked.
+- Pre-candidate historical holds cannot be reconstructed automatically.
+- Separate follow-up: omitted/null generation caps are not materialized into the
+  forwarded body. This change addresses collisions, not that adjacent contract.
+- Separate inherited follow-up: the structured-admission timeout branch can
+  ignore finality on a retained coordinator response. No blanket claim that all
+  settlement paths are repaired is made.
+- No real-wire Swift partial-write/deadline race, separate-process consumer
+  restart, full Swift app suite, ML inference, or production rollout was tested.
+  Wallet candidate storage/generation and local-usage recovery are covered, but
+  a wallet-specific outage/restart/reconcile end-to-end scenario remains untested.
+- These fixes do not establish full conformance or production readiness.
+- The trailer-tail drain is line-granular (potentially nearly 2 MiB, not an exact
+  1 MiB budget); it remains time- and per-line-bounded. Headerless quarantine
+  restart tests seed the stored candidate; the live caller persistence condition
+  was reviewed statically rather than through a new full HTTP regression.

--- a/audits/security-high-fixes-2026-09-08.md
+++ b/audits/security-high-fixes-2026-09-08.md
@@ -1,6 +1,8 @@
 # Security High Findings: Implementation Verification
 
-Base: `b63ccb465fa9ae6fab2084e45e703103efe40a9e` (fetched `origin/main`).
+Initial base: `b63ccb465fa9ae6fab2084e45e703103efe40a9e` (fetched `origin/main`).
+Final landing base: `00984a3105dc09d899ae6dd5d14d39f197124215`
+(fetched `origin/main` after the adversarial correction round).
 Branch: `codex/security-high-fixes-2026-09-08`.
 Scope: F01-F04 from the 2026-09-07 security boundary audit. This record captures
 implementation verification before PR publication. No deployment, production
@@ -17,6 +19,10 @@ credentials, or signed journey operation was performed.
   gateway restarts. An initial coordinator attempt ID, persisted with the
   candidate, fences the lookup and must be echoed after membership validation;
   an earlier logged retry cannot substitute for a current unlogged attempt.
+  Every production path that leaves a reconcileable hold now persists this
+  binding first. Legacy rows and persistence failures without a candidate stay
+  held without contacting the coordinator. Verified demo recovery also writes
+  the paired `demo_usage_events` audit row.
 - F03: exchange a hashed, single-use issuance intent for an in-memory API key;
   transactionally store only the key hash and consume the intent. Schema 12
   invalidates legacy plaintext handoffs and stores settlement recovery state.
@@ -37,6 +43,22 @@ Commands run from the named package in this worktree unless otherwise stated.
 | Coordinator | `go vet ./internal/billing ./internal/buyer` | Exit 0 |
 | Swift | `swift test --scratch-path /tmp/macprovider-security-high-fixes-20260908-cli-swift-build --disable-automatic-resolution --filter ConsumeCommandTests` | 127 tests passed, zero failures |
 | Worktree | `git diff --check` | Exit 0 |
+
+After the final adversarial correction and clean rebase onto `00984a31`:
+
+| Package | Command | Result |
+| --- | --- | --- |
+| Gateway | `go test -count=1 -timeout 8m ./... && go vet ./...` | Exit 0; router 33.260s, SQLite 4.199s; all packages and vet passed |
+| Gateway | `go test -race -count=1 -timeout 5m ./internal/router -run '^(TestSettlementReconcileWithoutCurrentAttemptBindingRejectsPriorFinality\|TestSettlementReconcileVerifiedDemoWritesDemoAuditRow)$'` | Exit 0; 1.940s |
+| Coordinator | `go test -count=1 -timeout 8m ./... && go vet ./...` | Exit 0; all packages and vet passed |
+| Integration | `go test -race -count=1 -timeout 5m -run '^TestSpec022V04StreamingSettlementReconcilerE2E$' .` | Isolated rerun exit 0; 5.204s |
+| Swift | `swift test --scratch-path /tmp/macprovider-pr1431-final-swift-20260908 --disable-automatic-resolution --filter ConsumeCommandTests` | 130 tests passed, zero failures |
+| Worktree | `git diff --check origin/main...HEAD` | Exit 0 |
+
+The first post-rebase integration invocation ran concurrently with three heavy
+build/test commands and failed before the reconciler assertion because its seed
+gateway did not create the accounts schema. The exact isolated rerun above
+passed; the failed invocation is not represented as a pass.
 
 Final recovery/scheduling additions also passed:
 `go test ./internal/storage/sqlite ./internal/router -run 'TestSettlementFallback|TestObserveFallback|TestSPEC022GatewaySettlementReconcile|TestWalletSessionSettlementReconcile|TestSecurity' -race -count=1`
@@ -90,16 +112,21 @@ passed in 4.244s. Its timing assertion was not relaxed.
 ## Review Gate
 
 Independent code, security and architecture lanes reviewed the complete combined
-tracked/untracked fix against the base SHA, including current-attempt binding and
-empty-binding compatibility closure. All three reported zero introduced Critical,
-High or Medium findings. Review-discovered observe outage recovery, retry
-starvation, incomplete snapshot scope and unlogged-current scope gaps were fixed
-and re-reviewed. The LOW drain-bound note and test limitations below remain.
+fix. The final adversarial cross-check found one Medium current-attempt gap: a
+candidate-less hold still performed an unbound coordinator lookup. The correction
+requires a persisted candidate before any remote lookup and adds verified/refund
+prior-finality substitution regressions. A subsequent security lane found one Low
+demo audit-integrity gap; enforce reconciliation now uses atomic demo settlement
+and has a paired-row regression. The complete rebased landing diff was then
+re-reviewed. All three final lanes reported zero Critical, High or Medium findings.
+The inherited/operational limitations below remain.
 
 ## PR Publication Follow-Up
 
-PR #1431 rebased the fix onto `58fcd226078438d4c10fa5204496812f9f0f53a7`
-without changing its patch bytes. CI correctly rejected stale historical selector
+PR #1431 was initially rebased onto
+`58fcd226078438d4c10fa5204496812f9f0f53a7`, then rebased cleanly after the
+adversarial correction onto `00984a3105dc09d899ae6dd5d14d39f197124215`.
+CI correctly rejected stale historical selector
 evidence for SPEC-006-R003, SPEC-022-R005 and SPEC-022-R008. These mappings are
 demoted to pending, retaining historical evidence; issue #1433 tracks a separately
 authorized evidence refresh before re-promotion. No signed journey was created.
@@ -123,6 +150,4 @@ authorized evidence refresh before re-promotion. No signed journey was created.
   a wallet-specific outage/restart/reconcile end-to-end scenario remains untested.
 - These fixes do not establish full conformance or production readiness.
 - The trailer-tail drain is line-granular (potentially nearly 2 MiB, not an exact
-  1 MiB budget); it remains time- and per-line-bounded. Headerless quarantine
-  restart tests seed the stored candidate; the live caller persistence condition
-  was reviewed statically rather than through a new full HTTP regression.
+  1 MiB budget); it remains time- and per-line-bounded.

--- a/phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift
@@ -1744,60 +1744,11 @@ final class ConsumeCommandTests: XCTestCase {
     }
 
     func testPhase3DPreDispatchTransportFailureSettlesReservationToZero() throws {
-        let token = try ConsumeLocalToken.generate()
-        let home = try makeTemporaryDirectory()
-        let ledgerURL = home.appendingPathComponent("budget.jsonl")
-        let ledger = try ConsumeBudgetLedger.open(ledgerPath: ledgerURL.path, homeDirectory: home, startupDirectory: home)
-        let trustedRateCard = phase3CTrustedRateCard(
-            promptRatePerMtok: 1_000_000,
-            completionRatePerMtok: 2_000_000,
-            usdPerMillionCredits: 1.0
-        )
-        let budget = ConsumeBudgetConfig(
-            mode: .budget(ConsumeMicroUSD(rawValue: 100_000_000)),
-            maxRequestMicroUSD: nil,
-            allowUnpriced: false,
-            ledger: ledger,
-            ledgerPathClass: ledger.pathClass
-        )
-        let recorder = ConsumeUpstreamRequestRecorder()
-        let counter = ConsumeEndpointRequestCounter()
-        let upstreamClient = ConsumeStubUpstreamClient { request, eventLoop in
-            recorder.append(request)
-            return eventLoop.makeFailedFuture(ConsumeUpstreamForwardError.preDispatchUnavailable)
-        }
-        let runtime = consumeRuntime(
-            token: token,
-            credentialStatus: .environmentLoaded,
-            credentialCustody: consumeCredentialCustody("buyer-token"),
-            budget: budget,
-            trustedPricing: .available(trustedRateCard),
-            upstreamClient: upstreamClient,
-            now: { ConsumeCommandTests.phase3CTestNow },
-            requestCounter: counter
-        )
-        var headers = HTTPHeaders()
-        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+        try assertPreDispatchFailureAllowsNextAdmission(streaming: false)
+    }
 
-        let response = try response(
-            from: runtime,
-            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
-            body: Data(#"{"model":"llama-test","messages":[],"max_tokens":10}"#.utf8)
-        )
-
-        XCTAssertEqual(response.status, HTTPResponseStatus.serviceUnavailable)
-        XCTAssertEqual(try localError(from: response.body)["code"] as? String, "local_upstream_unavailable")
-        XCTAssertFalse(try localForwardedFlag(from: response.body))
-        XCTAssertEqual(recorder.snapshot().count, 1)
-        let summary = try ledger.summary()
-        XCTAssertEqual(summary.reserved.rawValue, 0)
-        XCTAssertEqual(summary.held.rawValue, 0)
-        XCTAssertEqual(summary.settled.rawValue, 0)
-        XCTAssertEqual(summary.heldReservationCount, 0)
-        let resourceSnapshot = counter.resourceSnapshot()
-        XCTAssertEqual(resourceSnapshot.responseSpoolBytes, 0)
-        XCTAssertEqual(resourceSnapshot.upstreamWorkerTasks, 0)
-        XCTAssertEqual(resourceSnapshot.upstreamSocketDescriptors, 0)
+    func testPhase3GPreDispatchTransportFailureSettlesReservationToZero() throws {
+        try assertPreDispatchFailureAllowsNextAdmission(streaming: true)
     }
 
     func testPhase3DSendFailuresAreAmbiguous() throws {
@@ -5933,6 +5884,84 @@ final class ConsumeCommandTests: XCTestCase {
     private func localError(from body: String) throws -> [String: Any] {
         let object = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(body.utf8)) as? [String: Any])
         return try XCTUnwrap(object["error"] as? [String: Any])
+    }
+
+    private func assertPreDispatchFailureAllowsNextAdmission(streaming: Bool) throws {
+        let token = try ConsumeLocalToken.generate()
+        let home = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let ledgerURL = home.appendingPathComponent("budget.jsonl")
+        let ledger = try ConsumeBudgetLedger.open(ledgerPath: ledgerURL.path, homeDirectory: home, startupDirectory: home)
+        let trustedRateCard = phase3CTrustedRateCard(
+            promptRatePerMtok: 1_000_000,
+            completionRatePerMtok: 2_000_000,
+            usdPerMillionCredits: 1.0
+        )
+        let body = streaming
+            ? #"{"model":"llama-test","messages":[],"max_tokens":10,"stream":true}"#
+            : #"{"model":"llama-test","messages":[],"max_tokens":10}"#
+        let expected = try ConsumePricedExposureEstimator.estimate(
+            bodyByteCount: Data(body.utf8).count,
+            request: StrictJSONParser.parse(body),
+            match: XCTUnwrap(trustedRateCard.match(model: "llama-test")),
+            projection: trustedRateCard.projection
+        ).amount
+        let budget = ConsumeBudgetConfig(
+            mode: .budget(expected),
+            maxRequestMicroUSD: nil,
+            allowUnpriced: false,
+            ledger: ledger,
+            ledgerPathClass: ledger.pathClass
+        )
+        let recorder = ConsumeUpstreamRequestRecorder()
+        let counter = ConsumeEndpointRequestCounter()
+        let upstreamClient = ConsumeStubUpstreamClient { request, eventLoop in
+            recorder.append(request)
+            return eventLoop.makeFailedFuture(ConsumeUpstreamForwardError.preDispatchUnavailable)
+        }
+        let runtime = consumeRuntime(
+            token: token,
+            credentialStatus: .environmentLoaded,
+            credentialCustody: consumeCredentialCustody("buyer-token"),
+            budget: budget,
+            trustedPricing: .available(trustedRateCard),
+            upstreamClient: upstreamClient,
+            now: { ConsumeCommandTests.phase3CTestNow },
+            requestCounter: counter
+        )
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+        let head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers)
+
+        for attempt in 1...2 {
+            let failed = try response(from: runtime, head: head, body: Data(body.utf8))
+            XCTAssertEqual(failed.status, .serviceUnavailable)
+            XCTAssertEqual(try localError(from: failed.body)["code"] as? String, "local_upstream_unavailable")
+            XCTAssertFalse(try localForwardedFlag(from: failed.body))
+            XCTAssertEqual(recorder.snapshot().count, attempt)
+            XCTAssertEqual(recorder.snapshot().last?.streaming, streaming)
+            let summary = try ledger.summary()
+            XCTAssertEqual(summary.reserved.rawValue, 0)
+            XCTAssertEqual(summary.held.rawValue, 0)
+            XCTAssertEqual(summary.settled.rawValue, 0)
+            XCTAssertEqual(summary.heldReservationCount, 0)
+            XCTAssertEqual(try summary.committedExposure(), .zero)
+            let resources = counter.resourceSnapshot()
+            XCTAssertEqual(resources.responseSpoolBytes, 0)
+            XCTAssertEqual(resources.upstreamWorkerTasks, 0)
+            XCTAssertEqual(resources.upstreamSocketDescriptors, 0)
+            XCTAssertEqual(resources.openStreamingResponses, 0)
+        }
+        let rows = try Data(contentsOf: ledgerURL).split(separator: 0x0a).map {
+            try XCTUnwrap(JSONSerialization.jsonObject(with: Data($0)) as? [String: Any])
+        }
+        XCTAssertEqual(rows.count, 4)
+        let settled = rows.filter { $0["state"] as? String == "settled" }
+        XCTAssertEqual(settled.count, 2)
+        for row in settled {
+            XCTAssertEqual(row["reason"] as? String, "upstream_pre_dispatch_failed")
+            XCTAssertEqual(row["settled_exposure_micro_usd"] as? String, "0")
+        }
     }
 
     private func assertAmbiguousSendPreservesExposure(streaming: Bool, error: Error) throws {

--- a/phase4-coordinator/internal/billing/settlement_finality.go
+++ b/phase4-coordinator/internal/billing/settlement_finality.go
@@ -9,9 +9,15 @@ import (
 )
 
 type RequestSettlementFinality struct {
-	RequestID                string `json:"request_id"`
-	PolicyVersion            string `json:"policy_version"`
-	Mode                     string `json:"mode"`
+	RequestID     string `json:"request_id"`
+	PolicyVersion string `json:"policy_version"`
+	Mode          string `json:"mode"`
+	// Present only after the required internal request is included in the
+	// account/generation-scoped external lookup, never a direct-ID lookup.
+	RequiredInternalRequestID string `json:"required_internal_request_id,omitempty"`
+	// Scope completeness covers policy/mode, not receipt verification. It binds
+	// the selected internal request, or every linked request for an external ID.
+	ModeScopeComplete        bool   `json:"mode_scope_complete"`
 	Outcome                  string `json:"outcome"`
 	ReceiptResult            string `json:"receipt_result"`
 	Reason                   string `json:"reason"`
@@ -44,13 +50,26 @@ const externalRequestFinalityLookupSkew = 5 * time.Minute
 const SettlementOutcomeOverlapBlockedTerminal = "overlap_blocked_terminal"
 
 func (s *Store) RequestSettlementFinalityForAccount(ctx context.Context, accountID, requestID string, nowUnixMS int64, notBeforeUnixMS ...int64) (RequestSettlementFinality, bool, error) {
-	accountScope := AccountScopeForSettlement(accountID)
 	notBefore := int64(0)
 	if len(notBeforeUnixMS) > 0 {
 		notBefore = notBeforeUnixMS[0]
 	}
-	directLookupAllowed := true
-	if notBefore > 0 {
+	return s.requestSettlementFinalityForAccount(ctx, accountID, requestID, "", nowUnixMS, notBefore)
+}
+
+// RequestSettlementFinalityForAccountBound prevents a prior logged retry from
+// authorizing recovery while the current stream has not written its request log.
+func (s *Store) RequestSettlementFinalityForAccountBound(ctx context.Context, accountID, requestID, requiredInternalRequestID string, nowUnixMS, notBeforeUnixMS int64) (RequestSettlementFinality, bool, error) {
+	if requiredInternalRequestID == "" || notBeforeUnixMS <= 0 {
+		return RequestSettlementFinality{}, false, fmt.Errorf("required internal request id and reservation timestamp are required")
+	}
+	return s.requestSettlementFinalityForAccount(ctx, accountID, requestID, requiredInternalRequestID, nowUnixMS, notBeforeUnixMS)
+}
+
+func (s *Store) requestSettlementFinalityForAccount(ctx context.Context, accountID, requestID, requiredInternalRequestID string, nowUnixMS, notBefore int64) (RequestSettlementFinality, bool, error) {
+	accountScope := AccountScopeForSettlement(accountID)
+	directLookupAllowed := requiredInternalRequestID == ""
+	if directLookupAllowed && notBefore > 0 {
 		var err error
 		directLookupAllowed, err = s.directRequestIDWithinReservationWindow(ctx, accountID, requestID, notBefore)
 		if err != nil {
@@ -66,6 +85,18 @@ func (s *Store) RequestSettlementFinalityForAccount(ctx context.Context, account
 	internalRequestIDs, err := s.requestIDsForExternalRequest(ctx, accountID, requestID, notBefore)
 	if err != nil || len(internalRequestIDs) == 0 {
 		return RequestSettlementFinality{}, false, err
+	}
+	if requiredInternalRequestID != "" {
+		included := false
+		for _, internalRequestID := range internalRequestIDs {
+			if internalRequestID == requiredInternalRequestID {
+				included = true
+				break
+			}
+		}
+		if !included {
+			return RequestSettlementFinality{}, false, nil
+		}
 	}
 	finalities := make([]RequestSettlementFinality, 0, len(internalRequestIDs))
 	missingFinality := false
@@ -84,7 +115,9 @@ func (s *Store) RequestSettlementFinalityForAccount(ctx context.Context, account
 		return RequestSettlementFinality{}, false, nil
 	}
 	finality := aggregateExternalRequestFinality(requestID, finalities)
-	if missingFinality && finality.Outcome == SettlementOutcomeVerified && finality.Closed {
+	finality.RequiredInternalRequestID = requiredInternalRequestID
+	if missingFinality {
+		finality.ModeScopeComplete = false
 		finality.Outcome = SettlementOutcomePending
 		finality.ReceiptResult = SettlementReceiptResultInconclusive
 		finality.Reason = "missing_current_settlement_finality"
@@ -189,6 +222,23 @@ func (s *Store) RequestSettlementFinality(ctx context.Context, accountScope, req
 			finality.PendingDeadlineUnixMS = minPositiveDeadline(finality.PendingDeadlineUnixMS, row.pendingDeadlineUnixMS)
 		}
 	}
+	scopeReason, err := s.requestSettlementScopeReason(ctx, accountScope, requestID, rows)
+	if err != nil {
+		return RequestSettlementFinality{}, false, err
+	}
+	if scopeReason != "" {
+		finality.Outcome = SettlementOutcomePending
+		finality.ReceiptResult = SettlementReceiptResultInconclusive
+		finality.Reason = scopeReason
+		finality.Closed = false
+		finality.TokenSource = ""
+		finality.PromptTokens = 0
+		finality.CompletionTokens = 0
+		finality.TotalTokens = 0
+		finality.PendingAttempts++
+		return finality, true, nil
+	}
+	finality.ModeScopeComplete = true
 	if finality.PendingAttempts > 0 {
 		finality.Outcome = SettlementOutcomePending
 		finality.ReceiptResult = SettlementReceiptResultInconclusive
@@ -275,6 +325,57 @@ SELECT attempt_n, provider_id, receipt_result, settlement_outcome, reason, close
 		out = append(out, row)
 	}
 	return out, rows.Err()
+}
+
+// Snapshots exist before pending verdicts do. Looking only at verdict rows can
+// hide a later attempt's policy or mode while advertising earlier observe scope.
+func (s *Store) requestSettlementScopeReason(ctx context.Context, accountScope, requestID string, verdicts []requestSettlementVerdictRow) (string, error) {
+	if len(verdicts) == 0 {
+		return "missing_current_settlement_finality", nil
+	}
+	type attemptKey struct {
+		attemptN   int64
+		providerID string
+	}
+	remaining := make(map[attemptKey]requestSettlementVerdictRow, len(verdicts))
+	for _, verdict := range verdicts {
+		remaining[attemptKey{verdict.attemptN, verdict.providerID}] = verdict
+	}
+	rows, err := s.db.QueryContext(ctx, `
+SELECT attempt_n, provider_id, route_snapshot_policy_version, route_snapshot_mode
+  FROM settlement_route_snapshots
+ WHERE account_scope = ? AND request_id = ?`, accountScope, requestID)
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+	reason := ""
+	for rows.Next() {
+		var key attemptKey
+		var policy, mode string
+		if err := rows.Scan(&key.attemptN, &key.providerID, &policy, &mode); err != nil {
+			return "", err
+		}
+		if policy != verdicts[0].policyVersion || mode != verdicts[0].mode {
+			return "mixed_settlement_policy_snapshot", nil
+		}
+		verdict, found := remaining[key]
+		if !found {
+			reason = "missing_current_settlement_finality"
+			continue
+		}
+		if verdict.policyVersion != policy || verdict.mode != mode {
+			return "mixed_settlement_policy_snapshot", nil
+		}
+		delete(remaining, key)
+	}
+	if err := rows.Err(); err != nil {
+		return "", err
+	}
+	if len(remaining) > 0 {
+		return "missing_current_settlement_finality", nil
+	}
+	return reason, nil
 }
 
 func (s *Store) requestSettlementUsage(ctx context.Context, accountScope, requestID string, attemptN int64, providerID string) (SettlementUsage, bool, error) {
@@ -385,15 +486,20 @@ SELECT request_id
 
 func aggregateExternalRequestFinality(externalRequestID string, finalities []RequestSettlementFinality) RequestSettlementFinality {
 	out := RequestSettlementFinality{
-		RequestID:     externalRequestID,
-		PolicyVersion: finalities[0].PolicyVersion,
-		Mode:          finalities[0].Mode,
+		RequestID:         externalRequestID,
+		PolicyVersion:     finalities[0].PolicyVersion,
+		Mode:              finalities[0].Mode,
+		ModeScopeComplete: true,
 	}
 	var firstTerminalRefund RequestSettlementFinality
 	hasTerminalRefund := false
 	for i := range finalities {
 		finality := finalities[i]
+		if !finality.ModeScopeComplete {
+			out.ModeScopeComplete = false
+		}
 		if finality.PolicyVersion != out.PolicyVersion || finality.Mode != out.Mode {
+			out.ModeScopeComplete = false
 			out.Outcome = SettlementOutcomePending
 			out.ReceiptResult = SettlementReceiptResultInconclusive
 			out.Reason = "mixed_settlement_policy_snapshot"

--- a/phase4-coordinator/internal/billing/settlement_finality_security_test.go
+++ b/phase4-coordinator/internal/billing/settlement_finality_security_test.go
@@ -1,0 +1,333 @@
+package billing
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/requestlog"
+)
+
+func TestRequestSettlementFinalityMissingCurrentVerdictInvalidatesEveryPriorOutcome(t *testing.T) {
+	fixtures := loadSettlementVerifierFixtures(t)
+	pubkey := decodeSettlementVerifierPubkey(t, fixtures.ProviderReceiptPubkeyB64)
+	tuple := firstSettlementTupleWithTerminal(t, fixtures, "normal_done")
+	for _, mode := range []string{RouteSnapshotModeObserve, RouteSnapshotModeEnforce} {
+		for _, outcome := range []string{SettlementOutcomeVerified, SettlementOutcomeQuarantined, SettlementOutcomeZeroSettled, SettlementOutcomePending} {
+			t.Run(mode+"/"+outcome, func(t *testing.T) {
+				input := settlementVerifierInputFromFixture(t, fixtures, tuple, pubkey)
+				accountID := "acct_finality_scope"
+				externalID := "external-finality-scope"
+				input.AccountScope = AccountScopeForSettlement(accountID)
+				input.RouteSnapshot.AccountScope = input.AccountScope
+				input.RouteSnapshot.RouteSnapshotMode = mode
+				reqStore, store := newRequestAndBillingStores(t)
+				seedFinalitySecurityVerdict(t, store, input, outcome)
+				now := input.TerminalStateTSUnixMS + 1
+
+				direct, found, err := store.RequestSettlementFinality(context.Background(), input.AccountScope, input.RequestID, now)
+				if err != nil || !found || !direct.ModeScopeComplete || direct.Mode != mode || direct.Outcome != outcome {
+					t.Fatalf("direct finality=%+v found=%v err=%v", direct, found, err)
+				}
+				assertFinalityModeScopeJSON(t, direct, true)
+				insertExternalFinalityRequestLog(t, reqStore, input, accountID, externalID, input.RequestID, now)
+				complete, found, err := store.RequestSettlementFinalityForAccount(context.Background(), accountID, externalID, now, now)
+				if err != nil || !found || !complete.ModeScopeComplete || complete.Outcome != outcome {
+					t.Fatalf("complete external finality=%+v found=%v err=%v", complete, found, err)
+				}
+
+				// A later request log entry is known, but its verdict has not been
+				// persisted. Earlier observe authority must not cover this gap.
+				insertExternalFinalityRequestLog(t, reqStore, input, accountID, externalID, input.RequestID+"-later", now+1)
+				ledgerRows := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_request_credits`)
+				finality, found, err := store.RequestSettlementFinalityForAccount(context.Background(), accountID, externalID, now+2, now)
+				if err != nil || !found {
+					t.Fatalf("missing-current lookup found=%v err=%v", found, err)
+				}
+				if finality.ModeScopeComplete || finality.Closed || finality.Mode != mode ||
+					finality.Outcome != SettlementOutcomePending ||
+					finality.ReceiptResult != SettlementReceiptResultInconclusive ||
+					finality.Reason != "missing_current_settlement_finality" ||
+					finality.PendingAttempts != complete.PendingAttempts+1 {
+					t.Fatalf("missing current verdict retained earlier authority: %+v", finality)
+				}
+				if finality.TokenSource != "" || finality.PromptTokens != 0 || finality.CompletionTokens != 0 || finality.TotalTokens != 0 {
+					t.Fatalf("incomplete finality retained billable usage: %+v", finality)
+				}
+				assertFinalityModeScopeJSON(t, finality, false)
+				if got := scalar(t, store.db, `SELECT COUNT(*) FROM ledger_request_credits`); got != ledgerRows {
+					t.Fatalf("finality lookup changed ledger rows: got %d want %d", got, ledgerRows)
+				}
+			})
+		}
+	}
+}
+
+func TestRequestSettlementFinalityMixedModeScopeIsIncomplete(t *testing.T) {
+	fixtures := loadSettlementVerifierFixtures(t)
+	pubkey := decodeSettlementVerifierPubkey(t, fixtures.ProviderReceiptPubkeyB64)
+	tuple := firstSettlementTupleWithTerminal(t, fixtures, "normal_done")
+	for _, lookup := range []string{"direct", "external"} {
+		t.Run(lookup, func(t *testing.T) {
+			input := settlementVerifierInputFromFixture(t, fixtures, tuple, pubkey)
+			accountID := "acct_mixed_finality_scope"
+			externalID := "external-mixed-finality-scope"
+			input.AccountScope = AccountScopeForSettlement(accountID)
+			input.RouteSnapshot.AccountScope = input.AccountScope
+			input.RouteSnapshot.RouteSnapshotMode = RouteSnapshotModeObserve
+			reqStore, store := newRequestAndBillingStores(t)
+			seedFinalitySecurityVerdict(t, store, input, SettlementOutcomeQuarantined)
+			now := input.TerminalStateTSUnixMS + 1
+			insertExternalFinalityRequestLog(t, reqStore, input, accountID, externalID, input.RequestID, now)
+			second := input
+			second.RouteSnapshot.RouteSnapshotMode = RouteSnapshotModeEnforce
+			if lookup == "direct" {
+				second.AttemptN++
+				second.RouteSnapshot.AttemptN = second.AttemptN
+			} else {
+				second.RequestID += "-later"
+				second.RouteSnapshot.RequestID = second.RequestID
+				insertExternalFinalityRequestLog(t, reqStore, second, accountID, externalID, second.RequestID, now+1)
+			}
+			seedFinalitySecurityVerdict(t, store, second, SettlementOutcomeZeroSettled)
+			requestID := input.RequestID
+			if lookup == "external" {
+				requestID = externalID
+			}
+			finality, found, err := store.RequestSettlementFinalityForAccount(context.Background(), accountID, requestID, now+2, now)
+			if err != nil || !found {
+				t.Fatalf("mixed scope lookup found=%v err=%v", found, err)
+			}
+			if finality.ModeScopeComplete || finality.Closed || finality.Outcome != SettlementOutcomePending || finality.Reason != "mixed_settlement_policy_snapshot" {
+				t.Fatalf("mixed modes retained complete authority: %+v", finality)
+			}
+			assertFinalityModeScopeJSON(t, finality, false)
+		})
+	}
+}
+
+func TestRequestSettlementFinalitySnapshotWithoutVerdictIsIncomplete(t *testing.T) {
+	fixtures := loadSettlementVerifierFixtures(t)
+	pubkey := decodeSettlementVerifierPubkey(t, fixtures.ProviderReceiptPubkeyB64)
+	tuple := firstSettlementTupleWithTerminal(t, fixtures, "normal_done")
+	for _, outcome := range []string{SettlementOutcomeVerified, SettlementOutcomeQuarantined, SettlementOutcomeZeroSettled, SettlementOutcomePending} {
+		for _, scope := range []string{"same_scope", "mixed_mode", "mixed_policy"} {
+			t.Run(outcome+"/"+scope, func(t *testing.T) {
+				input := settlementVerifierInputFromFixture(t, fixtures, tuple, pubkey)
+				accountID := "acct_snapshot_finality_scope"
+				input.AccountScope = AccountScopeForSettlement(accountID)
+				input.RouteSnapshot.AccountScope = input.AccountScope
+				input.RouteSnapshot.RouteSnapshotMode = RouteSnapshotModeObserve
+				_, store := newRequestAndBillingStores(t)
+				seedFinalitySecurityVerdict(t, store, input, outcome)
+				later := input
+				later.AttemptN++
+				later.RouteSnapshot.AttemptN = later.AttemptN
+				wantReason := "missing_current_settlement_finality"
+				if scope == "mixed_mode" {
+					later.RouteSnapshot.RouteSnapshotMode = RouteSnapshotModeEnforce
+					wantReason = "mixed_settlement_policy_snapshot"
+				} else if scope == "mixed_policy" {
+					later.RouteSnapshot.RouteSnapshotPolicyVersion = "spec022-prereq-v0"
+					wantReason = "mixed_settlement_policy_snapshot"
+				}
+				if _, err := store.InsertRouteSnapshot(context.Background(), later.RouteSnapshot); err != nil {
+					t.Fatal(err)
+				}
+				now := input.TerminalStateTSUnixMS + 1
+				finality, found, err := store.RequestSettlementFinalityForAccount(context.Background(), accountID, input.RequestID, now)
+				if err != nil || !found {
+					t.Fatalf("snapshot gap found=%v err=%v", found, err)
+				}
+				if finality.ModeScopeComplete || finality.Closed || finality.Outcome != SettlementOutcomePending ||
+					finality.ReceiptResult != SettlementReceiptResultInconclusive || finality.Reason != wantReason ||
+					finality.PromptTokens != 0 || finality.CompletionTokens != 0 || finality.TotalTokens != 0 || finality.TokenSource != "" {
+					t.Fatalf("snapshot without verdict retained finality authority: %+v", finality)
+				}
+				assertFinalityModeScopeJSON(t, finality, false)
+				if scope == "same_scope" {
+					insertFinalitySecurityVerdict(t, store, later, SettlementOutcomeZeroSettled)
+					complete, found, err := store.RequestSettlementFinalityForAccount(context.Background(), accountID, input.RequestID, now)
+					if err != nil || !found || !complete.ModeScopeComplete {
+						t.Fatalf("all snapshot verdicts did not restore known scope: finality=%+v found=%v err=%v", complete, found, err)
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestAggregateExternalRequestFinalityScopeRequiresEveryChild(t *testing.T) {
+	first := RequestSettlementFinality{
+		PolicyVersion: RouteSnapshotPolicyVersion, Mode: RouteSnapshotModeObserve,
+		ModeScopeComplete: true, Outcome: SettlementOutcomePending, PendingAttempts: 1,
+	}
+	for _, change := range []string{"incomplete_child", "different_policy"} {
+		t.Run(change, func(t *testing.T) {
+			second := first
+			if change == "incomplete_child" {
+				second.ModeScopeComplete = false
+			} else {
+				second.PolicyVersion = "spec022-prereq-v0"
+			}
+			finality := aggregateExternalRequestFinality("external", []RequestSettlementFinality{first, second})
+			if finality.ModeScopeComplete || finality.Closed || finality.Outcome != SettlementOutcomePending {
+				t.Fatalf("incomplete child scope retained authority: %+v", finality)
+			}
+		})
+	}
+}
+
+func TestRequestSettlementFinalityBoundRequiresCurrentLoggedRequest(t *testing.T) {
+	fixtures := loadSettlementVerifierFixtures(t)
+	pubkey := decodeSettlementVerifierPubkey(t, fixtures.ProviderReceiptPubkeyB64)
+	tuple := firstSettlementTupleWithTerminal(t, fixtures, "normal_done")
+	for _, mode := range []string{RouteSnapshotModeObserve, RouteSnapshotModeEnforce} {
+		t.Run(mode, func(t *testing.T) {
+			input := settlementVerifierInputFromFixture(t, fixtures, tuple, pubkey)
+			accountID, externalID := "acct_bound_finality", "external-bound-finality"
+			input.AccountScope = AccountScopeForSettlement(accountID)
+			input.RouteSnapshot.AccountScope = input.AccountScope
+			input.RouteSnapshot.RouteSnapshotMode = RouteSnapshotModeObserve
+			reqStore, store := newRequestAndBillingStores(t)
+			seedFinalitySecurityVerdict(t, store, input, SettlementOutcomeQuarantined)
+			now := input.TerminalStateTSUnixMS + 1
+			insertExternalFinalityRequestLog(t, reqStore, input, accountID, externalID, input.RequestID, now)
+			current := input
+			current.RequestID += "-current"
+			current.RouteSnapshot.RequestID = current.RequestID
+			current.RouteSnapshot.RouteSnapshotMode = mode
+			if _, err := store.InsertRouteSnapshot(context.Background(), current.RouteSnapshot); err != nil {
+				t.Fatal(err)
+			}
+			// Streaming writes this mapping after the terminal body. An earlier
+			// retry alone cannot prove the policy of the in-flight current request.
+			unbound, found, err := store.RequestSettlementFinalityForAccount(context.Background(), accountID, externalID, now, now)
+			if err != nil || !found || !unbound.ModeScopeComplete {
+				t.Fatalf("prior-only scope setup: finality=%+v found=%v err=%v", unbound, found, err)
+			}
+			bound, found, err := store.RequestSettlementFinalityForAccountBound(context.Background(), accountID, externalID, current.RequestID, now, now)
+			if err != nil || found || bound.ModeScopeComplete || bound.RequiredInternalRequestID != "" {
+				t.Fatalf("unlogged current request authorized prior scope: finality=%+v found=%v err=%v", bound, found, err)
+			}
+			insertExternalFinalityRequestLog(t, reqStore, current, accountID, externalID, current.RequestID, now+1)
+			bound, found, err = store.RequestSettlementFinalityForAccountBound(context.Background(), accountID, externalID, current.RequestID, now+2, now)
+			if err != nil || !found || bound.ModeScopeComplete || bound.RequiredInternalRequestID != current.RequestID || bound.Outcome != SettlementOutcomePending {
+				t.Fatalf("mapped current request without verdict authorized prior scope: finality=%+v found=%v err=%v", bound, found, err)
+			}
+			insertFinalitySecurityVerdict(t, store, current, SettlementOutcomeZeroSettled)
+			bound, found, err = store.RequestSettlementFinalityForAccountBound(context.Background(), accountID, externalID, current.RequestID, now+2, now)
+			if err != nil || !found || bound.RequiredInternalRequestID != current.RequestID || bound.RequestID != externalID {
+				t.Fatalf("bound lookup lost identity: finality=%+v found=%v err=%v", bound, found, err)
+			}
+			if bound.ModeScopeComplete != (mode == RouteSnapshotModeObserve) {
+				t.Fatalf("bound lookup failed to aggregate prior and current mode: %+v", bound)
+			}
+			if mode == RouteSnapshotModeEnforce && bound.Reason != "mixed_settlement_policy_snapshot" {
+				t.Fatalf("mixed retry policies were not preserved: %+v", bound)
+			}
+		})
+	}
+}
+
+func TestRequestSettlementFinalityBoundDoesNotBypassExternalIdentityFence(t *testing.T) {
+	fixtures := loadSettlementVerifierFixtures(t)
+	pubkey := decodeSettlementVerifierPubkey(t, fixtures.ProviderReceiptPubkeyB64)
+	tuple := firstSettlementTupleWithTerminal(t, fixtures, "normal_done")
+	input := settlementVerifierInputFromFixture(t, fixtures, tuple, pubkey)
+	accountID, externalID := "acct_identity_finality", "external-identity-finality"
+	input.AccountScope = AccountScopeForSettlement(accountID)
+	input.RouteSnapshot.AccountScope = input.AccountScope
+	input.RouteSnapshot.RouteSnapshotMode = RouteSnapshotModeObserve
+	reqStore, store := newRequestAndBillingStores(t)
+	seedFinalitySecurityVerdict(t, store, input, SettlementOutcomePending)
+	now := input.TerminalStateTSUnixMS + 1
+	insertExternalFinalityRequestLog(t, reqStore, input, accountID, externalID, input.RequestID, now)
+	for _, tc := range []struct {
+		name, accountID, externalID, requiredID string
+		start                                   int64
+	}{
+		{"other_account", "acct_other", externalID, input.RequestID, now},
+		{"other_external", accountID, "external-other", input.RequestID, now},
+		{"direct_id_collision", accountID, input.RequestID, input.RequestID, now},
+		{"other_internal", accountID, externalID, input.RequestID + "-other", now},
+		{"old_generation", accountID, externalID, input.RequestID, now + int64((6*time.Minute)/time.Millisecond)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			finality, found, err := store.RequestSettlementFinalityForAccountBound(context.Background(), tc.accountID, tc.externalID, tc.requiredID, now, tc.start)
+			if err != nil || found || finality.ModeScopeComplete || finality.RequiredInternalRequestID != "" {
+				t.Fatalf("identity fence bypassed: finality=%+v found=%v err=%v", finality, found, err)
+			}
+		})
+	}
+	finality, found, err := store.RequestSettlementFinalityForAccountBound(context.Background(), accountID, externalID, input.RequestID, now, now)
+	if err != nil || !found || !finality.ModeScopeComplete || finality.RequiredInternalRequestID != input.RequestID || finality.Outcome != SettlementOutcomePending {
+		t.Fatalf("complete observe pending scope should bind without receipt verification: finality=%+v found=%v err=%v", finality, found, err)
+	}
+	for _, tc := range []struct {
+		requiredID string
+		start      int64
+	}{{"", now}, {input.RequestID, 0}} {
+		if _, found, err := store.RequestSettlementFinalityForAccountBound(context.Background(), accountID, externalID, tc.requiredID, now, tc.start); err == nil || found {
+			t.Fatalf("missing binding input accepted: found=%v err=%v", found, err)
+		}
+	}
+}
+
+func seedFinalitySecurityVerdict(t *testing.T, store *Store, input SettlementVerifyInput, outcome string) {
+	t.Helper()
+	seedSettlementReceiptEvidence(t, store, input)
+	insertFinalitySecurityVerdict(t, store, input, outcome)
+}
+
+func insertFinalitySecurityVerdict(t *testing.T, store *Store, input SettlementVerifyInput, outcome string) {
+	t.Helper()
+	markSPEC022ReceiptVerified(t, store.db, input)
+	if outcome == SettlementOutcomeVerified {
+		insertSPEC022LedgerCreditWithMode(t, store.db, input, 700, input.RouteSnapshot.RouteSnapshotMode, "")
+		return
+	}
+	result, closed := SettlementReceiptResultValid, 1
+	if outcome == SettlementOutcomeQuarantined {
+		result = SettlementReceiptResultInvalid
+	} else if outcome == SettlementOutcomePending {
+		result, closed = SettlementReceiptResultInconclusive, 0
+	}
+	if _, err := store.db.Exec(`UPDATE settlement_receipt_verdicts
+SET settlement_outcome = ?, receipt_result = ?, closed = ?, reason = 'scope_fixture'
+WHERE account_scope_hash = ? AND request_id = ? AND attempt_n = ? AND provider_id = ?`,
+		outcome, result, closed, SettlementAccountScopeHash(input.AccountScope), input.RequestID, input.AttemptN, input.ProviderID); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func insertExternalFinalityRequestLog(t *testing.T, store *requestlog.Store, input SettlementVerifyInput, accountID, externalID, internalID string, ts int64) {
+	t.Helper()
+	if err := store.Insert(context.Background(), requestlog.Row{
+		TSUtc: time.UnixMilli(ts).UTC(), RequestID: internalID, ExternalRequestID: externalID,
+		AccountID: accountID, Model: input.RouteSnapshot.ModelID,
+		ProviderAssignedID: "assigned", Status: 200, Stream: true, BuyerIP: "127.0.0.1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertFinalityModeScopeJSON(t *testing.T, finality RequestSettlementFinality, want bool) {
+	t.Helper()
+	body, err := json.Marshal(finality)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(body, &fields); err != nil {
+		t.Fatal(err)
+	}
+	expected := "false"
+	if want {
+		expected = "true"
+	}
+	if string(fields["mode_scope_complete"]) != expected {
+		t.Fatalf("mode_scope_complete must be explicitly %s: %s", expected, body)
+	}
+}

--- a/phase4-coordinator/internal/buyer/server.go
+++ b/phase4-coordinator/internal/buyer/server.go
@@ -1124,6 +1124,14 @@ func (s *Server) handleInternalSettlementFinality(w http.ResponseWriter, r *http
 		writeError(w, http.StatusBadRequest, "invalid_request", "account_id and request_id are required")
 		return
 	}
+	requiredInternalRequestID := ""
+	if values, present := r.URL.Query()["required_internal_request_id"]; present {
+		if len(values) != 1 || sanitizeExternalRequestID(values[0]) == "" {
+			writeError(w, http.StatusBadRequest, "invalid_request", "required_internal_request_id must be a single valid request id")
+			return
+		}
+		requiredInternalRequestID = sanitizeExternalRequestID(values[0])
+	}
 	reservationCreatedAtUnixMS := int64(0)
 	if raw := strings.TrimSpace(r.URL.Query().Get("reservation_created_at_unix_ms")); raw != "" {
 		parsed, err := strconv.ParseInt(raw, 10, 64)
@@ -1133,12 +1141,23 @@ func (s *Server) handleInternalSettlementFinality(w http.ResponseWriter, r *http
 		}
 		reservationCreatedAtUnixMS = parsed
 	}
+	if requiredInternalRequestID != "" && reservationCreatedAtUnixMS == 0 {
+		writeError(w, http.StatusBadRequest, "invalid_request", "A required internal request id requires a positive reservation_created_at_unix_ms")
+		return
+	}
 	billingStore, _, _ := s.billingState()
 	if billingStore == nil {
 		writeError(w, http.StatusNotFound, "not_found", "Settlement finality is unavailable")
 		return
 	}
-	finality, found, err := billingStore.RequestSettlementFinalityForAccount(r.Context(), accountID, requestID, s.now().UnixMilli(), reservationCreatedAtUnixMS)
+	var finality billing.RequestSettlementFinality
+	var found bool
+	var err error
+	if requiredInternalRequestID != "" {
+		finality, found, err = billingStore.RequestSettlementFinalityForAccountBound(r.Context(), accountID, requestID, requiredInternalRequestID, s.now().UnixMilli(), reservationCreatedAtUnixMS)
+	} else {
+		finality, found, err = billingStore.RequestSettlementFinalityForAccount(r.Context(), accountID, requestID, s.now().UnixMilli(), reservationCreatedAtUnixMS)
+	}
 	if err != nil {
 		s.log.Warn().Err(err).Str("request_id", requestID).Str("account_id", accountID).Msg("internal settlement finality lookup failed")
 		writeError(w, http.StatusInternalServerError, "settlement_finality_failed", "Could not load settlement finality")
@@ -2343,6 +2362,9 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	// Coordinator-owned initial metadata binds recovery independently of
+	// settlement trailers and follows any idempotency-assigned internal ID.
+	w.Header().Set("X-MacProvider-Internal-Request-ID", requestID)
 	if !s.pool.ModelKnown(req.Model) && s.resolveModelClass(req.Model) == nil {
 		rec.logBuyerFailure(http.StatusNotFound, "No provider has advertised model "+req.Model)
 		writeError(w, http.StatusNotFound, "model_not_found", "No provider has advertised model "+req.Model)

--- a/phase4-coordinator/internal/buyer/settlement_finality_binding_test.go
+++ b/phase4-coordinator/internal/buyer/settlement_finality_binding_test.go
@@ -1,0 +1,139 @@
+package buyer_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-coordinator/internal/billing"
+	"github.com/augstar/macprovider-coordinator/internal/buyer"
+	"github.com/augstar/macprovider-coordinator/internal/config"
+	"github.com/augstar/macprovider-coordinator/internal/pool"
+	"github.com/rs/zerolog"
+)
+
+func TestSettlementInternalRequestHeaderIsCoordinatorOwnedBeforeStreamEOF(t *testing.T) {
+	const header = "X-MacProvider-Internal-Request-ID"
+	for _, idempotency := range []string{"", "binding-idempotency-key"} {
+		name := "fresh"
+		if idempotency != "" {
+			name = "idempotency"
+		}
+		t.Run(name, func(t *testing.T) {
+			release := make(chan struct{})
+			var releaseOnce sync.Once
+			releaseProvider := func() { releaseOnce.Do(func() { close(release) }) }
+			defer releaseProvider()
+			providerRequestID := make(chan string, 1)
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				providerRequestID <- r.Header.Get("X-Request-ID")
+				w.Header().Set(header, "provider-forged-id")
+				w.Header().Set("Content-Type", "text/event-stream")
+				_, _ = io.WriteString(w, "data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n")
+				w.(http.Flusher).Flush()
+				select {
+				case <-release:
+				case <-r.Context().Done():
+					return
+				}
+				_, _ = io.WriteString(w, "data: [DONE]\n\n")
+			}))
+			defer upstream.Close()
+			reqLog, _ := openBuyerRequestLog(t)
+			defer reqLog.Close()
+			registry := pool.NewRegistry([]config.ProviderConfig{{ProviderID: "p1", EndpointURL: upstream.URL}})
+			registerWithEndpoint(registry, "p1", "session-1", "model-a", pool.StateReady, 20000, 1, upstream.URL, 20)
+			server := buyer.NewServer(registry, zerolog.Nop(), time.Now(), buyer.WithRequestLog(reqLog), buyer.WithGatewayServiceToken("gateway-secret"))
+			coordinator := httptest.NewServer(server.Handler())
+			defer coordinator.Close()
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			req, err := http.NewRequestWithContext(ctx, http.MethodPost, coordinator.URL+"/v1/chat/completions", strings.NewReader(`{"model":"model-a","messages":[{"role":"user","content":"hello"}],"stream":true}`))
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.Header.Set("X-Request-ID", "gateway-external-id")
+			req.Header.Set("Authorization", "Bearer gateway-secret")
+			req.Header.Set("X-MacProvider-Account", "acct_header_binding")
+			req.Header.Set(header, "buyer-forged-id")
+			if idempotency != "" {
+				req.Header.Set("Idempotency-Key", idempotency)
+			}
+			resp, err := coordinator.Client().Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				body, _ := io.ReadAll(resp.Body)
+				t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+			}
+			internalID := resp.Header.Get(header)
+			if internalID == "" || internalID == "gateway-external-id" || internalID == "buyer-forged-id" || internalID == "provider-forged-id" {
+				t.Fatalf("initial header is not coordinator-owned: %q", internalID)
+			}
+			if got := <-providerRequestID; got != internalID {
+				t.Fatalf("initial internal ID=%q, provider dispatch ID=%q", internalID, got)
+			}
+			var rows int
+			if err := reqLog.DB().QueryRow(`SELECT COUNT(*) FROM request_log WHERE request_id = ?`, internalID).Scan(&rows); err != nil {
+				t.Fatal(err)
+			}
+			if rows != 0 {
+				t.Fatalf("request log exists before held stream finished: %d", rows)
+			}
+			releaseProvider()
+			if _, err := io.Copy(io.Discard, resp.Body); err != nil {
+				t.Fatal(err)
+			}
+			if err := reqLog.DB().QueryRow(`SELECT COUNT(*) FROM request_log WHERE request_id = ? AND external_request_id = 'gateway-external-id' AND account_id = 'acct_header_binding'`, internalID).Scan(&rows); err != nil {
+				t.Fatal(err)
+			}
+			if rows != 1 {
+				t.Fatalf("terminal mapping does not match initial internal ID: rows=%d", rows)
+			}
+		})
+	}
+}
+
+func TestSettlementFinalityRequiredInternalRequestQueryFailsClosed(t *testing.T) {
+	reqLog, _ := openBuyerRequestLog(t)
+	defer reqLog.Close()
+	store, err := billing.NewStore(reqLog.DB())
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := buyer.NewServer(pool.NewRegistry(nil), zerolog.Nop(), time.Now(),
+		buyer.WithBilling(store, config.RewardsConfig{}), buyer.WithGatewayServiceToken("gateway-secret"))
+	for _, tc := range []struct {
+		name, query, authorization string
+		status                     int
+	}{
+		{"unknown_current", "&required_internal_request_id=current&reservation_created_at_unix_ms=1", "Bearer gateway-secret", http.StatusNotFound},
+		{"missing_generation", "&required_internal_request_id=current", "Bearer gateway-secret", http.StatusBadRequest},
+		{"zero_generation", "&required_internal_request_id=current&reservation_created_at_unix_ms=0", "Bearer gateway-secret", http.StatusBadRequest},
+		{"empty_binding", "&required_internal_request_id=&reservation_created_at_unix_ms=1", "Bearer gateway-secret", http.StatusBadRequest},
+		{"duplicate_binding", "&required_internal_request_id=a&required_internal_request_id=b&reservation_created_at_unix_ms=1", "Bearer gateway-secret", http.StatusBadRequest},
+		{"invalid_binding", "&required_internal_request_id=%00&reservation_created_at_unix_ms=1", "Bearer gateway-secret", http.StatusBadRequest},
+		{"overlong_binding", "&required_internal_request_id=" + strings.Repeat("x", 129) + "&reservation_created_at_unix_ms=1", "Bearer gateway-secret", http.StatusBadRequest},
+		{"unauthorized", "&required_internal_request_id=current&reservation_created_at_unix_ms=1", "", http.StatusUnauthorized},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/internal/settlement/finality?account_id=acct_test&request_id=external"+tc.query, nil)
+			req.Header.Set("Authorization", tc.authorization)
+			rr := httptest.NewRecorder()
+			server.InternalHandler().ServeHTTP(rr, req)
+			if rr.Code != tc.status {
+				t.Fatalf("status=%d want=%d body=%s", rr.Code, tc.status, rr.Body.String())
+			}
+			if strings.Contains(rr.Body.String(), `"required_internal_request_id":`) {
+				t.Fatalf("unconfirmed membership echoed: %s", rr.Body.String())
+			}
+		})
+	}
+}

--- a/phase5-gateway/README.md
+++ b/phase5-gateway/README.md
@@ -16,7 +16,8 @@ Phase 5 gateway implementation for SPEC-006 v0.9.13. The gateway is intentionall
 - OpenAI-shaped chat forwarding to `coordinator.buyer_url`, including SSE pass-through and buyer disconnect cancellation.
 - `/v1/models`, `/v1/usage`, `/v1/chat/completions`, optional stateless `/v1/responses`, `/v1/status`, `/v1/feedback`, `/healthz`.
 - OpenAI-shaped chat forwarding to `coordinator.buyer_url`, including SSE pass-through and buyer disconnect cancellation; the optional Responses facade translates into the same billed path.
-- Quota reservation/settlement for success, 503 refund, 502/504 prompt-only or partial usage, demo chat usage, provider-reported streaming actuals, and byte-estimation fallback.
+- Quota reservation/settlement for success, 503 refund, 502/504 prompt-only or partial usage, demo chat usage, provider-reported streaming actuals, and byte-estimation fallback for legacy/observe traffic. Covered SPEC-022 enforce traffic retains receipt authority: missing declared finality holds the reservation for reconciliation, and facade validation errors cannot authorize a fallback debit.
+- Chat/Responses admission rejects duplicate or noncanonical recognized request fields before reservation and dispatch, preventing case-dependent token-cap interpretation across services.
 - Storage-backed per-account concurrency caps.
 - Inbound and outbound `X-MacProvider-*` stripping plus UUID-v4 `X-Request-ID` generation/forwarding.
 - Buyer-safe `/v1/status` from coordinator `/poolz` with redaction and 10-second cache.
@@ -24,6 +25,56 @@ Phase 5 gateway implementation for SPEC-006 v0.9.13. The gateway is intentionall
 - Deployment templates in `dist/` and AC status matrix in `docs/AC_STATUS.md`.
 
 Known gaps before production are documented in `docs/AC_STATUS.md`: live GitHub OAuth, live OpenAI SDK smoke, Pearl nginx/systemd verification, and front-door migration/docs checks.
+
+## OAuth Handoff Custody
+
+OAuth `return_to` redirects carry a five-minute, single-use handoff token. The
+database stores its hash and account-bound issuance intent, not an API key.
+Exchange generates the key in memory and atomically stores only its hash while
+consuming the intent. The handoff callback does not also deliver a key cookie.
+Direct `/account` delivery remains available, including when intent persistence
+fails; failed or expired handoffs require a fresh OAuth flow with `action=mint`.
+
+Schema version 12 invalidates every legacy plaintext handoff, including consumed
+rows, and replaces the table without its `api_key` column. Stop the old gateway
+before upgrading and migrate before serving requests; do not run old and new
+binaries against the same database. In-flight legacy handoffs must restart OAuth.
+Older binaries refuse the version-12 database. A rollback must follow the existing
+snapshot/drain/reconciliation policy, not simply restore a snapshot after new
+auth or billing traffic has occurred.
+
+This migration does not revoke existing API keys or erase historical database
+pages, WAL files, snapshots or backups containing old handoffs. Assess those
+copies and authorize any necessary key revocation or retention cleanup separately;
+do not print recovered keys or assume logical row deletion erased old secrets.
+
+## Receipt Finality Recovery
+
+Missing declared settlement trailers do not authorize a local debit. The gateway
+holds the reservation and persists its local usage candidate, bound to the exact
+reservation generation, before attempting observe-mode recovery. Reconciliation
+can recover that candidate after an authority outage or gateway restart without
+substituting receipt totals for locally observed usage.
+Retry order is persisted so unavailable older requests cannot monopolize bounded
+reconciliation batches across restarts.
+
+Deploy the coordinator update first: recovery requires its authenticated
+`mode_scope_complete` signal, a matching request scope containing the current
+`X-MacProvider-Internal-Request-ID`, and the recognized observe policy. The
+`required_internal_request_id` lookup fence prevents an earlier logged retry from
+authorizing recovery before the current attempt is visible. Older coordinator
+responses, incomplete or mixed scopes, and unavailable
+authority leave the candidate held. Enforce-mode receipt finality remains
+authoritative; local facade validation cannot replace it. Observe fallback is not
+a verified-receipt or privacy-conformance claim.
+
+Schema version 12 also stores recovery candidates. Historical holds created before
+candidate persistence are not automatically reconstructed; assess those through
+the existing reconciliation and operator procedures.
+Requests without the current-attempt header also cannot create an automatically
+recoverable observe candidate. Their empty binding is persisted as a hold that
+cannot enter unbound reconciliation; deploy the coordinator first to avoid these
+holds.
 
 ## Local Development
 

--- a/phase5-gateway/internal/router/anthropic_messages_test.go
+++ b/phase5-gateway/internal/router/anthropic_messages_test.go
@@ -472,7 +472,7 @@ func TestAnthropicMessagesNonStreamingContentFilterMapsToRefusal(t *testing.T) {
 	}
 }
 
-func TestAnthropicMessagesNonStreamingInvalidProviderResponseIgnoresVerifiedFinalityDebit(t *testing.T) {
+func TestAnthropicMessagesNonStreamingInvalidProviderResponsePreservesVerifiedFinality(t *testing.T) {
 	finality := settlementFinalityTrailerForTest("enforce", settlementPolicyVersion, "verified", "valid", "true", "receipt_verified")
 	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		body := `{"id":"chatcmpl_bad_verified","object":"chat.completion","created":1,"model":"claude",` +
@@ -494,13 +494,9 @@ func TestAnthropicMessagesNonStreamingInvalidProviderResponseIgnoresVerifiedFina
 	if resp.Code != http.StatusBadGateway {
 		t.Fatalf("status=%d want 502 body=%s", resp.Code, resp.Body.String())
 	}
-	outcome, source, completion, prompt := usageEventOutcomeAndTokens(t, dbPath, "acct_anthropic_bad_verified_finality")
-	if outcome != "invalid_provider_response" || source != "provider_reported" || completion != 7 || prompt != 5 {
-		t.Fatalf("usage outcome/source/completion/prompt=%s/%s/%d/%d want invalid_provider_response/provider_reported/7/5", outcome, source, completion, prompt)
-	}
 	snap := gatewaySettlementSnapshot(t, dbPath, "acct_anthropic_bad_verified_finality")
-	if snap.heldRows != 0 || snap.activeRows != 0 || snap.settledRows != 1 {
-		t.Fatalf("settlement snapshot=%+v want settled invalid-provider row with no finality hold", snap)
+	if snap.usageRows != 0 || snap.activeRows != 1 || snap.settledRows != 0 || snap.refundedRows != 0 {
+		t.Fatalf("settlement snapshot=%+v want coordinator finality hold without facade debit", snap)
 	}
 }
 
@@ -1589,7 +1585,7 @@ func TestAnthropicMessagesStreamingRefusalMapsToText(t *testing.T) {
 	}
 }
 
-func TestAnthropicMessagesStreamingInvalidProviderResponseIgnoresVerifiedFinalityDebit(t *testing.T) {
+func TestAnthropicMessagesStreamingInvalidProviderResponsePreservesVerifiedFinality(t *testing.T) {
 	stream := `data: {"id":"chatcmpl_refusal_verified","model":"claude-stream","choices":[{"delta":{"unsupported_output":"no"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":7,"total_tokens":12}}`
 	stream += "\n\ndata: [DONE]\n\n"
 	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
@@ -1615,13 +1611,9 @@ func TestAnthropicMessagesStreamingInvalidProviderResponseIgnoresVerifiedFinalit
 	if !strings.Contains(resp.Body.String(), "event: error") || !strings.Contains(resp.Body.String(), `"code":"invalid_provider_response"`) {
 		t.Fatalf("stream did not fail closed:\n%s", resp.Body.String())
 	}
-	outcome, source, completion, prompt := usageEventOutcomeAndTokens(t, dbPath, "acct_anthropic_stream_bad_verified_finality")
-	if outcome != "invalid_provider_response" || source != "gateway_estimated" || completion != 0 || prompt <= 0 {
-		t.Fatalf("usage outcome/source/completion/prompt=%s/%s/%d/%d want invalid_provider_response/gateway_estimated/0/nonzero", outcome, source, completion, prompt)
-	}
 	snap := gatewaySettlementSnapshot(t, dbPath, "acct_anthropic_stream_bad_verified_finality")
-	if snap.heldRows != 0 || snap.activeRows != 0 || snap.settledRows != 1 {
-		t.Fatalf("settlement snapshot=%+v want settled invalid-provider row with no finality hold", snap)
+	if snap.usageRows != 0 || snap.activeRows != 1 || snap.settledRows != 0 || snap.refundedRows != 0 {
+		t.Fatalf("settlement snapshot=%+v want coordinator finality hold without facade debit", snap)
 	}
 }
 

--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -51,13 +51,14 @@ type usageSubject struct {
 }
 
 const (
-	settlementOutcomeHeader       = "X-MacProvider-Settlement-Outcome"
-	settlementReceiptResultHeader = "X-MacProvider-Settlement-Receipt-Result"
-	settlementReasonHeader        = "X-MacProvider-Settlement-Reason"
-	settlementClosedHeader        = "X-MacProvider-Settlement-Closed"
-	settlementModeHeader          = "X-MacProvider-Settlement-Mode"
-	settlementPolicyVersionHeader = "X-MacProvider-Settlement-Policy-Version"
-	settlementPendingUntilHeader  = "X-MacProvider-Settlement-Pending-Deadline-Unix-Ms"
+	settlementOutcomeHeader            = "X-MacProvider-Settlement-Outcome"
+	settlementReceiptResultHeader      = "X-MacProvider-Settlement-Receipt-Result"
+	settlementReasonHeader             = "X-MacProvider-Settlement-Reason"
+	settlementClosedHeader             = "X-MacProvider-Settlement-Closed"
+	settlementModeHeader               = "X-MacProvider-Settlement-Mode"
+	settlementPolicyVersionHeader      = "X-MacProvider-Settlement-Policy-Version"
+	settlementPendingUntilHeader       = "X-MacProvider-Settlement-Pending-Deadline-Unix-Ms"
+	coordinatorInternalRequestIDHeader = "X-MacProvider-Internal-Request-ID"
 	// settlementNoPriorDispatchHeader mirrors the coordinator constant of the
 	// same name (separate Go module, intentionally duplicated). The coordinator
 	// sets it on a route_snapshot_failed ONLY when it is the genuine first
@@ -676,7 +677,13 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	if authn.WalletSession != nil && err == nil && resp != nil {
 		if markErr := s.store.MarkWalletSessionDispatched(context.Background(), authn.WalletSession.Session.SessionID, requestID(r), s.now().UTC()); markErr != nil {
 			_ = resp.Body.Close()
-			_ = s.store.HoldWalletSessionReservation(context.Background(), subject.AccountID, subject.WalletSessionID, requestID(r), s.now().UTC())
+			holdCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			_ = s.boundStreamingSettlementHoldWithCandidate(holdCtx, r, subject, coordinatorSettlementFinality{
+				Action:  settlementFinalityHold,
+				Outcome: "wallet_dispatch_persist_failed",
+				Reason:  "gateway_wallet_dispatch_persist_failed",
+			}, resp.Header, promptEstimate, 0, maxUsageTokens, "gateway_estimated", "wallet_dispatch_persist_failed", window)
 			writeError(w, http.StatusInternalServerError, "server_error", "settlement_failed", "Settlement failed")
 			return
 		}
@@ -1240,11 +1247,11 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 		if hasSettlementFinalityTrailerDeclaration(resp) || coordinatorSettlementFinalityFromHeaders(resp.Header).Action != settlementFinalityLegacy {
 			holdCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
-			if !s.boundStreamingSettlementHold(holdCtx, r, subject, coordinatorSettlementFinality{
+			if !s.boundStreamingSettlementHoldWithCandidate(holdCtx, r, subject, coordinatorSettlementFinality{
 				Action:  settlementFinalityHold,
 				Outcome: "stream_output_exceeded",
 				Reason:  "gateway_stream_output_exceeded",
-			}) {
+			}, resp.Header, promptEstimate, completion, maxUsageTokens, "gateway_estimated", "stream_output_exceeded", reservationWindow) {
 				slog.Error("gateway failed to persist output-exceeded streaming settlement hold",
 					"request_id", requestID(r),
 					"account_id", subject.AccountID,
@@ -1268,11 +1275,11 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 		if hasSettlementFinalityTrailerDeclaration(resp) || coordinatorSettlementFinalityFromHeaders(resp.Header).Action != settlementFinalityLegacy {
 			holdCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
-			if !s.boundStreamingSettlementHold(holdCtx, r, subject, coordinatorSettlementFinality{
+			if !s.boundStreamingSettlementHoldWithCandidate(holdCtx, r, subject, coordinatorSettlementFinality{
 				Action:  settlementFinalityHold,
 				Outcome: outcome,
 				Reason:  "gateway_" + outcome,
-			}) {
+			}, resp.Header, promptEstimate, gatewayContentEstimatedCompletion(), maxUsageTokens, "gateway_estimated", outcome, reservationWindow) {
 				slog.Error("gateway failed to persist local terminal streaming settlement hold",
 					"request_id", requestID(r),
 					"account_id", subject.AccountID,
@@ -1945,7 +1952,8 @@ func (s *Server) passThroughReceiptEligibleProviderError(w http.ResponseWriter, 
 	case settlementFinalityDebit:
 		holdCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		if !s.boundStreamingSettlementHold(holdCtx, r, subject, finality) {
+		if !s.boundStreamingSettlementHoldWithCandidate(holdCtx, r, subject, finality, resp.Header,
+			promptEstimate, 0, maxUsageTokens, "gateway_estimated", "upstream_error", "") {
 			writeError(w, http.StatusInternalServerError, "server_error", "settlement_failed", "Could not settle usage")
 			return
 		}
@@ -1958,7 +1966,8 @@ func (s *Server) passThroughReceiptEligibleProviderError(w http.ResponseWriter, 
 	case settlementFinalityHold:
 		holdCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		if !s.boundStreamingSettlementHold(holdCtx, r, subject, finality) {
+		if !s.boundStreamingSettlementHoldWithCandidate(holdCtx, r, subject, finality, resp.Header,
+			promptEstimate, 0, maxUsageTokens, "gateway_estimated", "upstream_error", "") {
 			writeError(w, http.StatusInternalServerError, "server_error", "settlement_failed", "Could not settle usage")
 			return
 		}
@@ -2251,7 +2260,8 @@ func (s *Server) settleBeforeResponseWithCoordinatorFinalityPolicy(w http.Respon
 	case settlementFinalityDebit:
 		holdCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		if !s.boundStreamingSettlementHold(holdCtx, r, subject, finality) {
+		if !s.boundStreamingSettlementHoldWithCandidate(holdCtx, r, subject, finality, h,
+			prompt, completion, maxTotal, source, outcome, "") {
 			writeError(w, http.StatusInternalServerError, "server_error", "settlement_failed", "Could not settle usage")
 			return false
 		}
@@ -2279,7 +2289,8 @@ func (s *Server) settleBeforeResponseWithCoordinatorFinalityPolicy(w http.Respon
 	case settlementFinalityHold:
 		holdCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		if !s.boundStreamingSettlementHold(holdCtx, r, subject, finality) {
+		if !s.boundStreamingSettlementHoldWithCandidate(holdCtx, r, subject, finality, h,
+			prompt, completion, maxTotal, source, outcome, "") {
 			writeError(w, http.StatusInternalServerError, "server_error", "settlement_failed", "Could not settle usage")
 			return false
 		}
@@ -2298,7 +2309,7 @@ func (s *Server) settleBeforeResponseWithCoordinatorFinalityPolicy(w http.Respon
 
 func (s *Server) settleStreamingAfterCommitWithCoordinatorFinality(r *http.Request, subject usageSubject, prompt, completion, maxTotal int64, source, outcome, reservationWindow string, resp *http.Response) {
 	finality := coordinatorStreamingSettlementFinality(resp)
-	internalRequestID := strings.TrimSpace(resp.Header.Get("X-MacProvider-Internal-Request-ID"))
+	internalRequestID := strings.TrimSpace(resp.Header.Get(coordinatorInternalRequestIDHeader))
 	if finality.Reason == "missing_settlement_finality_trailer" && !subject.ReservationCreatedAt.IsZero() && coordinatorHeadersPermitObserveFallback(resp.Header) {
 		fallbackOutcome := outcome
 		if fallbackOutcome == "ok" {
@@ -2335,7 +2346,8 @@ func (s *Server) settleStreamingAfterCommitWithCoordinatorFinality(r *http.Reque
 		}
 		s.settleAfterCommit(r, subject, prompt, completion, maxTotal, source, outcome, reservationWindow)
 	case settlementFinalityDebit:
-		s.markStreamingSettlementHoldForReconciliation(r, subject, finality)
+		s.markStreamingSettlementHoldForReconciliation(r, subject, finality, resp.Header,
+			prompt, completion, maxTotal, source, outcome, reservationWindow)
 	case settlementFinalityRefund:
 		if err := s.refundWalletAwareReservation(subject, requestID(r)); err != nil && !errors.Is(err, storage.ErrReservationNotFound) {
 			slog.Error("gateway streaming settlement refund failed after coordinator receipt finality",
@@ -2351,7 +2363,12 @@ func (s *Server) settleStreamingAfterCommitWithCoordinatorFinality(r *http.Reque
 		// receipt authority in the reconciler; missing finality is not a debit.
 		holdCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		if !s.boundStreamingSettlementHold(holdCtx, r, subject, finality) {
+		reconcileOutcome := outcome
+		if reconcileOutcome == "ok" {
+			reconcileOutcome = "unverified_streaming"
+		}
+		if !s.boundStreamingSettlementHoldWithCandidate(holdCtx, r, subject, finality, resp.Header,
+			prompt, completion, maxTotal, source, reconcileOutcome, reservationWindow) {
 			slog.Error("gateway failed to persist streaming settlement hold after coordinator finality",
 				"request_id", requestID(r),
 				"account_id", subject.AccountID,
@@ -2367,7 +2384,7 @@ func (s *Server) settleStreamingAfterCommitWithCoordinatorFinality(r *http.Reque
 // Only request-scoped coordinator authority can release an unknown-mode hold
 // into legacy accounting. Use the local usage tuple, not receipt-only totals.
 func (s *Server) resolveMissingFinalityAsObserve(r *http.Request, subject usageSubject, resp *http.Response) bool {
-	internalRequestID := strings.TrimSpace(resp.Header.Get("X-MacProvider-Internal-Request-ID"))
+	internalRequestID := strings.TrimSpace(resp.Header.Get(coordinatorInternalRequestIDHeader))
 	if subject.ReservationCreatedAt.IsZero() || s.cfg.Coordinator.OperatorURL == "" || internalRequestID == "" {
 		return false
 	}
@@ -2392,9 +2409,13 @@ func coordinatorHeadersPermitObserveFallback(h http.Header) bool {
 		(policy == "" || policy == settlementPolicyVersion || policy == legacySettlementPolicyVersion)
 }
 
-func (s *Server) markStreamingSettlementHoldForReconciliation(r *http.Request, subject usageSubject, finality coordinatorSettlementFinality) {
+func (s *Server) markStreamingSettlementHoldForReconciliation(r *http.Request, subject usageSubject, finality coordinatorSettlementFinality,
+	h http.Header, prompt, completion, maxTotal int64, source, outcome, reservationWindow string,
+) {
 	holdCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
+	s.persistSettlementReconcileCandidate(holdCtx, r, subject, finality, h,
+		prompt, completion, maxTotal, source, outcome, reservationWindow)
 	if err := s.holdWalletAwareReservation(holdCtx, subject, requestID(r)); err != nil {
 		if errors.Is(err, storage.ErrReservationNotFound) || errors.Is(err, storage.ErrReservationTerminal) {
 			slog.Info("gateway skipped streaming settlement hold after coordinator finality because reservation is not active",
@@ -2444,6 +2465,56 @@ func (s *Server) markStreamingSettlementHoldForReconciliation(r *http.Request, s
 		"settlement_outcome", finality.Outcome,
 		"settlement_reason", finality.Reason,
 	)
+}
+
+func (s *Server) boundStreamingSettlementHoldWithCandidate(ctx context.Context, r *http.Request, subject usageSubject,
+	finality coordinatorSettlementFinality, h http.Header, prompt, completion, maxTotal int64, source, outcome, reservationWindow string,
+) bool {
+	s.persistSettlementReconcileCandidate(ctx, r, subject, finality, h,
+		prompt, completion, maxTotal, source, outcome, reservationWindow)
+	return s.boundStreamingSettlementHold(ctx, r, subject, finality)
+}
+
+func (s *Server) persistSettlementReconcileCandidate(ctx context.Context, r *http.Request, subject usageSubject,
+	finality coordinatorSettlementFinality, h http.Header, prompt, completion, maxTotal int64, source, outcome, reservationWindow string,
+) {
+	if subject.ReservationCreatedAt.IsZero() {
+		slog.Error("gateway could not persist current-attempt settlement binding",
+			"request_id", requestID(r),
+			"account_id", subject.AccountID,
+			"settlement_outcome", finality.Outcome,
+			"settlement_reason", finality.Reason,
+			"error", "reservation creation time is unavailable",
+		)
+		return
+	}
+	if reservationWindow == "" && !subject.ReservationCreatedAt.IsZero() {
+		reservationWindow = subject.ReservationCreatedAt.UTC().Format("2006-01-02")
+	}
+	candidate := storage.SettlementFallbackCandidate{
+		AccountID:                 subject.AccountID,
+		RequestID:                 requestID(r),
+		RequiredInternalRequestID: strings.TrimSpace(h.Get(coordinatorInternalRequestIDHeader)),
+		ReservationCreatedAt:      subject.ReservationCreatedAt,
+		WalletSessionID:           subject.WalletSessionID,
+		DemoIdentity:              subject.DemoIdentity,
+		DemoTokenHash:             subject.DemoTokenHash,
+		WindowDate:                reservationWindow,
+		PromptTokens:              prompt,
+		CompletionTokens:          completion,
+		MaxTotalTokens:            maxTotal,
+		TokenSource:               source,
+		Outcome:                   outcome,
+	}
+	if err := s.store.SaveSettlementFallbackCandidate(ctx, candidate); err != nil {
+		slog.Error("gateway could not persist current-attempt settlement binding",
+			"request_id", requestID(r),
+			"account_id", subject.AccountID,
+			"settlement_outcome", finality.Outcome,
+			"settlement_reason", finality.Reason,
+			"error", err,
+		)
+	}
 }
 
 func (s *Server) boundStreamingSettlementHold(ctx context.Context, r *http.Request, subject usageSubject, finality coordinatorSettlementFinality) bool {

--- a/phase5-gateway/internal/router/chat_proxy.go
+++ b/phase5-gateway/internal/router/chat_proxy.go
@@ -43,10 +43,11 @@ type tokenUsage struct {
 }
 
 type usageSubject struct {
-	AccountID       string
-	DemoIdentity    string
-	DemoTokenHash   string
-	WalletSessionID string
+	AccountID            string
+	DemoIdentity         string
+	DemoTokenHash        string
+	WalletSessionID      string
+	ReservationCreatedAt time.Time
 }
 
 const (
@@ -452,18 +453,19 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid_request_error", "token_limit_overflow", "Requested token reservation overflows")
 		return
 	}
-	window := s.now().UTC().Format("2006-01-02")
+	subject.ReservationCreatedAt = s.now().UTC()
+	window := subject.ReservationCreatedAt.Format("2006-01-02")
 	reservationMaxAge := time.Duration(s.cfg.Quotas.ReservationMaxAgeHours) * time.Hour
 	var decision storage.QuotaDecision
 	var sessionDecision storage.WalletSessionAdmissionDecision
 	if authn.WalletSession != nil {
-		sessionDecision, err = s.admitWalletSessionInference(r, authn.WalletSession, originalBody, model, reservationTokens, dailyQuota, window, s.now().Add(reservationMaxAge))
+		sessionDecision, err = s.admitWalletSessionInference(r, authn.WalletSession, originalBody, model, reservationTokens, dailyQuota, window, subject.ReservationCreatedAt, s.now().Add(reservationMaxAge))
 		decision = sessionDecision.AccountQuota
 	} else {
 		decision, err = s.store.ReserveQuota(r.Context(), storage.ReservationRequest{
 			AccountID: subject.AccountID, RequestID: requestID(r), WindowDate: window,
 			RequestedTokens: reservationTokens, DailyQuota: dailyQuota,
-			CreatedAt: s.now(), ExpiresAt: s.now().Add(reservationMaxAge),
+			CreatedAt: subject.ReservationCreatedAt, ExpiresAt: s.now().Add(reservationMaxAge),
 		})
 	}
 	if errors.Is(err, storage.ErrQuotaExceeded) {
@@ -1235,7 +1237,7 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 		// This is a gateway-authored terminal SSE error. The gateway cancels
 		// the coordinator stream before EOF, so declared settlement trailers
 		// may be unavailable and must not rewrite the buyer-visible outcome.
-		if hasSettlementFinalityTrailerDeclaration(resp) {
+		if hasSettlementFinalityTrailerDeclaration(resp) || coordinatorSettlementFinalityFromHeaders(resp.Header).Action != settlementFinalityLegacy {
 			holdCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 			if !s.boundStreamingSettlementHold(holdCtx, r, subject, coordinatorSettlementFinality{
@@ -1263,7 +1265,7 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 		if estimateTokensFromBytes(emitted) > maxStreamingCompletionTokens(maxTokens) {
 			outcome = "stream_output_exceeded"
 		}
-		if hasSettlementFinalityTrailerDeclaration(resp) {
+		if hasSettlementFinalityTrailerDeclaration(resp) || coordinatorSettlementFinalityFromHeaders(resp.Header).Action != settlementFinalityLegacy {
 			holdCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 			if !s.boundStreamingSettlementHold(holdCtx, r, subject, coordinatorSettlementFinality{
@@ -1504,6 +1506,10 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 			return false
 		}
 		if adapter := anthropicMessagesAdapterFromContext(r.Context()); adapter != nil && adapter.streamDone && terminalStructuredErrorCode == "" {
+			if flusher != nil {
+				flusher.Flush()
+			}
+			drainFacadeSettlementTrailers(r.Context(), reader, resp, cancelCoordinator)
 			if reported != nil && !invalidReportedUsage {
 				settleReported(adapter.settlementOutcome("ok"))
 			} else {
@@ -1517,6 +1523,10 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 			return false
 		}
 		if adapter := responsesAdapterFromContext(r.Context()); adapter != nil && adapter.streamTerminal && terminalStructuredErrorCode == "" {
+			if flusher != nil {
+				flusher.Flush()
+			}
+			drainFacadeSettlementTrailers(r.Context(), reader, resp, cancelCoordinator)
 			if reported != nil && !invalidReportedUsage {
 				settleReported(adapter.settlementOutcome("ok"))
 			} else {
@@ -1692,6 +1702,28 @@ func (s *Server) forwardStreamingChat(w http.ResponseWriter, r *http.Request, re
 type streamingReadResult struct {
 	line []byte
 	err  error
+}
+
+// The facade terminal event is not HTTP EOF. Read only a bounded tail so the
+// transport can publish finality, without forwarding or accounting later data.
+func drainFacadeSettlementTrailers(ctx context.Context, reader *bufio.Reader, resp *http.Response, cancel func()) {
+	if !hasSettlementFinalityTrailerDeclaration(resp) || hasAnySettlementFinalityHeader(resp.Trailer) {
+		return
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	remaining := maxStreamingLineBytes
+	for remaining > 0 {
+		line, err := readStreamingLineWithIdleTimeout(ctx, reader, deadline, cancel, resp.Body)
+		remaining -= len(line)
+		if err == io.EOF {
+			return
+		}
+		if err != nil {
+			cancel()
+			return
+		}
+	}
+	cancel()
 }
 
 // streamingProgressDeadline converts the configured idle budget into the
@@ -2212,9 +2244,6 @@ func (s *Server) settleBeforeStreamingResponseWithCoordinatorFinality(w http.Res
 }
 
 func (s *Server) settleBeforeResponseWithCoordinatorFinalityPolicy(w http.ResponseWriter, r *http.Request, subject usageSubject, prompt, completion, maxTotal int64, source, outcome string, h http.Header, boundHold bool) bool {
-	if gatewayInvalidResponseOverridesCoordinatorFinality(outcome) {
-		return s.settleBeforeResponse(w, r, subject, prompt, completion, maxTotal, source, outcome)
-	}
 	finality := coordinatorSettlementFinalityFromHeaders(h)
 	switch finality.Action {
 	case settlementFinalityLegacy:
@@ -2268,11 +2297,37 @@ func (s *Server) settleBeforeResponseWithCoordinatorFinalityPolicy(w http.Respon
 }
 
 func (s *Server) settleStreamingAfterCommitWithCoordinatorFinality(r *http.Request, subject usageSubject, prompt, completion, maxTotal int64, source, outcome, reservationWindow string, resp *http.Response) {
-	if gatewayInvalidResponseOverridesCoordinatorFinality(outcome) {
-		s.settleAfterCommit(r, subject, prompt, completion, maxTotal, source, outcome, reservationWindow)
-		return
-	}
 	finality := coordinatorStreamingSettlementFinality(resp)
+	internalRequestID := strings.TrimSpace(resp.Header.Get("X-MacProvider-Internal-Request-ID"))
+	if finality.Reason == "missing_settlement_finality_trailer" && !subject.ReservationCreatedAt.IsZero() && coordinatorHeadersPermitObserveFallback(resp.Header) {
+		fallbackOutcome := outcome
+		if fallbackOutcome == "ok" {
+			fallbackOutcome = "unverified_streaming"
+		}
+		if reservationWindow == "" {
+			reservationWindow = subject.ReservationCreatedAt.UTC().Format("2006-01-02")
+		}
+		candidate := storage.SettlementFallbackCandidate{
+			RequiredInternalRequestID: internalRequestID,
+			AccountID:                 subject.AccountID, RequestID: requestID(r), ReservationCreatedAt: subject.ReservationCreatedAt,
+			WalletSessionID: subject.WalletSessionID, DemoIdentity: subject.DemoIdentity, DemoTokenHash: subject.DemoTokenHash,
+			WindowDate: reservationWindow, PromptTokens: prompt, CompletionTokens: completion,
+			MaxTotalTokens: maxTotal, TokenSource: source, Outcome: fallbackOutcome,
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		err := s.store.SaveSettlementFallbackCandidate(ctx, candidate)
+		cancel()
+		if err != nil {
+			slog.Error("gateway could not persist unknown-mode settlement candidate", "request_id", requestID(r), "error", err)
+		} else if s.resolveMissingFinalityAsObserve(r, subject, resp) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if err := s.settleObserveFallbackCandidate(ctx, candidate); err != nil {
+				slog.Error("gateway deferred observe fallback to durable reconciliation", "request_id", requestID(r), "error", err)
+			}
+			return
+		}
+	}
 	switch finality.Action {
 	case settlementFinalityLegacy:
 		if outcome == "ok" {
@@ -2292,10 +2347,8 @@ func (s *Server) settleStreamingAfterCommitWithCoordinatorFinality(r *http.Reque
 			)
 		}
 	case settlementFinalityHold:
-		if finality.Reason == "missing_settlement_finality_trailer" {
-			s.settleAfterCommit(r, subject, prompt, completion, maxTotal, source, "unverified_streaming", reservationWindow)
-			return
-		}
+		// A facade may finish before HTTP EOF makes trailers available. Keep
+		// receipt authority in the reconciler; missing finality is not a debit.
 		holdCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		if !s.boundStreamingSettlementHold(holdCtx, r, subject, finality) {
@@ -2311,8 +2364,32 @@ func (s *Server) settleStreamingAfterCommitWithCoordinatorFinality(r *http.Reque
 	}
 }
 
-func gatewayInvalidResponseOverridesCoordinatorFinality(outcome string) bool {
-	return outcome == "invalid_provider_response"
+// Only request-scoped coordinator authority can release an unknown-mode hold
+// into legacy accounting. Use the local usage tuple, not receipt-only totals.
+func (s *Server) resolveMissingFinalityAsObserve(r *http.Request, subject usageSubject, resp *http.Response) bool {
+	internalRequestID := strings.TrimSpace(resp.Header.Get("X-MacProvider-Internal-Request-ID"))
+	if subject.ReservationCreatedAt.IsZero() || s.cfg.Coordinator.OperatorURL == "" || internalRequestID == "" {
+		return false
+	}
+	if !coordinatorHeadersPermitObserveFallback(resp.Header) {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	finality, found, err := s.fetchCoordinatorRequestSettlementFinality(ctx, storage.ActiveReservation{
+		AccountID: subject.AccountID, RequestID: requestID(r), CreatedAt: subject.ReservationCreatedAt,
+	}, internalRequestID)
+	if err != nil || !found || finality.RequestID != requestID(r) || finality.RequiredInternalRequestID != internalRequestID {
+		return false
+	}
+	return coordinatorObserveFallbackAllowed(finality)
+}
+
+func coordinatorHeadersPermitObserveFallback(h http.Header) bool {
+	mode := strings.TrimSpace(h.Get(settlementModeHeader))
+	policy := strings.TrimSpace(h.Get(settlementPolicyVersionHeader))
+	return (mode == "" || mode == "observe") &&
+		(policy == "" || policy == settlementPolicyVersion || policy == legacySettlementPolicyVersion)
 }
 
 func (s *Server) markStreamingSettlementHoldForReconciliation(r *http.Request, subject usageSubject, finality coordinatorSettlementFinality) {
@@ -2440,7 +2517,7 @@ func coordinatorStreamingSettlementFinality(resp *http.Response) coordinatorSett
 	if hasSettlementFinalityTrailerDeclaration(resp) {
 		return coordinatorSettlementFinality{Action: settlementFinalityHold, Reason: "missing_settlement_finality_trailer"}
 	}
-	return coordinatorSettlementFinality{Action: settlementFinalityLegacy}
+	return coordinatorSettlementFinalityFromHeaders(resp.Header)
 }
 
 func coordinatorSettlementFinalityFromHeaders(h http.Header) coordinatorSettlementFinality {
@@ -3400,6 +3477,9 @@ func writeProviderDisconnectedSSE(w http.ResponseWriter) {
 
 func parseChatRequest(body []byte) (chatRequest, error) {
 	var req chatRequest
+	if err := validateChatRequestFieldNames(body); err != nil {
+		return req, err
+	}
 	if err := json.Unmarshal(body, &req); err != nil {
 		return chatRequest{}, errors.New("Malformed JSON")
 	}

--- a/phase5-gateway/internal/router/oauth.go
+++ b/phase5-gateway/internal/router/oauth.go
@@ -120,74 +120,46 @@ func (s *Server) handleGitHubCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var fullKey string
+	issueKey := false
+	keyAction := ""
 	account, err := s.store.LookupAccountByIdentity(r.Context(), "github", identity.ProviderUserID)
 	if errors.Is(err, storage.ErrNotFound) {
 		account, err = s.createSignupAccount(w, r.Context(), r, identity)
 		if err != nil {
 			return
 		}
-		fullKey, _, err = s.keyMgr.Issue(r.Context(), s.store, account.AccountID)
-		if err != nil {
-			writeError(w, http.StatusInternalServerError, "server_error", "api_key_issuance_failed", "Could not issue API key")
-			return
-		}
+		issueKey = true
 	} else if err != nil {
 		writeError(w, http.StatusInternalServerError, "server_error", "account_lookup_failed", "Could not load account")
 		return
 	} else if action == "mint" {
-		// Existing account, operator-initiated mint. Issue a fresh API key
-		// and deliver via the same one-shot cookie the signup path uses.
-		// keyMgr.Issue stores the new key alongside existing ones; the user
-		// can revoke older keys via POST /auth/api-keys/{key_id}/revoke once
-		// they have a working bearer. Re-issuing (not rotating) preserves
-		// any other still-in-use keys the operator has elsewhere.
-		var summary storage.APIKey
-		fullKey, summary, err = s.keyMgr.Issue(r.Context(), s.store, account.AccountID)
+		issueKey = true
+		keyAction = "mint"
+	}
+	if returnTo != "" {
+		if !issueKey {
+			s.redirectOAuthReturn(w, r, returnTo, "no_key")
+			return
+		}
+		if err := s.redirectOAuthHandoff(r.Context(), w, r, returnTo, account.AccountID, keyAction); err == nil {
+			return
+		}
+		// No key exists yet. If intent persistence fails, issue directly to
+		// the gateway's one-shot /account cookie instead of persisting a key.
+	}
+	if issueKey {
+		fullKey, summary, err := s.keyMgr.Issue(r.Context(), s.store, account.AccountID)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "server_error", "api_key_issuance_failed", "Could not issue API key")
 			return
 		}
-		// Audit payload includes key_id and key_prefix so the lifecycle of
-		// each minted key is traceable end-to-end alongside the revoke/rotate
-		// events in api_key_events. account_id is in Actor; the action label
-		// is in Type so it is filterable without parsing payload.
-		_ = s.store.InsertAuditEvent(r.Context(), storage.AuditEvent{
-			EventID: mustID("audit"), RequestID: requestID(r), Actor: account.AccountID,
-			Type: "api_key_minted_via_oauth",
-			Payload: fmt.Sprintf(`{"action":"mint","key_id":%q,"key_prefix":%q}`,
-				summary.KeyID, summary.KeyHashPrefix),
-			CreatedAt: s.now(),
-		})
-	}
-	// The mp_new_api_key cookie is scoped to the gateway origin's /account
-	// path, so it is not readable by any Malibu return_to page. Setting it
-	// on every fullKey!="" path (not just the legacy /account redirect)
-	// keeps the fallback: if the handoff persistence fails after we have
-	// already consumed the OAuth state and issued the key, the user can
-	// still recover the key by visiting api.malibu.tech/account.
-	if fullKey != "" {
+		if keyAction == "mint" {
+			s.recordOAuthKeyMint(r, account.AccountID, summary)
+		}
 		http.SetCookie(w, &http.Cookie{
 			Name: "mp_new_api_key", Value: fullKey, Path: "/account", HttpOnly: true,
 			Secure: s.secureCookies(), SameSite: http.SameSiteLaxMode, MaxAge: 300,
 		})
-	}
-	if returnTo != "" {
-		if fullKey == "" {
-			s.redirectOAuthReturn(w, r, returnTo, "no_key")
-			return
-		}
-		if err := s.redirectOAuthHandoff(r.Context(), w, r, returnTo, fullKey); err != nil {
-			// Handoff-token persistence failed AFTER the OAuth state was
-			// consumed and a fresh API key was minted. The Malibu handoff
-			// contract can no longer complete (there is no token to
-			// exchange), so we anchor the recovery UX in the gateway itself:
-			// redirect to /account, which reads the mp_new_api_key cookie
-			// set above and shows the key. This keeps the recovery path
-			// stable regardless of what the paired client does on error.
-			http.Redirect(w, r, s.cfg.Public.AccountPath, http.StatusFound)
-		}
-		return
 	}
 	http.Redirect(w, r, s.cfg.Public.AccountPath, http.StatusFound)
 }
@@ -209,13 +181,31 @@ func (s *Server) handleHandoffExchange(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid_request_error", "invalid_handoff", "Handoff token is invalid")
 		return
 	}
-	apiKey, err := s.store.ConsumeOAuthHandoff(r.Context(), auth.StateHash(req.Handoff), s.now())
+	apiKey, key, err := s.keyMgr.Generate("")
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "server_error", "api_key_issuance_failed", "Could not issue API key")
+		return
+	}
+	handoff, err := s.store.ConsumeOAuthHandoff(r.Context(), auth.StateHash(req.Handoff), key, s.now())
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "invalid_request_error", "invalid_handoff", "Handoff token is invalid")
 		return
 	}
+	if handoff.Action == "mint" {
+		s.recordOAuthKeyMint(r, handoff.AccountID, key)
+	}
 	setNoStoreHeaders(w.Header())
 	writeJSON(w, http.StatusOK, map[string]any{"api_key": apiKey})
+}
+
+func (s *Server) recordOAuthKeyMint(r *http.Request, accountID string, key storage.APIKey) {
+	_ = s.store.InsertAuditEvent(r.Context(), storage.AuditEvent{
+		EventID: mustID("audit"), RequestID: requestID(r), Actor: accountID,
+		Type: "api_key_minted_via_oauth",
+		Payload: fmt.Sprintf(`{"action":"mint","key_id":%q,"key_prefix":%q}`,
+			key.KeyID, key.KeyHashPrefix),
+		CreatedAt: s.now(),
+	})
 }
 
 func (s *Server) createSignupAccount(w http.ResponseWriter, ctx context.Context, r *http.Request, identity auth.OAuthIdentity) (storage.Account, error) {
@@ -360,7 +350,7 @@ func (s *Server) callbackAllowed(callback string) bool {
 	return false
 }
 
-func (s *Server) redirectOAuthHandoff(ctx context.Context, w http.ResponseWriter, r *http.Request, returnTo, apiKey string) error {
+func (s *Server) redirectOAuthHandoff(ctx context.Context, w http.ResponseWriter, r *http.Request, returnTo, accountID, action string) error {
 	token, err := auth.StateToken()
 	if err != nil {
 		return err
@@ -368,7 +358,8 @@ func (s *Server) redirectOAuthHandoff(ctx context.Context, w http.ResponseWriter
 	now := s.now()
 	if err := s.store.StoreOAuthHandoff(ctx, storage.OAuthHandoff{
 		TokenHash: auth.StateHash(token),
-		APIKey:    apiKey,
+		AccountID: accountID,
+		Action:    action,
 		CreatedAt: now,
 		ExpiresAt: now.Add(5 * time.Minute),
 	}); err != nil {

--- a/phase5-gateway/internal/router/oauth_handoff_test.go
+++ b/phase5-gateway/internal/router/oauth_handoff_test.go
@@ -8,9 +8,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/augstar/macprovider-gateway/internal/auth"
 	"github.com/augstar/macprovider-gateway/internal/config"
@@ -19,11 +23,7 @@ import (
 )
 
 // failingHandoffStore wraps a Store and forces StoreOAuthHandoff to fail.
-// The wrapper is used to pin the recovery UX when handoff persistence
-// breaks after the OAuth state has been consumed and the API key issued —
-// the callback must redirect to the gateway /account page (which reads the
-// mp_new_api_key cookie) so the user can retrieve the newly minted key
-// without depending on the paired client's error-handling behavior.
+// Recovery issues directly to /account only after intent persistence fails.
 type failingHandoffStore struct {
 	Store
 }
@@ -81,7 +81,7 @@ func TestReturnToAllowedRejectsPrefixAndTraversal(t *testing.T) {
 
 func TestOAuthHandoffFlowRoundTrip(t *testing.T) {
 	identity := auth.OAuthIdentity{ProviderUserID: "handoff-user", Scopes: []string{"read:user"}}
-	h, _, _, _ := newTestHarnessConfig(t, fakeOAuth{identity: identity}, withMalibuReturnTo)
+	h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{identity: identity}, withMalibuReturnTo)
 	returnTo := "https://malibu.tech/console/auth/callback.html"
 
 	startPath := "/auth/github/start?redirect_uri=" + url.QueryEscape("https://api.malibu.tech/auth/github/callback") + "&return_to=" + url.QueryEscape(returnTo)
@@ -126,9 +126,15 @@ func TestOAuthHandoffFlowRoundTrip(t *testing.T) {
 	if got := callbackResp.Header().Get("Cache-Control"); got != "no-store" {
 		t.Fatalf("Cache-Control=%q want no-store", got)
 	}
-	// Fallback cookie is set so /account still works if Malibu is unreachable.
-	if findCookie(callbackResp, "mp_new_api_key") == "" {
-		t.Fatal("mp_new_api_key fallback cookie missing on handoff callback")
+	if findCookie(callbackResp, "mp_new_api_key") != "" {
+		t.Fatal("handoff callback must not issue or expose a key before exchange")
+	}
+	account, err := store.LookupAccountByIdentity(context.Background(), "github", identity.ProviderUserID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if keys, err := store.ListAPIKeys(context.Background(), account.AccountID); err != nil || len(keys) != 0 {
+		t.Fatalf("keys before exchange=%d err=%v", len(keys), err)
 	}
 
 	body, _ := json.Marshal(map[string]string{"handoff": handoff})
@@ -151,6 +157,22 @@ func TestOAuthHandoffFlowRoundTrip(t *testing.T) {
 	if !strings.HasPrefix(reply.APIKey, "mp_") {
 		t.Fatalf("api_key=%q must start with mp_", reply.APIKey)
 	}
+	manager := auth.NewKeyManager(cfg.Auth.KeyPrefix, cfg.Auth.KeyHash, cfg.Auth.KeyHashSecret)
+	if validation, err := manager.Validate(context.Background(), store, reply.APIKey); err != nil || validation.AccountID != account.AccountID {
+		t.Fatalf("exchanged key account=%q err=%v", validation.AccountID, err)
+	}
+	for _, path := range []string{cfg.Storage.DBPath, cfg.Storage.DBPath + "-wal"} {
+		data, err := os.ReadFile(path)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		if bytes.Contains(data, []byte(reply.APIKey)) || bytes.Contains(data, []byte(handoff)) {
+			t.Fatal("OAuth flow persisted a raw credential")
+		}
+	}
 
 	// Replay must fail with the same generic error surface.
 	replayReq := httptest.NewRequest(http.MethodPost, "/auth/handoff/exchange", bytes.NewReader(body))
@@ -163,14 +185,14 @@ func TestOAuthHandoffFlowRoundTrip(t *testing.T) {
 	if !strings.Contains(replayResp.Body.String(), "invalid_handoff") {
 		t.Fatalf("replay body=%q want invalid_handoff", replayResp.Body.String())
 	}
+	if keys, err := store.ListAPIKeys(context.Background(), account.AccountID); err != nil || len(keys) != 1 {
+		t.Fatalf("keys after replay=%d err=%v", len(keys), err)
+	}
 }
 
 // TestOAuthHandoffPersistenceFailureRedirectsToAccount pins the recovery
-// contract when StoreOAuthHandoff fails after the OAuth state is consumed
-// and the API key is minted. The callback must NOT redirect back to
-// Malibu (there is no handoff token to exchange) — it must anchor the
-// recovery UX inside the gateway by redirecting to Public.AccountPath so
-// the pre-set mp_new_api_key cookie can hand the user their key.
+// contract when intent persistence fails: issue once to the gateway cookie
+// and redirect to /account, without requiring a handoff exchange.
 func TestOAuthHandoffPersistenceFailureRedirectsToAccount(t *testing.T) {
 	identity := auth.OAuthIdentity{ProviderUserID: "handoff-fail-user", Scopes: []string{"read:user"}}
 	cfg := config.Default()
@@ -250,6 +272,124 @@ func TestHandoffExchangeErrorSurface(t *testing.T) {
 	h.ServeHTTP(unknownResp, unknownReq)
 	if unknownResp.Code != http.StatusBadRequest || !strings.Contains(unknownResp.Body.String(), "invalid_handoff") {
 		t.Fatalf("unknown token status=%d body=%s", unknownResp.Code, unknownResp.Body.String())
+	}
+}
+
+func TestOAuthHandoffConcurrentHTTPExchange(t *testing.T) {
+	h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, withMalibuReturnTo)
+	ctx := context.Background()
+	if err := store.CreateAccount(ctx, storage.Account{
+		AccountID: "acct_handoff", Status: "active", QuotaClass: "default", ConcurrencyClass: "default", CreatedAt: fixedNow(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	token, err := auth.StateToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.StoreOAuthHandoff(ctx, storage.OAuthHandoff{
+		TokenHash: auth.StateHash(token), AccountID: "acct_handoff", Action: "mint",
+		CreatedAt: fixedNow(), ExpiresAt: fixedNow().Add(5 * time.Minute),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	body, _ := json.Marshal(map[string]string{"handoff": token})
+	var succeeded atomic.Int32
+	var rejected atomic.Int32
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			response := httptest.NewRecorder()
+			h.ServeHTTP(response, httptest.NewRequest(http.MethodPost, "/auth/handoff/exchange", bytes.NewReader(body)))
+			switch response.Code {
+			case http.StatusOK:
+				succeeded.Add(1)
+				var reply struct {
+					APIKey string `json:"api_key"`
+				}
+				if err := json.Unmarshal(response.Body.Bytes(), &reply); err != nil {
+					t.Errorf("decode: %v", err)
+					return
+				}
+				manager := auth.NewKeyManager(cfg.Auth.KeyPrefix, cfg.Auth.KeyHash, cfg.Auth.KeyHashSecret)
+				if validation, err := manager.Validate(ctx, store, reply.APIKey); err != nil || validation.AccountID != "acct_handoff" {
+					t.Errorf("issued key account=%q err=%v", validation.AccountID, err)
+				}
+			case http.StatusBadRequest:
+				rejected.Add(1)
+				if !strings.Contains(response.Body.String(), "invalid_handoff") {
+					t.Error("replay response did not use generic invalid_handoff")
+				}
+			default:
+				t.Errorf("exchange status=%d", response.Code)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	if succeeded.Load() != 1 || rejected.Load() != 15 {
+		t.Fatalf("succeeded=%d rejected=%d", succeeded.Load(), rejected.Load())
+	}
+	if keys, err := store.ListAPIKeys(ctx, "acct_handoff"); err != nil || len(keys) != 1 {
+		t.Fatalf("issued keys=%d err=%v", len(keys), err)
+	}
+}
+
+func TestOAuthHandoffExistingAccountIntent(t *testing.T) {
+	for _, action := range []string{"", "mint"} {
+		t.Run("action_"+action, func(t *testing.T) {
+			ctx := context.Background()
+			identity := auth.OAuthIdentity{ProviderUserID: "existing-handoff", Scopes: []string{"read:user"}}
+			h, store, _, _ := newTestHarnessConfig(t, fakeOAuth{identity: identity}, withMalibuReturnTo)
+			completeOAuth(t, h, "", "https://api.malibu.tech/auth/github/callback")
+			account, err := store.LookupAccountByIdentity(ctx, "github", identity.ProviderUserID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			query := url.Values{"action": {action}, "return_to": {"https://malibu.tech/console/auth/callback.html"}}
+			start := httptest.NewRecorder()
+			h.ServeHTTP(start, httptest.NewRequest(http.MethodGet, "/auth/github/start?"+query.Encode(), nil))
+			location, err := url.Parse(start.Header().Get("Location"))
+			if err != nil || start.Code != http.StatusFound {
+				t.Fatalf("start status=%d err=%v", start.Code, err)
+			}
+			callback := httptest.NewRequest(http.MethodGet, "/auth/github/callback?code=ok&state="+url.QueryEscape(location.Query().Get("state")), nil)
+			for _, cookie := range start.Result().Cookies() {
+				callback.AddCookie(cookie)
+			}
+			response := httptest.NewRecorder()
+			h.ServeHTTP(response, callback)
+			if response.Code != http.StatusFound || findCookie(response, "mp_new_api_key") != "" {
+				t.Fatalf("callback status=%d or premature key cookie", response.Code)
+			}
+			if keys, err := store.ListAPIKeys(ctx, account.AccountID); err != nil || len(keys) != 1 {
+				t.Fatalf("keys before exchange=%d err=%v", len(keys), err)
+			}
+			target, err := url.Parse(response.Header().Get("Location"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			token := target.Query().Get("handoff")
+			if action == "" {
+				if token != "" || target.Query().Get("error") != "no_key" {
+					t.Fatal("plain sign-in unexpectedly created an issuance intent")
+				}
+				return
+			}
+			body, _ := json.Marshal(map[string]string{"handoff": token})
+			exchange := httptest.NewRecorder()
+			h.ServeHTTP(exchange, httptest.NewRequest(http.MethodPost, "/auth/handoff/exchange", bytes.NewReader(body)))
+			if exchange.Code != http.StatusOK {
+				t.Fatalf("exchange status=%d", exchange.Code)
+			}
+			if keys, err := store.ListAPIKeys(ctx, account.AccountID); err != nil || len(keys) != 2 {
+				t.Fatalf("keys after mint=%d err=%v", len(keys), err)
+			}
+		})
 	}
 }
 

--- a/phase5-gateway/internal/router/request_field_validation.go
+++ b/phase5-gateway/internal/router/request_field_validation.go
@@ -1,0 +1,104 @@
+package router
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// Validate before struct decoding or translation can merge duplicate members or
+// case-fold names that downstream exact-key parsers interpret differently.
+// Only schema-owned fields are constrained; extension and user-defined keys are
+// not a closed schema. The HTTP body limit and encoding/json depth limit bound
+// work, and nested values are consumed without a recursive custom parser.
+func validateRequestFieldNames(body []byte, names ...string) (map[string]json.RawMessage, error) {
+	dec := json.NewDecoder(bytes.NewReader(body))
+	start, err := dec.Token()
+	if err != nil || start != json.Delim('{') {
+		return nil, fmt.Errorf("request must be a JSON object")
+	}
+	fields := make(map[string]json.RawMessage, len(names))
+	for dec.More() {
+		token, err := dec.Token()
+		if err != nil {
+			return nil, fmt.Errorf("Malformed JSON")
+		}
+		name, ok := token.(string)
+		if !ok {
+			return nil, fmt.Errorf("Malformed JSON")
+		}
+		canonical := ""
+		for _, candidate := range names {
+			if strings.EqualFold(name, candidate) {
+				canonical = candidate
+				break
+			}
+		}
+		if canonical != "" {
+			if name != canonical {
+				return nil, fmt.Errorf("%s must use its canonical field name", canonical)
+			}
+			if _, exists := fields[canonical]; exists {
+				return nil, fmt.Errorf("%s must not be repeated", canonical)
+			}
+		}
+		var value json.RawMessage
+		if err := dec.Decode(&value); err != nil {
+			return nil, fmt.Errorf("Malformed JSON")
+		}
+		if canonical != "" {
+			fields[canonical] = value
+		}
+	}
+	if end, err := dec.Token(); err != nil || end != json.Delim('}') {
+		return nil, fmt.Errorf("Malformed JSON")
+	}
+	if _, err := dec.Token(); err != io.EOF {
+		return nil, fmt.Errorf("Malformed JSON")
+	}
+	return fields, nil
+}
+
+func validateChatRequestFieldNames(body []byte) error {
+	fields, err := validateRequestFieldNames(body,
+		"model", "messages", "max_tokens", "n", "stream", "response_format")
+	if err != nil {
+		return err
+	}
+	// response_format.type selects the structured-stream deadline. Do not
+	// inspect arbitrary property names inside the buyer's JSON schema.
+	format := bytes.TrimSpace(fields["response_format"])
+	if len(format) > 0 && format[0] == '{' {
+		if _, err := validateRequestFieldNames(format, "type"); err != nil {
+			return fmt.Errorf("response_format: %w", err)
+		}
+	}
+	return nil
+}
+
+func validateResponsesRequestFieldNames(body []byte) error {
+	fields, err := validateRequestFieldNames(body,
+		"model", "input", "instructions", "tools", "tool_choice",
+		"max_output_tokens", "stream", "previous_response_id", "store",
+		"temperature", "top_p", "response_format", "text", "metadata", "user",
+		"reasoning", "parallel_tool_calls", "conversation", "include", "truncation", "background")
+	if err != nil {
+		return err
+	}
+	text := bytes.TrimSpace(fields["text"])
+	if len(text) > 0 && text[0] == '{' {
+		textFields, err := validateRequestFieldNames(text, "format")
+		if err != nil {
+			return fmt.Errorf("text: %w", err)
+		}
+		format := bytes.TrimSpace(textFields["format"])
+		if len(format) > 0 && format[0] == '{' {
+			if _, err := validateRequestFieldNames(format, "type"); err != nil {
+				return fmt.Errorf("text.format: %w", err)
+			}
+		}
+	}
+	return nil
+}

--- a/phase5-gateway/internal/router/request_field_validation_test.go
+++ b/phase5-gateway/internal/router/request_field_validation_test.go
@@ -1,0 +1,236 @@
+package router
+
+import (
+	"database/sql"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/augstar/macprovider-gateway/internal/config"
+)
+
+func TestChatRequestRejectsAmbiguousAdmissionFields(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		fields string
+	}{
+		{"token_case_after", `"max_tokens":100000,"Max_tokens":1`},
+		{"token_case_before", `"Max_tokens":1,"max_tokens":100000`},
+		{"token_uppercase", `"MAX_TOKENS":1`},
+		{"token_unicode_fold", `"max_to\u212aens":1`},
+		{"token_duplicate", `"max_tokens":100000,"max_tokens":1`},
+		{"token_duplicate_null", `"max_tokens":100000,"max_tokens":null`},
+		{"token_escaped_duplicate", `"max_tokens":100000,"max_\u0074okens":1`},
+		{"stream_case_after", `"stream":true,"Stream":false`},
+		{"stream_case_before", `"Stream":false,"stream":true`},
+		{"stream_duplicate", `"stream":true,"stream":false`},
+		{"stream_unicode_fold", `"\u017ftream":false`},
+		{"model_case", `"Model":"other"`},
+		{"model_duplicate", `"model":"other"`},
+		{"messages_case", `"Messages":[{"role":"user","content":"other"}]`},
+		{"messages_duplicate", `"messages":[{"role":"user","content":"other"}]`},
+		{"n_case", `"n":2,"N":1`},
+		{"n_duplicate", `"n":2,"n":1`},
+		{"format_case", `"Response_format":{"type":"json_object"}`},
+		{"format_duplicate", `"response_format":{"type":"json_object"},"response_format":null`},
+		{"format_type_case", `"response_format":{"type":"json_object","Type":"text"}`},
+		{"format_type_duplicate", `"response_format":{"type":"json_object","type":"text"}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			body := `{"model":"model-a","messages":[{"role":"user","content":"hi"}],` + tc.fields + `}`
+			if _, err := parseChatRequest([]byte(body)); err == nil {
+				t.Fatal("ambiguous request was accepted")
+			}
+		})
+	}
+}
+
+func TestChatRequestFieldValidationPreservesExtensions(t *testing.T) {
+	body := []byte(`{"mo\u0064el":"model-a","messages":[{"role":"user","content":"hi","Extension":true}],"max_tokens":20,"stream":true,"n":1,"Vendor":{"Stream":true,"stream":false},"vendor":1,"vendor":2,"max_completion_tokens":7,"response_format":{"type":"json_schema","json_schema":{"name":"example","schema":{"type":"object","properties":{"Type":{"type":"string"},"type":{"type":"number"}}}}}}`)
+	original := string(body)
+	req, err := parseChatRequest(body)
+	if err != nil {
+		t.Fatalf("canonical request with extensions rejected: %v", err)
+	}
+	if req.Model != "model-a" || req.MaxTokens == nil || *req.MaxTokens != 20 || !req.Stream || !req.hasStructuredOutput() {
+		t.Fatalf("unexpected parsed request: %+v", req)
+	}
+	if string(body) != original {
+		t.Fatal("validation mutated the raw body")
+	}
+}
+
+func TestRequestFieldValidationRejectsMalformedAndOverdeepJSON(t *testing.T) {
+	for _, body := range []string{
+		`null`, `[]`, `"request"`, `{`, `{"model":}`, `{"model":"a",}`,
+		`{"model":"a"} {}`, `{"model":"a"} false`, `{"model":"a"} trailing`,
+		`{"extension":` + strings.Repeat(`[`, 10001) + `0` + strings.Repeat(`]`, 10001) + `}`,
+	} {
+		if _, err := validateRequestFieldNames([]byte(body), "model"); err == nil {
+			t.Errorf("accepted malformed or overdeep JSON (bytes=%d)", len(body))
+		}
+	}
+}
+
+func TestResponsesRequestRejectsAmbiguityBeforeTranslation(t *testing.T) {
+	for _, fields := range []string{
+		`"max_output_tokens":100000,"Max_output_tokens":1`,
+		`"Max_output_tokens":1,"max_output_tokens":100000`,
+		`"max_output_tokens":100000,"max_output_tokens":1`,
+		`"max_output_tokens":100000,"max_output_\u0074okens":1`,
+		`"stream":true,"Stream":false`,
+		`"stream":true,"stream":false`,
+		`"Model":"other"`, `"model":"other"`, `"Input":"other"`,
+		`"store":true,"Store":false`,
+		`"previous_response_id":"other","Previous_response_id":""`,
+		`"background":true,"Background":false`,
+		`"text":{},"Text":{}`, `"tools":[],"Tools":[]`,
+		`"text":{"format":{"type":"text"},"Format":{"type":"json_object"}}`,
+		`"text":{"format":{"type":"text"},"format":{"type":"json_object"}}`,
+		`"text":{"format":{"type":"text","Type":"json_object"}}`,
+		`"text":{"format":{"type":"text","type":"json_object"}}`,
+	} {
+		a := responsesAdapter{model: "unchanged", stream: true}
+		body := []byte(`{"model":"model-a","input":"hi",` + fields + `}`)
+		if translated, err := a.translateRequest(body); err == nil || translated != nil {
+			t.Errorf("ambiguous request accepted: %s", fields)
+		}
+		if a.model != "unchanged" || !a.stream {
+			t.Fatal("rejected request mutated adapter state")
+		}
+	}
+}
+
+func TestResponsesRequestFieldValidationPreservesExtensions(t *testing.T) {
+	a := responsesAdapter{}
+	body := []byte(`{"model":"model-a","input":"hi","max_output_tokens":20,"stream":false,"store":false,"vendor_extension":{"Stream":true,"stream":false},"VendorExtension":1,"VendorExtension":2}`)
+	translated, err := a.translateRequest(body)
+	if err != nil {
+		t.Fatalf("extension rejected: %v", err)
+	}
+	req, parseErr := parseChatRequest(translated)
+	if parseErr != nil || req.MaxTokens == nil || *req.MaxTokens != 20 || req.Stream {
+		t.Fatalf("translation changed admission controls: req=%+v err=%v", req, parseErr)
+	}
+}
+
+func TestInferenceAmbiguousFieldsRejectBeforeDispatchAndReservation(t *testing.T) {
+	for _, mode := range []string{"api_key", "demo", "wallet"} {
+		t.Run(mode, func(t *testing.T) {
+			var dispatches atomic.Int64
+			models := walletModelsClient()
+			client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				if r.URL.Path == "/v1/chat/completions" {
+					dispatches.Add(1)
+					return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}}, `{"choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`), nil
+				}
+				return models.Transport.RoundTrip(r)
+			})}
+			h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+				enableResponsesWithCoordinator(cfg)
+				cfg.Features.AnthropicMessagesEnabled = true
+				cfg.Quotas.AccountRequestRatePerSecond = 10000
+				cfg.Public.BaseURL = "https://api.malibu.test"
+				cfg.Auth.WalletSessions.Enabled = true
+				cfg.Auth.WalletSessions.BearerHashKeys = map[string]string{"k1": strings.Repeat("b", 32)}
+				cfg.Auth.WalletSessions.CurrentBearerHashKeyID = "k1"
+				cfg.Auth.WalletSessions.WalletFingerprintSecret = strings.Repeat("f", 32)
+			}, WithHTTPClient(client))
+			accountID := "acct_ambiguous_" + mode
+			key := createAccountAndKey(t, store, cfg, accountID)
+			var demo string
+			var wallet walletSessionTestClient
+			if mode == "demo" {
+				demo = issueDemoToken(t, h, "1.2.3.4")
+			} else if mode == "wallet" {
+				wallet = registerWalletSessionViaAPIWithCaps(t, h, cfg, key, accountID, []string{"model-a"}, 10000, 1000)
+			}
+			for _, endpoint := range []struct {
+				path, input, tokens string
+			}{
+				{"/v1/chat/completions", `"messages":[{"role":"user","content":"hi"}]`, "max_tokens"},
+				{"/v1/responses", `"input":"hi"`, "max_output_tokens"},
+				{"/v1/messages", `"messages":[{"role":"user","content":"hi"}]`, "max_tokens"},
+			} {
+				t.Run(endpoint.path, func(t *testing.T) {
+					variant := "M" + endpoint.tokens[1:]
+					for _, fields := range []string{
+						fmt.Sprintf(`%q:100000,%q:1`, endpoint.tokens, variant),
+						fmt.Sprintf(`%q:1,%q:100000`, variant, endpoint.tokens),
+						fmt.Sprintf(`%q:100000,%q:1`, endpoint.tokens, endpoint.tokens),
+						fmt.Sprintf(`%q:1,"stream":true,"Stream":false`, endpoint.tokens),
+						fmt.Sprintf(`%q:1,"Stream":false,"stream":true`, endpoint.tokens),
+					} {
+						body := []byte(`{"model":"model-a",` + endpoint.input + `,` + fields + `}`)
+						req := httptest.NewRequest(http.MethodPost, endpoint.path, strings.NewReader(string(body)))
+						req.Header.Set("X-Request-ID", newUUID())
+						switch mode {
+						case "api_key":
+							req.Header.Set("Authorization", "Bearer "+key)
+						case "demo":
+							req.Header.Set("X-Demo-Token", demo)
+							req.Header.Set("X-Real-IP", "1.2.3.4")
+						case "wallet":
+							req = signedWalletRequest(t, wallet, http.MethodPost, endpoint.path, endpoint.path, newUUID(), body)
+						}
+						req.Header.Set("Content-Type", "application/json")
+						resp := httptest.NewRecorder()
+						h.ServeHTTP(resp, req)
+						wantStatus := http.StatusBadRequest
+						if mode == "demo" && endpoint.path == "/v1/messages" {
+							// Messages excludes demo auth before request parsing.
+							wantStatus = http.StatusUnauthorized
+							assertErrorCode(t, resp.Body.String(), "invalid_demo_token")
+						}
+						if resp.Code != wantStatus {
+							t.Errorf("fields=%s status=%d want %d body=%s", fields, resp.Code, wantStatus, resp.Body.String())
+						}
+					}
+				})
+			}
+			if got := dispatches.Load(); got != 0 {
+				t.Errorf("ambiguous requests caused %d coordinator dispatches", got)
+			}
+			db, err := sql.Open("sqlite", dbPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+			for _, table := range []string{"quota_reservations", "wallet_session_reservations", "wallet_session_replays", "usage_events"} {
+				var count int
+				if err := db.QueryRow("SELECT COUNT(*) FROM " + table).Scan(&count); err != nil {
+					t.Fatal(err)
+				}
+				if count != 0 {
+					t.Errorf("rejected requests mutated %s: %d rows", table, count)
+				}
+			}
+		})
+	}
+}
+
+func TestChatAdmissionCanonicalExtensionsForwardUnchanged(t *testing.T) {
+	body := `{"model":"model-a","messages":[{"role":"user","content":"hi"}],"max_tokens":20,"stream":false,"vendor_extension":{"Stream":true,"stream":false}}`
+	var forwarded string
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			return nil, err
+		}
+		forwarded = string(raw)
+		return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}}, `{"choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`), nil
+	})}
+	h, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, enableResponsesWithCoordinator, WithHTTPClient(client))
+	key := createAccountAndKey(t, store, cfg, "acct_canonical_extensions")
+	resp := postChat(t, h, key, body, nil)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	if forwarded != body {
+		t.Fatalf("raw request changed: got %s want %s", forwarded, body)
+	}
+}

--- a/phase5-gateway/internal/router/responses.go
+++ b/phase5-gateway/internal/router/responses.go
@@ -248,6 +248,9 @@ func (a *responsesAdapter) prepareNonStreamingResponse(body []byte) error {
 }
 
 func (a *responsesAdapter) translateRequest(body []byte) ([]byte, *responsesTranslationError) {
+	if err := validateResponsesRequestFieldNames(body); err != nil {
+		return nil, &responsesTranslationError{code: "invalid_request", message: err.Error()}
+	}
 	var req struct {
 		Model              string           `json:"model"`
 		Input              json.RawMessage  `json:"input"`

--- a/phase5-gateway/internal/router/security_finality_test.go
+++ b/phase5-gateway/internal/router/security_finality_test.go
@@ -1,0 +1,404 @@
+package router
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-gateway/internal/config"
+)
+
+// Real HTTP transport does not expose trailers until EOF. The facades can end
+// earlier, but neither that nor a missing trailer may authorize a local debit.
+func TestSecurityFinalityDelayedTrailers(t *testing.T) {
+	for _, endpoint := range []string{"/v1/chat/completions", "/v1/messages", "/v1/responses"} {
+		for _, outcome := range []string{"verified", "pending", "quarantined", "zero_settled", "missing", "observe", "missing_observe"} {
+			t.Run(endpoint+"/"+outcome, func(t *testing.T) {
+				flushed := make(chan struct{})
+				release := make(chan struct{})
+				var releaseOnce sync.Once
+				unblock := func() { releaseOnce.Do(func() { close(release) }) }
+				defer unblock()
+				result, closed := "valid", true
+				if outcome == "pending" {
+					result, closed = "inconclusive", false
+				} else if outcome == "quarantined" {
+					result = "invalid"
+				}
+				coordinator := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.URL.Path == "/internal/settlement/finality" {
+						if outcome == "missing_observe" && r.URL.Query().Get("required_internal_request_id") != "internal_current" {
+							t.Error("observe recovery omitted current coordinator attempt")
+						}
+						finalOutcome := outcome
+						mode := "enforce"
+						if outcome == "observe" || outcome == "missing_observe" {
+							mode, finalOutcome = "observe", "quarantined"
+						}
+						if finalOutcome == "missing" {
+							finalOutcome = "pending"
+						}
+						finalResult, finalClosed := result, closed
+						prompt, completion, total := 3, 4, 7
+						if mode == "observe" {
+							finalResult = "invalid"
+							// Receipt-only totals deliberately differ from local usage.
+							prompt, completion, total = 0, 0, 0
+						}
+						if finalOutcome == "pending" {
+							finalResult, finalClosed = "inconclusive", false
+						}
+						writeJSON(w, http.StatusOK, map[string]any{
+							"required_internal_request_id": r.URL.Query().Get("required_internal_request_id"),
+							"request_id":                   r.URL.Query().Get("request_id"),
+							"policy_version":               settlementPolicyVersion, "mode": mode, "mode_scope_complete": true,
+							"outcome": finalOutcome, "receipt_result": finalResult,
+							"closed": finalClosed, "reason": "security_regression",
+							"prompt_tokens": prompt, "completion_tokens": completion, "total_tokens": total,
+							"token_source": "coordinator_observed", "verified_attempts": 1,
+							"pending_deadline_unix_ms": fixedNow().Add(5 * time.Minute).UnixMilli(),
+						})
+						return
+					}
+					w.Header().Set("Content-Type", "text/event-stream")
+					w.Header().Set("X-MacProvider-Internal-Request-ID", "internal_current")
+					w.Header().Set("Trailer", strings.Join(settlementFinalityHeaderNamesForTest(), ", "))
+					_, _ = io.WriteString(w, "data: {\"id\":\"chatcmpl_finality\",\"object\":\"chat.completion.chunk\",\"model\":\"llama\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"ok\"},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":4,\"total_tokens\":7}}\n\ndata: [DONE]\n\n")
+					w.(http.Flusher).Flush()
+					close(flushed)
+					<-release
+					if outcome != "missing" && outcome != "missing_observe" {
+						mode := "enforce"
+						if outcome == "observe" {
+							mode = "observe"
+						}
+						finality := settlementFinalityTrailerForTest(mode, settlementPolicyVersion, outcome, result, fmt.Sprint(closed), "security_regression", fixedNow().Add(5*time.Minute).UnixMilli())
+						for key, values := range finality {
+							w.Header()[key] = values
+						}
+					}
+				}))
+				defer coordinator.Close()
+				// Unblock before Close even if an assertion aborts the test.
+				defer unblock()
+				h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+					cfg.Coordinator.BuyerURL = coordinator.URL
+					cfg.Coordinator.OperatorURL = coordinator.URL
+					cfg.Features.AnthropicMessagesEnabled = true
+					cfg.Features.ResponsesAPIEnabled = true
+				}, WithHTTPClient(coordinator.Client()))
+				accountID := "acct_finality_http"
+				key := createAccountAndKey(t, store, cfg, accountID)
+				body := `{"model":"llama","stream":true,"max_tokens":20,"messages":[{"role":"user","content":"hi"}]}`
+				if endpoint == "/v1/responses" {
+					body = `{"model":"llama","stream":true,"max_output_tokens":20,"input":"hi"}`
+				}
+				req := httptest.NewRequest(http.MethodPost, endpoint, strings.NewReader(body))
+				req.Header.Set("Authorization", "Bearer "+key)
+				req.Header.Set("Content-Type", "application/json")
+				req.Header.Set("anthropic-version", "2023-06-01")
+				resp := httptest.NewRecorder()
+				done := make(chan struct{})
+				go func() {
+					defer close(done)
+					h.ServeHTTP(resp, req)
+				}()
+				defer func() {
+					unblock()
+					select {
+					case <-done:
+					case <-time.After(5 * time.Second):
+						t.Error("gateway handler did not stop")
+					}
+				}()
+				select {
+				case <-flushed:
+				case <-done:
+					t.Fatalf("gateway returned before upstream stream: %d %s", resp.Code, resp.Body.String())
+				case <-time.After(5 * time.Second):
+					t.Fatal("upstream stream did not start")
+				}
+				snap := gatewaySettlementSnapshot(t, dbPath, accountID)
+				if snap.usageRows != 0 || snap.settledRows != 0 || snap.activeRows != 1 {
+					t.Fatalf("before finality: %+v, want reservation without debit", snap)
+				}
+				unblock()
+				select {
+				case <-done:
+				case <-time.After(5 * time.Second):
+					t.Fatal("gateway did not finish")
+				}
+				if resp.Code != http.StatusOK || strings.Contains(resp.Body.String(), "invalid_provider_response") {
+					t.Fatalf("response=%d %s", resp.Code, resp.Body.String())
+				}
+				snap = gatewaySettlementSnapshot(t, dbPath, accountID)
+				observe := outcome == "observe" || outcome == "missing_observe"
+				if !observe && (snap.usageRows != 0 || snap.settledRows != 0) {
+					t.Fatalf("response path locally debited: %+v", snap)
+				}
+				reconcile := httptest.NewRequest(http.MethodPost, "/admin/settlement/reconcile?limit=10", nil)
+				reconcile.Header.Set("Authorization", "Bearer operator-key")
+				reconciled := httptest.NewRecorder()
+				h.ServeHTTP(reconciled, reconcile)
+				if reconciled.Code != http.StatusOK {
+					t.Fatalf("reconcile=%d %s", reconciled.Code, reconciled.Body.String())
+				}
+				snap = gatewaySettlementSnapshot(t, dbPath, accountID)
+				switch outcome {
+				case "observe", "missing_observe":
+					if snap.usageRows != 1 || snap.settledRows != 1 || snap.heldRows != 0 {
+						t.Fatalf("observe fallback accounting: %+v", snap)
+					}
+					_, source, completion, prompt := usageEventOutcomeAndTokens(t, dbPath, accountID)
+					if source != "provider_reported" || prompt != 3 || completion != 4 {
+						t.Fatalf("observe did not retain local usage: %s/%d/%d", source, prompt, completion)
+					}
+				case "verified":
+					if snap.usageRows != 1 || snap.settledRows != 1 || snap.activeRows != 0 {
+						t.Fatalf("verified reconcile: %+v", snap)
+					}
+				case "quarantined", "zero_settled":
+					if snap.usageRows != 0 || snap.refundedRows != 1 || snap.activeRows != 0 {
+						t.Fatalf("refund reconcile: %+v", snap)
+					}
+				default:
+					if snap.usageRows != 0 || snap.settledRows != 0 || snap.heldRows != 1 {
+						t.Fatalf("pending reconcile: %+v", snap)
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestSecurityInvalidFacadeResponsePreservesFinality(t *testing.T) {
+	for _, endpoint := range []string{"/v1/messages", "/v1/responses"} {
+		for _, stream := range []bool{false, true} {
+			for _, outcome := range []string{"verified", "pending", "quarantined", "zero_settled", "observe"} {
+				t.Run(fmt.Sprintf("%s/stream=%t/%s", endpoint, stream, outcome), func(t *testing.T) {
+					mode, receipt, closed := "enforce", "valid", "true"
+					if outcome == "observe" {
+						mode = "observe"
+					} else if outcome == "pending" {
+						receipt, closed = "inconclusive", "false"
+					} else if outcome == "quarantined" {
+						receipt = "invalid"
+					}
+					finality := settlementFinalityTrailerForTest(mode, settlementPolicyVersion, outcome, receipt, closed, "security_regression")
+					client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+						payload := `{"id":"bad","object":"chat.completion","model":"llama","usage":{"prompt_tokens":3,"completion_tokens":4,"total_tokens":7},"choices":[{"index":0,"message":{"role":"assistant","content":"","unsupported_output":"hidden"},"finish_reason":"stop"}]}`
+						if endpoint == "/v1/responses" {
+							payload = "not-json"
+						}
+						h := finality.Clone()
+						h.Set("Content-Type", "application/json")
+						resp := responseWithBody(http.StatusOK, h, payload)
+						if stream {
+							payload = "data: {\"id\":\"bad\",\"object\":\"chat.completion.chunk\",\"model\":\"llama\",\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":4,\"total_tokens\":7},\"choices\":[{\"index\":0,\"delta\":{\"unsupported_output\":\"hidden\"},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n"
+							if endpoint == "/v1/responses" {
+								payload = "data: not-json\n\n"
+							}
+							resp.Header = http.Header{"Content-Type": {"text/event-stream"}, "Trailer": {strings.Join(settlementFinalityHeaderNamesForTest(), ", ")}}
+							resp.Body = io.NopCloser(strings.NewReader(payload))
+							resp.Trailer = finality.Clone()
+						}
+						return resp, nil
+					})}
+					h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+						cfg.Coordinator.BuyerURL = "http://coordinator.test"
+						cfg.Features.AnthropicMessagesEnabled = true
+						cfg.Features.ResponsesAPIEnabled = true
+					}, WithHTTPClient(client))
+					key := createAccountAndKey(t, store, cfg, "acct_invalid_finality")
+					body := fmt.Sprintf(`{"model":"llama","max_tokens":20,"stream":%t,"messages":[{"role":"user","content":"hi"}]}`, stream)
+					if endpoint == "/v1/responses" {
+						body = fmt.Sprintf(`{"model":"llama","max_output_tokens":20,"stream":%t,"input":"hi"}`, stream)
+					}
+					req := httptest.NewRequest(http.MethodPost, endpoint, strings.NewReader(body))
+					req.Header.Set("Authorization", "Bearer "+key)
+					req.Header.Set("Content-Type", "application/json")
+					req.Header.Set("anthropic-version", "2023-06-01")
+					resp := httptest.NewRecorder()
+					h.ServeHTTP(resp, req)
+					wantCode := "invalid_provider_response"
+					if endpoint == "/v1/responses" && stream {
+						wantCode = "stream_malformed"
+					}
+					if !strings.Contains(resp.Body.String(), wantCode) {
+						t.Fatalf("missing invalid-response error: %d %s", resp.Code, resp.Body.String())
+					}
+					snap := gatewaySettlementSnapshot(t, dbPath, "acct_invalid_finality")
+					switch outcome {
+					case "observe":
+						if snap.usageRows != 1 || snap.settledRows != 1 {
+							t.Fatalf("observe compatibility: %+v", snap)
+						}
+					case "quarantined", "zero_settled":
+						if snap.usageRows != 0 || snap.refundedRows != 1 || snap.activeRows != 0 {
+							t.Fatalf("finality refund: %+v", snap)
+						}
+					default:
+						if snap.usageRows != 0 || snap.heldRows != 1 || snap.settledRows != 0 {
+							t.Fatalf("finality hold: %+v", snap)
+						}
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestSecurityStreamingFinalityHeaderWithoutTrailer(t *testing.T) {
+	h := settlementFinalityTrailerForTest("enforce", settlementPolicyVersion, "pending", "inconclusive", "false", "pending")
+	if got := coordinatorStreamingSettlementFinality(&http.Response{Header: h}); got.Action != settlementFinalityHold {
+		t.Fatalf("enforce header was treated as legacy: %+v", got)
+	}
+}
+
+func TestSecurityFacadeFinalityDrainBounds(t *testing.T) {
+	for _, canceledContext := range []bool{false, true} {
+		t.Run(fmt.Sprint(canceledContext), func(t *testing.T) {
+			ctx, stop := context.WithCancel(context.Background())
+			defer stop()
+			if canceledContext {
+				stop()
+			}
+			resp := responseWithBody(http.StatusOK, http.Header{
+				"Trailer": {settlementModeHeader},
+			}, strings.Repeat("x", maxStreamingLineBytes*2))
+			var canceled atomic.Bool
+			drainFacadeSettlementTrailers(ctx, bufio.NewReaderSize(resp.Body, maxStreamingLineBytes), resp, func() {
+				canceled.Store(true)
+			})
+			if !canceled.Load() {
+				t.Fatal("unbounded or canceled trailer tail did not cancel upstream")
+			}
+		})
+	}
+}
+
+func TestSecurityMissingFinalityObserveAuthority(t *testing.T) {
+	for _, tc := range []struct {
+		name, mode, policy, returnedID, reason, headerMode string
+		closed, missingAdmission                           bool
+		incompleteScope                                    bool
+		missingInternalID                                  bool
+		missingInternalEcho                                bool
+		status                                             int
+		want                                               bool
+	}{
+		{name: "observe", mode: "observe", policy: settlementPolicyVersion, returnedID: "req_fence", reason: "receipt_invalid", closed: true, want: true},
+		{name: "observe_pending", mode: "observe", policy: settlementPolicyVersion, returnedID: "req_fence", reason: "receipt_verdict_pending", want: true},
+		{name: "enforce", mode: "enforce", policy: settlementPolicyVersion, returnedID: "req_fence", closed: true},
+		{name: "wrong_request", mode: "observe", policy: settlementPolicyVersion, returnedID: "other", closed: true},
+		{name: "missing_request", mode: "observe", policy: settlementPolicyVersion, closed: true},
+		{name: "unknown_policy", mode: "observe", policy: "future", returnedID: "req_fence", closed: true},
+		{name: "old_coordinator_without_scope", mode: "observe", policy: settlementPolicyVersion, returnedID: "req_fence", closed: true, incompleteScope: true},
+		{name: "contradictory_header", mode: "observe", policy: settlementPolicyVersion, returnedID: "req_fence", headerMode: "enforce", closed: true},
+		{name: "missing_generation", mode: "observe", policy: settlementPolicyVersion, returnedID: "req_fence", missingAdmission: true, closed: true},
+		{name: "missing_current_internal_id", mode: "observe", policy: settlementPolicyVersion, returnedID: "req_fence", missingInternalID: true, closed: true},
+		{name: "lookup_ignored_current_internal_id", mode: "observe", policy: settlementPolicyVersion, returnedID: "req_fence", missingInternalEcho: true, closed: true},
+		{name: "lookup_unavailable", status: http.StatusServiceUnavailable},
+		{name: "lookup_not_found", status: http.StatusNotFound},
+		{name: "mixed_policy", mode: "observe", policy: settlementPolicyVersion, returnedID: "req_fence", reason: "mixed_settlement_policy_snapshot"},
+		{name: "missing_current_scope", mode: "observe", policy: settlementPolicyVersion, returnedID: "req_fence", reason: "missing_current_settlement_finality"},
+		{name: "unknown_pending", mode: "observe", policy: settlementPolicyVersion, returnedID: "req_fence", reason: "future_pending"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.Default()
+			cfg.Coordinator.OperatorURL = "http://coordinator.test"
+			cfg.Coordinator.ServiceToken = "test-internal"
+			client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				if r.Header.Get("Authorization") != "Bearer test-internal" ||
+					r.URL.Query().Get("required_internal_request_id") != "internal_current" ||
+					r.URL.Query().Get("account_id") != "acct_fence" ||
+					r.URL.Query().Get("request_id") != "req_fence" ||
+					r.URL.Query().Get("reservation_created_at_unix_ms") != fmt.Sprint(fixedNow().UnixMilli()) {
+					t.Errorf("lookup did not bind service authority/account/request/generation")
+				}
+				if deadline, ok := r.Context().Deadline(); !ok || time.Until(deadline) > 5*time.Second {
+					t.Error("lookup lacks bounded deadline")
+				}
+				status := tc.status
+				if status == 0 {
+					status = http.StatusOK
+				}
+				outcome, receipt := "quarantined", "invalid"
+				pendingAttempts := int64(0)
+				if !tc.closed {
+					outcome, receipt = "pending", "inconclusive"
+					pendingAttempts = 1
+				}
+				internalEcho := "internal_current"
+				if tc.missingInternalEcho {
+					internalEcho = ""
+				}
+				body, err := json.Marshal(coordinatorRequestSettlementFinality{
+					RequiredInternalRequestID: internalEcho,
+					RequestID:                 tc.returnedID, Mode: tc.mode, PolicyVersion: tc.policy,
+					ModeScopeComplete: !tc.incompleteScope,
+					Outcome:           outcome, ReceiptResult: receipt, Reason: tc.reason, Closed: tc.closed, PendingAttempts: pendingAttempts,
+				})
+				if err != nil {
+					return nil, err
+				}
+				return responseWithBody(status, http.Header{}, string(body)), nil
+			})}
+			s := &Server{cfg: cfg, client: client}
+			req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+			req = req.WithContext(context.WithValue(req.Context(), requestIDKey{}, "req_fence"))
+			subject := usageSubject{AccountID: "acct_fence", ReservationCreatedAt: fixedNow()}
+			if tc.missingAdmission {
+				subject.ReservationCreatedAt = time.Time{}
+			}
+			resp := &http.Response{Header: http.Header{}}
+			if !tc.missingInternalID {
+				resp.Header.Set("X-MacProvider-Internal-Request-ID", "internal_current")
+			}
+			if tc.headerMode != "" {
+				resp.Header.Set(settlementModeHeader, tc.headerMode)
+			}
+			if got := s.resolveMissingFinalityAsObserve(req, subject, resp); got != tc.want {
+				t.Fatalf("observe authority=%t want %t", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSecurityStreamingTerminalPreservesHeaderFinality(t *testing.T) {
+	for _, mode := range []string{"enforce", "observe"} {
+		t.Run(mode, func(t *testing.T) {
+			client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				h := settlementFinalityTrailerForTest(mode, settlementPolicyVersion, "pending", "inconclusive", "false", "pending")
+				h.Set("Content-Type", "text/event-stream")
+				payload := fmt.Sprintf("data: {\"choices\":[{\"delta\":{\"content\":%q}}]}\n\n", strings.Repeat("x", 1024))
+				return responseWithBody(http.StatusOK, h, payload), nil
+			})}
+			h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+				cfg.Coordinator.BuyerURL = "http://coordinator.test"
+			}, WithHTTPClient(client))
+			key := createAccountAndKey(t, store, cfg, "acct_header_finality")
+			resp := postChat(t, h, key, `{"model":"llama","max_tokens":20,"stream":true,"messages":[{"role":"user","content":"hi"}]}`, nil)
+			if !strings.Contains(resp.Body.String(), "stream_output_exceeded") {
+				t.Fatalf("expected gateway truncation: %d %s", resp.Code, resp.Body.String())
+			}
+			snap := gatewaySettlementSnapshot(t, dbPath, "acct_header_finality")
+			if mode == "enforce" {
+				if snap.usageRows != 0 || snap.heldRows != 1 || snap.settledRows != 0 {
+					t.Fatalf("header finality bypass: %+v", snap)
+				}
+			} else if snap.usageRows != 1 || snap.settledRows != 1 {
+				t.Fatalf("observe compatibility: %+v", snap)
+			}
+		})
+	}
+}

--- a/phase5-gateway/internal/router/server_test.go
+++ b/phase5-gateway/internal/router/server_test.go
@@ -2437,10 +2437,11 @@ func TestSPEC022GatewayStreamingSettlementTrailersControlBuyerDebit(t *testing.T
 			wantExpiresAt:  pendingDeadlineUnixMS,
 		},
 		{
-			name:          "declared-missing-trailer-settles-unverified",
-			declareOnly:   true,
-			wantUsageRows: 1,
-			wantSettled:   1,
+			name:           "declared-missing-trailer-holds-without-debit",
+			declareOnly:    true,
+			wantActive:     1,
+			wantActiveHold: promptCapTokens([]byte(body)) + 20,
+			wantExpiresAt:  fixedNow().Add(settlementHoldFallbackTTL).UnixMilli(),
 		},
 	}
 	for _, tc := range cases {

--- a/phase5-gateway/internal/router/server_test.go
+++ b/phase5-gateway/internal/router/server_test.go
@@ -2535,6 +2535,7 @@ func TestSPEC022GatewayStreamingNonOKFinalityBoundsHold(t *testing.T) {
 func TestSPEC022GatewaySettlementReconcileFinalizesHeldReservation(t *testing.T) {
 	accountID := "acct_spec022_reconcile_verified"
 	requestID := "req_spec022_reconcile_verified"
+	internalRequestID := "internal_spec022_reconcile_verified"
 	var captured http.Header
 	coordinator := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		captured = r.Header.Clone()
@@ -2550,19 +2551,23 @@ func TestSPEC022GatewaySettlementReconcileFinalizesHeldReservation(t *testing.T)
 		if got, want := r.URL.Query().Get("reservation_created_at_unix_ms"), strconv.FormatInt(fixedNow().UnixMilli(), 10); got != want {
 			t.Fatalf("reservation_created_at_unix_ms query=%q want %q", got, want)
 		}
+		if got := r.URL.Query().Get("required_internal_request_id"); got != internalRequestID {
+			t.Fatalf("required_internal_request_id query=%q want %q", got, internalRequestID)
+		}
 		writeJSON(w, http.StatusOK, map[string]any{
-			"request_id":        requestID,
-			"policy_version":    settlementPolicyVersion,
-			"mode":              "enforce",
-			"outcome":           "verified",
-			"receipt_result":    "valid",
-			"reason":            "verified_settlement",
-			"closed":            true,
-			"prompt_tokens":     8,
-			"completion_tokens": 4,
-			"total_tokens":      12,
-			"token_source":      "coordinator_observed",
-			"verified_attempts": 1,
+			"request_id":                   requestID,
+			"required_internal_request_id": internalRequestID,
+			"policy_version":               settlementPolicyVersion,
+			"mode":                         "enforce",
+			"outcome":                      "verified",
+			"receipt_result":               "valid",
+			"reason":                       "verified_settlement",
+			"closed":                       true,
+			"prompt_tokens":                8,
+			"completion_tokens":            4,
+			"total_tokens":                 12,
+			"token_source":                 "coordinator_observed",
+			"verified_attempts":            1,
 		})
 	}))
 	defer coordinator.Close()
@@ -2585,6 +2590,7 @@ func TestSPEC022GatewaySettlementReconcileFinalizesHeldReservation(t *testing.T)
 	if err := store.ClampReservationExpiry(context.Background(), accountID, requestID, fixedNow().Add(4*time.Minute)); err != nil {
 		t.Fatalf("ClampReservationExpiry: %v", err)
 	}
+	seedBoundSettlementCandidate(t, store, accountID, requestID, internalRequestID, fixedNow(), 20, "")
 
 	req := httptest.NewRequest(http.MethodPost, "/admin/settlement/reconcile?limit=10", nil)
 	req.Header.Set("Authorization", "Bearer operator-key")
@@ -2616,6 +2622,7 @@ func TestSPEC022GatewaySettlementReconcileFinalizesHeldReservation(t *testing.T)
 func TestSPEC022GatewayStreamingReconcileConsumesCoordinatorVerifiedFinality(t *testing.T) {
 	accountID := "acct_spec022_streaming_contract"
 	requestID := "req_spec015_v04_streaming_tool_call_nonzero_prefix"
+	internalRequestID := "internal_spec022_streaming_contract"
 	const promptTokens int64 = 11
 	const completionTokens int64 = 7
 	coordinator := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2631,19 +2638,23 @@ func TestSPEC022GatewayStreamingReconcileConsumesCoordinatorVerifiedFinality(t *
 		if got := r.Header.Get("Authorization"); got != "Bearer service-token" {
 			t.Fatalf("coordinator Authorization=%q want service token", got)
 		}
+		if got := r.URL.Query().Get("required_internal_request_id"); got != internalRequestID {
+			t.Fatalf("required_internal_request_id query=%q want %q", got, internalRequestID)
+		}
 		writeJSON(w, http.StatusOK, map[string]any{
-			"request_id":        requestID,
-			"policy_version":    settlementPolicyVersion,
-			"mode":              "enforce",
-			"outcome":           "verified",
-			"receipt_result":    "valid",
-			"reason":            "verified_settlement",
-			"closed":            true,
-			"prompt_tokens":     promptTokens,
-			"completion_tokens": completionTokens,
-			"total_tokens":      promptTokens + completionTokens,
-			"token_source":      "coordinator_observed",
-			"verified_attempts": 1,
+			"request_id":                   requestID,
+			"required_internal_request_id": internalRequestID,
+			"policy_version":               settlementPolicyVersion,
+			"mode":                         "enforce",
+			"outcome":                      "verified",
+			"receipt_result":               "valid",
+			"reason":                       "verified_settlement",
+			"closed":                       true,
+			"prompt_tokens":                promptTokens,
+			"completion_tokens":            completionTokens,
+			"total_tokens":                 promptTokens + completionTokens,
+			"token_source":                 "coordinator_observed",
+			"verified_attempts":            1,
 		})
 	}))
 	defer coordinator.Close()
@@ -2666,6 +2677,7 @@ func TestSPEC022GatewayStreamingReconcileConsumesCoordinatorVerifiedFinality(t *
 	if err := store.ClampReservationExpiry(context.Background(), accountID, requestID, fixedNow().Add(4*time.Minute)); err != nil {
 		t.Fatalf("ClampReservationExpiry: %v", err)
 	}
+	seedBoundSettlementCandidate(t, store, accountID, requestID, internalRequestID, fixedNow(), 32, "")
 
 	req := httptest.NewRequest(http.MethodPost, "/admin/settlement/reconcile?limit=10", nil)
 	req.Header.Set("Authorization", "Bearer operator-key")
@@ -2695,22 +2707,24 @@ func TestSPEC022GatewayStreamingReconcileConsumesCoordinatorVerifiedFinality(t *
 func TestSPEC022GatewaySettlementReconcileRejectsMissingTokenSource(t *testing.T) {
 	accountID := "acct_spec022_missing_token_source"
 	requestID := "req_spec022_missing_token_source"
+	internalRequestID := "internal_spec022_missing_token_source"
 	coordinator := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/internal/settlement/finality" {
 			t.Fatalf("coordinator path=%s", r.URL.Path)
 		}
 		writeJSON(w, http.StatusOK, map[string]any{
-			"request_id":        requestID,
-			"policy_version":    settlementPolicyVersion,
-			"mode":              "enforce",
-			"outcome":           "verified",
-			"receipt_result":    "valid",
-			"reason":            "verified_settlement",
-			"closed":            true,
-			"prompt_tokens":     11,
-			"completion_tokens": 7,
-			"total_tokens":      18,
-			"verified_attempts": 1,
+			"request_id":                   requestID,
+			"required_internal_request_id": internalRequestID,
+			"policy_version":               settlementPolicyVersion,
+			"mode":                         "enforce",
+			"outcome":                      "verified",
+			"receipt_result":               "valid",
+			"reason":                       "verified_settlement",
+			"closed":                       true,
+			"prompt_tokens":                11,
+			"completion_tokens":            7,
+			"total_tokens":                 18,
+			"verified_attempts":            1,
 		})
 	}))
 	defer coordinator.Close()
@@ -2733,6 +2747,7 @@ func TestSPEC022GatewaySettlementReconcileRejectsMissingTokenSource(t *testing.T
 	if err := store.ClampReservationExpiry(context.Background(), accountID, requestID, fixedNow().Add(4*time.Minute)); err != nil {
 		t.Fatalf("ClampReservationExpiry: %v", err)
 	}
+	seedBoundSettlementCandidate(t, store, accountID, requestID, internalRequestID, fixedNow(), 32, "")
 
 	req := httptest.NewRequest(http.MethodPost, "/admin/settlement/reconcile?limit=10", nil)
 	req.Header.Set("Authorization", "Bearer operator-key")
@@ -2759,23 +2774,25 @@ func TestSPEC022GatewaySettlementReconcileRefundsAndHolds(t *testing.T) {
 	pendingDeadlineUnixMS := now.Add(2 * time.Minute).UnixMilli()
 	finalities := map[string]map[string]any{
 		"req_refund": {
-			"request_id":     "req_refund",
-			"policy_version": settlementPolicyVersion,
-			"mode":           "enforce",
-			"outcome":        "quarantined",
-			"receipt_result": "invalid",
-			"reason":         "signature_verify_failed",
-			"closed":         true,
+			"request_id":                   "req_refund",
+			"required_internal_request_id": "internal_req_refund",
+			"policy_version":               settlementPolicyVersion,
+			"mode":                         "enforce",
+			"outcome":                      "quarantined",
+			"receipt_result":               "invalid",
+			"reason":                       "signature_verify_failed",
+			"closed":                       true,
 		},
 		"req_hold": {
-			"request_id":               "req_hold",
-			"policy_version":           settlementPolicyVersion,
-			"mode":                     "enforce",
-			"outcome":                  "pending",
-			"receipt_result":           "inconclusive",
-			"reason":                   "receipt_verdict_pending",
-			"closed":                   false,
-			"pending_deadline_unix_ms": pendingDeadlineUnixMS,
+			"request_id":                   "req_hold",
+			"required_internal_request_id": "internal_req_hold",
+			"policy_version":               settlementPolicyVersion,
+			"mode":                         "enforce",
+			"outcome":                      "pending",
+			"receipt_result":               "inconclusive",
+			"reason":                       "receipt_verdict_pending",
+			"closed":                       false,
+			"pending_deadline_unix_ms":     pendingDeadlineUnixMS,
 		},
 	}
 	coordinator := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2810,6 +2827,7 @@ func TestSPEC022GatewaySettlementReconcileRefundsAndHolds(t *testing.T) {
 		if err := store.ClampReservationExpiry(context.Background(), "acct_spec022_reconcile", requestID, expiresAt); err != nil {
 			t.Fatalf("ClampReservationExpiry %s: %v", requestID, err)
 		}
+		seedBoundSettlementCandidate(t, store, "acct_spec022_reconcile", requestID, "internal_"+requestID, now, 20, "")
 	}
 	if _, err := store.ReserveQuota(context.Background(), storage.ReservationRequest{
 		AccountID:       "acct_spec022_reconcile",
@@ -2834,12 +2852,12 @@ func TestSPEC022GatewaySettlementReconcileRefundsAndHolds(t *testing.T) {
 	if err := json.Unmarshal(resp.Body.Bytes(), &summary); err != nil {
 		t.Fatalf("decode summary: %v", err)
 	}
-	if summary.Scanned != 3 || summary.Refunded != 1 || summary.StaleHeld != 1 || summary.Held != 1 || summary.Coordinator404 != 1 || summary.Skipped != 0 || summary.Errors != 0 {
-		t.Fatalf("summary=%+v, want refund/hold/stale-held coordinator-404 split", summary)
+	if summary.Scanned != 3 || summary.Refunded != 1 || summary.StaleHeld != 0 || summary.Held != 2 || summary.Coordinator404 != 1 || summary.Skipped != 0 || summary.Errors != 0 {
+		t.Fatalf("summary=%+v, want one refund and two safely held reservations", summary)
 	}
 	got := gatewaySettlementSnapshot(t, dbPath, "acct_spec022_reconcile")
-	if got.usageRows != 0 || got.settledRows != 0 || got.refundedRows != 1 || got.activeRows != 2 || got.expiredRows != 0 || got.staleHeldRows != 1 || got.activeReserved != 40 {
-		t.Fatalf("settlement snapshot=%+v, want one refund, one stale-held coordinator-404 hold, one held pending reservation, and one ordinary active reservation", got)
+	if got.usageRows != 0 || got.settledRows != 0 || got.refundedRows != 1 || got.activeRows != 3 || got.expiredRows != 0 || got.staleHeldRows != 0 || got.activeReserved != 60 {
+		t.Fatalf("settlement snapshot=%+v, want one refund, two held reservations, and one ordinary active reservation", got)
 	}
 	if got := gatewayReservationExpiresAtUnixMSForRequest(t, dbPath, "acct_spec022_reconcile", "req_hold"); got != pendingDeadlineUnixMS {
 		t.Fatalf("held reservation expires_at=%d want %d", got, pendingDeadlineUnixMS)
@@ -2960,7 +2978,7 @@ func TestSPEC022GatewayStreamingVerifiedHoldIgnoresBuyerCanceledContext(t *testi
 		Action:  settlementFinalityDebit,
 		Outcome: "verified",
 		Reason:  "verified_settlement",
-	})
+	}, nil, 0, 0, 0, "", "", "")
 
 	if wrapped.markCtxErr != nil {
 		t.Fatalf("MarkReservationSettlementHold ctx err=%v want nil despite canceled buyer context", wrapped.markCtxErr)
@@ -6950,6 +6968,25 @@ type gatewaySettlementState struct {
 	activeRows     int64
 	activeReserved int64
 	heldRows       int64
+}
+
+func seedBoundSettlementCandidate(t *testing.T, store *sqlite.Store, accountID, requestID, internalRequestID string,
+	createdAt time.Time, maxTotalTokens int64, walletSessionID string,
+) {
+	t.Helper()
+	if err := store.SaveSettlementFallbackCandidate(context.Background(), storage.SettlementFallbackCandidate{
+		AccountID:                 accountID,
+		RequestID:                 requestID,
+		RequiredInternalRequestID: internalRequestID,
+		ReservationCreatedAt:      createdAt,
+		WalletSessionID:           walletSessionID,
+		WindowDate:                createdAt.UTC().Format("2006-01-02"),
+		MaxTotalTokens:            maxTotalTokens,
+		TokenSource:               "gateway_estimated",
+		Outcome:                   "reconcile_test_hold",
+	}); err != nil {
+		t.Fatalf("SaveSettlementFallbackCandidate: %v", err)
+	}
 }
 
 func gatewaySettlementSnapshot(t *testing.T, dbPath, accountID string) gatewaySettlementState {

--- a/phase5-gateway/internal/router/settlement_observe_recovery_test.go
+++ b/phase5-gateway/internal/router/settlement_observe_recovery_test.go
@@ -133,6 +133,169 @@ func TestObserveFallbackRecoverySurvivesOutageAndRestart(t *testing.T) {
 	}
 }
 
+func TestSettlementReconcileWithoutCurrentAttemptBindingRejectsPriorFinality(t *testing.T) {
+	for _, outcome := range []string{"verified", "quarantined"} {
+		t.Run(outcome, func(t *testing.T) {
+			var coordinatorCalls atomic.Int32
+			coordinator := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				coordinatorCalls.Add(1)
+				_ = json.NewEncoder(w).Encode(coordinatorRequestSettlementFinality{
+					RequestID:                 "req_unbound_current_attempt",
+					RequiredInternalRequestID: "internal_prior_attempt",
+					Mode:                      "enforce",
+					PolicyVersion:             settlementPolicyVersion,
+					Outcome:                   outcome,
+					ReceiptResult:             "valid",
+					Reason:                    "prior_attempt_finality",
+					Closed:                    true,
+					PromptTokens:              4,
+					CompletionTokens:          5,
+					TotalTokens:               9,
+					TokenSource:               "coordinator_observed",
+					VerifiedAttempts:          1,
+				})
+			}))
+			defer coordinator.Close()
+
+			h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+				cfg.Coordinator.OperatorURL = coordinator.URL
+				cfg.Coordinator.OperatorKey = "operator-key"
+				cfg.Coordinator.ServiceToken = "service-token"
+			}, WithHTTPClient(coordinator.Client()))
+			createdAt := fixedNow()
+			if _, err := store.ReserveQuota(context.Background(), storage.ReservationRequest{
+				AccountID:       "acct_unbound_current_attempt",
+				RequestID:       "req_unbound_current_attempt",
+				WindowDate:      createdAt.UTC().Format("2006-01-02"),
+				RequestedTokens: 10,
+				DailyQuota:      cfg.Quotas.AccountDailyTokens,
+				CreatedAt:       createdAt,
+				ExpiresAt:       createdAt.Add(time.Minute),
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if err := store.MarkReservationSettlementHold(context.Background(), "acct_unbound_current_attempt", "req_unbound_current_attempt"); err != nil {
+				t.Fatal(err)
+			}
+
+			req := httptest.NewRequest(http.MethodPost, "/admin/settlement/reconcile?limit=10", nil)
+			req.Header.Set("Authorization", "Bearer operator-key")
+			resp := httptest.NewRecorder()
+			h.ServeHTTP(resp, req)
+			if resp.Code != http.StatusOK {
+				t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+			}
+			var summary settlementReconcileSummary
+			if err := json.Unmarshal(resp.Body.Bytes(), &summary); err != nil {
+				t.Fatal(err)
+			}
+			if summary.Scanned != 1 || summary.Held != 1 || summary.Verified != 0 || summary.Refunded != 0 || summary.Errors != 0 {
+				t.Fatalf("summary=%+v, want unbound reservation held without finality", summary)
+			}
+			if calls := coordinatorCalls.Load(); calls != 0 {
+				t.Fatalf("coordinator calls=%d want 0 for unbound current attempt", calls)
+			}
+			state := gatewaySettlementSnapshot(t, dbPath, "acct_unbound_current_attempt")
+			if state.activeRows != 1 || state.heldRows != 1 || state.usageRows != 0 || state.settledRows != 0 || state.refundedRows != 0 {
+				t.Fatalf("settlement state=%+v, want current reservation quarantined", state)
+			}
+		})
+	}
+}
+
+func TestSettlementReconcileVerifiedDemoWritesDemoAuditRow(t *testing.T) {
+	const (
+		accountID         = "demo:192.0.2.25"
+		requestID         = "req_demo_verified_reconcile"
+		internalRequestID = "internal_demo_verified_reconcile"
+		demoIdentity      = "192.0.2.25"
+		demoTokenHash     = "demo-token-hash-verified"
+	)
+	coordinator := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("required_internal_request_id"); got != internalRequestID {
+			t.Fatalf("required_internal_request_id=%q want %q", got, internalRequestID)
+		}
+		_ = json.NewEncoder(w).Encode(coordinatorRequestSettlementFinality{
+			RequestID:                 requestID,
+			RequiredInternalRequestID: internalRequestID,
+			Mode:                      "enforce",
+			PolicyVersion:             settlementPolicyVersion,
+			Outcome:                   "verified",
+			ReceiptResult:             "valid",
+			Reason:                    "verified_settlement",
+			Closed:                    true,
+			PromptTokens:              4,
+			CompletionTokens:          5,
+			TotalTokens:               9,
+			TokenSource:               "coordinator_observed",
+			VerifiedAttempts:          1,
+		})
+	}))
+	defer coordinator.Close()
+
+	h, store, dbPath, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.OperatorURL = coordinator.URL
+		cfg.Coordinator.OperatorKey = "operator-key"
+		cfg.Coordinator.ServiceToken = "service-token"
+	}, WithHTTPClient(coordinator.Client()))
+	createdAt := fixedNow()
+	window := createdAt.UTC().Format("2006-01-02")
+	if _, err := store.ReserveQuota(context.Background(), storage.ReservationRequest{
+		AccountID:       accountID,
+		RequestID:       requestID,
+		WindowDate:      window,
+		RequestedTokens: 10,
+		DailyQuota:      cfg.Quotas.DemoDailyTokensPerIP,
+		CreatedAt:       createdAt,
+		ExpiresAt:       createdAt.Add(time.Minute),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveSettlementFallbackCandidate(context.Background(), storage.SettlementFallbackCandidate{
+		AccountID:                 accountID,
+		RequestID:                 requestID,
+		RequiredInternalRequestID: internalRequestID,
+		ReservationCreatedAt:      createdAt,
+		DemoIdentity:              demoIdentity,
+		DemoTokenHash:             demoTokenHash,
+		WindowDate:                window,
+		PromptTokens:              2,
+		CompletionTokens:          3,
+		MaxTotalTokens:            10,
+		TokenSource:               "gateway_estimated",
+		Outcome:                   "unverified_streaming",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/admin/settlement/reconcile?limit=10", nil)
+	req.Header.Set("Authorization", "Bearer operator-key")
+	resp := httptest.NewRecorder()
+	h.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	var summary settlementReconcileSummary
+	if err := json.Unmarshal(resp.Body.Bytes(), &summary); err != nil {
+		t.Fatal(err)
+	}
+	if summary.Verified != 1 || summary.Errors != 0 {
+		t.Fatalf("summary=%+v want one verified demo reconciliation", summary)
+	}
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	var count, total int64
+	if err := db.QueryRow(`SELECT COUNT(*), COALESCE(SUM(total_tokens), 0) FROM demo_usage_events WHERE request_id = ? AND demo_token_hash = ?`, requestID, demoTokenHash).Scan(&count, &total); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 || total != 9 {
+		t.Fatalf("demo audit rows=%d total=%d want 1/9", count, total)
+	}
+}
+
 func TestObserveFallbackAuthorityIsCompleteAndClosed(t *testing.T) {
 	base := coordinatorRequestSettlementFinality{
 		RequestID: "req", Mode: "observe", ModeScopeComplete: true, PolicyVersion: settlementPolicyVersion,
@@ -427,12 +590,6 @@ func TestObserveFallbackReconciliationRotatesPastBatchLimitAcrossRestarts(t *tes
 			DailyQuota: 10000, CreatedAt: reservationCreated, ExpiresAt: reservationCreated.Add(time.Minute),
 		}); err != nil {
 			t.Fatal(err)
-		}
-		if requestID == "recover_enforce" {
-			if err := store.MarkReservationSettlementHold(ctx, accountID, requestID); err != nil {
-				t.Fatal(err)
-			}
-			continue
 		}
 		if err := store.SaveSettlementFallbackCandidate(ctx, storage.SettlementFallbackCandidate{
 			AccountID: accountID, RequestID: requestID, ReservationCreatedAt: reservationCreated,

--- a/phase5-gateway/internal/router/settlement_observe_recovery_test.go
+++ b/phase5-gateway/internal/router/settlement_observe_recovery_test.go
@@ -1,0 +1,489 @@
+package router
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-gateway/internal/config"
+	"github.com/augstar/macprovider-gateway/internal/storage"
+	"github.com/augstar/macprovider-gateway/internal/storage/sqlite"
+)
+
+func TestObserveFallbackRecoverySurvivesOutageAndRestart(t *testing.T) {
+	for _, demo := range []bool{false, true} {
+		t.Run(strconv.FormatBool(demo), func(t *testing.T) {
+			ctx := context.Background()
+			created := fixedNow()
+			var status atomic.Int32
+			status.Store(http.StatusServiceUnavailable)
+			coordinator := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/internal/settlement/finality" || r.Header.Get("Authorization") != "Bearer service-token" ||
+					r.URL.Query().Get("account_id") != "acct_observe" || r.URL.Query().Get("request_id") != "req_observe" ||
+					r.URL.Query().Get("required_internal_request_id") != "internal_req_observe" ||
+					r.URL.Query().Get("reservation_created_at_unix_ms") != strconv.FormatInt(created.UnixMilli(), 10) {
+					t.Error("finality lookup missing authenticated reservation scope")
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+				if code := int(status.Load()); code != http.StatusOK {
+					w.WriteHeader(code)
+					return
+				}
+				_ = json.NewEncoder(w).Encode(coordinatorRequestSettlementFinality{
+					RequestID: "req_observe", Mode: "observe", ModeScopeComplete: true, PolicyVersion: settlementPolicyVersion,
+					RequiredInternalRequestID: "internal_req_observe",
+					Outcome:                   "verified", ReceiptResult: "valid", Reason: "verified_settlement", Closed: true,
+					PromptTokens: 40, CompletionTokens: 50, TotalTokens: 90, TokenSource: "coordinator_observed", VerifiedAttempts: 1,
+				})
+			}))
+			defer coordinator.Close()
+			cfg := baselineValidConfig(t)
+			cfg.Coordinator.OperatorURL = coordinator.URL
+			cfg.Storage.DBPath = filepath.Join(t.TempDir(), "gateway.db")
+			store, err := sqlite.Open(ctx, cfg.Storage.DBPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = store.Close() }()
+			if err := store.CreateAccount(ctx, storage.Account{
+				AccountID: "acct_observe", Status: "active", QuotaClass: "default", ConcurrencyClass: "default", CreatedAt: created,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			window := created.Format("2006-01-02")
+			if _, err := store.ReserveQuota(ctx, storage.ReservationRequest{
+				AccountID: "acct_observe", RequestID: "req_observe", WindowDate: window,
+				RequestedTokens: 10, DailyQuota: 100, CreatedAt: created, ExpiresAt: created.Add(time.Minute),
+			}); err != nil {
+				t.Fatal(err)
+			}
+			candidate := storage.SettlementFallbackCandidate{
+				AccountID: "acct_observe", RequestID: "req_observe", ReservationCreatedAt: created,
+				RequiredInternalRequestID: "internal_req_observe",
+				WindowDate:                window, PromptTokens: 2, CompletionTokens: 3, MaxTotalTokens: 10,
+				TokenSource: "gateway_estimated", Outcome: "unverified_streaming",
+			}
+			if demo {
+				candidate.DemoIdentity, candidate.DemoTokenHash = "192.0.2.10", "synthetic-demo-hash"
+			}
+			if err := store.SaveSettlementFallbackCandidate(ctx, candidate); err != nil {
+				t.Fatal(err)
+			}
+			// Reconcile after the fallback TTL; neither an outage nor a 404
+			// may make a delivered local tuple permanently undiscoverable.
+			now := created.Add(24 * time.Hour)
+			server := New(cfg, store, fakeOAuth{}, WithNow(func() time.Time { return now }))
+			if summary, err := server.ReconcileSettlementHolds(ctx, 10); err != nil || summary.Errors != 1 || summary.StaleHeld != 0 {
+				t.Fatalf("outage summary=%+v err=%v", summary, err)
+			}
+			status.Store(http.StatusNotFound)
+			if summary, err := server.ReconcileSettlementHolds(ctx, 10); err != nil || summary.Held != 1 || summary.Coordinator404 != 1 || summary.StaleHeld != 0 {
+				t.Fatalf("missing summary=%+v err=%v", summary, err)
+			}
+			if n, err := store.ReapExpiredReservations(ctx, now); err != nil || n != 0 {
+				t.Fatalf("reaped=%d err=%v", n, err)
+			}
+			if err := store.Close(); err != nil {
+				t.Fatal(err)
+			}
+			store, err = sqlite.Open(ctx, cfg.Storage.DBPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			server = New(cfg, store, fakeOAuth{}, WithNow(func() time.Time { return now }))
+			status.Store(http.StatusOK)
+			if summary, err := server.ReconcileSettlementHolds(ctx, 10); err != nil || summary.Observed != 1 || summary.Verified != 0 {
+				t.Fatalf("recovered summary=%+v err=%v", summary, err)
+			}
+			if summary, err := server.ReconcileSettlementHolds(ctx, 10); err != nil || summary.Scanned != 0 {
+				t.Fatalf("repeat summary=%+v err=%v", summary, err)
+			}
+			used, reserved, err := store.DailyUsage(ctx, candidate.AccountID, window)
+			if err != nil || used != 5 || reserved != 0 {
+				t.Fatalf("used=%d reserved=%d err=%v", used, reserved, err)
+			}
+			db, err := sql.Open("sqlite", cfg.Storage.DBPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+			var count, prompt, completion int64
+			var source, outcome, gotWindow string
+			if err := db.QueryRow(`SELECT COUNT(*), prompt_tokens, completion_tokens, token_source, outcome, window_date FROM usage_events`).Scan(
+				&count, &prompt, &completion, &source, &outcome, &gotWindow); err != nil || count != 1 || prompt != 2 || completion != 3 ||
+				source != candidate.TokenSource || outcome != candidate.Outcome || gotWindow != window {
+				t.Fatalf("local usage count=%d tokens=%d/%d source=%q outcome=%q window=%q err=%v", count, prompt, completion, source, outcome, gotWindow, err)
+			}
+			if demo {
+				var total int64
+				if err := db.QueryRow(`SELECT COUNT(*), total_tokens FROM demo_usage_events WHERE demo_token_hash = ?`, candidate.DemoTokenHash).Scan(&count, &total); err != nil || count != 1 || total != 5 {
+					t.Fatalf("demo usage count=%d total=%d err=%v", count, total, err)
+				}
+			}
+		})
+	}
+}
+
+func TestObserveFallbackAuthorityIsCompleteAndClosed(t *testing.T) {
+	base := coordinatorRequestSettlementFinality{
+		RequestID: "req", Mode: "observe", ModeScopeComplete: true, PolicyVersion: settlementPolicyVersion,
+		RequiredInternalRequestID: "internal_req",
+		Outcome:                   "verified", ReceiptResult: "valid", Closed: true,
+	}
+	for _, tc := range []struct {
+		name string
+		edit func(*coordinatorRequestSettlementFinality)
+		want bool
+	}{
+		{"verified", func(*coordinatorRequestSettlementFinality) {}, true},
+		{"old_coordinator", func(f *coordinatorRequestSettlementFinality) { f.ModeScopeComplete = false }, false},
+		{"missing_request", func(f *coordinatorRequestSettlementFinality) { f.RequestID = "" }, false},
+		{"missing_internal_request", func(f *coordinatorRequestSettlementFinality) { f.RequiredInternalRequestID = "" }, false},
+		{"enforce", func(f *coordinatorRequestSettlementFinality) { f.Mode = "enforce" }, false},
+		{"unknown_policy", func(f *coordinatorRequestSettlementFinality) { f.PolicyVersion = "unknown" }, false},
+		{"mixed", func(f *coordinatorRequestSettlementFinality) { f.Reason = "mixed_settlement_policy_snapshot" }, false},
+		{"missing_scope", func(f *coordinatorRequestSettlementFinality) { f.Reason = "missing_current_settlement_finality" }, false},
+		{"incomplete", func(f *coordinatorRequestSettlementFinality) { f.Closed = false }, false},
+		{"invalid_receipt", func(f *coordinatorRequestSettlementFinality) { f.ReceiptResult = "invalid" }, false},
+		{"unknown_outcome", func(f *coordinatorRequestSettlementFinality) { f.Outcome = "other" }, false},
+		{"pending", func(f *coordinatorRequestSettlementFinality) {
+			f.Outcome, f.ReceiptResult, f.Reason, f.Closed, f.PendingAttempts = "pending", "inconclusive", "receipt_verdict_pending", false, 1
+		}, true},
+		{"unknown_pending", func(f *coordinatorRequestSettlementFinality) {
+			f.Outcome, f.ReceiptResult, f.Reason, f.Closed, f.PendingAttempts = "pending", "inconclusive", "other", false, 1
+		}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			finality := base
+			tc.edit(&finality)
+			if got := coordinatorObserveFallbackAllowed(finality); got != tc.want {
+				t.Fatalf("allowed=%t want=%t", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestObserveFallbackSavedCandidateCannotOverrideAuthority(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		edit           func(*coordinatorRequestSettlementFinality)
+		used, reserved int64
+	}{
+		{"observe", func(*coordinatorRequestSettlementFinality) {}, 5, 0},
+		{"enforce_verified", func(f *coordinatorRequestSettlementFinality) { f.Mode = "enforce" }, 9, 0},
+		{"enforce_refund", func(f *coordinatorRequestSettlementFinality) {
+			f.Mode = "enforce"
+			f.Outcome = "quarantined"
+			f.ReceiptResult = "invalid"
+		}, 0, 0},
+		{"old_coordinator", func(f *coordinatorRequestSettlementFinality) { f.ModeScopeComplete = false }, 0, 10},
+		{"missing_internal_echo", func(f *coordinatorRequestSettlementFinality) { f.RequiredInternalRequestID = "" }, 0, 10},
+		{"wrong_internal_echo", func(f *coordinatorRequestSettlementFinality) { f.RequiredInternalRequestID = "other_attempt" }, 0, 10},
+		{"enforce_missing_internal_echo", func(f *coordinatorRequestSettlementFinality) {
+			f.Mode, f.RequiredInternalRequestID = "enforce", ""
+		}, 0, 10},
+		{"refund_wrong_internal_echo", func(f *coordinatorRequestSettlementFinality) {
+			f.Mode, f.Outcome, f.ReceiptResult, f.RequiredInternalRequestID = "enforce", "quarantined", "invalid", "other_attempt"
+		}, 0, 10},
+		{"unknown_policy", func(f *coordinatorRequestSettlementFinality) { f.PolicyVersion = "unknown" }, 0, 10},
+		{"mixed_scope", func(f *coordinatorRequestSettlementFinality) { f.Reason = "mixed_settlement_policy_snapshot" }, 0, 10},
+		{"missing_scope", func(f *coordinatorRequestSettlementFinality) { f.Reason = "missing_current_settlement_finality" }, 0, 10},
+		{"wrong_request", func(f *coordinatorRequestSettlementFinality) { f.RequestID = "another" }, 0, 10},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			finality := coordinatorRequestSettlementFinality{
+				RequestID: "req_candidate", Mode: "observe", ModeScopeComplete: true, PolicyVersion: settlementPolicyVersion,
+				RequiredInternalRequestID: "internal_req_candidate",
+				Outcome:                   "verified", ReceiptResult: "valid", Closed: true, PromptTokens: 4, CompletionTokens: 5,
+				TotalTokens: 9, TokenSource: "coordinator_observed", VerifiedAttempts: 1,
+			}
+			tc.edit(&finality)
+			coordinator := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { _ = json.NewEncoder(w).Encode(finality) }))
+			defer coordinator.Close()
+			_, store, _, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) { cfg.Coordinator.OperatorURL = coordinator.URL })
+			candidate := reserveObserveRecoveryFixture(t, store)
+			if err := store.SaveSettlementFallbackCandidate(context.Background(), candidate); err != nil {
+				t.Fatal(err)
+			}
+			server := New(cfg, store, fakeOAuth{}, WithNow(fixedNow))
+			if _, err := server.ReconcileSettlementHolds(context.Background(), 10); err != nil {
+				t.Fatal(err)
+			}
+			used, reserved, err := store.DailyUsage(context.Background(), candidate.AccountID, candidate.WindowDate)
+			if err != nil || used != tc.used || reserved != tc.reserved {
+				t.Fatalf("used=%d reserved=%d want=%d/%d err=%v", used, reserved, tc.used, tc.reserved, err)
+			}
+		})
+	}
+}
+
+func TestObserveFallbackDemoOverCapFailsWithoutDebit(t *testing.T) {
+	_, store, path, cfg := newTestHarnessConfig(t, fakeOAuth{}, nil)
+	candidate := reserveObserveRecoveryFixture(t, store)
+	candidate.PromptTokens = 11
+	candidate.DemoIdentity, candidate.DemoTokenHash = "192.0.2.12", "synthetic-demo-hash"
+	if err := store.SaveSettlementFallbackCandidate(context.Background(), candidate); err == nil {
+		t.Fatal("over-cap demo candidate persisted")
+	}
+	server := New(cfg, store, fakeOAuth{}, WithNow(fixedNow))
+	if err := server.settleObserveFallbackCandidate(context.Background(), candidate); err == nil {
+		t.Fatal("over-cap demo candidate settled")
+	}
+	used, reserved, err := store.DailyUsage(context.Background(), candidate.AccountID, candidate.WindowDate)
+	if err != nil || used != 0 || reserved != 10 {
+		t.Fatalf("used=%d reserved=%d err=%v", used, reserved, err)
+	}
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM demo_usage_events`).Scan(&count); err != nil || count != 0 {
+		t.Fatalf("demo events=%d err=%v", count, err)
+	}
+}
+
+func TestObserveFallbackMissingCurrentHeaderQuarantinesBeforeLookup(t *testing.T) {
+	var lookups atomic.Int32
+	coordinator := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		lookups.Add(1)
+		_ = json.NewEncoder(w).Encode(coordinatorRequestSettlementFinality{
+			RequestID: "req_candidate", Mode: "enforce", ModeScopeComplete: true, PolicyVersion: settlementPolicyVersion,
+			Outcome: "verified", ReceiptResult: "valid", Closed: true, PromptTokens: 4, CompletionTokens: 5,
+			TotalTokens: 9, TokenSource: "coordinator_observed", VerifiedAttempts: 1,
+		})
+	}))
+	defer coordinator.Close()
+	_, store, path, cfg := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) { cfg.Coordinator.OperatorURL = coordinator.URL })
+	candidate := reserveObserveRecoveryFixture(t, store)
+	candidate.RequiredInternalRequestID = ""
+	if err := store.SaveSettlementFallbackCandidate(context.Background(), candidate); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	store, err := sqlite.Open(context.Background(), path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	server := New(cfg, store, fakeOAuth{}, WithNow(func() time.Time { return fixedNow().Add(24 * time.Hour) }))
+	for pass := 0; pass < 2; pass++ {
+		if summary, err := server.ReconcileSettlementHolds(context.Background(), 10); err != nil || summary.Held != 1 || summary.Errors != 0 {
+			t.Fatalf("pass=%d summary=%+v err=%v", pass, summary, err)
+		}
+	}
+	if lookups.Load() != 0 {
+		t.Fatalf("unbound coordinator lookup attempted %d times", lookups.Load())
+	}
+	if err := server.settleObserveFallbackCandidate(context.Background(), candidate); err == nil {
+		t.Fatal("quarantined candidate directly settled")
+	}
+	used, reserved, err := store.DailyUsage(context.Background(), candidate.AccountID, candidate.WindowDate)
+	if err != nil || used != 0 || reserved != 10 {
+		t.Fatalf("used=%d reserved=%d err=%v", used, reserved, err)
+	}
+}
+
+func reserveObserveRecoveryFixture(t *testing.T, store *sqlite.Store) storage.SettlementFallbackCandidate {
+	t.Helper()
+	ctx := context.Background()
+	created := fixedNow()
+	if err := store.CreateAccount(ctx, storage.Account{
+		AccountID: "acct_candidate", Status: "active", QuotaClass: "default", ConcurrencyClass: "default", CreatedAt: created,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	window := created.Format("2006-01-02")
+	if _, err := store.ReserveQuota(ctx, storage.ReservationRequest{
+		AccountID: "acct_candidate", RequestID: "req_candidate", WindowDate: window,
+		RequestedTokens: 10, DailyQuota: 100, CreatedAt: created, ExpiresAt: created.Add(time.Minute),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return storage.SettlementFallbackCandidate{
+		AccountID: "acct_candidate", RequestID: "req_candidate", ReservationCreatedAt: created,
+		RequiredInternalRequestID: "internal_req_candidate",
+		WindowDate:                window, PromptTokens: 2, CompletionTokens: 3, MaxTotalTokens: 10,
+		TokenSource: "gateway_estimated", Outcome: "unverified_streaming",
+	}
+}
+
+func TestObserveFallbackWalletReconciliationUsesLocalUsage(t *testing.T) {
+	modelsClient := walletModelsClient()
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Path == "/internal/settlement/finality" {
+			if r.URL.Query().Get("required_internal_request_id") != "internal_req_wallet_candidate" {
+				t.Error("wallet recovery lookup missing current internal request fence")
+			}
+			return responseWithBody(http.StatusOK, http.Header{"Content-Type": {"application/json"}},
+				`{"request_id":"req_wallet_candidate","required_internal_request_id":"internal_req_wallet_candidate","mode":"observe","mode_scope_complete":true,"policy_version":"`+settlementPolicyVersion+`","outcome":"pending","receipt_result":"inconclusive","reason":"receipt_verdict_pending","pending_attempts":1,"closed":false}`), nil
+		}
+		return modelsClient.Do(r)
+	})}
+	h, store, _, cfg := newWalletSessionHarness(t, client)
+	const accountID = "acct_wallet_candidate"
+	key := createAccountAndKey(t, store, cfg, accountID)
+	wallet := registerWalletSessionViaAPIWithCaps(t, h, cfg, key, accountID, []string{"model-a"}, 100, 10)
+	created := fixedNow()
+	window := created.Format("2006-01-02")
+	if _, err := store.AdmitWalletSessionInference(context.Background(), storage.WalletSessionAdmissionRequest{
+		SessionID: wallet.SessionID, AccountID: accountID, RequestID: "req_wallet_candidate", ModelID: "model-a",
+		Method: http.MethodPost, CanonicalRoute: "/v1/chat/completions", WindowDate: window,
+		RequestedTokens: 10, DailyQuota: 100, CreatedAt: created, ExpiresAt: created.Add(time.Minute),
+		Replay: storage.WalletSessionReplayMaterial{SemanticHeadersHash: []byte("headers"), RawBodyHash: []byte("body")},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveSettlementFallbackCandidate(context.Background(), storage.SettlementFallbackCandidate{
+		AccountID: accountID, RequestID: "req_wallet_candidate", WalletSessionID: wallet.SessionID,
+		RequiredInternalRequestID: "internal_req_wallet_candidate",
+		ReservationCreatedAt:      created, WindowDate: window, PromptTokens: 2, CompletionTokens: 3, MaxTotalTokens: 10,
+		TokenSource: "gateway_estimated", Outcome: "unverified_streaming",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	server := New(cfg, store, fakeOAuth{}, WithNow(fixedNow), WithHTTPClient(client))
+	if summary, err := server.ReconcileSettlementHolds(context.Background(), 10); err != nil || summary.Observed != 1 {
+		t.Fatalf("summary=%+v err=%v", summary, err)
+	}
+	if summary, err := server.ReconcileSettlementHolds(context.Background(), 10); err != nil || summary.Scanned != 0 {
+		t.Fatalf("repeat summary=%+v err=%v", summary, err)
+	}
+	usage, err := store.WalletSessionUsage(context.Background(), accountID, wallet.SessionID)
+	if err != nil || usage.SettledTokens != 5 || usage.ReservedTokens != 0 || usage.HeldTokens != 0 {
+		t.Fatalf("wallet usage=%+v err=%v", usage, err)
+	}
+	used, reserved, err := store.DailyUsage(context.Background(), accountID, window)
+	if err != nil || used != 5 || reserved != 0 {
+		t.Fatalf("account used=%d reserved=%d err=%v", used, reserved, err)
+	}
+}
+
+func TestObserveFallbackReconciliationRotatesPastBatchLimitAcrossRestarts(t *testing.T) {
+	ctx := context.Background()
+	const limit = 100
+	const blocked = limit + 1
+	const accountID = "acct_retry_fairness"
+	created := fixedNow()
+	window := created.Format("2006-01-02")
+	var mu sync.Mutex
+	attempts := make(map[string]int)
+	coordinator := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestID := r.URL.Query().Get("request_id")
+		mu.Lock()
+		attempts[requestID]++
+		mu.Unlock()
+		if requestID != "recover_observe" && requestID != "recover_enforce" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		mode := "observe"
+		if requestID == "recover_enforce" {
+			mode = "enforce"
+		}
+		_ = json.NewEncoder(w).Encode(coordinatorRequestSettlementFinality{
+			RequestID: requestID, Mode: mode, ModeScopeComplete: true, PolicyVersion: settlementPolicyVersion,
+			RequiredInternalRequestID: r.URL.Query().Get("required_internal_request_id"),
+			Outcome:                   "verified", ReceiptResult: "valid", Closed: true, PromptTokens: 4, CompletionTokens: 5,
+			TotalTokens: 9, TokenSource: "coordinator_observed", VerifiedAttempts: 1,
+		})
+	}))
+	defer coordinator.Close()
+	cfg := baselineValidConfig(t)
+	cfg.Coordinator.OperatorURL = coordinator.URL
+	cfg.Storage.DBPath = filepath.Join(t.TempDir(), "gateway.db")
+	store, err := sqlite.Open(ctx, cfg.Storage.DBPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = store.Close() }()
+	if err := store.CreateAccount(ctx, storage.Account{
+		AccountID: accountID, Status: "active", QuotaClass: "default", ConcurrencyClass: "default", CreatedAt: created,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < blocked+2; i++ {
+		requestID := "orphan_" + strconv.Itoa(i)
+		if i == blocked {
+			requestID = "recover_observe"
+		} else if i == blocked+1 {
+			requestID = "recover_enforce"
+		}
+		reservationCreated := created.Add(time.Duration(i) * time.Second)
+		if _, err := store.ReserveQuota(ctx, storage.ReservationRequest{
+			AccountID: accountID, RequestID: requestID, WindowDate: window, RequestedTokens: 10,
+			DailyQuota: 10000, CreatedAt: reservationCreated, ExpiresAt: reservationCreated.Add(time.Minute),
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if requestID == "recover_enforce" {
+			if err := store.MarkReservationSettlementHold(ctx, accountID, requestID); err != nil {
+				t.Fatal(err)
+			}
+			continue
+		}
+		if err := store.SaveSettlementFallbackCandidate(ctx, storage.SettlementFallbackCandidate{
+			AccountID: accountID, RequestID: requestID, ReservationCreatedAt: reservationCreated,
+			RequiredInternalRequestID: "internal_" + requestID,
+			WindowDate:                window, PromptTokens: 2, CompletionTokens: 3, MaxTotalTokens: 10,
+			TokenSource: "gateway_estimated", Outcome: "unverified_streaming",
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Keep the clock fixed across all three processes. Expired, unanswered
+	// candidates stay held, but cannot monopolize the next bounded batch.
+	now := created.Add(24 * time.Hour)
+	for pass := 0; pass < 3; pass++ {
+		if pass > 0 {
+			if err := store.Close(); err != nil {
+				t.Fatal(err)
+			}
+			store, err = sqlite.Open(ctx, cfg.Storage.DBPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		server := New(cfg, store, fakeOAuth{}, WithNow(func() time.Time { return now }))
+		summary, err := server.ReconcileSettlementHolds(ctx, limit)
+		if err != nil || summary.Scanned != limit || summary.Errors != 0 || summary.StaleHeld != 0 {
+			t.Fatalf("pass=%d summary=%+v err=%v", pass, summary, err)
+		}
+		wantObserved, wantVerified := 0, 0
+		if pass == 1 {
+			wantObserved, wantVerified = 1, 1
+		}
+		if summary.Observed != wantObserved || summary.Verified != wantVerified || summary.Held != limit-wantObserved-wantVerified {
+			t.Fatalf("pass=%d summary=%+v", pass, summary)
+		}
+	}
+	used, reserved, err := store.DailyUsage(ctx, accountID, window)
+	if err != nil || used != 14 || reserved != blocked*10 {
+		t.Fatalf("used=%d reserved=%d err=%v", used, reserved, err)
+	}
+	if n, err := store.ReapExpiredReservations(ctx, now); err != nil || n != 0 {
+		t.Fatalf("candidate holds reaped=%d err=%v", n, err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	for i := 0; i < blocked; i++ {
+		if n := attempts["orphan_"+strconv.Itoa(i)]; n < 2 {
+			t.Fatalf("orphan=%d attempts=%d: retry did not rotate across restarts", i, n)
+		}
+	}
+	if attempts["recover_observe"] != 1 || attempts["recover_enforce"] != 1 {
+		t.Fatalf("terminal requests retried: observe=%d enforce=%d", attempts["recover_observe"], attempts["recover_enforce"])
+	}
+}

--- a/phase5-gateway/internal/router/settlement_reconcile.go
+++ b/phase5-gateway/internal/router/settlement_reconcile.go
@@ -159,10 +159,17 @@ func (s *Server) reconcileSettlementReservation(ctx context.Context, reservation
 		return "", err
 	}
 	candidate, candidateErr := s.store.LookupSettlementFallbackCandidate(ctx, reservation)
-	if candidateErr != nil && !errors.Is(candidateErr, storage.ErrNotFound) {
+	if errors.Is(candidateErr, storage.ErrNotFound) {
+		// Reconciliation without the coordinator-owned current-attempt binding
+		// could apply an earlier retry's otherwise valid finality to this hold.
+		// Legacy and persistence-failure rows remain quarantined until an
+		// operator can establish that binding through a separate recovery path.
+		return "held", nil
+	}
+	if candidateErr != nil {
 		return "", candidateErr
 	}
-	if candidateErr == nil && candidate.RequiredInternalRequestID == "" {
+	if candidate.RequiredInternalRequestID == "" {
 		// A missing trusted header quarantines this delivery. An unbound
 		// lookup could return a previous retry's otherwise valid finality.
 		return "held", nil
@@ -172,36 +179,14 @@ func (s *Server) reconcileSettlementReservation(ctx context.Context, reservation
 		return "", err
 	}
 	if !found {
-		if candidateErr == nil {
-			// A missing coordinator lookup is not authority to discard local
-			// delivered usage. Keep this specific hold discoverable for retry.
-			return "coordinator_404_held", nil
-		}
-		now := s.now()
-		if !reservation.ExpiresAt.IsZero() && !now.Before(reservation.ExpiresAt) {
-			var err error
-			if reservation.WalletSessionID != "" {
-				err = s.store.MarkWalletSessionReservationStaleHeld(ctx, reservation.AccountID, reservation.WalletSessionID, reservation.RequestID, now)
-			} else {
-				err = s.store.MarkReservationStaleHeld(ctx, reservation.AccountID, reservation.RequestID, now)
-			}
-			if err != nil {
-				if errors.Is(err, storage.ErrReservationNotFound) || errors.Is(err, storage.ErrReservationTerminal) {
-					return "already_terminal", nil
-				}
-				return "", err
-			}
-			return "coordinator_404_expired", nil
-		}
-		return "coordinator_404", nil
+		// A missing coordinator lookup is not authority to discard local
+		// delivered usage. Keep this specific hold discoverable for retry.
+		return "coordinator_404_held", nil
 	}
-	if candidateErr == nil && finality.RequiredInternalRequestID != candidate.RequiredInternalRequestID {
+	if finality.RequiredInternalRequestID != candidate.RequiredInternalRequestID {
 		return "held", nil
 	}
 	if finality.RequestID == reservation.RequestID && !reservation.CreatedAt.IsZero() && coordinatorObserveFallbackAllowed(finality) {
-		if candidateErr != nil {
-			return "held", nil
-		}
 		if err := s.settleObserveFallbackCandidate(ctx, candidate); err != nil {
 			if errors.Is(err, storage.ErrReservationNotFound) || errors.Is(err, storage.ErrReservationTerminal) {
 				return "already_terminal", nil
@@ -245,6 +230,14 @@ func (s *Server) reconcileSettlementReservation(ctx context.Context, reservation
 				TokenSource:                  settlement.TokenSource,
 				Outcome:                      settlement.Outcome,
 				SettledAt:                    settlement.SettledAt,
+			})
+		} else if candidate.DemoIdentity != "" {
+			settleErr = s.store.SettleDemoReservation(ctx, settlement, storage.DemoUsageEvent{
+				RequestID:     candidate.RequestID,
+				ClientIP:      candidate.DemoIdentity,
+				DemoTokenHash: candidate.DemoTokenHash,
+				WindowDate:    candidate.WindowDate,
+				CreatedAt:     settlement.SettledAt,
 			})
 		} else {
 			settleErr = s.store.SettleReservation(ctx, settlement)

--- a/phase5-gateway/internal/router/settlement_reconcile.go
+++ b/phase5-gateway/internal/router/settlement_reconcile.go
@@ -20,27 +20,30 @@ const defaultSettlementReconcileLimit = 100
 const maxSettlementReconcileLimit = 500
 
 type coordinatorRequestSettlementFinality struct {
-	RequestID             string `json:"request_id"`
-	PolicyVersion         string `json:"policy_version"`
-	Mode                  string `json:"mode"`
-	Outcome               string `json:"outcome"`
-	ReceiptResult         string `json:"receipt_result"`
-	Reason                string `json:"reason"`
-	Closed                bool   `json:"closed"`
-	PendingDeadlineUnixMS int64  `json:"pending_deadline_unix_ms"`
-	PromptTokens          int64  `json:"prompt_tokens"`
-	CompletionTokens      int64  `json:"completion_tokens"`
-	TotalTokens           int64  `json:"total_tokens"`
-	TokenSource           string `json:"token_source"`
-	VerifiedAttempts      int64  `json:"verified_attempts"`
-	PendingAttempts       int64  `json:"pending_attempts"`
-	QuarantinedAttempts   int64  `json:"quarantined_attempts"`
-	ZeroSettledAttempts   int64  `json:"zero_settled_attempts"`
+	RequestID                 string `json:"request_id"`
+	RequiredInternalRequestID string `json:"required_internal_request_id"`
+	PolicyVersion             string `json:"policy_version"`
+	Mode                      string `json:"mode"`
+	ModeScopeComplete         bool   `json:"mode_scope_complete"`
+	Outcome                   string `json:"outcome"`
+	ReceiptResult             string `json:"receipt_result"`
+	Reason                    string `json:"reason"`
+	Closed                    bool   `json:"closed"`
+	PendingDeadlineUnixMS     int64  `json:"pending_deadline_unix_ms"`
+	PromptTokens              int64  `json:"prompt_tokens"`
+	CompletionTokens          int64  `json:"completion_tokens"`
+	TotalTokens               int64  `json:"total_tokens"`
+	TokenSource               string `json:"token_source"`
+	VerifiedAttempts          int64  `json:"verified_attempts"`
+	PendingAttempts           int64  `json:"pending_attempts"`
+	QuarantinedAttempts       int64  `json:"quarantined_attempts"`
+	ZeroSettledAttempts       int64  `json:"zero_settled_attempts"`
 }
 
 type SettlementReconcileSummary struct {
 	Scanned        int `json:"scanned"`
 	Verified       int `json:"verified"`
+	Observed       int `json:"observed"`
 	Refunded       int `json:"refunded"`
 	Expired        int `json:"expired"`
 	StaleHeld      int `json:"stale_held"`
@@ -112,6 +115,8 @@ func (s *Server) ReconcileSettlementHolds(ctx context.Context, limit int) (Settl
 		switch result {
 		case "verified":
 			summary.Verified++
+		case "observed":
+			summary.Observed++
 		case "refunded":
 			summary.Refunded++
 		case "held":
@@ -122,6 +127,9 @@ func (s *Server) ReconcileSettlementHolds(ctx context.Context, limit int) (Settl
 		case "coordinator_404":
 			summary.Coordinator404++
 			summary.Skipped++
+		case "coordinator_404_held":
+			summary.Coordinator404++
+			summary.Held++
 		default:
 			summary.Skipped++
 		}
@@ -144,28 +152,63 @@ func parseSettlementReconcileLimit(raw string) (int, error) {
 }
 
 func (s *Server) reconcileSettlementReservation(ctx context.Context, reservation storage.ActiveReservation) (string, error) {
-	finality, found, err := s.fetchCoordinatorRequestSettlementFinality(ctx, reservation)
-	if err != nil || !found {
-		if !found {
-			now := s.now()
-			if !reservation.ExpiresAt.IsZero() && !now.Before(reservation.ExpiresAt) {
-				var err error
-				if reservation.WalletSessionID != "" {
-					err = s.store.MarkWalletSessionReservationStaleHeld(ctx, reservation.AccountID, reservation.WalletSessionID, reservation.RequestID, now)
-				} else {
-					err = s.store.MarkReservationStaleHeld(ctx, reservation.AccountID, reservation.RequestID, now)
-				}
-				if err != nil {
-					if errors.Is(err, storage.ErrReservationNotFound) || errors.Is(err, storage.ErrReservationTerminal) {
-						return "already_terminal", nil
-					}
-					return "", err
-				}
-				return "coordinator_404_expired", nil
-			}
-			return "coordinator_404", nil
+	if err := s.store.MarkSettlementReconcileAttempt(ctx, reservation); err != nil {
+		if errors.Is(err, storage.ErrReservationNotFound) || errors.Is(err, storage.ErrReservationTerminal) {
+			return "already_terminal", nil
 		}
 		return "", err
+	}
+	candidate, candidateErr := s.store.LookupSettlementFallbackCandidate(ctx, reservation)
+	if candidateErr != nil && !errors.Is(candidateErr, storage.ErrNotFound) {
+		return "", candidateErr
+	}
+	if candidateErr == nil && candidate.RequiredInternalRequestID == "" {
+		// A missing trusted header quarantines this delivery. An unbound
+		// lookup could return a previous retry's otherwise valid finality.
+		return "held", nil
+	}
+	finality, found, err := s.fetchCoordinatorRequestSettlementFinality(ctx, reservation, candidate.RequiredInternalRequestID)
+	if err != nil {
+		return "", err
+	}
+	if !found {
+		if candidateErr == nil {
+			// A missing coordinator lookup is not authority to discard local
+			// delivered usage. Keep this specific hold discoverable for retry.
+			return "coordinator_404_held", nil
+		}
+		now := s.now()
+		if !reservation.ExpiresAt.IsZero() && !now.Before(reservation.ExpiresAt) {
+			var err error
+			if reservation.WalletSessionID != "" {
+				err = s.store.MarkWalletSessionReservationStaleHeld(ctx, reservation.AccountID, reservation.WalletSessionID, reservation.RequestID, now)
+			} else {
+				err = s.store.MarkReservationStaleHeld(ctx, reservation.AccountID, reservation.RequestID, now)
+			}
+			if err != nil {
+				if errors.Is(err, storage.ErrReservationNotFound) || errors.Is(err, storage.ErrReservationTerminal) {
+					return "already_terminal", nil
+				}
+				return "", err
+			}
+			return "coordinator_404_expired", nil
+		}
+		return "coordinator_404", nil
+	}
+	if candidateErr == nil && finality.RequiredInternalRequestID != candidate.RequiredInternalRequestID {
+		return "held", nil
+	}
+	if finality.RequestID == reservation.RequestID && !reservation.CreatedAt.IsZero() && coordinatorObserveFallbackAllowed(finality) {
+		if candidateErr != nil {
+			return "held", nil
+		}
+		if err := s.settleObserveFallbackCandidate(ctx, candidate); err != nil {
+			if errors.Is(err, storage.ErrReservationNotFound) || errors.Is(err, storage.ErrReservationTerminal) {
+				return "already_terminal", nil
+			}
+			return "", err
+		}
+		return "observed", nil
 	}
 	action := coordinatorSettlementFinalityFromHeaders(finalityHeaders(finality))
 	switch action.Action {
@@ -177,29 +220,31 @@ func (s *Server) reconcileSettlementReservation(ctx context.Context, reservation
 			return "", err
 		}
 		settlement := storage.ReservationSettlement{
-			AccountID:        reservation.AccountID,
-			RequestID:        reservation.RequestID,
-			PromptTokens:     prompt,
-			CompletionTokens: completion,
-			TotalTokens:      total,
-			MaxTotalTokens:   reservation.ReservedTokens,
-			TokenSource:      finality.TokenSource,
-			Outcome:          "spec022_verified",
-			SettledAt:        s.now(),
+			ExpectedReservationCreatedAt: reservation.CreatedAt,
+			AccountID:                    reservation.AccountID,
+			RequestID:                    reservation.RequestID,
+			PromptTokens:                 prompt,
+			CompletionTokens:             completion,
+			TotalTokens:                  total,
+			MaxTotalTokens:               reservation.ReservedTokens,
+			TokenSource:                  finality.TokenSource,
+			Outcome:                      "spec022_verified",
+			SettledAt:                    s.now(),
 		}
 		var settleErr error
 		if reservation.WalletSessionID != "" {
 			settleErr = s.store.FinalizeWalletSessionReservation(ctx, storage.WalletSessionReservationSettlement{
-				AccountID:        settlement.AccountID,
-				SessionID:        reservation.WalletSessionID,
-				RequestID:        settlement.RequestID,
-				PromptTokens:     settlement.PromptTokens,
-				CompletionTokens: settlement.CompletionTokens,
-				TotalTokens:      settlement.TotalTokens,
-				MaxTotalTokens:   settlement.MaxTotalTokens,
-				TokenSource:      settlement.TokenSource,
-				Outcome:          settlement.Outcome,
-				SettledAt:        settlement.SettledAt,
+				ExpectedReservationCreatedAt: reservation.CreatedAt,
+				AccountID:                    settlement.AccountID,
+				SessionID:                    reservation.WalletSessionID,
+				RequestID:                    settlement.RequestID,
+				PromptTokens:                 settlement.PromptTokens,
+				CompletionTokens:             settlement.CompletionTokens,
+				TotalTokens:                  settlement.TotalTokens,
+				MaxTotalTokens:               settlement.MaxTotalTokens,
+				TokenSource:                  settlement.TokenSource,
+				Outcome:                      settlement.Outcome,
+				SettledAt:                    settlement.SettledAt,
 			})
 		} else {
 			settleErr = s.store.SettleReservation(ctx, settlement)
@@ -239,7 +284,58 @@ func (s *Server) reconcileSettlementReservation(ctx context.Context, reservation
 	}
 }
 
-func (s *Server) fetchCoordinatorRequestSettlementFinality(ctx context.Context, reservation storage.ActiveReservation) (coordinatorRequestSettlementFinality, bool, error) {
+// Observe recovery needs positive, complete request-scoped mode authority.
+// Older coordinators omit the completeness flag and remain fail-closed.
+func coordinatorObserveFallbackAllowed(finality coordinatorRequestSettlementFinality) bool {
+	if !finality.ModeScopeComplete || finality.RequestID == "" || strings.TrimSpace(finality.RequiredInternalRequestID) == "" || finality.Mode != "observe" ||
+		(finality.PolicyVersion != settlementPolicyVersion && finality.PolicyVersion != legacySettlementPolicyVersion) ||
+		finality.Reason == "mixed_settlement_policy_snapshot" || finality.Reason == "missing_current_settlement_finality" {
+		return false
+	}
+	if finality.Outcome == "pending" {
+		return !finality.Closed && finality.ReceiptResult == "inconclusive" &&
+			finality.Reason == "receipt_verdict_pending" && finality.PendingAttempts > 0
+	}
+	if finality.PendingAttempts != 0 {
+		return false
+	}
+	finality.Mode = "enforce"
+	action := coordinatorSettlementFinalityFromHeaders(finalityHeaders(finality)).Action
+	return action == settlementFinalityDebit || action == settlementFinalityRefund
+}
+
+// The caller must first establish observe authority. Only the persisted local
+// tuple is used here; coordinator receipt totals cannot replace legacy usage.
+func (s *Server) settleObserveFallbackCandidate(ctx context.Context, candidate storage.SettlementFallbackCandidate) error {
+	if candidate.ReservationCreatedAt.IsZero() || strings.TrimSpace(candidate.RequiredInternalRequestID) == "" {
+		return fmt.Errorf("observe fallback reservation creation time and current internal request ID are required")
+	}
+	settlement := storage.ReservationSettlement{
+		ExpectedReservationCreatedAt: candidate.ReservationCreatedAt,
+		AccountID:                    candidate.AccountID, RequestID: candidate.RequestID,
+		PromptTokens: candidate.PromptTokens, CompletionTokens: candidate.CompletionTokens,
+		MaxTotalTokens: candidate.MaxTotalTokens,
+		TokenSource:    candidate.TokenSource, Outcome: candidate.Outcome, SettledAt: s.now(),
+	}
+	if candidate.WalletSessionID != "" {
+		return s.store.FinalizeWalletSessionReservation(ctx, storage.WalletSessionReservationSettlement{
+			ExpectedReservationCreatedAt: candidate.ReservationCreatedAt,
+			AccountID:                    candidate.AccountID, SessionID: candidate.WalletSessionID, RequestID: candidate.RequestID,
+			PromptTokens: settlement.PromptTokens, CompletionTokens: settlement.CompletionTokens,
+			TotalTokens: settlement.TotalTokens, MaxTotalTokens: settlement.MaxTotalTokens,
+			TokenSource: settlement.TokenSource, Outcome: settlement.Outcome, SettledAt: settlement.SettledAt,
+		})
+	}
+	if candidate.DemoIdentity != "" {
+		return s.store.SettleDemoReservation(ctx, settlement, storage.DemoUsageEvent{
+			RequestID: candidate.RequestID, ClientIP: candidate.DemoIdentity, DemoTokenHash: candidate.DemoTokenHash,
+			WindowDate: candidate.WindowDate, CreatedAt: settlement.SettledAt,
+		})
+	}
+	return s.store.SettleReservation(ctx, settlement)
+}
+
+func (s *Server) fetchCoordinatorRequestSettlementFinality(ctx context.Context, reservation storage.ActiveReservation, requiredInternalRequestID ...string) (coordinatorRequestSettlementFinality, bool, error) {
 	base := strings.TrimRight(s.cfg.Coordinator.OperatorURL, "/")
 	if base == "" {
 		return coordinatorRequestSettlementFinality{}, false, fmt.Errorf("coordinator operator URL is not configured")
@@ -251,6 +347,9 @@ func (s *Server) fetchCoordinatorRequestSettlementFinality(ctx context.Context, 
 	q := u.Query()
 	q.Set("account_id", reservation.AccountID)
 	q.Set("request_id", reservation.RequestID)
+	if len(requiredInternalRequestID) > 0 && strings.TrimSpace(requiredInternalRequestID[0]) != "" {
+		q.Set("required_internal_request_id", requiredInternalRequestID[0])
+	}
 	if !reservation.CreatedAt.IsZero() {
 		q.Set("reservation_created_at_unix_ms", strconv.FormatInt(reservation.CreatedAt.UTC().UnixMilli(), 10))
 	}

--- a/phase5-gateway/internal/router/wallet_sessions.go
+++ b/phase5-gateway/internal/router/wallet_sessions.go
@@ -597,7 +597,7 @@ func (s *Server) admitWalletSessionMetadata(w http.ResponseWriter, r *http.Reque
 	return false
 }
 
-func (s *Server) admitWalletSessionInference(r *http.Request, sessionAuth *walletSessionAuth, rawBody []byte, model string, reservationTokens, dailyQuota int64, window string, expiresAt time.Time) (storage.WalletSessionAdmissionDecision, error) {
+func (s *Server) admitWalletSessionInference(r *http.Request, sessionAuth *walletSessionAuth, rawBody []byte, model string, reservationTokens, dailyQuota int64, window string, createdAt, expiresAt time.Time) (storage.WalletSessionAdmissionDecision, error) {
 	bodyHash := sha256.Sum256(rawBody)
 	headersHash, err := auth.SemanticHeadersSHA256Base64URL(walletCanonicalRouteForRequest(r), r.Header)
 	if err != nil {
@@ -616,7 +616,7 @@ func (s *Server) admitWalletSessionInference(r *http.Request, sessionAuth *walle
 			CanonicalRoute: walletCanonicalRouteForRequest(r), SemanticHeadersHash: headersHashBytes,
 			RawBodyHash: bodyHash[:], BodyBytes: int64(len(rawBody)),
 		},
-		CreatedAt: s.now().UTC(), ExpiresAt: expiresAt.UTC(),
+		CreatedAt: createdAt.UTC(), ExpiresAt: expiresAt.UTC(),
 	})
 }
 

--- a/phase5-gateway/internal/router/wallet_sessions_test.go
+++ b/phase5-gateway/internal/router/wallet_sessions_test.go
@@ -350,12 +350,12 @@ func TestWalletSessionSettlementReconcileClosesWalletHeldReservations(t *testing
 			},
 		},
 		{
-			name:            "expired_404_stale_held",
+			name:            "expired_404_remains_held",
 			requestID:       "req_wallet_reconcile_404",
 			coordinatorCode: http.StatusNotFound,
 			expireBeforeRun: true,
 			wantSummary: func(s settlementReconcileSummary) bool {
-				return s.Scanned == 1 && s.Coordinator404 == 1 && s.StaleHeld == 1 && s.Errors == 0
+				return s.Scanned == 1 && s.Coordinator404 == 1 && s.Held == 1 && s.StaleHeld == 0 && s.Errors == 0
 			},
 			wantUsage: func(u storage.WalletSessionUsage) bool {
 				return u.SettledTokens == 0 && u.HeldTokens == 20 && u.RemainingTokens == 80
@@ -397,11 +397,18 @@ func TestWalletSessionSettlementReconcileClosesWalletHeldReservations(t *testing
 				if got := r.URL.Query().Get("account_id"); got != accountID {
 					t.Fatalf("account_id query=%q want %q", got, accountID)
 				}
+				internalRequestID := "internal_" + tc.requestID
+				if got := r.URL.Query().Get("required_internal_request_id"); got != internalRequestID {
+					t.Fatalf("required_internal_request_id query=%q want %q", got, internalRequestID)
+				}
 				if tc.coordinatorCode == http.StatusNotFound {
 					w.WriteHeader(http.StatusNotFound)
 					return
 				}
-				body := map[string]any{"request_id": tc.requestID}
+				body := map[string]any{
+					"request_id":                   tc.requestID,
+					"required_internal_request_id": internalRequestID,
+				}
 				for k, v := range tc.finality {
 					body[k] = v
 				}
@@ -450,6 +457,7 @@ func TestWalletSessionSettlementReconcileClosesWalletHeldReservations(t *testing
 			if err := store.HoldWalletSessionReservation(context.Background(), accountID, sessionID, tc.requestID, fixedNow().Add(time.Minute)); err != nil {
 				t.Fatalf("HoldWalletSessionReservation: %v", err)
 			}
+			seedBoundSettlementCandidate(t, store, accountID, tc.requestID, "internal_"+tc.requestID, fixedNow(), 20, sessionID)
 			if tc.expireBeforeRun {
 				if err := store.ClampReservationExpiry(context.Background(), accountID, tc.requestID, fixedNow().Add(-time.Minute)); err != nil {
 					t.Fatalf("ClampReservationExpiry: %v", err)

--- a/phase5-gateway/internal/storage/interfaces.go
+++ b/phase5-gateway/internal/storage/interfaces.go
@@ -20,7 +20,7 @@ type AuthStore interface {
 	StoreOAuthStateWithCap(ctx context.Context, state OAuthState, maxPerIP int, now time.Time) error
 	ConsumeOAuthState(ctx context.Context, stateHash []byte, sessionID string, now time.Time) (redirectURI, action, returnTo string, err error)
 	StoreOAuthHandoff(ctx context.Context, handoff OAuthHandoff) error
-	ConsumeOAuthHandoff(ctx context.Context, tokenHash []byte, now time.Time) (apiKey string, err error)
+	ConsumeOAuthHandoff(ctx context.Context, tokenHash []byte, key APIKey, now time.Time) (OAuthHandoff, error)
 	PruneExpiredOAuthHandoffs(ctx context.Context, now time.Time) (int64, error)
 	PruneExpiredOAuthState(ctx context.Context, now time.Time) (int64, error)
 	ReservePublicIssuance(ctx context.Context, reservation PublicIssuanceReservation) error
@@ -54,7 +54,7 @@ type OAuthStateStore interface {
 	StoreOAuthStateWithCap(ctx context.Context, state OAuthState, maxPerIP int, now time.Time) error
 	ConsumeOAuthState(ctx context.Context, stateHash []byte, sessionID string, now time.Time) (redirectURI, action, returnTo string, err error)
 	StoreOAuthHandoff(ctx context.Context, handoff OAuthHandoff) error
-	ConsumeOAuthHandoff(ctx context.Context, tokenHash []byte, now time.Time) (apiKey string, err error)
+	ConsumeOAuthHandoff(ctx context.Context, tokenHash []byte, key APIKey, now time.Time) (OAuthHandoff, error)
 	PruneExpiredOAuthHandoffs(ctx context.Context, now time.Time) (int64, error)
 	PruneExpiredOAuthState(ctx context.Context, now time.Time) (int64, error)
 }
@@ -74,6 +74,9 @@ type UsageStore interface {
 	MarkReservationSettlementHold(ctx context.Context, accountID, requestID string) error
 	ClampReservationExpiry(ctx context.Context, accountID, requestID string, expiresAt time.Time) error
 	ListSettlementHeldReservations(ctx context.Context, limit int) ([]ActiveReservation, error)
+	MarkSettlementReconcileAttempt(ctx context.Context, reservation ActiveReservation) error
+	SaveSettlementFallbackCandidate(ctx context.Context, candidate SettlementFallbackCandidate) error
+	LookupSettlementFallbackCandidate(ctx context.Context, reservation ActiveReservation) (SettlementFallbackCandidate, error)
 	InsertUsageEvent(ctx context.Context, event UsageEvent) error
 	// EnsureUsageEvent inserts a usage_events row idempotently. The
 	// idempotency key is the composite (account_id, request_id), matching

--- a/phase5-gateway/internal/storage/sqlite/migrate.go
+++ b/phase5-gateway/internal/storage/sqlite/migrate.go
@@ -244,6 +244,46 @@ BEGIN
 END;
 `
 
+const settlementFallbackCandidatesDDL = `
+CREATE TABLE IF NOT EXISTS settlement_reconcile_attempts (
+	attempt_sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+	account_id TEXT NOT NULL,
+	request_id TEXT NOT NULL,
+	reservation_created_at TEXT NOT NULL,
+	UNIQUE (account_id, request_id),
+	FOREIGN KEY (account_id, request_id) REFERENCES quota_reservations(account_id, request_id) ON DELETE CASCADE
+);
+CREATE TABLE IF NOT EXISTS settlement_fallback_candidates (
+	account_id TEXT NOT NULL,
+	request_id TEXT NOT NULL,
+	required_internal_request_id TEXT NOT NULL CHECK (length(required_internal_request_id) <= 128),
+	reservation_created_at TEXT NOT NULL,
+	wallet_session_id TEXT NOT NULL DEFAULT '',
+	demo_identity TEXT NOT NULL DEFAULT '',
+	demo_token_hash TEXT NOT NULL DEFAULT '',
+	window_date TEXT NOT NULL,
+	prompt_tokens INTEGER NOT NULL CHECK (prompt_tokens >= 0),
+	completion_tokens INTEGER NOT NULL CHECK (completion_tokens >= 0),
+	max_total_tokens INTEGER NOT NULL CHECK (max_total_tokens > 0),
+	token_source TEXT NOT NULL CHECK (token_source IN ('provider_reported', 'gateway_estimated')),
+	outcome TEXT NOT NULL,
+	PRIMARY KEY (account_id, request_id, reservation_created_at),
+	FOREIGN KEY (account_id, request_id) REFERENCES quota_reservations(account_id, request_id) ON DELETE CASCADE
+);
+`
+
+const oauthHandoffsTableDDL = `
+CREATE TABLE IF NOT EXISTS oauth_handoffs (
+	token_hash BLOB PRIMARY KEY,
+	account_id TEXT NOT NULL REFERENCES accounts(account_id),
+	action TEXT NOT NULL DEFAULT '' CHECK (action IN ('', 'mint')),
+	created_at TEXT NOT NULL,
+	expires_at TEXT NOT NULL,
+	consumed_at TEXT NOT NULL DEFAULT ''
+);
+CREATE INDEX IF NOT EXISTS idx_oauth_handoffs_expires ON oauth_handoffs(expires_at);
+`
+
 const schemaSQL = `
 PRAGMA foreign_keys = ON;
 
@@ -283,16 +323,7 @@ CREATE TABLE IF NOT EXISTS oauth_states (
 	action TEXT NOT NULL DEFAULT ''
 );
 
-CREATE TABLE IF NOT EXISTS oauth_handoffs (
-	token_hash BLOB PRIMARY KEY,
-	api_key TEXT NOT NULL,
-	created_at TEXT NOT NULL,
-	expires_at TEXT NOT NULL,
-	consumed_at TEXT NOT NULL DEFAULT ''
-);
-
-CREATE INDEX IF NOT EXISTS idx_oauth_handoffs_expires ON oauth_handoffs(expires_at);
-
+` + oauthHandoffsTableDDL + `
 CREATE TABLE IF NOT EXISTS public_issuance_events (
 	event_id INTEGER PRIMARY KEY AUTOINCREMENT,
 	surface TEXT NOT NULL,

--- a/phase5-gateway/internal/storage/sqlite/oauth_handoff_test.go
+++ b/phase5-gateway/internal/storage/sqlite/oauth_handoff_test.go
@@ -1,0 +1,243 @@
+package sqlite
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-gateway/internal/auth"
+	"github.com/augstar/macprovider-gateway/internal/storage"
+)
+
+func oauthHandoffTestKey(id string) storage.APIKey {
+	hash := keyHash(id)
+	return storage.APIKey{KeyID: "key_" + id, KeyHash: hash[:], KeyHashPrefix: "mp_test", Status: "active"}
+}
+
+func storeHandoffIntent(t *testing.T, store *Store, token string) []byte {
+	t.Helper()
+	hash := auth.StateHash(token)
+	if err := store.StoreOAuthHandoff(context.Background(), storage.OAuthHandoff{
+		TokenHash: hash, AccountID: "acct_handoff", Action: "mint",
+		CreatedAt: fixedTime(), ExpiresAt: fixedTime().Add(5 * time.Minute),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return hash
+}
+
+func assertHandoffKeyCount(t *testing.T, store *Store, want int) {
+	t.Helper()
+	var count int
+	if err := store.db.QueryRow(`SELECT COUNT(*) FROM api_keys`).Scan(&count); err != nil || count != want {
+		t.Fatalf("key count=%d want=%d err=%v", count, want, err)
+	}
+}
+
+func TestOAuthHandoffConcurrentExchangeIssuesExactlyOneKey(t *testing.T) {
+	store := newTestStore(t)
+	createAccount(t, store, "acct_handoff")
+	tokenHash := storeHandoffIntent(t, store, "concurrent-handoff")
+	const attempts = 16
+	start := make(chan struct{})
+	var succeeded atomic.Int32
+	var rejected atomic.Int32
+	var wg sync.WaitGroup
+	for i := 0; i < attempts; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			_, err := store.ConsumeOAuthHandoff(context.Background(), tokenHash, oauthHandoffTestKey(fmt.Sprint(i)), fixedTime())
+			switch {
+			case err == nil:
+				succeeded.Add(1)
+			case errors.Is(err, storage.ErrNotFound):
+				rejected.Add(1)
+			default:
+				t.Errorf("exchange: %v", err)
+			}
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+	if succeeded.Load() != 1 || rejected.Load() != attempts-1 {
+		t.Fatalf("succeeded=%d rejected=%d", succeeded.Load(), rejected.Load())
+	}
+	assertHandoffKeyCount(t, store, 1)
+}
+
+func TestOAuthHandoffExchangeRollback(t *testing.T) {
+	for _, phase := range []string{"key_insert", "intent_consume"} {
+		t.Run(phase, func(t *testing.T) {
+			ctx := context.Background()
+			store := newTestStore(t)
+			createAccount(t, store, "acct_handoff")
+			tokenHash := storeHandoffIntent(t, store, "rollback-handoff")
+			trigger := `CREATE TRIGGER fail_exchange BEFORE INSERT ON api_keys BEGIN SELECT RAISE(ABORT, 'test failure'); END`
+			if phase == "intent_consume" {
+				trigger = `CREATE TRIGGER fail_exchange BEFORE UPDATE ON oauth_handoffs BEGIN SELECT RAISE(ABORT, 'test failure'); END`
+			}
+			if _, err := store.db.Exec(trigger); err != nil {
+				t.Fatal(err)
+			}
+			key := oauthHandoffTestKey(phase)
+			if _, err := store.ConsumeOAuthHandoff(ctx, tokenHash, key, fixedTime()); err == nil {
+				t.Fatal("induced failure unexpectedly succeeded")
+			}
+			assertHandoffKeyCount(t, store, 0)
+			var consumed string
+			if err := store.db.QueryRow(`SELECT consumed_at FROM oauth_handoffs WHERE token_hash = ?`, tokenHash).Scan(&consumed); err != nil || consumed != "" {
+				t.Fatalf("consumed=%q err=%v", consumed, err)
+			}
+			if _, err := store.db.Exec(`DROP TRIGGER fail_exchange`); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := store.ConsumeOAuthHandoff(ctx, tokenHash, key, fixedTime()); err != nil {
+				t.Fatalf("retry: %v", err)
+			}
+			assertHandoffKeyCount(t, store, 1)
+		})
+	}
+}
+
+func TestOAuthHandoffExchangeUsesActiveIntentAccount(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	createAccount(t, store, "acct_handoff")
+	createAccount(t, store, "acct_other")
+	tokenHash := storeHandoffIntent(t, store, "account-handoff")
+	key := oauthHandoffTestKey("account")
+	key.AccountID = "acct_other"
+	if _, err := store.db.Exec(`UPDATE accounts SET status = 'blocked' WHERE account_id = 'acct_handoff'`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.ConsumeOAuthHandoff(ctx, tokenHash, key, fixedTime()); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("blocked account err=%v", err)
+	}
+	assertHandoffKeyCount(t, store, 0)
+	if _, err := store.db.Exec(`UPDATE accounts SET status = 'active' WHERE account_id = 'acct_handoff'`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.ConsumeOAuthHandoff(ctx, tokenHash, key, fixedTime()); err != nil {
+		t.Fatal(err)
+	}
+	validation, err := store.ValidateAPIKeyHash(ctx, key.KeyHash)
+	if err != nil || validation.AccountID != "acct_handoff" {
+		t.Fatalf("account=%q err=%v", validation.AccountID, err)
+	}
+}
+
+func TestOAuthHandoffDatabaseContainsNoReusableSecret(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "gateway.db")
+	store, err := Open(ctx, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	createAccount(t, store, "acct_handoff")
+	token, err := auth.StateToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tokenHash := storeHandoffIntent(t, store, token)
+	assertHandoffKeyCount(t, store, 0)
+	manager := auth.NewKeyManager("mp_", "hmac_sha256", "test-only-key-hash-secret")
+	secret, key, err := manager.Generate("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.ConsumeOAuthHandoff(ctx, tokenHash, key, fixedTime()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.Validate(ctx, store, secret); err != nil {
+		t.Fatalf("issued key invalid: %v", err)
+	}
+	var rawColumns int
+	if err := store.db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('oauth_handoffs') WHERE name = 'api_key'`).Scan(&rawColumns); err != nil || rawColumns != 0 {
+		t.Fatalf("raw key columns=%d err=%v", rawColumns, err)
+	}
+	// Inspect active WAL and checkpointed database bytes, not only live rows.
+	assertNoSecret := func() {
+		t.Helper()
+		for _, name := range []string{path, path + "-wal"} {
+			data, err := os.ReadFile(name)
+			if os.IsNotExist(err) {
+				continue
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if bytes.Contains(data, []byte(secret)) || bytes.Contains(data, []byte(token)) {
+				t.Fatal("database contains reusable credential or raw handoff token")
+			}
+		}
+	}
+	assertNoSecret()
+	if _, err := store.db.Exec(`PRAGMA wal_checkpoint(TRUNCATE)`); err != nil {
+		t.Fatal(err)
+	}
+	assertNoSecret()
+}
+
+func TestOAuthHandoffMigrationInvalidatesLegacyRows(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	createAccount(t, store, "acct_handoff")
+	legacyKey := oauthHandoffTestKey("legacy")
+	legacyKey.AccountID = "acct_handoff"
+	if err := store.CreateAPIKey(ctx, legacyKey); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.Exec(`
+		DROP TABLE oauth_handoffs;
+		DELETE FROM schema_migrations WHERE version = 12;
+		CREATE TABLE oauth_handoffs (
+			token_hash BLOB PRIMARY KEY, api_key TEXT NOT NULL, created_at TEXT NOT NULL,
+			expires_at TEXT NOT NULL, consumed_at TEXT NOT NULL DEFAULT ''
+		);
+		CREATE INDEX idx_oauth_handoffs_expires ON oauth_handoffs(expires_at)`); err != nil {
+		t.Fatal(err)
+	}
+	for _, consumed := range []string{"", encodeTime(fixedTime())} {
+		if _, err := store.db.Exec(`INSERT INTO oauth_handoffs VALUES(?, ?, ?, ?, ?)`,
+			auth.StateHash("legacy"+consumed), "mp_legacy-test-only-secret", encodeTime(fixedTime()), encodeTime(fixedTime().Add(time.Hour)), consumed); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for i := 0; i < 2; i++ {
+		if err := store.Migrate(ctx); err != nil {
+			t.Fatalf("migration %d: %v", i, err)
+		}
+	}
+	var columns, rows, version int
+	if err := store.db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('oauth_handoffs') WHERE name = 'api_key'`).Scan(&columns); err != nil || columns != 0 {
+		t.Fatalf("plaintext columns=%d err=%v", columns, err)
+	}
+	if err := store.db.QueryRow(`SELECT COUNT(*) FROM oauth_handoffs`).Scan(&rows); err != nil || rows != 0 {
+		t.Fatalf("legacy rows=%d err=%v", rows, err)
+	}
+	if err := store.db.QueryRow(`SELECT MAX(version) FROM schema_migrations`).Scan(&version); err != nil || version != 12 {
+		t.Fatalf("schema version=%d err=%v", version, err)
+	}
+	if _, err := store.ConsumeOAuthHandoff(ctx, auth.StateHash("legacy"), oauthHandoffTestKey("rejected"), fixedTime()); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("legacy handoff err=%v", err)
+	}
+	// Migration invalidates handoffs, not unrelated or previously issued keys.
+	validation, err := store.ValidateAPIKeyHash(ctx, legacyKey.KeyHash)
+	if err != nil || validation.KeyStatus != "active" {
+		t.Fatalf("legacy key status=%q err=%v", validation.KeyStatus, err)
+	}
+	tokenHash := storeHandoffIntent(t, store, "after-upgrade")
+	if _, err := store.ConsumeOAuthHandoff(ctx, tokenHash, oauthHandoffTestKey("new"), fixedTime()); err != nil {
+		t.Fatalf("post-upgrade exchange: %v", err)
+	}
+}

--- a/phase5-gateway/internal/storage/sqlite/settlement_fallback.go
+++ b/phase5-gateway/internal/storage/sqlite/settlement_fallback.go
@@ -1,0 +1,144 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/augstar/macprovider-gateway/internal/storage"
+)
+
+// MarkSettlementReconcileAttempt rotates a hold before its remote lookup, so
+// unreachable old requests cannot monopolize bounded reconciliation batches.
+func (s *Store) MarkSettlementReconcileAttempt(ctx context.Context, reservation storage.ActiveReservation) error {
+	if reservation.CreatedAt.IsZero() {
+		return storage.ErrReservationNotFound
+	}
+	tx, err := s.beginImmediate(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	var active int
+	if err := tx.QueryRowContext(ctx, `SELECT 1 FROM quota_reservations
+		WHERE account_id = ? AND request_id = ? AND created_at = ? AND status = 'active' AND settlement_hold = 1`,
+		reservation.AccountID, reservation.RequestID, encodeTime(reservation.CreatedAt.UTC())).Scan(&active); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return storage.ErrReservationNotFound
+		}
+		return err
+	}
+	// REPLACE intentionally allocates a new AUTOINCREMENT sequence, including
+	// retries in the same clock tick or after a process restart.
+	if _, err := tx.ExecContext(ctx, `INSERT OR REPLACE INTO settlement_reconcile_attempts
+		(account_id, request_id, reservation_created_at) VALUES(?, ?, ?)`,
+		reservation.AccountID, reservation.RequestID, encodeTime(reservation.CreatedAt.UTC())); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func (s *Store) SaveSettlementFallbackCandidate(ctx context.Context, candidate storage.SettlementFallbackCandidate) error {
+	if candidate.ReservationCreatedAt.IsZero() || candidate.MaxTotalTokens <= 0 ||
+		len(candidate.RequiredInternalRequestID) > 128 || strings.TrimSpace(candidate.RequiredInternalRequestID) != candidate.RequiredInternalRequestID ||
+		(candidate.TokenSource != "provider_reported" && candidate.TokenSource != "gateway_estimated") ||
+		candidate.Outcome == "" || len(candidate.Outcome) > 128 ||
+		len(candidate.DemoIdentity) > 128 || len(candidate.DemoTokenHash) > 128 ||
+		(candidate.DemoIdentity == "") != (candidate.DemoTokenHash == "") ||
+		(candidate.WalletSessionID != "" && candidate.DemoTokenHash != "") {
+		return fmt.Errorf("invalid settlement fallback candidate")
+	}
+	usage := storage.ReservationSettlement{
+		PromptTokens: candidate.PromptTokens, CompletionTokens: candidate.CompletionTokens, MaxTotalTokens: candidate.MaxTotalTokens,
+	}
+	if err := normalizeSettlementTokens(&usage); err != nil {
+		return err
+	}
+	tx, err := s.beginImmediate(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	var window, createdAt, status, sessionID string
+	var reservedTokens int64
+	if err := tx.QueryRowContext(ctx, `
+		SELECT qr.window_date, qr.created_at, qr.status, qr.reserved_tokens, COALESCE(wrm.session_id, '')
+		FROM quota_reservations qr LEFT JOIN wallet_session_request_map wrm
+		ON wrm.account_id = qr.account_id AND wrm.request_id = qr.request_id
+		WHERE qr.account_id = ? AND qr.request_id = ?`, candidate.AccountID, candidate.RequestID).
+		Scan(&window, &createdAt, &status, &reservedTokens, &sessionID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return storage.ErrReservationNotFound
+		}
+		return err
+	}
+	if createdAt != encodeTime(candidate.ReservationCreatedAt.UTC()) || window != candidate.WindowDate || sessionID != candidate.WalletSessionID {
+		return fmt.Errorf("settlement fallback reservation identity mismatch")
+	}
+	if status != "active" {
+		return storage.ErrReservationTerminal
+	}
+	if candidate.MaxTotalTokens > reservedTokens {
+		return fmt.Errorf("settlement fallback exceeds reservation")
+	}
+	existing, err := lookupSettlementFallbackCandidate(ctx, tx, storage.ActiveReservation{
+		AccountID: candidate.AccountID, RequestID: candidate.RequestID, CreatedAt: candidate.ReservationCreatedAt,
+	})
+	if err == nil {
+		existing.ReservationCreatedAt = candidate.ReservationCreatedAt
+		if existing != candidate {
+			return fmt.Errorf("settlement fallback candidate mismatch")
+		}
+	} else if errors.Is(err, storage.ErrNotFound) {
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO settlement_fallback_candidates(account_id, request_id, required_internal_request_id, reservation_created_at,
+				wallet_session_id, demo_identity, demo_token_hash, window_date, prompt_tokens, completion_tokens,
+				max_total_tokens, token_source, outcome)
+			VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			candidate.AccountID, candidate.RequestID, candidate.RequiredInternalRequestID, createdAt, candidate.WalletSessionID, candidate.DemoIdentity,
+			candidate.DemoTokenHash, candidate.WindowDate, candidate.PromptTokens, candidate.CompletionTokens,
+			candidate.MaxTotalTokens, candidate.TokenSource, candidate.Outcome); err != nil {
+			return err
+		}
+	} else {
+		return err
+	}
+	// Saving usage and making it discoverable for recovery are one write.
+	if _, err := tx.ExecContext(ctx, `UPDATE quota_reservations SET settlement_hold = 1
+		WHERE account_id = ? AND request_id = ?`, candidate.AccountID, candidate.RequestID); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func (s *Store) LookupSettlementFallbackCandidate(ctx context.Context, reservation storage.ActiveReservation) (storage.SettlementFallbackCandidate, error) {
+	return lookupSettlementFallbackCandidate(ctx, s.db, reservation)
+}
+
+func lookupSettlementFallbackCandidate(ctx context.Context, q interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}, reservation storage.ActiveReservation) (storage.SettlementFallbackCandidate, error) {
+	var candidate storage.SettlementFallbackCandidate
+	var createdAt string
+	err := q.QueryRowContext(ctx, `
+		SELECT c.account_id, c.request_id, c.required_internal_request_id, c.reservation_created_at, c.wallet_session_id,
+			c.demo_identity, c.demo_token_hash, c.window_date, c.prompt_tokens, c.completion_tokens,
+			c.max_total_tokens, c.token_source, c.outcome
+		FROM settlement_fallback_candidates c JOIN quota_reservations qr
+		ON qr.account_id = c.account_id AND qr.request_id = c.request_id AND qr.created_at = c.reservation_created_at
+		WHERE c.account_id = ? AND c.request_id = ? AND c.reservation_created_at = ? AND qr.status = 'active'`,
+		reservation.AccountID, reservation.RequestID, encodeTime(reservation.CreatedAt.UTC())).Scan(
+		&candidate.AccountID, &candidate.RequestID, &candidate.RequiredInternalRequestID, &createdAt, &candidate.WalletSessionID,
+		&candidate.DemoIdentity, &candidate.DemoTokenHash, &candidate.WindowDate, &candidate.PromptTokens,
+		&candidate.CompletionTokens, &candidate.MaxTotalTokens, &candidate.TokenSource, &candidate.Outcome)
+	if errors.Is(err, sql.ErrNoRows) {
+		return storage.SettlementFallbackCandidate{}, storage.ErrNotFound
+	}
+	if err != nil {
+		return storage.SettlementFallbackCandidate{}, err
+	}
+	candidate.ReservationCreatedAt = decodeTime(createdAt)
+	return candidate, nil
+}

--- a/phase5-gateway/internal/storage/sqlite/settlement_fallback_test.go
+++ b/phase5-gateway/internal/storage/sqlite/settlement_fallback_test.go
@@ -1,0 +1,275 @@
+package sqlite
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/augstar/macprovider-gateway/internal/storage"
+)
+
+func fallbackTestCandidate(t *testing.T, store *Store) storage.SettlementFallbackCandidate {
+	t.Helper()
+	createAccount(t, store, "acct_fallback")
+	now := fixedTime()
+	if _, err := store.ReserveQuota(context.Background(), storage.ReservationRequest{
+		AccountID: "acct_fallback", RequestID: "req_fallback", WindowDate: now.Format("2006-01-02"),
+		RequestedTokens: 10, DailyQuota: 100, CreatedAt: now, ExpiresAt: now.Add(time.Minute),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return storage.SettlementFallbackCandidate{
+		AccountID: "acct_fallback", RequestID: "req_fallback", ReservationCreatedAt: now,
+		RequiredInternalRequestID: "internal_req_fallback",
+		WindowDate:                now.Format("2006-01-02"), PromptTokens: 2, CompletionTokens: 3,
+		MaxTotalTokens: 10, TokenSource: "gateway_estimated", Outcome: "unverified_streaming",
+	}
+}
+
+func TestSettlementFallbackCandidateIdempotentAndReservationBound(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	candidate := fallbackTestCandidate(t, store)
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := store.SaveSettlementFallbackCandidate(ctx, candidate); err != nil {
+				t.Errorf("save: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+	for _, change := range []func(*storage.SettlementFallbackCandidate){
+		func(c *storage.SettlementFallbackCandidate) { c.CompletionTokens++ },
+		func(c *storage.SettlementFallbackCandidate) { c.RequiredInternalRequestID = "other_attempt" },
+		func(c *storage.SettlementFallbackCandidate) { c.RequiredInternalRequestID = "" },
+		func(c *storage.SettlementFallbackCandidate) {
+			c.ReservationCreatedAt = c.ReservationCreatedAt.Add(time.Second)
+		},
+		func(c *storage.SettlementFallbackCandidate) { c.AccountID = "other" },
+		func(c *storage.SettlementFallbackCandidate) { c.WindowDate = "2026-05-30" },
+		func(c *storage.SettlementFallbackCandidate) { c.WalletSessionID = "other" },
+		func(c *storage.SettlementFallbackCandidate) { c.MaxTotalTokens++ },
+		func(c *storage.SettlementFallbackCandidate) { c.TokenSource = "coordinator_observed" },
+		func(c *storage.SettlementFallbackCandidate) {
+			c.CompletionTokens = 11
+			c.DemoIdentity = "192.0.2.1"
+			c.DemoTokenHash = "demo-hash"
+		},
+	} {
+		changed := candidate
+		change(&changed)
+		if err := store.SaveSettlementFallbackCandidate(ctx, changed); err == nil {
+			t.Fatal("mismatched candidate accepted")
+		}
+	}
+	rows, err := store.ListSettlementHeldReservations(ctx, 10)
+	if err != nil || len(rows) != 1 {
+		t.Fatalf("holds=%d err=%v", len(rows), err)
+	}
+	got, err := store.LookupSettlementFallbackCandidate(ctx, rows[0])
+	if err != nil || got != candidate {
+		t.Fatalf("candidate=%+v err=%v", got, err)
+	}
+	if n, err := store.ReapExpiredReservations(ctx, fixedTime().Add(time.Hour)); err != nil || n != 0 {
+		t.Fatalf("candidate hold reaped=%d err=%v", n, err)
+	}
+}
+
+func TestSettlementFallbackCandidateWithoutCurrentInternalRequestRemainsHeld(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	candidate := fallbackTestCandidate(t, store)
+	for _, invalid := range []string{"   ", strings.Repeat("x", 129)} {
+		candidate.RequiredInternalRequestID = invalid
+		if err := store.SaveSettlementFallbackCandidate(ctx, candidate); err == nil {
+			t.Fatal("candidate with invalid current internal request persisted")
+		}
+	}
+	var count int
+	if err := store.db.QueryRow(`SELECT COUNT(*) FROM settlement_fallback_candidates`).Scan(&count); err != nil || count != 0 {
+		t.Fatalf("invalid candidates=%d err=%v", count, err)
+	}
+	if rows, err := store.ListSettlementHeldReservations(ctx, 10); err != nil || len(rows) != 0 {
+		t.Fatalf("invalid candidate changed holds=%d err=%v", len(rows), err)
+	}
+	candidate.RequiredInternalRequestID = ""
+	if err := store.SaveSettlementFallbackCandidate(ctx, candidate); err != nil {
+		t.Fatal(err)
+	}
+	rows, err := store.ListSettlementHeldReservations(ctx, 10)
+	if err != nil || len(rows) != 1 {
+		t.Fatalf("quarantined holds=%d err=%v", len(rows), err)
+	}
+	got, err := store.LookupSettlementFallbackCandidate(ctx, rows[0])
+	if err != nil || got != candidate {
+		t.Fatalf("quarantined candidate=%+v err=%v", got, err)
+	}
+	if n, err := store.ReapExpiredReservations(ctx, fixedTime().Add(24*time.Hour)); err != nil || n != 0 {
+		t.Fatalf("quarantined holds reaped=%d err=%v", n, err)
+	}
+	candidate.RequiredInternalRequestID = "inferred_later_attempt"
+	if err := store.SaveSettlementFallbackCandidate(ctx, candidate); err == nil {
+		t.Fatal("quarantined candidate binding replaced")
+	}
+}
+
+func TestSettlementFallbackCandidateSaveRollbackAndReusedID(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	candidate := fallbackTestCandidate(t, store)
+	if _, err := store.db.Exec(`CREATE TRIGGER fail_fallback_hold BEFORE UPDATE ON quota_reservations BEGIN SELECT RAISE(ABORT, 'test failure'); END`); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveSettlementFallbackCandidate(ctx, candidate); err == nil {
+		t.Fatal("save unexpectedly succeeded")
+	}
+	var count int
+	if err := store.db.QueryRow(`SELECT COUNT(*) FROM settlement_fallback_candidates`).Scan(&count); err != nil || count != 0 {
+		t.Fatalf("rolled-back candidates=%d err=%v", count, err)
+	}
+	if _, err := store.db.Exec(`DROP TRIGGER fail_fallback_hold`); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveSettlementFallbackCandidate(ctx, candidate); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.RefundReservation(ctx, candidate.AccountID, candidate.RequestID, fixedTime().Unix()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.Exec(`DELETE FROM quota_reservations WHERE account_id = ? AND request_id = ?`, candidate.AccountID, candidate.RequestID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.ReserveQuota(ctx, storage.ReservationRequest{
+		AccountID: candidate.AccountID, RequestID: candidate.RequestID, WindowDate: candidate.WindowDate,
+		RequestedTokens: 10, DailyQuota: 100, CreatedAt: fixedTime().Add(time.Second), ExpiresAt: fixedTime().Add(time.Hour),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveSettlementFallbackCandidate(ctx, candidate); err == nil {
+		t.Fatal("old candidate accepted for reused request id")
+	}
+	if _, err := store.LookupSettlementFallbackCandidate(ctx, storage.ActiveReservation{
+		AccountID: candidate.AccountID, RequestID: candidate.RequestID, CreatedAt: candidate.ReservationCreatedAt,
+	}); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("stale lookup err=%v", err)
+	}
+	settlement := storage.ReservationSettlement{
+		ExpectedReservationCreatedAt: candidate.ReservationCreatedAt, AccountID: candidate.AccountID,
+		RequestID: candidate.RequestID, PromptTokens: 2, CompletionTokens: 3, TotalTokens: 5, MaxTotalTokens: 10,
+		TokenSource: candidate.TokenSource, Outcome: candidate.Outcome,
+	}
+	if err := store.SettleReservation(ctx, settlement); !errors.Is(err, storage.ErrReservationNotFound) {
+		t.Fatalf("stale account settlement err=%v", err)
+	}
+	if err := store.SettleDemoReservation(ctx, settlement, storage.DemoUsageEvent{}); !errors.Is(err, storage.ErrReservationNotFound) {
+		t.Fatalf("stale demo settlement err=%v", err)
+	}
+	used, reserved, err := store.DailyUsage(ctx, candidate.AccountID, candidate.WindowDate)
+	if err != nil || used != 0 || reserved != 10 {
+		t.Fatalf("used=%d reserved=%d err=%v", used, reserved, err)
+	}
+}
+
+func TestSettlementFallbackWalletGenerationFence(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	createWalletSession(t, store, "acct_wallet_fallback", "ws_fallback", 100, 10)
+	request := walletAdmission("acct_wallet_fallback", "ws_fallback", "req_wallet_fallback", 10)
+	if _, err := store.AdmitWalletSessionInference(ctx, request); err != nil {
+		t.Fatal(err)
+	}
+	candidate := storage.SettlementFallbackCandidate{
+		AccountID: request.AccountID, RequestID: request.RequestID, WalletSessionID: request.SessionID,
+		RequiredInternalRequestID: "internal_req_wallet_fallback",
+		ReservationCreatedAt:      request.CreatedAt, WindowDate: request.WindowDate,
+		PromptTokens: 2, CompletionTokens: 3, MaxTotalTokens: 10, TokenSource: "provider_reported", Outcome: "unverified_streaming",
+	}
+	if err := store.SaveSettlementFallbackCandidate(ctx, candidate); err != nil {
+		t.Fatal(err)
+	}
+	settlement := storage.WalletSessionReservationSettlement{
+		ExpectedReservationCreatedAt: request.CreatedAt.Add(time.Second), AccountID: request.AccountID,
+		SessionID: request.SessionID, RequestID: request.RequestID, PromptTokens: 2, CompletionTokens: 3,
+		TotalTokens: 5, MaxTotalTokens: 10, TokenSource: candidate.TokenSource, Outcome: candidate.Outcome,
+	}
+	if err := store.FinalizeWalletSessionReservation(ctx, settlement); !errors.Is(err, storage.ErrReservationNotFound) {
+		t.Fatalf("stale wallet settlement err=%v", err)
+	}
+	settlement.ExpectedReservationCreatedAt = request.CreatedAt
+	if err := store.FinalizeWalletSessionReservation(ctx, settlement); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.FinalizeWalletSessionReservation(ctx, settlement); !errors.Is(err, storage.ErrReservationTerminal) {
+		t.Fatalf("duplicate wallet settlement err=%v", err)
+	}
+}
+
+func TestSettlementFallbackReconcileAttemptIsMonotonicAndGenerationBound(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	candidate := fallbackTestCandidate(t, store)
+	reservation := storage.ActiveReservation{
+		AccountID: candidate.AccountID, RequestID: candidate.RequestID, CreatedAt: candidate.ReservationCreatedAt,
+	}
+	if err := store.MarkSettlementReconcileAttempt(ctx, reservation); !errors.Is(err, storage.ErrReservationNotFound) {
+		t.Fatalf("unheld mark err=%v", err)
+	}
+	if err := store.SaveSettlementFallbackCandidate(ctx, candidate); err != nil {
+		t.Fatal(err)
+	}
+	sequence := func() int64 {
+		t.Helper()
+		var value int64
+		if err := store.db.QueryRow(`SELECT COALESCE(MAX(attempt_sequence), 0) FROM settlement_reconcile_attempts`).Scan(&value); err != nil {
+			t.Fatal(err)
+		}
+		return value
+	}
+	for i := 0; i < 2; i++ {
+		if rows, err := store.ListSettlementHeldReservations(ctx, 10); err != nil || len(rows) != 1 {
+			t.Fatalf("list rows=%d err=%v", len(rows), err)
+		}
+	}
+	if got := sequence(); got != 0 {
+		t.Fatalf("read-only listing changed sequence=%d", got)
+	}
+	if err := store.MarkSettlementReconcileAttempt(ctx, reservation); err != nil {
+		t.Fatal(err)
+	}
+	first := sequence()
+	if err := store.MarkSettlementReconcileAttempt(ctx, reservation); err != nil {
+		t.Fatal(err)
+	}
+	second := sequence()
+	if first == 0 || second <= first {
+		t.Fatalf("retry sequence did not advance: %d -> %d", first, second)
+	}
+	stale := reservation
+	stale.CreatedAt = stale.CreatedAt.Add(time.Second)
+	if err := store.MarkSettlementReconcileAttempt(ctx, stale); !errors.Is(err, storage.ErrReservationNotFound) {
+		t.Fatalf("stale generation mark err=%v", err)
+	}
+	canceled, cancel := context.WithCancel(ctx)
+	cancel()
+	if err := store.MarkSettlementReconcileAttempt(canceled, reservation); !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled mark err=%v", err)
+	}
+	if got := sequence(); got != second {
+		t.Fatalf("failed mark changed sequence: %d -> %d", second, got)
+	}
+	if err := store.RefundReservation(ctx, candidate.AccountID, candidate.RequestID, fixedTime().Unix()); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.MarkSettlementReconcileAttempt(ctx, reservation); !errors.Is(err, storage.ErrReservationNotFound) {
+		t.Fatalf("terminal mark err=%v", err)
+	}
+	if got := sequence(); got != second {
+		t.Fatalf("terminal mark changed sequence: %d -> %d", second, got)
+	}
+}

--- a/phase5-gateway/internal/storage/sqlite/store.go
+++ b/phase5-gateway/internal/storage/sqlite/store.go
@@ -109,6 +109,7 @@ func (s *Store) Ping(ctx context.Context) error {
 //	v9 — oauth return_to + oauth_handoffs support.
 //	v10 — SPEC-040 wallet-native buyer session tables.
 //	v11 — SPEC-041 relay-blind replay ledger.
+//	v12 — OAuth issuance intent and reservation-bound observe recovery candidates.
 //
 // At Open time the store reads the current applied version; if it
 // exceeds this constant the binary is older than the DB and refuses
@@ -119,7 +120,7 @@ func (s *Store) Ping(ctx context.Context) error {
 // Operators rolling back the gateway binary on a DB at a higher
 // version must restore /var/lib/macprovider/gateway.db from the
 // pre-deploy snapshot (deploy-pearl-vps.sh step 5b writes one).
-const maxKnownSchemaVersion = 11
+const maxKnownSchemaVersion = 12
 
 func (s *Store) Migrate(ctx context.Context) error {
 	if err := s.checkSchemaVersionGate(ctx); err != nil {
@@ -190,6 +191,9 @@ func (s *Store) Migrate(ctx context.Context) error {
 	if err := s.ensureQuotaReservationStaleHeldStatus(ctx); err != nil {
 		return err
 	}
+	if _, err := s.db.ExecContext(ctx, settlementFallbackCandidatesDDL); err != nil {
+		return err
+	}
 	// Stamp the schema version. We always insert v1 (preserves
 	// historical behavior for any tooling that checked exactly that
 	// row) AND the post-#196 marker v2. INSERT OR IGNORE keeps it
@@ -232,6 +236,9 @@ func (s *Store) Migrate(ctx context.Context) error {
 		return err
 	}
 	if _, err := s.db.ExecContext(ctx, "INSERT OR IGNORE INTO schema_migrations(version, applied_at) VALUES(11, ?)", now); err != nil {
+		return err
+	}
+	if _, err := s.db.ExecContext(ctx, "INSERT OR IGNORE INTO schema_migrations(version, applied_at) VALUES(12, ?)", now); err != nil {
 		return err
 	}
 	return nil
@@ -370,17 +377,31 @@ func (s *Store) ensureOAuthStateReturnToColumn(ctx context.Context) error {
 }
 
 func (s *Store) ensureOAuthHandoffsTable(ctx context.Context) error {
-	_, err := s.db.ExecContext(ctx, `
-		CREATE TABLE IF NOT EXISTS oauth_handoffs (
-			token_hash BLOB PRIMARY KEY,
-			api_key TEXT NOT NULL,
-			created_at TEXT NOT NULL,
-			expires_at TEXT NOT NULL,
-			consumed_at TEXT NOT NULL DEFAULT ''
-		);
-		CREATE INDEX IF NOT EXISTS idx_oauth_handoffs_expires ON oauth_handoffs(expires_at);
-	`)
-	return err
+	var legacyColumns int
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM pragma_table_info('oauth_handoffs') WHERE name = 'api_key'`).Scan(&legacyColumns); err != nil {
+		return err
+	}
+	if legacyColumns == 0 {
+		return nil
+	}
+	tx, err := s.beginImmediate(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	// Legacy tokens cannot be converted into issuance intent safely. Expire
+	// every old handoff and remove its plaintext column atomically with the
+	// version fence. Historical WAL/backups still need operator remediation.
+	if _, err := tx.ExecContext(ctx, `DROP TABLE oauth_handoffs`); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, oauthHandoffsTableDDL); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT OR IGNORE INTO schema_migrations(version, applied_at) VALUES(12, ?)`, encodeTime(time.Now().UTC())); err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 // ensureUsageEventsCompositePK upgrades pre-issue-#196 gateway.db files
@@ -1095,39 +1116,48 @@ func (s *Store) StoreOAuthHandoff(ctx context.Context, handoff storage.OAuthHand
 		consumedAt = encodeTime(handoff.ConsumedAt)
 	}
 	_, err := s.db.ExecContext(ctx, `
-		INSERT INTO oauth_handoffs(token_hash, api_key, created_at, expires_at, consumed_at)
-		VALUES(?, ?, ?, ?, ?)`,
-		handoff.TokenHash, handoff.APIKey, encodeTime(handoff.CreatedAt), encodeTime(handoff.ExpiresAt), consumedAt)
+		INSERT INTO oauth_handoffs(token_hash, account_id, action, created_at, expires_at, consumed_at)
+		VALUES(?, ?, ?, ?, ?, ?)`,
+		handoff.TokenHash, handoff.AccountID, handoff.Action, encodeTime(handoff.CreatedAt), encodeTime(handoff.ExpiresAt), consumedAt)
 	return err
 }
 
-func (s *Store) ConsumeOAuthHandoff(ctx context.Context, tokenHash []byte, now time.Time) (string, error) {
+// ConsumeOAuthHandoff binds a generated key hash to the stored account and
+// commits issuance together with consumption. The reusable secret never enters
+// storage, and a failed issuance leaves the intent available for a retry.
+func (s *Store) ConsumeOAuthHandoff(ctx context.Context, tokenHash []byte, key storage.APIKey, now time.Time) (storage.OAuthHandoff, error) {
 	tx, err := s.beginImmediate(ctx)
 	if err != nil {
-		return "", err
+		return storage.OAuthHandoff{}, err
 	}
 	defer tx.Rollback()
-	var apiKey string
+	var handoff storage.OAuthHandoff
 	var expiresAt string
 	var consumedAt string
 	if err := tx.QueryRowContext(ctx, `
-		SELECT api_key, expires_at, consumed_at
-		FROM oauth_handoffs
-		WHERE token_hash = ?`,
-		tokenHash).Scan(&apiKey, &expiresAt, &consumedAt); err != nil {
+		SELECT h.account_id, h.action, h.expires_at, h.consumed_at
+		FROM oauth_handoffs h JOIN accounts a ON a.account_id = h.account_id
+		WHERE h.token_hash = ? AND a.status = 'active'`,
+		tokenHash).Scan(&handoff.AccountID, &handoff.Action, &expiresAt, &consumedAt); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return "", storage.ErrNotFound
+			return storage.OAuthHandoff{}, storage.ErrNotFound
 		}
-		return "", err
+		return storage.OAuthHandoff{}, err
 	}
 	if consumedAt != "" || !now.Before(decodeTime(expiresAt)) {
-		return "", storage.ErrNotFound
+		return storage.OAuthHandoff{}, storage.ErrNotFound
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO api_keys(key_id, account_id, key_hash, key_hash_prefix, status, created_at)
+		VALUES(?, ?, ?, ?, 'active', ?)`,
+		key.KeyID, handoff.AccountID, key.KeyHash, key.KeyHashPrefix, encodeTime(now.UTC())); err != nil {
+		return storage.OAuthHandoff{}, err
 	}
 	_, err = tx.ExecContext(ctx, `UPDATE oauth_handoffs SET consumed_at = ? WHERE token_hash = ?`, encodeTime(now.UTC()), tokenHash)
 	if err != nil {
-		return "", err
+		return storage.OAuthHandoff{}, err
 	}
-	return apiKey, tx.Commit()
+	return handoff, tx.Commit()
 }
 
 func (s *Store) PruneExpiredOAuthHandoffs(ctx context.Context, now time.Time) (int64, error) {
@@ -1342,13 +1372,17 @@ func (s *Store) SettleReservation(ctx context.Context, settlement storage.Reserv
 	defer tx.Rollback()
 	var windowDate string
 	var status string
+	var createdAt string
 	if err := tx.QueryRowContext(ctx, `
-		SELECT window_date, status FROM quota_reservations
-		WHERE account_id = ? AND request_id = ?`, settlement.AccountID, settlement.RequestID).Scan(&windowDate, &status); err != nil {
+		SELECT window_date, status, created_at FROM quota_reservations
+		WHERE account_id = ? AND request_id = ?`, settlement.AccountID, settlement.RequestID).Scan(&windowDate, &status, &createdAt); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return storage.ErrReservationNotFound
 		}
 		return err
+	}
+	if !settlement.ExpectedReservationCreatedAt.IsZero() && createdAt != encodeTime(settlement.ExpectedReservationCreatedAt.UTC()) {
+		return storage.ErrReservationNotFound
 	}
 	if status != "active" {
 		return fmt.Errorf("%w: reservation %s is %s", storage.ErrReservationTerminal, settlement.RequestID, status)
@@ -1386,13 +1420,17 @@ func (s *Store) SettleDemoReservation(ctx context.Context, settlement storage.Re
 	defer tx.Rollback()
 	var windowDate string
 	var status string
+	var createdAt string
 	if err := tx.QueryRowContext(ctx, `
-		SELECT window_date, status FROM quota_reservations
-		WHERE account_id = ? AND request_id = ?`, settlement.AccountID, settlement.RequestID).Scan(&windowDate, &status); err != nil {
+		SELECT window_date, status, created_at FROM quota_reservations
+		WHERE account_id = ? AND request_id = ?`, settlement.AccountID, settlement.RequestID).Scan(&windowDate, &status, &createdAt); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return storage.ErrReservationNotFound
 		}
 		return err
+	}
+	if !settlement.ExpectedReservationCreatedAt.IsZero() && createdAt != encodeTime(settlement.ExpectedReservationCreatedAt.UTC()) {
+		return storage.ErrReservationNotFound
 	}
 	if status != "active" {
 		// Wraps the sentinel exactly like SettleReservation does. A caller
@@ -1603,8 +1641,10 @@ func (s *Store) ListSettlementHeldReservations(ctx context.Context, limit int) (
 		FROM quota_reservations qr
 		LEFT JOIN wallet_session_request_map wrm
 			ON wrm.account_id = qr.account_id AND wrm.request_id = qr.request_id
+		LEFT JOIN settlement_reconcile_attempts sra
+			ON sra.account_id = qr.account_id AND sra.request_id = qr.request_id AND sra.reservation_created_at = qr.created_at
 		WHERE qr.status = 'active' AND qr.settlement_hold = 1
-		ORDER BY qr.expires_at ASC, qr.created_at ASC
+		ORDER BY COALESCE(sra.attempt_sequence, 0) ASC, qr.expires_at ASC, qr.created_at ASC
 		LIMIT ?`, limit)
 	if err != nil {
 		return nil, err
@@ -2475,17 +2515,20 @@ func (s *Store) FinalizeWalletSessionReservation(ctx context.Context, settlement
 	if err := normalizeSettlementTokens(&accountSettlement); err != nil {
 		return err
 	}
-	var windowDate, quotaStatus, sessionStatus string
+	var windowDate, quotaStatus, sessionStatus, reservationCreatedAt string
 	if err := tx.QueryRowContext(ctx, `
-		SELECT qr.window_date, qr.status, sr.status
+		SELECT qr.window_date, qr.status, sr.status, qr.created_at
 		FROM quota_reservations qr
 		JOIN wallet_session_reservations sr ON sr.account_id = qr.account_id AND sr.request_id = qr.request_id
 		WHERE qr.account_id = ? AND qr.request_id = ? AND sr.session_id = ?`,
-		settlement.AccountID, settlement.RequestID, settlement.SessionID).Scan(&windowDate, &quotaStatus, &sessionStatus); err != nil {
+		settlement.AccountID, settlement.RequestID, settlement.SessionID).Scan(&windowDate, &quotaStatus, &sessionStatus, &reservationCreatedAt); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return storage.ErrReservationNotFound
 		}
 		return err
+	}
+	if !settlement.ExpectedReservationCreatedAt.IsZero() && reservationCreatedAt != encodeTime(settlement.ExpectedReservationCreatedAt.UTC()) {
+		return storage.ErrReservationNotFound
 	}
 	if quotaStatus != "active" || (sessionStatus != "active" && sessionStatus != "held") {
 		return fmt.Errorf("%w: wallet reservation %s is %s/%s", storage.ErrReservationTerminal, settlement.RequestID, quotaStatus, sessionStatus)

--- a/phase5-gateway/internal/storage/sqlite/store_test.go
+++ b/phase5-gateway/internal/storage/sqlite/store_test.go
@@ -360,21 +360,27 @@ func TestOAuthStateReturnToRoundTrip(t *testing.T) {
 func TestOAuthHandoffStoreConsumeReplay(t *testing.T) {
 	ctx := context.Background()
 	store := newTestStore(t)
+	createAccount(t, store, "acct_handoff")
 	now := fixedTime()
 	tokenHash := keyHash("handoff-token")
 	if err := store.StoreOAuthHandoff(ctx, storage.OAuthHandoff{
-		TokenHash: tokenHash[:], APIKey: "mp_abc123", CreatedAt: now, ExpiresAt: now.Add(5 * time.Minute),
+		TokenHash: tokenHash[:], AccountID: "acct_handoff", Action: "mint", CreatedAt: now, ExpiresAt: now.Add(5 * time.Minute),
 	}); err != nil {
 		t.Fatalf("StoreOAuthHandoff: %v", err)
 	}
-	apiKey, err := store.ConsumeOAuthHandoff(ctx, tokenHash[:], now.Add(time.Minute))
+	key := oauthHandoffTestKey("first")
+	handoff, err := store.ConsumeOAuthHandoff(ctx, tokenHash[:], key, now.Add(time.Minute))
 	if err != nil {
 		t.Fatalf("ConsumeOAuthHandoff: %v", err)
 	}
-	if apiKey != "mp_abc123" {
-		t.Fatalf("apiKey=%q want mp_abc123", apiKey)
+	if handoff.AccountID != "acct_handoff" || handoff.Action != "mint" {
+		t.Fatalf("handoff=%+v", handoff)
 	}
-	if _, err := store.ConsumeOAuthHandoff(ctx, tokenHash[:], now.Add(2*time.Minute)); !errors.Is(err, storage.ErrNotFound) {
+	validation, err := store.ValidateAPIKeyHash(ctx, key.KeyHash)
+	if err != nil || validation.AccountID != "acct_handoff" {
+		t.Fatalf("issued key account=%q err=%v", validation.AccountID, err)
+	}
+	if _, err := store.ConsumeOAuthHandoff(ctx, tokenHash[:], oauthHandoffTestKey("replay"), now.Add(2*time.Minute)); !errors.Is(err, storage.ErrNotFound) {
 		t.Fatalf("replay err=%v want ErrNotFound", err)
 	}
 }
@@ -382,14 +388,15 @@ func TestOAuthHandoffStoreConsumeReplay(t *testing.T) {
 func TestOAuthHandoffExpiredReturnsNotFound(t *testing.T) {
 	ctx := context.Background()
 	store := newTestStore(t)
+	createAccount(t, store, "acct_handoff")
 	now := fixedTime()
 	tokenHash := keyHash("handoff-expired")
 	if err := store.StoreOAuthHandoff(ctx, storage.OAuthHandoff{
-		TokenHash: tokenHash[:], APIKey: "mp_expired", CreatedAt: now, ExpiresAt: now.Add(time.Minute),
+		TokenHash: tokenHash[:], AccountID: "acct_handoff", CreatedAt: now, ExpiresAt: now.Add(time.Minute),
 	}); err != nil {
 		t.Fatalf("StoreOAuthHandoff: %v", err)
 	}
-	if _, err := store.ConsumeOAuthHandoff(ctx, tokenHash[:], now.Add(2*time.Minute)); !errors.Is(err, storage.ErrNotFound) {
+	if _, err := store.ConsumeOAuthHandoff(ctx, tokenHash[:], oauthHandoffTestKey("expired"), now.Add(time.Minute)); !errors.Is(err, storage.ErrNotFound) {
 		t.Fatalf("expired err=%v want ErrNotFound", err)
 	}
 }
@@ -397,11 +404,12 @@ func TestOAuthHandoffExpiredReturnsNotFound(t *testing.T) {
 func TestPruneExpiredOAuthHandoffs(t *testing.T) {
 	ctx := context.Background()
 	store := newTestStore(t)
+	createAccount(t, store, "acct_handoff")
 	now := fixedTime()
 	for i := 0; i < 3; i++ {
 		hash := keyHash(fmt.Sprintf("handoff-fresh-%d", i))
 		if err := store.StoreOAuthHandoff(ctx, storage.OAuthHandoff{
-			TokenHash: hash[:], APIKey: fmt.Sprintf("mp_fresh_%d", i), CreatedAt: now, ExpiresAt: now.Add(10 * time.Minute),
+			TokenHash: hash[:], AccountID: "acct_handoff", CreatedAt: now, ExpiresAt: now.Add(10 * time.Minute),
 		}); err != nil {
 			t.Fatalf("StoreOAuthHandoff fresh %d: %v", i, err)
 		}
@@ -409,7 +417,7 @@ func TestPruneExpiredOAuthHandoffs(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		hash := keyHash(fmt.Sprintf("handoff-stale-%d", i))
 		if err := store.StoreOAuthHandoff(ctx, storage.OAuthHandoff{
-			TokenHash: hash[:], APIKey: fmt.Sprintf("mp_stale_%d", i), CreatedAt: now, ExpiresAt: now.Add(time.Minute),
+			TokenHash: hash[:], AccountID: "acct_handoff", CreatedAt: now, ExpiresAt: now.Add(time.Minute),
 		}); err != nil {
 			t.Fatalf("StoreOAuthHandoff stale %d: %v", i, err)
 		}

--- a/phase5-gateway/internal/storage/types.go
+++ b/phase5-gateway/internal/storage/types.go
@@ -66,7 +66,8 @@ type OAuthState struct {
 
 type OAuthHandoff struct {
 	TokenHash  []byte
-	APIKey     string
+	AccountID  string
+	Action     string
 	CreatedAt  time.Time
 	ExpiresAt  time.Time
 	ConsumedAt time.Time
@@ -136,6 +137,24 @@ type ActiveReservation struct {
 	CreatedAt       time.Time
 }
 
+// SettlementFallbackCandidate preserves local usage while request-scoped
+// coordinator mode is unavailable. It is not authority to debit on its own.
+type SettlementFallbackCandidate struct {
+	AccountID                 string
+	RequestID                 string
+	RequiredInternalRequestID string
+	ReservationCreatedAt      time.Time
+	WalletSessionID           string
+	DemoIdentity              string
+	DemoTokenHash             string
+	WindowDate                string
+	PromptTokens              int64
+	CompletionTokens          int64
+	MaxTotalTokens            int64
+	TokenSource               string
+	Outcome                   string
+}
+
 type QuotaDecision struct {
 	Admitted        bool
 	LimitTokens     int64
@@ -146,15 +165,16 @@ type QuotaDecision struct {
 }
 
 type ReservationSettlement struct {
-	AccountID        string
-	RequestID        string
-	PromptTokens     int64
-	CompletionTokens int64
-	TotalTokens      int64
-	MaxTotalTokens   int64
-	TokenSource      string
-	Outcome          string
-	SettledAt        time.Time
+	ExpectedReservationCreatedAt time.Time
+	AccountID                    string
+	RequestID                    string
+	PromptTokens                 int64
+	CompletionTokens             int64
+	TotalTokens                  int64
+	MaxTotalTokens               int64
+	TokenSource                  string
+	Outcome                      string
+	SettledAt                    time.Time
 }
 
 type ConcurrencyRequest struct {
@@ -348,16 +368,17 @@ type WalletSessionDispatchArm struct {
 }
 
 type WalletSessionReservationSettlement struct {
-	SessionID        string
-	AccountID        string
-	RequestID        string
-	PromptTokens     int64
-	CompletionTokens int64
-	TotalTokens      int64
-	MaxTotalTokens   int64
-	TokenSource      string
-	Outcome          string
-	SettledAt        time.Time
+	ExpectedReservationCreatedAt time.Time
+	SessionID                    string
+	AccountID                    string
+	RequestID                    string
+	PromptTokens                 int64
+	CompletionTokens             int64
+	TotalTokens                  int64
+	MaxTotalTokens               int64
+	TokenSource                  string
+	Outcome                      string
+	SettledAt                    time.Time
 }
 
 type FeedbackEvent struct {

--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -4313,7 +4313,7 @@
     {
       "requirement_id": "SPEC-006-R003",
       "spec_id": "SPEC-006",
-      "state": "conformant",
+      "state": "pending",
       "implementation": [
         "phase5-gateway/internal/storage/sqlite/store.go:ReserveQuota",
         "phase5-gateway/internal/storage/sqlite/store.go:SettleReservation",
@@ -4342,7 +4342,12 @@
           "expires_at": "2026-09-16"
         }
       ],
-      "gap": null
+      "gap": {
+        "verdict": "UNKNOWN",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/1433",
+        "rationale": "The security fixes change mapped quota settlement selectors beyond the historical 5ed5d719 candidate. Existing implementation mappings, tests, journeys, and evidence are retained as historical provenance; full requirement conformance requires refreshed matching candidate and signed paid-path journey evidence. Local regression results do not renew the historical attestation."
+      }
     },
     {
       "requirement_id": "SPEC-006-R004",
@@ -4708,7 +4713,7 @@
     {
       "requirement_id": "SPEC-022-R005",
       "spec_id": "SPEC-022",
-      "state": "conformant",
+      "state": "pending",
       "implementation": [
         "phase5-gateway/internal/router/chat_proxy.go:forwardStreamingChat",
         "phase4-coordinator/internal/billing/settlement_receipts.go:IngestSettlementReceipt"
@@ -4734,7 +4739,12 @@
           "expires_at": "2026-09-16"
         }
       ],
-      "gap": null
+      "gap": {
+        "verdict": "UNKNOWN",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/1433",
+        "rationale": "The security fixes change the mapped streaming finality selector beyond the historical 5ed5d719 candidate, including missing-trailer holds and request-bound observe recovery. Existing implementation mappings, tests, journeys, and evidence are retained as historical provenance; full requirement conformance requires refreshed matching candidate and signed paid-path journey evidence. Local regression results do not renew the historical attestation."
+      }
     },
     {
       "requirement_id": "SPEC-022-R006",
@@ -4805,7 +4815,7 @@
     {
       "requirement_id": "SPEC-022-R008",
       "spec_id": "SPEC-022",
-      "state": "conformant",
+      "state": "pending",
       "implementation": [
         "phase5-gateway/internal/storage/sqlite/store.go:ReserveQuota",
         "phase5-gateway/internal/storage/sqlite/store.go:SettleReservation",
@@ -4833,7 +4843,12 @@
           "expires_at": "2026-09-17"
         }
       ],
-      "gap": null
+      "gap": {
+        "verdict": "UNKNOWN",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/1433",
+        "rationale": "The security fixes change mapped reservation settlement selectors beyond the historical caa6ae4a candidate, including generation-bound reconciliation. Existing implementation mappings, tests, journeys, and evidence are retained as historical provenance; full requirement conformance requires refreshed matching candidate and signed enforce journey evidence. Local regression results do not renew the historical attestation."
+      }
     },
     {
       "requirement_id": "SPEC-022-R009",

--- a/specs/README.md
+++ b/specs/README.md
@@ -14,7 +14,7 @@ it can no longer drift. Do not hand-edit the table; edit each spec's
 | SPEC-003 | Open Onboarding: Distribution, Lifecycle & Onboarding UX | 0.11.2 | normative | pending | pending: 2 | [SPEC-003-open-onboarding.md](SPEC-003-open-onboarding.md) |
 | SPEC-004 | Smart Router | 0.3.4 | normative | pending | pending corpus migration | [SPEC-004-smart-router.md](SPEC-004-smart-router.md) |
 | SPEC-005 | Billing, Settlement, and Provider Rewards | 0.6.4 | normative | complete | conformant: 3, pending: 6 | [SPEC-005-billing.md](SPEC-005-billing.md) |
-| SPEC-006 | Buyer API Gateway: Mac Provider's first public buyer surface | 0.9.21 | normative | complete | conformant: 3, pending: 6 | [SPEC-006-buyer-api.md](SPEC-006-buyer-api.md) |
+| SPEC-006 | Buyer API Gateway: Mac Provider's first public buyer surface | 0.9.21 | normative | complete | conformant: 2, pending: 7 | [SPEC-006-buyer-api.md](SPEC-006-buyer-api.md) |
 | SPEC-007 | Internal Operator Protocol Explorer | 0.5.1 | normative | pending | pending corpus migration | [SPEC-007-explorer.md](SPEC-007-explorer.md) |
 | SPEC-008 | Tier-2 Trust Layer | 0.6.1 | normative | pending | pending: 1 | [SPEC-008-tier2.md](SPEC-008-tier2.md) |
 | SPEC-009 | MacProvider Console v2 | 0.1 | normative | pending | pending corpus migration | [SPEC-009-console-v2.md](SPEC-009-console-v2.md) |
@@ -30,7 +30,7 @@ it can no longer drift. Do not hand-edit the table; edit each spec's
 | SPEC-019 | Structured output (`response_format: json_schema`) | 0.2.5 | normative | pending | pending corpus migration | [SPEC-019-structured-output.md](SPEC-019-structured-output.md) |
 | SPEC-020 | Provider autoupdate | v0.1.19 | normative | pending | pending: 5 | [SPEC-020-provider-autoupdate.md](SPEC-020-provider-autoupdate.md) |
 | SPEC-021 | MALIBU rewards emission ledger | 0.4.0 | draft | complete | pending: 10 | [SPEC-021-malibu-emission-ledger.md](SPEC-021-malibu-emission-ledger.md) |
-| SPEC-022 | Verified model settlement | v0.1.7 | draft | complete | conformant: 11 | [SPEC-022-verified-model-settlement.md](SPEC-022-verified-model-settlement.md) |
+| SPEC-022 | Verified model settlement | v0.1.7 | draft | complete | conformant: 9, pending: 2 | [SPEC-022-verified-model-settlement.md](SPEC-022-verified-model-settlement.md) |
 | SPEC-023 | Installer-Integrated Autotune Recommend | v0.9.5 | normative | pending | conformant: 2, pending: 1 | [SPEC-023-installer-autotune-recommend.md](SPEC-023-installer-autotune-recommend.md) |
 | SPEC-024 | Prefix-cache billing and provider-local cache isolation | 0.2.1 | normative | pending | pending corpus migration | [SPEC-024-prefix-cache-billing.md](SPEC-024-prefix-cache-billing.md) |
 | SPEC-025 | Native Mac App (signed `.dmg` + menu bar wrapper) | v0.29 | draft | pending | pending corpus migration | [SPEC-025-native-mac-app.md](SPEC-025-native-mac-app.md) |


### PR DESCRIPTION
## Summary
- F01: reject duplicate/case-colliding schema-owned request fields before translation, quota reservation, replay admission, or dispatch; preserve extension schemas.
- F02: preserve coordinator receipt authority through missing trailers and facade failures. Add durable generation-bound recovery, complete snapshot/current-attempt membership checks, exact binding echoes, fair retries, and fail-closed headerless holds.
- F02 correction: persist current-attempt reconciliation bindings before production holds, reject candidate-less or mismatched finality without coordinator fallback, and preserve paired demo audit rows during verified recovery.
- F03: replace plaintext OAuth key handoffs with hashed single-use issuance intents; mint keys only during atomic exchange with hash-only persistence.
- Demote SPEC-006-R003, SPEC-022-R005, and SPEC-022-R008 to pending because historical signed candidates no longer match changed selectors; preserve historical evidence and track refresh in #1433.
- Supporting test-only F04 coverage: production fix already merged in #1407; no new Swift production behavior here.

## Verification and Review
- Full gateway suite and vet passed on final source; focused gateway/storage race tests passed.
- Full gateway race passed before the final headerless-hold tightening; final tightening has focused race and full non-race coverage.
- Full coordinator suite and vet, isolated cross-service reconciliation race coverage, and 130 Swift consume tests passed.
- Independent code, security, and architecture reviews of the final rebased combined diff: zero Critical/High/Medium findings.
- Rebased onto current main without conflicts; the final landing diff was reviewed at `0c5942e8` over `00984a31`.
- Exact commands, results, negative tests, and limitations: [implementation audit](audits/security-high-fixes-2026-09-08.md).
- Known unrelated test instability is disclosed: coordinator admin rate limiter fails under slow race instrumentation; one gateway timing-uniformity run failed and passed isolated/full reruns. Assertions were not weakened.

## Rollout and Limits
- Deploy coordinator binding support first, then stop old gateway binaries and migrate schema 12 before serving.
- Legacy OAuth handoffs are invalidated. Migration does not erase historical WAL/backups or revoke existing keys.
- Older/missing binding remains held; historical holds are not reconstructed automatically.
- No production operations or signed journeys were performed. No conformance, privacy, or production-readiness promotion.
- Adjacent inherited admission-timeout and omitted-cap issues, plus bounded LOW/test gaps, remain explicitly documented.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "issue": "https://github.com/Augustas11/macprovider/issues/1433",
  "contract_change": "yes",
  "specs": ["SPEC-006", "SPEC-022", "SPEC-045"],
  "requirements": ["SPEC-006-R001", "SPEC-006-R003", "SPEC-022-R001", "SPEC-022-R003", "SPEC-022-R005", "SPEC-022-R008", "SPEC-045-R005", "SPEC-045-R007"],
  "authority_domains": ["buyer-api-error-contract", "verified-model-settlement", "local-consumer-endpoint"],
  "arbitration": ["CODE_BUG", "UNKNOWN"],
  "tests": ["gateway full suite and vet", "gateway/storage security and recovery race tests", "coordinator full suite and vet", "isolated cross-service reconciliation race test", "130 ConsumeCommandTests"],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END
