### PR TITLE
fix(autoupdate): treat coordinator trusted tier as eligible

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/AutoUpdateTrustState.swift
+++ b/phase3-binary/Sources/macprovider-cli/AutoUpdateTrustState.swift
@@ -61,18 +61,23 @@ struct AutoUpdateTrustState: Sendable {
         guard connected else { return .coordinatorDisconnected }
         guard v2Accepted else { return .legacyHelloAck }
         if bearerlessDuplicate { return .bearerlessDuplicate }
-        // Tier gate: pinned always passes. Provisional passes when
-        // acceptProvisional is true (the default; config opts out via
+        // Tier gate: pinned and trusted always pass. The coordinator wire
+        // domain includes `trusted` (earned MALIBU trust; pool.TierTrusted)
+        // as a distinct label from operator `pinned`. Treating unknown
+        // non-provisional tiers as notify-only made production trusted
+        // machines skip coordinator-driven autoupdate after graduating from
+        // provisional. Provisional passes when acceptProvisional is true
+        // (the default; config opts out via
         // `auto_update_accept_provisional: false`). Passing this gate is
         // necessary but not sufficient — the encrypted-leg, attestation, and
         // token-validation guards below still apply. A provisional session
         // reaches `.eligible` whether or not it holds a validated token: the
         // token guard (`!tokenConfigured || tokenValidated`) only blocks a
         // session with a configured-but-invalid token, and passes trivially
-        // when no token is configured at all (SPEC-020 v0.1.5 trust table;
-        // see "Eligible does not always mean bearer-validated").
-        if tier != "pinned" {
-            guard tier == "provisional" && acceptProvisional else { return .provisional }
+        // when no token is configured at all (SPEC-020 v0.1.5/v0.1.19 trust
+        // table; see "Eligible does not always mean bearer-validated").
+        guard Self.tierPassesAutoupdateGate(tier, acceptProvisional: acceptProvisional) else {
+            return .provisional
         }
         guard encryptedLegValid else { return .encryptedLegFailed }
         guard !attestationRequired || attestationSatisfied else { return .attestationFailed }
@@ -86,6 +91,21 @@ struct AutoUpdateTrustState: Sendable {
 
     var lossReason: String {
         stableReason ?? verdict.rawValue
+    }
+
+    /// Coordinator wire tiers that may proceed past the autoupdate tier gate.
+    /// `trusted` is not an alias of `pinned`; it is the earned-trust label the
+    /// coordinator actually emits for MALIBU-verified providers. Unknown
+    /// values (including `rejected`) stay notify-only.
+    static func tierPassesAutoupdateGate(_ tier: String?, acceptProvisional: Bool) -> Bool {
+        switch tier {
+        case "pinned", "trusted":
+            return true
+        case "provisional":
+            return acceptProvisional
+        default:
+            return false
+        }
     }
 
     static func fromCoordinatorPayload(

--- a/phase3-binary/Tests/macprovider-cliTests/AutoUpdateTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/AutoUpdateTests.swift
@@ -3928,8 +3928,8 @@ final class AutoUpdateTests: XCTestCase {
     }
 
     // Rejected tier is a hard-refuse from the coordinator; acceptProvisional
-    // must not turn it into eligible. Only "pinned" and "provisional+opt-in"
-    // pass the gate.
+    // must not turn it into eligible. Only "pinned", "trusted", and
+    // "provisional+opt-in" pass the gate.
     func testAcceptProvisionalDoesNotEscalateRejectedTier() {
         let state = AutoUpdateTrustState(
             v2Accepted: true,
@@ -3946,8 +3946,8 @@ final class AutoUpdateTests: XCTestCase {
         XCTAssertEqual(state.verdict, .provisional)
     }
 
-    // Pinned providers must remain eligible with or without the flag — flag
-    // affects only the provisional tier gate.
+    // Pinned and trusted providers must remain eligible with or without the
+    // flag — flag affects only the provisional tier gate.
     func testPinnedRemainsEligibleWhenAcceptProvisionalIsFalse() {
         let state = AutoUpdateTrustState(
             v2Accepted: true,
@@ -3962,6 +3962,85 @@ final class AutoUpdateTests: XCTestCase {
             acceptProvisional: false
         )
         XCTAssertEqual(state.verdict, .eligible)
+    }
+
+    func testTrustVerdictTrustedDefaultsToEligible() {
+        let state = AutoUpdateTrustState(
+            v2Accepted: true,
+            tier: "trusted",
+            encryptedLegValid: true,
+            attestationRequired: false,
+            attestationSatisfied: true,
+            tokenConfigured: false,
+            tokenValidated: true,
+            bearerlessDuplicate: false,
+            connected: true
+        )
+        XCTAssertEqual(state.verdict, .eligible)
+        XCTAssertTrue(state.isEligible)
+    }
+
+    func testTrustedRemainsEligibleWhenAcceptProvisionalIsFalse() {
+        let state = AutoUpdateTrustState(
+            v2Accepted: true,
+            tier: "trusted",
+            encryptedLegValid: true,
+            attestationRequired: false,
+            attestationSatisfied: true,
+            tokenConfigured: false,
+            tokenValidated: true,
+            bearerlessDuplicate: false,
+            connected: true,
+            acceptProvisional: false
+        )
+        XCTAssertEqual(state.verdict, .eligible)
+        XCTAssertTrue(state.isEligible)
+    }
+
+    func testTrustedDoesNotBypassEncryptedLegGate() {
+        let state = AutoUpdateTrustState(
+            v2Accepted: true,
+            tier: "trusted",
+            encryptedLegValid: false,
+            attestationRequired: false,
+            attestationSatisfied: true,
+            tokenConfigured: false,
+            tokenValidated: true,
+            bearerlessDuplicate: false,
+            connected: true
+        )
+        XCTAssertEqual(state.verdict, .encryptedLegFailed)
+        XCTAssertFalse(state.isEligible)
+    }
+
+    func testFromCoordinatorPayloadTrustedTierIsEligible() throws {
+        let payload: [String: Any] = [
+            "type": "auth_response",
+            "status": "accepted",
+            "tier": "trusted",
+            "auth_state": "bearer_validated",
+        ]
+        let session = try Tier2ProviderSession(
+            providerID: "provider-test",
+            assignedID: "assigned-test",
+            selectedAEAD: Tier2ProviderSession.aeadSuite,
+            keyID: "kid-test",
+            c2pKey: Data(repeating: 0x11, count: 32),
+            p2cKey: Data(repeating: 0x22, count: 32),
+            c2pNonceBase: Data([0x01, 0x02, 0x03, 0x04]),
+            p2cNonceBase: Data([0x05, 0x06, 0x07, 0x08])
+        )
+        let state = AutoUpdateTrustState.fromCoordinatorPayload(
+            payload,
+            isV2: true,
+            session: session,
+            providerToken: "token",
+            assignedProviderTokenAdopted: false,
+            acceptProvisional: false
+        )
+        XCTAssertEqual(state.tier, "trusted")
+        XCTAssertEqual(state.verdict, .eligible)
+        XCTAssertTrue(state.isEligible)
     }
 
     // fromCoordinatorPayload must forward the flag intact. Prior version

--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -561,7 +561,7 @@
     {
       "spec_id": "SPEC-020",
       "title": "Provider autoupdate",
-      "version": "v0.1.18",
+      "version": "v0.1.19",
       "path": "specs/SPEC-020-provider-autoupdate.md",
       "status": "normative",
       "owner": "@Augustas11",
@@ -1833,10 +1833,14 @@
       "implementation": [
         "phase3-binary/Sources/macprovider-cli/AutoUpdater.swift:handleCoordinatorRecommendation",
         "phase3-binary/Sources/macprovider-cli/AutoUpdater.swift:handleSignedReleaseDiscovery",
+        "phase3-binary/Sources/macprovider-cli/AutoUpdateTrustState.swift:tierPassesAutoupdateGate",
         "phase3-binary/Sources/macprovider-cli/CoordinatorClient.swift:runSignedRecoveryDiscoveryIfDue",
         "phase3-binary/Sources/macprovider-cli/SignedReleaseDiscovery.swift:SignedReleaseDiscoveryHead"
       ],
       "tests": [
+        "phase3-binary/Tests/macprovider-cliTests/AutoUpdateTests.swift::testTrustVerdictTrustedDefaultsToEligible",
+        "phase3-binary/Tests/macprovider-cliTests/AutoUpdateTests.swift::testTrustedRemainsEligibleWhenAcceptProvisionalIsFalse",
+        "phase3-binary/Tests/macprovider-cliTests/AutoUpdateTests.swift::testFromCoordinatorPayloadTrustedTierIsEligible",
         "phase3-binary/Tests/macprovider-cliTests/SelfUpdateTests.swift::testDefaultUpdateUsesBoundedAppendOnlyDiscoveryListing",
         "phase3-binary/Tests/macprovider-cliTests/SelfUpdateTests.swift::testDiscoveryFailsClosedOnHighestMutableTransportWithoutFallingBack",
         "scripts/test-release-discovery-transport.sh:versioned immutable transport fails closed",

--- a/specs/README.md
+++ b/specs/README.md
@@ -28,7 +28,7 @@ it can no longer drift. Do not hand-edit the table; edit each spec's
 | SPEC-017 | Network Stats API | 0.2.0 | normative | pending | pending: 1 | [SPEC-017-network-stats-api.md](SPEC-017-network-stats-api.md) |
 | SPEC-018 | Agentic tool calling (provider-side response synthesis) | 0.2.7 | normative | pending | conformant: 1, pending: 1 | [SPEC-018-agentic-tool-calling.md](SPEC-018-agentic-tool-calling.md) |
 | SPEC-019 | Structured output (`response_format: json_schema`) | 0.2.5 | normative | pending | pending corpus migration | [SPEC-019-structured-output.md](SPEC-019-structured-output.md) |
-| SPEC-020 | Provider autoupdate | v0.1.18 | normative | pending | pending: 5 | [SPEC-020-provider-autoupdate.md](SPEC-020-provider-autoupdate.md) |
+| SPEC-020 | Provider autoupdate | v0.1.19 | normative | pending | pending: 5 | [SPEC-020-provider-autoupdate.md](SPEC-020-provider-autoupdate.md) |
 | SPEC-021 | MALIBU rewards emission ledger | 0.4.0 | draft | complete | pending: 10 | [SPEC-021-malibu-emission-ledger.md](SPEC-021-malibu-emission-ledger.md) |
 | SPEC-022 | Verified model settlement | v0.1.7 | draft | complete | conformant: 11 | [SPEC-022-verified-model-settlement.md](SPEC-022-verified-model-settlement.md) |
 | SPEC-023 | Installer-Integrated Autotune Recommend | v0.9.5 | normative | pending | conformant: 2, pending: 1 | [SPEC-023-installer-autotune-recommend.md](SPEC-023-installer-autotune-recommend.md) |

--- a/specs/SPEC-020-provider-autoupdate.md
+++ b/specs/SPEC-020-provider-autoupdate.md
@@ -1,6 +1,6 @@
 # SPEC-020 - Provider autoupdate
 
-Version: v0.1.18
+Version: v0.1.19
 Status: Normative; coordinator-independent recovery is reconciled and
 implementation remains nonconformant under issue #610. The production path ran
 the 2026-07-10 incident-recovery
@@ -37,6 +37,10 @@ v0.1.13 removes watchdog rollback ownership. The companion watchdog remains a
 local liveness monitor only; installer, Malibu repair, and CLI startup recovery
 are the only transaction owners allowed to mutate pending markers, rollback
 backups, live release bytes, watchdog scripts, plists, or Malibu app artifacts.
+v0.1.19 adds coordinator wire tier `trusted` to the autoupdate eligibility
+table as a pinned-equivalent pass (encrypted-leg, attestation, and token
+guards still apply). Production MALIBU-verified providers emit `trusted`, not
+`pinned`; the previous table treated that label as notify-only.
 
 ## Goal
 
@@ -137,6 +141,22 @@ The following trust-state table is normative for autoupdate eligibility:
 | v2 accepted | pinned | succeeded with matching AEAD/KID | failed | * | notify-only |
 | v2 accepted | pinned | succeeded with matching AEAD/KID | satisfied or not-required | rejected | notify-only |
 | v2 accepted | pinned | succeeded with matching AEAD/KID | satisfied or not-required | validated or not-configured | **eligible** |
+| v2 accepted | trusted | failed | * | * | notify-only |
+| v2 accepted | trusted | succeeded with matching AEAD/KID | failed | * | notify-only |
+| v2 accepted | trusted | succeeded with matching AEAD/KID | satisfied or not-required | rejected | notify-only |
+| v2 accepted | trusted | succeeded with matching AEAD/KID | satisfied or not-required | validated or not-configured | **eligible** |
+
+**Rationale for `trusted` eligibility.** The coordinator wire domain
+(`phase4-coordinator/internal/pool/provider.go`) emits `pinned` for operator
+pin-list members and `trusted` for earned MALIBU trust. `trusted` is strictly
+stronger than `provisional` and is not an unknown/rejected label. The v0.1.5
+tier gate implemented `if tier != "pinned" { require provisional+opt-in }`, so
+a provider that graduated from provisional to trusted became notify-only for
+coordinator-driven autoupdate and could not receive coordinator-triggered
+automatic updates without SSH.
+`trusted` therefore uses the same autoupdate eligibility as `pinned`. The
+`auto_update_accept_provisional` opt-out does not apply to `trusted` or
+`pinned`. Unrecognized tiers, including `rejected`, remain notify-only.
 
 **Rationale for provisional eligibility.** 100% of the production fleet is
 provisional by design: the coordinator ships with an empty `providers: []`
@@ -1136,8 +1156,10 @@ hello_ack-only, unauthenticated, a notify-only provisional sub-state
 token guards is eligible per the normative trust-state table, not
 notify-only, whether or not it holds a validated token), failed
 encrypted-leg, failed
-attestation, rejected token, or otherwise notify-only coordinator state from
-the normative trust-state table, a newer `recommended_binary_version` does not
+attestation, rejected token, unrecognized coordinator tier (not `pinned`,
+`trusted`, or opted-in `provisional`), or otherwise notify-only coordinator
+state from the normative trust-state table, a newer `recommended_binary_version`
+does not
 trigger download, drain, swap, marker creation, or cooldown. The provider
 records the current table result in an explicit `autoupdate_trust_state` field
 for the coordinator session and re-evaluates that field before each
@@ -1504,6 +1526,13 @@ Deferred to v0.3.0 or later:
 
 ## Change log
 
+- v0.1.19 (2026-09-08): Trust-table amendment: coordinator wire tier `trusted`
+  is autoupdate-eligible on the same encrypted-leg, attestation, and token
+  guards as `pinned`. Closes the production skip where MALIBU-verified
+  providers recorded `reason:provisional` and stayed notify-only after
+  graduating from provisional. Unrecognized tiers remain notify-only. Binary
+  replacement remains independently crypto-gated; this change does not cut a
+  CLI release by itself.
 - v0.1.18 (2026-09-05): R-4.14 write-fence carve-out for supervisor telemetry
   (RFC-001 §7 / F5, #1386). The watchdog may additionally write its own private
   single `supervisor-beacon.json` (a non-executable, non-config diagnostic


### PR DESCRIPTION
## Summary
- Treat coordinator wire tier `trusted` as autoupdate-eligible on the same encrypted-leg, attestation, and token guards as `pinned`.
- SPEC-020 v0.1.19 records that MALIBU-verified providers emit `trusted`, not `pinned`; the old gate skipped coordinator-driven autoupdate after graduation from provisional.
- Does not bump `binaryVersion` and does not cut 1.8.123.

## Test plan
- [x] `cd phase3-binary && swift test --filter AutoUpdateTests` (102 passed)
- [x] `python3 scripts/check_spec_governance.py`
- [ ] CI green
- [ ] Do not tag or promote a CLI release from this PR

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": ["SPEC-020"],
  "requirements": ["SPEC-020-R001"],
  "authority_domains": ["provider-autoupdate"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "phase3-binary/Tests/macprovider-cliTests/AutoUpdateTests.swift::testTrustVerdictTrustedDefaultsToEligible",
    "phase3-binary/Tests/macprovider-cliTests/AutoUpdateTests.swift::testTrustedRemainsEligibleWhenAcceptProvisionalIsFalse",
    "phase3-binary/Tests/macprovider-cliTests/AutoUpdateTests.swift::testFromCoordinatorPayloadTrustedTierIsEligible"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END

Made with [Cursor](https://cursor.com)