### PR TITLE
Add SPEC-045 restart exposure regression

### DIFF
--- a/phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift
@@ -5592,6 +5592,71 @@ final class ConsumeCommandTests: XCTestCase {
         XCTAssertEqual(summary.heldReservationCount, 1)
     }
 
+    func testPhase3StartupRecoveryHoldsPriorRunReservationsBeforeAdmission() throws {
+        let home = try makeTemporaryDirectory()
+        let ledgerURL = home.appendingPathComponent("budget.jsonl")
+        let crashedRunID = "crashed-run"
+        let restartRunID = "restart-run"
+        let exposure = ConsumeMicroUSD(rawValue: 1_000_000)
+        let reservationID: String
+
+        do {
+            let crashedLedger = try ConsumeBudgetLedger.open(
+                ledgerPath: ledgerURL.path,
+                homeDirectory: home,
+                startupDirectory: home
+            )
+            reservationID = try crashedLedger.reserve(
+                runID: crashedRunID,
+                amount: exposure,
+                reason: "priced_proxy_forwarding"
+            )
+            let summary = try crashedLedger.summary()
+            XCTAssertEqual(summary.reserved.rawValue, exposure.rawValue)
+            XCTAssertEqual(summary.held.rawValue, 0)
+            XCTAssertEqual(summary.heldReservationCount, 0)
+        }
+
+        let recovered = try ConsumeBudgetConfig.parse(
+            budgetUSD: "1.00",
+            maxRequestUSD: nil,
+            noBudget: false,
+            ledgerPath: ledgerURL.path,
+            allowUnpriced: false,
+            runID: restartRunID,
+            homeDirectory: home,
+            startupDirectory: home
+        )
+        let recoveredLedger = try XCTUnwrap(recovered.ledger)
+        let summary = try recoveredLedger.summary()
+        XCTAssertEqual(summary.reserved.rawValue, 0)
+        XCTAssertEqual(summary.held.rawValue, exposure.rawValue)
+        XCTAssertEqual(summary.heldReservationCount, 1)
+        XCTAssertEqual(try summary.committedExposure().rawValue, exposure.rawValue)
+
+        let admission = try recoveredLedger.reservePricedEstimateForForwarding(
+            runID: restartRunID,
+            budget: exposure,
+            estimate: exposure,
+            maxRequest: nil
+        )
+        guard case .budgetExceeded = admission else {
+            return XCTFail("restart-held exposure must prevent spending the same local budget")
+        }
+
+        let rows = try Data(contentsOf: ledgerURL).split(separator: 0x0a).map {
+            try XCTUnwrap(JSONSerialization.jsonObject(with: Data($0)) as? [String: Any])
+        }
+        XCTAssertEqual(rows.count, 2)
+        XCTAssertEqual(rows[0]["state"] as? String, "reserved")
+        XCTAssertEqual(rows[0]["run_id"] as? String, crashedRunID)
+        XCTAssertEqual(rows[0]["reservation_id"] as? String, reservationID)
+        XCTAssertEqual(rows[1]["state"] as? String, "held")
+        XCTAssertEqual(rows[1]["reason"] as? String, "restart_recovery")
+        XCTAssertEqual(rows[1]["run_id"] as? String, crashedRunID)
+        XCTAssertEqual(rows[1]["reservation_id"] as? String, reservationID)
+    }
+
     func testPhase3BudgetedUnpricedRequestIsHeldUntilRelease() throws {
         let token = try ConsumeLocalToken.generate()
         let home = try makeTemporaryDirectory()


### PR DESCRIPTION
## Summary
- Adds a SPEC-045 regression proving startup recovery converts a prior-run reserved local budget reservation into held exposure before new admission.
- Verifies that the recovered held exposure still counts against the run budget and blocks spending the same local budget again.
- Leaves conformance/evidence metadata unchanged; this is local automated coverage, not signed journey evidence.

## Behavior
- A crash-left/prior-run `reserved` ledger row is recovered through `ConsumeBudgetConfig.parse` as `held` with reason `restart_recovery`.
- The held row preserves the original immutable `run_id` and `reservation_id`.
- `committedExposure()` includes the held amount, so same-budget new admission returns `budgetExceeded` instead of releasing potentially spent exposure.

## Tests
- `cd phase3-binary && swift test --filter 'ConsumeCommandTests/testPhase3(StartupRecoveryHoldsPriorRunReservationsBeforeAdmission|DAmbiguousSendFailureHoldsReservationAcrossRestart|GAmbiguousSendFailureAccountsEstimateAcrossRestart|BudgetedUnpricedRequestIsHeldUntilRelease)'` - 4 tests, 0 failures.
- `cd phase3-binary && swift test --filter ConsumeCommandTests` - 127 tests, 0 failures.
- `git diff --check` - passed.
- Code review, security review, and architecture/spec-boundary review lanes - 0 Critical, 0 High, 0 Medium, 0 Low findings.

## Conformance
- No conformance rows are promoted or demoted in this PR.
- SPEC-045 R005/R008 remain pending broader release evidence, including full recovery-command and signed staging/production local-consumer journey proof.
- This PR does not claim production readiness and does not create or modify signed journey artifacts.

## Known Gaps
- No live `NWConnection` callback/deadline race coverage.
- No OS-level separate-process binary restart harness.
- No refreshed signed gateway journey.
- Full Swift suite was not run.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": [
    "SPEC-045"
  ],
  "requirements": [
    "SPEC-045-R005",
    "SPEC-045-R008"
  ],
  "authority_domains": [
    "local-consumer-endpoint"
  ],
  "arbitration": [
    "CODE_BUG"
  ],
  "tests": [
    "cd phase3-binary && swift test --filter 'ConsumeCommandTests/testPhase3(StartupRecoveryHoldsPriorRunReservationsBeforeAdmission|DAmbiguousSendFailureHoldsReservationAcrossRestart|GAmbiguousSendFailureAccountsEstimateAcrossRestart|BudgetedUnpricedRequestIsHeldUntilRelease)'",
    "cd phase3-binary && swift test --filter ConsumeCommandTests",
    "git diff --check"
  ],
  "journeys": [
    "not-required"
  ]
}
SPEC-GOVERNANCE-DECLARATION-END
