### PR TITLE
fix(uninstall): make uninstall idempotent wrt reinstall (#1420)

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/UninstallCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/UninstallCommand.swift
@@ -9,7 +9,7 @@ struct UninstallCommand: AsyncParsableCommand {
         abstract: "Stop macprovider-cli and remove installed artifacts."
     )
 
-    @Flag(help: "Accepted for compatibility; support files and logs are always removed.")
+    @Flag(help: "Accepted for compatibility; support files, logs, and pending-update residue are always removed. The provider identity (config provider_id + CLI credential, in Keychain or protected-file custody) is preserved for safe reinstall per SPEC-001; a future full-identity-reset is required to destroy it.")
     var removeConfigAndLogs = false
 
     @Flag(help: "Accepted for compatibility; uninstall is non-interactive.")
@@ -123,6 +123,20 @@ struct UninstallCommand: AsyncParsableCommand {
         for dataDir in manifest.dataDirs {
             removeIfPresent(URL(fileURLWithPath: dataDir), allowed: allowed.dataDirs, label: "data directory", warnings: &warnings)
         }
+        // Clear the autoupdate transaction residue (`pending.json`, `update.lock`)
+        // under the provider state root. Both launchd jobs are proven absent by
+        // this point, so no updater owns these markers; leaving `pending.json`
+        // makes the next `install.sh` falsely report "a provider update is
+        // awaiting coordinator admission or recovery" and refuse to install
+        // (issue #1420). Preserves the rest of the state root and the identity.
+        if let residue = allowed.autoupdateResidue {
+            removeIfPresent(
+                URL(fileURLWithPath: residue),
+                allowed: [residue],
+                label: "autoupdate transaction residue",
+                warnings: &warnings
+            )
+        }
         removeIfPresent(paths.manifest, allowed: [paths.manifest.path], label: "manifest", warnings: &warnings)
         Self.cleanupApplicationSupportPreservingLifecycleState(
             paths.applicationSupportDirectory,
@@ -131,7 +145,10 @@ struct UninstallCommand: AsyncParsableCommand {
 
         try removePathMarker(from: home.appendingPathComponent(".zshrc"))
         if FileManager.default.fileExists(atPath: paths.cacheDirectory.path) {
-            warnings.append("left cache directory in place: \(paths.cacheDirectory.path)")
+            warnings.append(
+                "left cache directory in place: \(paths.cacheDirectory.path)"
+                + " — this does not block reinstall; remove it with"
+                + " `rm -rf \(paths.cacheDirectory.path)` for a full wipe.")
         }
         for warning in warnings {
             print("warning: \(warning)")
@@ -205,9 +222,14 @@ struct UninstallCommand: AsyncParsableCommand {
         var description: String {
             switch self {
             case .serviceStillLoaded(let label):
-                return "refusing to remove provider artifacts while launchd service remains loaded: \(label)"
+                return "refusing to remove provider artifacts while launchd service remains loaded: \(label). "
+                    + "Remedy: stop it and re-run uninstall — `launchctl bootout gui/$(id -u)/\(label)` "
+                    + "(or reboot), then `malibu-cli uninstall`."
             case .serviceAbsenceVerificationFailed(let label, let status):
-                return "refusing to remove provider artifacts because launchd service absence could not be verified: \(label) (launchctl print exited \(status))"
+                return "refusing to remove provider artifacts because launchd service absence could not be verified: "
+                    + "\(label) (launchctl print exited \(status)). "
+                    + "Remedy: inspect with `launchctl print gui/$(id -u)/\(label)`, boot it out with "
+                    + "`launchctl bootout gui/$(id -u)/\(label)` (or reboot), then re-run `malibu-cli uninstall`."
             case .unexpectedServiceLabel(let label):
                 return "refusing to use an unrecognized launchd service label from the install manifest: \(label)"
             case .unsupportedHeadlessInstallProfile:
@@ -230,11 +252,21 @@ struct UninstallCommand: AsyncParsableCommand {
         "live.streamvc.macprovider",
     ]
 
+    // `bootout` is asynchronous: it can return while the job is still in its
+    // exiting state, during which `launchctl print` still reports status 0
+    // ("loaded"). SPEC-001 still requires proving absence before removing
+    // artifacts, so we re-check for a bounded grace window and treat a
+    // persistent status 0 as still-loaded (fail closed) only after it elapses.
+    // Any other non-absent result is indeterminate and fails closed at once.
+    static let serviceAbsenceMaxAttempts = 20
+    static let serviceAbsencePollIntervalMicroseconds: useconds_t = 100_000
+
     static func stopLaunchdServices(
         labels: [String],
         uid: uid_t,
         run: ([String]) throws -> Int32,
-        beforeBootout: (String) -> Void = { _ in }
+        beforeBootout: (String) -> Void = { _ in },
+        sleep: (useconds_t) -> Void = { _ = usleep($0) }
     ) throws {
         let managedLabels = Set(managedLaunchdStopOrder)
         for label in Set(labels) where !managedLabels.contains(label) {
@@ -254,13 +286,13 @@ struct UninstallCommand: AsyncParsableCommand {
             // `bootout` returns nonzero both for an absent job and for real
             // failures. A follow-up `print` is the stop proof: only a missing
             // job is safe before deleting the executable and plist.
-            try verifyServiceAbsent(label: label, uid: uid, run: run)
+            try verifyServiceAbsent(label: label, uid: uid, run: run, sleep: sleep)
         }
 
         // Recheck the complete managed set only after every restart-capable job
         // has stopped. This closes the provider-first/watchdog-restart race.
         for label in managedLaunchdStopOrder {
-            try verifyServiceAbsent(label: label, uid: uid, run: run)
+            try verifyServiceAbsent(label: label, uid: uid, run: run, sleep: sleep)
         }
     }
 
@@ -294,15 +326,28 @@ struct UninstallCommand: AsyncParsableCommand {
     private static func verifyServiceAbsent(
         label: String,
         uid: uid_t,
-        run: ([String]) throws -> Int32
+        run: ([String]) throws -> Int32,
+        sleep: (useconds_t) -> Void = { _ = usleep($0) }
     ) throws {
         let target = "gui/\(uid)/\(label)"
-        let printStatus = try run(["print", target])
-        guard printStatus != 0 else {
-            throw UninstallError.serviceStillLoaded(label)
-        }
-        guard isLaunchdAbsentStatus(printStatus) else {
-            throw UninstallError.serviceAbsenceVerificationFailed(label, printStatus)
+        var attempt = 0
+        while true {
+            let printStatus = try run(["print", target])
+            if isLaunchdAbsentStatus(printStatus) {
+                return
+            }
+            // Status 0 == still loaded. Immediately after `bootout` this may just
+            // be the asynchronous teardown finishing, so poll for a bounded grace
+            // window before failing closed. Every other non-absent result is
+            // indeterminate per SPEC-001 and fails closed without retry.
+            guard printStatus == 0 else {
+                throw UninstallError.serviceAbsenceVerificationFailed(label, printStatus)
+            }
+            attempt += 1
+            if attempt >= serviceAbsenceMaxAttempts {
+                throw UninstallError.serviceStillLoaded(label)
+            }
+            sleep(serviceAbsencePollIntervalMicroseconds)
         }
     }
 
@@ -357,6 +402,12 @@ struct UninstallCommand: AsyncParsableCommand {
         let launchdPlists: [String]
         let installProfile: String?
         let launchdDomain: String?
+        /// Root of the provider's `~/.local/share/macprovider` state tree. Its
+        /// `autoupdate/` subdirectory holds in-flight update transaction residue
+        /// (`pending.json`, `update.lock`) that must be cleared on uninstall so a
+        /// subsequent install is not falsely told an update is awaiting
+        /// admission. Optional for backward compatibility with older manifests.
+        let providerStateRoot: String?
 
         enum CodingKeys: String, CodingKey {
             case installPrefix = "install_prefix"
@@ -368,6 +419,35 @@ struct UninstallCommand: AsyncParsableCommand {
             case launchdPlists = "launchd_plists"
             case installProfile = "install_profile"
             case launchdDomain = "launchd_domain"
+            case providerStateRoot = "provider_state_root"
+        }
+
+        // Explicit memberwise initializer with a default for `providerStateRoot`
+        // so existing constructors (and older tests) remain source-compatible.
+        // Codable's synthesized `init(from:)` is unaffected and decodes a missing
+        // `provider_state_root` key as nil.
+        init(
+            installPrefix: String,
+            launchdLabels: [String],
+            dataDirs: [String],
+            version: String?,
+            binaryPath: String?,
+            symlinkPath: String?,
+            launchdPlists: [String],
+            installProfile: String?,
+            launchdDomain: String?,
+            providerStateRoot: String? = nil
+        ) {
+            self.installPrefix = installPrefix
+            self.launchdLabels = launchdLabels
+            self.dataDirs = dataDirs
+            self.version = version
+            self.binaryPath = binaryPath
+            self.symlinkPath = symlinkPath
+            self.launchdPlists = launchdPlists
+            self.installProfile = installProfile
+            self.launchdDomain = launchdDomain
+            self.providerStateRoot = providerStateRoot
         }
     }
 
@@ -414,7 +494,8 @@ struct UninstallCommand: AsyncParsableCommand {
                 home.appendingPathComponent("Library/LaunchAgents/live.streamvc.macprovider-watchdog.plist").path,
             ],
             installProfile: nil,
-            launchdDomain: nil
+            launchdDomain: nil,
+            providerStateRoot: home.appendingPathComponent(".local/share/macprovider").path
         )
     }
 
@@ -463,11 +544,35 @@ struct UninstallCommand: AsyncParsableCommand {
         let symlinks: [String]
         let binaries: [String]
         let dataDirs: [String]
+        /// The single `<provider_state_root>/autoupdate` directory holding update
+        /// transaction residue, or nil when no safe state root can be resolved.
+        let autoupdateResidue: String?
+    }
+
+    /// Canonical provider state root when the manifest does not record one
+    /// (older manifests predate `provider_state_root`); matches install.sh's
+    /// `$HOME/.local/share/macprovider`.
+    static func defaultProviderStateRoot(home: URL) -> URL {
+        home.appendingPathComponent(".local/share/macprovider", isDirectory: true)
     }
 
     static func allowedRemovalPaths(home: URL, manifest: InstallManifest) throws -> AllowedRemovalPaths {
         let paths = artifactPaths(home: home)
         let installPrefix = URL(fileURLWithPath: manifest.installPrefix)
+        // Only honor a manifest-supplied provider_state_root when it is exactly
+        // the canonical location. A corrupt or tampered manifest must not be able
+        // to redirect the recursive autoupdate-residue removal at an arbitrary
+        // path (audit finding). install.sh only ever writes the canonical
+        // `~/.local/share/macprovider`, so this loses nothing in practice and
+        // fails safe to the canonical path for any other value.
+        let canonicalStateRoot = defaultProviderStateRoot(home: home)
+        let stateRoot: URL
+        if let declared = manifest.providerStateRoot.map({ URL(fileURLWithPath: $0) }),
+           declared.standardizedFileURL.path == canonicalStateRoot.standardizedFileURL.path {
+            stateRoot = declared
+        } else {
+            stateRoot = canonicalStateRoot
+        }
         return AllowedRemovalPaths(
             plists: [
                 paths.plist.path,
@@ -486,7 +591,8 @@ struct UninstallCommand: AsyncParsableCommand {
                 installPrefix.path,
                 paths.logsDirectory.path,
                 paths.watchdogDirectory.path,
-            ]
+            ],
+            autoupdateResidue: stateRoot.appendingPathComponent("autoupdate", isDirectory: true).path
         )
     }
 

--- a/phase3-binary/Tests/macprovider-cliTests/UninstallCommandTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/UninstallCommandTests.swift
@@ -137,7 +137,8 @@ final class UninstallCommandTests: XCTestCase {
                 run: { arguments in
                     guard arguments.first == "print" else { return 0 }
                     return arguments.last?.hasSuffix("/live.malibu.provider-watchdog") == true ? 113 : 0
-                }
+                },
+                sleep: { _ in }
             )
         ) { error in
             XCTAssertEqual(
@@ -145,6 +146,29 @@ final class UninstallCommandTests: XCTestCase {
                 .serviceStillLoaded("live.malibu.provider")
             )
         }
+    }
+
+    // A `bootout` that returns before the job finishes tearing down leaves
+    // `launchctl print` reporting status 0 for a brief window. The absence check
+    // must poll through that grace window rather than immediately refusing, so a
+    // job that becomes absent on a later poll is accepted (issue #1420, Claim 1).
+    func testStopLaunchdServicesToleratesBootoutTeardownLag() throws {
+        var providerPrints = 0
+        var sleeps = 0
+        try UninstallCommand.stopLaunchdServices(
+            labels: ["live.malibu.provider"],
+            uid: 501,
+            run: { arguments in
+                guard arguments.first == "print" else { return 3 }
+                guard arguments.last?.hasSuffix("/live.malibu.provider") == true else { return 113 }
+                providerPrints += 1
+                // First poll: still tearing down (0); second poll: gone (113).
+                return providerPrints >= 2 ? 113 : 0
+            },
+            sleep: { _ in sleeps += 1 }
+        )
+        XCTAssertGreaterThanOrEqual(providerPrints, 2)
+        XCTAssertGreaterThanOrEqual(sleeps, 1)
     }
 
     func testStopLaunchdServicesRejectsIndeterminatePrintFailure() {
@@ -180,10 +204,15 @@ final class UninstallCommandTests: XCTestCase {
                     guard arguments.first == "print" else { return 0 }
                     if arguments.last?.hasSuffix("/live.malibu.provider") == true {
                         providerPrints += 1
+                        // Absent at the per-label stop proof, then persistently
+                        // re-loaded (status 0) once the watchdog restarts it — the
+                        // final recheck polls through the grace window and still
+                        // fails closed.
                         return providerPrints == 1 ? 113 : 0
                     }
                     return 113
-                }
+                },
+                sleep: { _ in }
             )
         ) { error in
             XCTAssertEqual(
@@ -192,10 +221,11 @@ final class UninstallCommandTests: XCTestCase {
             )
         }
 
-        XCTAssertEqual(Array(calls.suffix(2)), [
-            ["print", "gui/501/live.malibu.provider-watchdog"],
-            ["print", "gui/501/live.malibu.provider"],
-        ])
+        // The final recheck detects the restarted provider; the last launchctl
+        // call is a print of the provider label (repeated across the grace-window
+        // polls before failing closed).
+        XCTAssertEqual(calls.last, ["print", "gui/501/live.malibu.provider"])
+        XCTAssertGreaterThan(providerPrints, 2)
     }
 
     func testStopLaunchdServicesRejectsUnexpectedManifestLabelBeforeLaunchctl() {
@@ -246,6 +276,7 @@ final class UninstallCommandTests: XCTestCase {
           "launchd_labels": ["live.malibu.provider", "live.malibu.provider-watchdog"],
           "launchd_plists": ["\(root.path)/Library/LaunchAgents/live.malibu.provider.plist"],
           "data_dirs": ["\(root.path)/custom", "\(root.path)/Library/Logs/macprovider"],
+          "provider_state_root": "\(root.path)/.local/share/macprovider",
           "version": "v1.8.10"
         }
         """.write(to: manifest, atomically: true, encoding: .utf8)
@@ -258,8 +289,65 @@ final class UninstallCommandTests: XCTestCase {
         XCTAssertEqual(loaded.launchdLabels, ["live.malibu.provider", "live.malibu.provider-watchdog"])
         XCTAssertEqual(loaded.dataDirs, ["\(root.path)/custom", "\(root.path)/Library/Logs/macprovider"])
         XCTAssertEqual(loaded.symlinkPath, "\(root.path)/.local/bin/macprovider-cli")
+        XCTAssertEqual(loaded.providerStateRoot, "\(root.path)/.local/share/macprovider")
         XCTAssertNil(loaded.installProfile)
         XCTAssertNil(loaded.launchdDomain)
+
+        // The autoupdate transaction residue removed on uninstall lives under
+        // the manifest's provider_state_root (issue #1420, Claim 2).
+        let allowed = try UninstallCommand.allowedRemovalPaths(home: root, manifest: loaded)
+        XCTAssertEqual(
+            allowed.autoupdateResidue,
+            "\(root.path)/.local/share/macprovider/autoupdate"
+        )
+    }
+
+    func testAllowedRemovalPathsFallsBackToCanonicalStateRootWhenManifestOmitsIt() throws {
+        let home = URL(fileURLWithPath: "/Users/tester")
+        // Older manifests predate `provider_state_root`; uninstall must still
+        // clear the canonical autoupdate residue so reinstall is not blocked.
+        let manifest = UninstallCommand.InstallManifest(
+            installPrefix: "/Users/tester/macprovider",
+            launchdLabels: ["live.malibu.provider", "live.malibu.provider-watchdog"],
+            dataDirs: ["/Users/tester/macprovider"],
+            version: "v1.8.10",
+            binaryPath: nil,
+            symlinkPath: "/Users/tester/.local/bin/macprovider-cli",
+            launchdPlists: [],
+            installProfile: nil,
+            launchdDomain: nil
+        )
+        XCTAssertNil(manifest.providerStateRoot)
+        let allowed = try UninstallCommand.allowedRemovalPaths(home: home, manifest: manifest)
+        XCTAssertEqual(
+            allowed.autoupdateResidue,
+            "/Users/tester/.local/share/macprovider/autoupdate"
+        )
+    }
+
+    func testAllowedRemovalPathsRejectsOffTreeManifestStateRoot() throws {
+        let home = URL(fileURLWithPath: "/Users/tester")
+        // A corrupt/tampered manifest must not redirect recursive residue removal
+        // at an arbitrary path; a non-canonical provider_state_root falls back to
+        // the canonical location instead of being honored (issue #1420 audit).
+        let manifest = UninstallCommand.InstallManifest(
+            installPrefix: "/Users/tester/macprovider",
+            launchdLabels: ["live.malibu.provider", "live.malibu.provider-watchdog"],
+            dataDirs: ["/Users/tester/macprovider"],
+            version: "v1.8.10",
+            binaryPath: nil,
+            symlinkPath: "/Users/tester/.local/bin/macprovider-cli",
+            launchdPlists: [],
+            installProfile: nil,
+            launchdDomain: nil,
+            providerStateRoot: "/Users/tester/Documents"
+        )
+        let allowed = try UninstallCommand.allowedRemovalPaths(home: home, manifest: manifest)
+        XCTAssertEqual(
+            allowed.autoupdateResidue,
+            "/Users/tester/.local/share/macprovider/autoupdate"
+        )
+        XCTAssertNotEqual(allowed.autoupdateResidue, "/Users/tester/Documents/autoupdate")
     }
 
     func testLoadManifestFailsClosedOnMalformedManifest() throws {

--- a/phase3-binary/dist/install.sh
+++ b/phase3-binary/dist/install.sh
@@ -17,6 +17,10 @@ set -euo pipefail
 REFERRAL_CODE_SOURCE_FILE="${MACPROVIDER_REFERRAL_CODE_FILE:-}"
 CREATED_REFERRAL_CODE_SOURCE_FILE=0
 FRESH_REFERRAL_BOOTSTRAP=0
+# Set when a provider identity (config provider_id) survives a routine uninstall
+# but no binary/manifest/plist remains, so the referral demand is deferred until
+# the staged CLI can authoritatively verify the preserved credential (#1420).
+SURVIVING_IDENTITY_REINSTALL=0
 REFERRAL_REPLACE_INCUMBENT="${MACPROVIDER_REFERRAL_REPLACE_INCUMBENT:-0}"
 REPAIR_EXISTING_INSTALL="${MACPROVIDER_REPAIR_EXISTING_INSTALL:-0}"
 BUNDLED_CLI="${MACPROVIDER_BUNDLED_CLI:-}"
@@ -1392,6 +1396,7 @@ acquire_install_lock() {
     "${REPAIR_EXISTING_INSTALL:-0}" <<'PY' &
 import fcntl
 import ctypes
+import datetime
 import errno
 import grp
 import json
@@ -1626,7 +1631,28 @@ try:
     if pending_info is not None:
         if not stat.S_ISREG(pending_info.st_mode) or stat.S_ISLNK(pending_info.st_mode) or pending_info.st_uid != uid or pending_info.st_nlink != 1 or pending_info.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
             raise RuntimeError("pending provider mutation marker is unsafe")
-        write_status("mutation-pending")
+        # Classify the marker so the installer can give a truthful remedy instead
+        # of always telling the operator to "wait" (#1420). A marker whose
+        # `marker_deadline` is still in the future is a genuine in-progress
+        # update/rollback; an expired or malformed/unparseable deadline is an
+        # abandoned transaction that nothing is finishing, which `recover-update`
+        # is the tool to clear (mirrors recover-update treating an unparseable
+        # deadline as expired).
+        marker_stale = True
+        try:
+            marker_fd = os.open(mutation_pending_path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+            try:
+                marker_raw = os.read(marker_fd, 1024 * 1024)
+            finally:
+                os.close(marker_fd)
+            marker = json.loads(marker_raw.decode("utf-8"))
+            deadline = datetime.datetime.strptime(
+                marker["marker_deadline"], "%Y-%m-%dT%H:%M:%SZ"
+            ).replace(tzinfo=datetime.timezone.utc)
+            marker_stale = deadline < datetime.datetime.now(datetime.timezone.utc)
+        except (KeyError, ValueError, TypeError, OSError):
+            marker_stale = True
+        write_status("mutation-pending-stale" if marker_stale else "mutation-pending-active")
         raise SystemExit(73)
     token = secrets.token_hex(32)
     parent_start = process_start(owner_pid)
@@ -1697,10 +1723,15 @@ PY
       INSTALL_LOCK_HOLDER_PID=""
       die 73 "another provider update is active; wait for it to finish"
       ;;
-    mutation-pending)
+    mutation-pending-active)
       wait "$INSTALL_LOCK_HOLDER_PID" >/dev/null 2>&1 || true
       INSTALL_LOCK_HOLDER_PID=""
-      die 73 "a provider update is awaiting coordinator admission or recovery; wait for it to finish"
+      die 73 "a provider update is awaiting coordinator admission or recovery; wait for it to finish, then re-run. If it does not complete, clear it with: macprovider-cli recover-update"
+      ;;
+    mutation-pending-stale|mutation-pending)
+      wait "$INSTALL_LOCK_HOLDER_PID" >/dev/null 2>&1 || true
+      INSTALL_LOCK_HOLDER_PID=""
+      die 73 "a previous provider update did not finish and its recovery deadline has passed; nothing is running now. Clear the stale marker with: macprovider-cli recover-update (reinstall the CLI first if it was removed), then re-run the installer"
       ;;
     *)
       kill -TERM "$INSTALL_LOCK_HOLDER_PID" >/dev/null 2>&1 || true
@@ -8309,6 +8340,25 @@ prepare_fresh_referral_code() {
     fi
     log "Fresh provider replacement requested; incumbent files and config stay unchanged until replacement cutover."
   fi
+  # A routine uninstall preserves the provider identity (config provider_id +
+  # Keychain/protected-file credential) for safe reinstall per SPEC-001, but
+  # removes the binary, manifest, and plist -- so restart_safe_incumbent_present
+  # cannot see it (it needs an installed binary). Without this, a plain reinstall
+  # demands a fresh invite code and later redeems it against the surviving
+  # onboarding journal, which fails with referral_conflict (#1420). When a
+  # provider_id survives but no binary is installed and the operator supplied
+  # neither a referral code nor a replace request, defer the referral decision:
+  # ensure_provider_credentials runs the freshly-staged CLI's `credentials
+  # verify` as the authoritative check. An intact credential is reused with no
+  # referral; a missing/invalid one fails closed there with a named remedy.
+  if [ "$REFERRAL_REPLACE_INCUMBENT" != "1" ] \
+    && [ -z "$REFERRAL_CODE_SOURCE_FILE" ] \
+    && [ -z "$(installed_provider_binary_path)" ] \
+    && [ -n "$(read_config_provider_id || true)" ]; then
+    SURVIVING_IDENTITY_REINSTALL=1
+    log "Found a preserved provider identity with no installed binary; will verify the preserved credential with the staged CLI before requesting an invite code."
+    return 0
+  fi
   if [ -n "$REFERRAL_CODE_SOURCE_FILE" ]; then
     validate_supplied_referral_code_file
     FRESH_REFERRAL_BOOTSTRAP=1
@@ -10519,8 +10569,11 @@ ensure_provider_credentials() {
         if headless_acceptance_repair_mode; then
           die 6 "headless acceptance repair credential custody changed after incumbent verification; refusing to bootstrap over protected-file state"
         fi
+        if [ "${SURVIVING_IDENTITY_REINSTALL:-0}" -eq 1 ]; then
+          die 6 "a preserved provider identity ($(read_config_provider_id || true)) is present in $CONFIG_DIR but its credential is missing or unreadable, so this reinstall cannot reuse it. Remedy: restore the preserved credential, or replace this identity with a new one by re-running with MACPROVIDER_REFERRAL_REPLACE_INCUMBENT=1 and an invite code (MACPROVIDER_REFERRAL_CODE_FILE=...). A plain invite code alone will not help: the preserved provider_id is reused, so it would conflict again."
+        fi
         ;;
-      *) die 6 "existing CLI Keychain credential is unavailable or invalid; refusing unsafe bootstrap" ;;
+      *) die 6 "existing CLI credential is unavailable or invalid; refusing unsafe bootstrap. Remedy: inspect it with \`macprovider-cli credentials verify\`; if it cannot be recovered, restore it, or replace the identity by re-running with MACPROVIDER_REFERRAL_REPLACE_INCUMBENT=1 and an invite code." ;;
     esac
   fi
   if [ "$credential_already_present" -eq 0 ]; then
@@ -10630,6 +10683,16 @@ run_autotune_recommend_apply() {
   fi
   if [ ! -x "${MACPROVIDER_CLI_EXECUTABLE:-$INSTALL_DIR/macprovider-cli}" ]; then
     die 5 "staged macprovider-cli missing before autotune recommendation"
+  fi
+  # #1420: a surviving-identity reinstall deferred the referral demand to the
+  # staged CLI's `credentials verify`. That authoritative check must run before
+  # ANY commit reachable from this function -- including the donor and
+  # start-declined no-start branches below, not only the paid-start path -- so a
+  # missing/invalid preserved credential fails closed with its remedy instead of
+  # silently committing a half-identity install. On the reuse path (verify=0,
+  # no referral supplied) this is an idempotent no-op verify.
+  if [ "${SURVIVING_IDENTITY_REINSTALL:-0}" -eq 1 ]; then
+    ensure_provider_credentials
   fi
   autotune_candidate_args=()
   upgrade_candidate_model_id="${AUTOTUNE_UPGRADE_CANDIDATE_MODEL_ID:-}"

--- a/phase3-binary/dist/test/install_referral_handoff.test.sh
+++ b/phase3-binary/dist/test/install_referral_handoff.test.sh
@@ -335,4 +335,55 @@ set -e
 }
 printf '%s' "$stale_output" | grep -Fq "invite code is required"
 
+# A routine uninstall preserves the provider identity (config provider_id +
+# credential) but removes the binary/manifest/plist. On reinstall, with a
+# surviving provider_id, no installed binary, and neither a referral code nor a
+# replace request, prepare_fresh_referral_code must DEFER the invite demand
+# (not die 20) so the staged CLI can verify and reuse the preserved credential
+# (#1420) instead of redeeming an unrelated fresh code and conflicting.
+surviving_dir="$workdir/surviving"
+mkdir -p "$surviving_dir/config"
+INSTALL_DIR="$surviving_dir/macprovider"
+BINARY_PATH="$surviving_dir/bin/macprovider-cli"
+MANIFEST_PATH="$surviving_dir/install_manifest.json"
+PLIST_PATH="$surviving_dir/live.malibu.provider.plist"
+PROVIDER_ID_PATH="$surviving_dir/provider_id"
+CONFIG_PATH="$surviving_dir/config/config.yaml"
+printf '%s\n' 'provider_id: "mp-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"' > "$CONFIG_PATH"
+NO_PROMPT=1
+REFERRAL_CODE_SOURCE_FILE=""
+CREATED_REFERRAL_CODE_SOURCE_FILE=0
+FRESH_REFERRAL_BOOTSTRAP=0
+REFERRAL_REPLACE_INCUMBENT=0
+SURVIVING_IDENTITY_REINSTALL=0
+prepare_fresh_referral_code
+[ "$SURVIVING_IDENTITY_REINSTALL" -eq 1 ] || {
+  echo "surviving-identity reinstall did not defer the referral demand" >&2
+  exit 1
+}
+[ -z "$REFERRAL_CODE_SOURCE_FILE" ] || {
+  echo "surviving-identity reinstall must not create a referral file" >&2
+  exit 1
+}
+[ "$CREATED_REFERRAL_CODE_SOURCE_FILE" -eq 0 ]
+[ "$FRESH_REFERRAL_BOOTSTRAP" -eq 0 ]
+
+# The same surviving-identity state WITH an explicit invite code must NOT defer:
+# the operator explicitly asked for a fresh referral, so honor it.
+explicit_file="$workdir/surviving-explicit-referral"
+printf '%s' "$valid_code" > "$explicit_file"
+chmod 600 "$explicit_file"
+REFERRAL_CODE_SOURCE_FILE="$explicit_file"
+CREATED_REFERRAL_CODE_SOURCE_FILE=0
+FRESH_REFERRAL_BOOTSTRAP=0
+SURVIVING_IDENTITY_REINSTALL=0
+prepare_fresh_referral_code
+[ "$SURVIVING_IDENTITY_REINSTALL" -eq 0 ] || {
+  echo "explicit invite code must not trigger the surviving-identity defer" >&2
+  exit 1
+}
+[ "$REFERRAL_CODE_SOURCE_FILE" = "$explicit_file" ]
+[ "$FRESH_REFERRAL_BOOTSTRAP" -eq 1 ]
+rm -f "$explicit_file"
+
 echo "install_referral_handoff: PASS"

--- a/phase3-binary/dist/test/install_transaction_lock.test.sh
+++ b/phase3-binary/dist/test/install_transaction_lock.test.sh
@@ -171,17 +171,46 @@ kill "$mutation_holder_pid"
 wait "$mutation_holder_pid" >/dev/null 2>&1 || true
 mutation_holder_pid=""
 
-# A durable pending updater marker remains an active transaction even after the
-# updater process restarted and released its kernel locks. Installer must wait
-# for coordinator admission or rollback recovery instead of overwriting it.
-printf '{}\n' > "$TMP/home/.local/share/macprovider/autoupdate/pending.json"
-chmod 600 "$TMP/home/.local/share/macprovider/autoupdate/pending.json"
+# A durable pending updater marker with a future recovery deadline remains an
+# active transaction even after the updater process restarted and released its
+# kernel locks. Installer must wait for coordinator admission or rollback
+# recovery instead of overwriting it, and must name recover-update as the escape
+# hatch if it never completes (#1420).
+python3 - "$TMP/home/.local/share/macprovider/autoupdate/pending.json" future <<'PY'
+import datetime, json, os, sys
+path, kind = sys.argv[1], sys.argv[2]
+delta = datetime.timedelta(minutes=10) if kind == "future" else datetime.timedelta(minutes=-10)
+deadline = (datetime.datetime.now(datetime.timezone.utc) + delta).strftime("%Y-%m-%dT%H:%M:%SZ")
+fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+os.write(fd, (json.dumps({"marker_deadline": deadline}) + "\n").encode("utf-8"))
+os.close(fd)
+PY
 set +e
 run_lock_shell once > "$TMP/mutation-pending.out" 2> "$TMP/mutation-pending.err"
 mutation_pending_rc=$?
 set -e
 [ "$mutation_pending_rc" -eq 73 ]
 grep -F 'awaiting coordinator admission or recovery' "$TMP/mutation-pending.err" >/dev/null
+grep -F 'recover-update' "$TMP/mutation-pending.err" >/dev/null
+rm -f "$TMP/home/.local/share/macprovider/autoupdate/pending.json"
+
+# An expired or malformed marker is an abandoned transaction that nothing is
+# finishing. The installer must stop telling the operator to "wait" and instead
+# point at recover-update to clear the stale marker (#1420, acceptance 3). An
+# empty/malformed marker (no parseable marker_deadline) is treated as stale.
+printf '{}\n' > "$TMP/home/.local/share/macprovider/autoupdate/pending.json"
+chmod 600 "$TMP/home/.local/share/macprovider/autoupdate/pending.json"
+set +e
+run_lock_shell once > "$TMP/mutation-stale.out" 2> "$TMP/mutation-stale.err"
+mutation_stale_rc=$?
+set -e
+[ "$mutation_stale_rc" -eq 73 ]
+grep -F 'recover-update' "$TMP/mutation-stale.err" >/dev/null
+grep -F 'has passed' "$TMP/mutation-stale.err" >/dev/null
+if grep -F 'wait for it to finish' "$TMP/mutation-stale.err" >/dev/null; then
+  echo "stale marker message must not tell the operator to wait" >&2
+  exit 1
+fi
 rm -f "$TMP/home/.local/share/macprovider/autoupdate/pending.json"
 run_lock_shell once
 


### PR DESCRIPTION
## Summary

Fixes #1420. A Mac that has ever onboarded could not be cleanly reinstalled: `uninstall --yes --remove-config-and-logs` reported success but left artifacts that each blocked the next install with a **remedy-less** error. This makes uninstall idempotent w.r.t. reinstall and gives every refusal a runnable remedy.

An adversarial verification pass first confirmed the issue is substantively true, with two corrections to the report's own theory that shaped the fix:

- **Launchd leftover (Claim 1):** real, but the cause is a `bootout`→`print` *teardown race*, not "operator must unload first."
- **Keychain token (Claim 3):** the token does survive, but deleting it (as the report implies) would **violate SPEC-001** and make reinstall *worse*. The real reinstall blocker is the surviving `provider_id` + onboarding journal, so the fix is to make the preserved identity **safely reused**, not destroyed.

## Changes

**`phase3-binary/Sources/macprovider-cli/UninstallCommand.swift`**
- Fix the launchd `bootout`→`print` teardown race: `verifyServiceAbsent` now polls a bounded grace window for absence, still failing closed on a persistent status 0 and immediately on any indeterminate status (SPEC-001 absence proof preserved).
- Remove the autoupdate transaction residue (`<provider_state_root>/autoupdate`, i.e. `pending.json` + `update.lock`) once both launchd jobs are proven absent, so the next install is not falsely told "a provider update is awaiting coordinator admission or recovery". `provider_state_root` is decoded from the manifest and **constrained to the canonical `~/.local/share/macprovider`** (a tampered manifest cannot redirect removal off-tree).
- Name a runnable remedy in every refusal, and on the left-in-place cache warning.
- Make the `--remove-config-and-logs` help honest: identity (config `provider_id` + CLI credential, Keychain or protected-file) is preserved for safe reinstall per SPEC-001.

**`phase3-binary/dist/install.sh`**
- Classify the pending-update marker: a future `marker_deadline` is a genuine in-progress update (wait, with `recover-update` as the escape hatch); an expired/malformed marker is abandoned and points at `recover-update` instead of telling the operator to "wait for it to finish".
- **Reuse a surviving identity on reinstall:** when a config `provider_id` survives but no binary is installed and neither a referral code nor a replace was requested, defer the referral demand and let the freshly-staged CLI's `credentials verify` decide — an intact preserved credential is reused with no referral (avoiding `referral_conflict`); a missing/invalid one fails closed with an accurate remedy (restore the credential, or replace the identity with `MACPROVIDER_REFERRAL_REPLACE_INCUMBENT=1` + invite code). This check runs before *any* commit path (incl. donor/no-start).

## Tests

- Swift `UninstallCommandTests` (25): launchd teardown-lag tolerance; restarted-provider still fails closed; `provider_state_root` decode + off-tree fallback; autoupdate-residue path resolution.
- `dist/test/install_transaction_lock.test.sh`: active-vs-stale pending-marker message classification.
- `dist/test/install_referral_handoff.test.sh`: surviving-identity defer gate + explicit-invite non-defer.

## Audit

Three-lane codex audit (code / security / architecture) over the full combined diff, two passes. Final: **0 CRITICAL, 0 HIGH, 0 MEDIUM.** Security lane confirmed no referral-bypass and no secret printing. Architecture lane confirmed SPEC-001 alignment with no line-3 version bump required.

Carried LOWs (fail-closed, non-blocking):
- `isLaunchdAbsentStatus` treats launchctl `print` statuses 1/3 as absence in addition to 113 — **pre-existing** (this diff does not touch that function); tightening it risks fail-closing on genuine absence, which would regress the very refusal #1420 fixes.
- pending.json `lstat`→`open` is not descriptor-identity-checked (same-user, private dir; both branches still exit 73 — no fail-open).
- A future-deadline-but-otherwise-malformed pending marker is classed "active"; still fails closed and names `recover-update`.

## SPEC governance

Behavior change to the uninstall/install runtime paths; **no SPEC contract or manifest change.** Conforms to SPEC-001 uninstall absence-proof + identity-preservation prose (SPEC-001-phase3-binary.md:1099-1105) and SPEC-020 autoupdate recovery. There is no granular CONFORMANCE requirement dedicated to uninstall idempotency; the declaration below cites the governing specs and the closest existing autoupdate-recovery requirement (SPEC-020-R004) rather than fabricating one.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "issue": "https://github.com/Augustas11/macprovider/issues/1420",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-001", "SPEC-020"],
  "requirements": ["SPEC-020-R004"],
  "authority_domains": ["provider-autoupdate", "provider-onboarding-identity", "native-app-lifecycle"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "phase3-binary/Tests/macprovider-cliTests/UninstallCommandTests.swift:testStopLaunchdServicesToleratesBootoutTeardownLag",
    "phase3-binary/dist/test/install_transaction_lock.test.sh",
    "phase3-binary/dist/test/install_referral_handoff.test.sh"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
