### PR TITLE
Fill SPEC-045 status diagnostic ring

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift
@@ -4079,6 +4079,7 @@ struct ConsumeEndpointRuntime: Sendable {
     let pricingAdmissionGate: ConsumePricingAdmissionGate
     let now: @Sendable () -> Date
     let requestCounter: ConsumeEndpointRequestCounter
+    let diagnostics: ConsumeStatusDiagnostics
 
     init(
         launchID: String,
@@ -4109,6 +4110,7 @@ struct ConsumeEndpointRuntime: Sendable {
         self.pricingAdmissionGate = pricingAdmissionGate
         self.now = now
         self.requestCounter = requestCounter
+        self.diagnostics = ConsumeStatusDiagnostics()
     }
 
     func beginIncompleteConnection() -> Bool {
@@ -4155,6 +4157,7 @@ struct ConsumeEndpointRuntime: Sendable {
 
     func statusPayload() -> [String: Any] {
         let resourceSnapshot = requestCounter.resourceSnapshot()
+        let diagnosticSnapshot = diagnostics.snapshot()
         var payload: [String: Any] = [
             "schema_version": "local_consumer_endpoint.status.v1",
             "process_launch_id": launchID,
@@ -4170,8 +4173,8 @@ struct ConsumeEndpointRuntime: Sendable {
             "upstream_worker_task_count": resourceSnapshot.upstreamWorkerTasks,
             "upstream_socket_descriptor_count": resourceSnapshot.upstreamSocketDescriptors,
             "open_streaming_response_count": resourceSnapshot.openStreamingResponses,
-            "last_successful_upstream_contact_at": NSNull(),
-            "error_ring": [],
+            "last_successful_upstream_contact_at": diagnosticSnapshot.lastSuccessfulUpstreamContactAt ?? NSNull(),
+            "error_ring": diagnosticSnapshot.errorRing,
         ]
         for (key, value) in budget.statusFields(
             trustedPricing: trustedPricing.revalidated(now: now()),
@@ -4180,6 +4183,151 @@ struct ConsumeEndpointRuntime: Sendable {
             payload[key] = value
         }
         return payload
+    }
+}
+
+final class ConsumeStatusDiagnostics: @unchecked Sendable {
+    private let lock = NSLock()
+    private var lastSuccessfulUpstreamContactAt: String?
+    private var errorRing: [[String: Any]] = []
+
+    private static let maxErrorEntries = 100
+    private static let minErrorEntries = 5
+    private static let maxTotalBytes = 8 * 1024
+    private static let maxDiagnosticBodyBytes = 64 * 1024
+    private static let maxFieldBytes = [
+        "error_type": 48,
+        "error_code": 64,
+        "canonical_request_id": 40,
+    ]
+
+    func recordLocalError(code: String) {
+        append(errorType: "macprovider_local_error", errorCode: code, canonicalRequestID: nil)
+    }
+
+    func recordUpstreamContact(at date: Date) {
+        lock.lock()
+        lastSuccessfulUpstreamContactAt = ConsumeEndpointStatus.iso8601(date)
+        lock.unlock()
+    }
+
+    func recordUpstreamError(response: ConsumeUpstreamResponse) {
+        guard response.statusCode >= 400 else { return }
+        let headerRequestID = Self.firstRequestID(in: response.headers)
+        guard response.body.count <= Self.maxDiagnosticBodyBytes else {
+            append(
+                errorType: "upstream_error",
+                errorCode: "upstream_http_error",
+                canonicalRequestID: Self.canonicalRequestID(headerRequestID)
+            )
+            return
+        }
+        let parsed = Self.upstreamErrorFields(response.body)
+        append(
+            errorType: Self.safeErrorClass(parsed.errorType, fallback: "upstream_error"),
+            errorCode: Self.safeErrorClass(parsed.errorCode, fallback: "upstream_http_error"),
+            canonicalRequestID: Self.canonicalRequestID(headerRequestID ?? parsed.requestID)
+        )
+    }
+
+    func snapshot() -> (lastSuccessfulUpstreamContactAt: String?, errorRing: [[String: Any]]) {
+        lock.lock()
+        defer { lock.unlock() }
+        return (lastSuccessfulUpstreamContactAt, errorRing)
+    }
+
+    private func append(errorType: String, errorCode: String, canonicalRequestID: String?) {
+        var truncated = false
+        var entry: [String: Any] = [
+            "error_type": Self.boundedField(errorType, key: "error_type", truncated: &truncated),
+            "error_code": Self.boundedField(errorCode, key: "error_code", truncated: &truncated),
+        ]
+        if let canonicalRequestID {
+            entry["canonical_request_id"] = Self.boundedField(
+                canonicalRequestID,
+                key: "canonical_request_id",
+                truncated: &truncated
+            )
+        }
+        entry["truncated"] = truncated
+
+        lock.lock()
+        errorRing.append(entry)
+        pruneLocked()
+        lock.unlock()
+    }
+
+    private func pruneLocked() {
+        while errorRing.count > Self.maxErrorEntries {
+            errorRing.removeFirst()
+        }
+        while errorRing.count > Self.minErrorEntries && Self.encodedBytes(errorRing) > Self.maxTotalBytes {
+            errorRing.removeFirst()
+        }
+    }
+
+    private static func boundedField(_ value: String, key: String, truncated: inout Bool) -> String {
+        let maximum = maxFieldBytes[key] ?? 64
+        guard value.utf8.count > maximum else { return value }
+        truncated = true
+        var output = ""
+        output.reserveCapacity(maximum)
+        for scalar in value.unicodeScalars {
+            let next = String(scalar)
+            guard output.utf8.count + next.utf8.count <= maximum else { break }
+            output.append(next)
+        }
+        return output
+    }
+
+    private static func encodedBytes(_ ring: [[String: Any]]) -> Int {
+        (try? JSONSerialization.data(withJSONObject: ring, options: []).count) ?? Int.max
+    }
+
+    private static func upstreamErrorFields(_ body: Data) -> (errorType: String?, errorCode: String?, requestID: String?) {
+        guard let text = String(data: body, encoding: .utf8),
+              case .object(let root) = try? StrictJSONParser.parse(text),
+              case .object(let error)? = root["error"] else {
+            return (nil, nil, nil)
+        }
+        let errorType = stringValue(error["type"])
+        let errorCode = stringValue(error["code"])
+        let requestID = stringValue(error["request_id"])
+        return (errorType, errorCode, requestID)
+    }
+
+    private static func stringValue(_ value: JSONValue?) -> String? {
+        guard case .string(let string)? = value else { return nil }
+        return string.isEmpty ? nil : string
+    }
+
+    private static func firstRequestID(in headers: [(String, String)]) -> String? {
+        for preferred in ["x-macprovider-request-id", "x-request-id", "openai-request-id"] {
+            if let value = headers.first(where: { name, _ in name.caseInsensitiveCompare(preferred) == .orderedSame })?.1,
+               !value.isEmpty {
+                return value
+            }
+        }
+        return nil
+    }
+
+    private static func canonicalRequestID(_ requestID: String?) -> String? {
+        guard let requestID, !requestID.isEmpty else { return nil }
+        let digest = SHA256.hash(data: Data(requestID.utf8))
+        return "sha256:" + digest.prefix(16).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func safeErrorClass(_ value: String?, fallback: String) -> String {
+        guard let value,
+              !value.isEmpty,
+              value.unicodeScalars.allSatisfy({ scalar in
+                scalar.value == 95 || scalar.value == 45 || scalar.value == 46 ||
+                    (97...122).contains(scalar.value) ||
+                    (48...57).contains(scalar.value)
+              }) else {
+            return fallback
+        }
+        return value
     }
 }
 
@@ -4747,7 +4895,7 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
 
     private func handleHead(_ head: HTTPRequestHead, context: ChannelHandlerContext) {
         if head.method == .HEAD {
-            writeHeadOnly(context: context, status: .methodNotAllowed)
+            writeHeadOnly(context: context, status: .methodNotAllowed, code: "local_endpoint_unsupported")
             return
         }
         if let error = validatePreAuthBoundsAndFraming(head) {
@@ -6490,6 +6638,7 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
         forwardedUpstream: Bool = false,
         extraHeaders: [(String, String)] = []
     ) {
+        runtime.diagnostics.recordLocalError(code: code)
         writeJSON(
             context: context,
             status: status,
@@ -6566,6 +6715,7 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
         extraHeaders: [(String, String)]
     ) {
         guard !responseStarted else { return }
+        runtime.diagnostics.recordUpstreamContact(at: runtime.now())
         var headers = HTTPHeaders()
         for (name, value) in responseHeaders {
             let normalized = name.lowercased()
@@ -6614,6 +6764,8 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
         context: ChannelHandlerContext,
         extraHeaders: [(String, String)]
     ) {
+        runtime.diagnostics.recordUpstreamContact(at: runtime.now())
+        runtime.diagnostics.recordUpstreamError(response: response)
         var headers = HTTPHeaders()
         for (name, value) in response.headers {
             let normalized = name.lowercased()
@@ -6718,7 +6870,10 @@ final class ConsumeLocalHandler: ChannelInboundHandler, @unchecked Sendable {
         }
     }
 
-    private func writeHeadOnly(context: ChannelHandlerContext, status: HTTPResponseStatus) {
+    private func writeHeadOnly(context: ChannelHandlerContext, status: HTTPResponseStatus, code: String? = nil) {
+        if let code {
+            runtime.diagnostics.recordLocalError(code: code)
+        }
         var headers = HTTPHeaders()
         headers.add(name: "content-length", value: "0")
         headers.add(name: "connection", value: "close")

--- a/phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift
@@ -679,6 +679,157 @@ final class ConsumeCommandTests: XCTestCase {
         XCTAssertEqual(head.body, "")
     }
 
+    func testStatusDiagnosticsRecordBoundedRedactedErrorsAndContact() throws {
+        let token = try ConsumeLocalToken.generate()
+        let rawUpstreamRequestID = "upstream-request-id-that-must-not-appear-in-status"
+        let secretMessage = "buyer-token prompt and completion must stay out of diagnostics"
+        let upstreamClient = ConsumeStubUpstreamClient { _, eventLoop in
+            eventLoop.makeSucceededFuture(ConsumeUpstreamResponse(
+                statusCode: 429,
+                headers: [
+                    ("content-type", "application/json"),
+                    ("x-request-id", rawUpstreamRequestID),
+                ],
+                body: Data("""
+                {"error":{"message":"\(secretMessage)","type":"rate_limit_exceeded","param":null,"code":"UPSTREAM SECRET CODE","request_id":"body-request-id"}}
+                """.utf8)
+            ))
+        }
+        let fixedNow = ISO8601DateFormatter.autotuneInternet.date(from: "2026-08-23T12:34:56Z")!
+        let runtime = consumeRuntime(
+            token: token,
+            credentialStatus: .environmentLoaded,
+            credentialCustody: consumeCredentialCustody("buyer-token"),
+            budget: ConsumeBudgetConfig(mode: .noBudget, maxRequestMicroUSD: nil, allowUnpriced: false, ledger: nil, ledgerPathClass: nil),
+            trustedPricing: .available(phase3CTrustedRateCard(
+                promptRatePerMtok: 1,
+                completionRatePerMtok: 1,
+                usdPerMillionCredits: 1.0
+            )),
+            upstreamClient: upstreamClient,
+            now: { fixedNow }
+        )
+        var headers = HTTPHeaders()
+        headers.add(name: "Authorization", value: "Bearer \(token.value)")
+
+        let localFailure = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+            body: Data(#"{"model":"not-allowed","messages":[],"max_tokens":1}"#.utf8)
+        )
+        XCTAssertEqual(localFailure.status, .badRequest)
+
+        let upstreamFailure = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .POST, uri: "/v1/chat/completions", headers: headers),
+            body: Data(#"{"model":"llama-test","messages":[],"max_tokens":1}"#.utf8)
+        )
+        XCTAssertEqual(upstreamFailure.status, HTTPResponseStatus(statusCode: 429))
+
+        let headFailure = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .HEAD, uri: "/v1/status", headers: headers)
+        )
+        XCTAssertEqual(headFailure.status, .methodNotAllowed)
+        XCTAssertEqual(headFailure.body, "")
+
+        let status = try response(
+            from: runtime,
+            head: HTTPRequestHead(version: .http1_1, method: .GET, uri: "/v1/status", headers: headers)
+        )
+        XCTAssertEqual(status.status, .ok)
+        XCTAssertEqual(status.headers.first(name: "cache-control"), "no-store")
+        XCTAssertFalse(status.body.contains(token.value))
+        XCTAssertFalse(status.body.contains("buyer-token"))
+        XCTAssertFalse(status.body.contains(secretMessage))
+        XCTAssertFalse(status.body.contains(rawUpstreamRequestID))
+        XCTAssertFalse(status.body.contains("body-request-id"))
+        XCTAssertFalse(status.body.contains("UPSTREAM SECRET CODE"))
+
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(status.body.utf8)) as? [String: Any])
+        XCTAssertEqual(object["last_successful_upstream_contact_at"] as? String, ConsumeEndpointStatus.iso8601(fixedNow))
+        let ring = try XCTUnwrap(object["error_ring"] as? [[String: Any]])
+        XCTAssertEqual(ring.count, 3)
+        XCTAssertEqual(ring[0]["error_type"] as? String, "macprovider_local_error")
+        XCTAssertEqual(ring[0]["error_code"] as? String, "local_model_not_allowed")
+        XCTAssertEqual(ring[0]["truncated"] as? Bool, false)
+        XCTAssertNil(ring[0]["canonical_request_id"])
+        XCTAssertEqual(ring[1]["error_type"] as? String, "rate_limit_exceeded")
+        XCTAssertEqual(ring[1]["error_code"] as? String, "upstream_http_error")
+        XCTAssertEqual(ring[1]["truncated"] as? Bool, false)
+        let canonicalRequestID = try XCTUnwrap(ring[1]["canonical_request_id"] as? String)
+        XCTAssertTrue(canonicalRequestID.hasPrefix("sha256:"))
+        XCTAssertEqual(canonicalRequestID.utf8.count, 39)
+        XCTAssertEqual(ring[2]["error_type"] as? String, "macprovider_local_error")
+        XCTAssertEqual(ring[2]["error_code"] as? String, "local_endpoint_unsupported")
+        XCTAssertNil(ring[2]["canonical_request_id"])
+    }
+
+    func testStatusDiagnosticsBoundEntryCountAndFieldBytes() throws {
+        let diagnostics = ConsumeStatusDiagnostics()
+        for index in 0..<105 {
+            diagnostics.recordLocalError(code: "local_error_\(index)")
+        }
+
+        var snapshot = diagnostics.snapshot()
+        XCTAssertGreaterThanOrEqual(snapshot.errorRing.count, 5)
+        XCTAssertLessThanOrEqual(snapshot.errorRing.count, 100)
+        XCTAssertEqual(snapshot.errorRing.last?["error_code"] as? String, "local_error_104")
+        let encodedRing = try JSONSerialization.data(withJSONObject: snapshot.errorRing, options: [])
+        XCTAssertLessThanOrEqual(encodedRing.count, 8 * 1024)
+
+        diagnostics.recordLocalError(code: String(repeating: "a", count: 200))
+        snapshot = diagnostics.snapshot()
+        let last = try XCTUnwrap(snapshot.errorRing.last)
+        let errorCode = try XCTUnwrap(last["error_code"] as? String)
+        XCTAssertLessThanOrEqual(errorCode.utf8.count, 64)
+        XCTAssertEqual(last["truncated"] as? Bool, true)
+        let encodedEntry = try JSONSerialization.data(withJSONObject: last, options: [])
+        XCTAssertLessThanOrEqual(encodedEntry.count, 256)
+
+        let longSafeCode = String(repeating: "a", count: 200)
+        let upstreamDiagnostics = ConsumeStatusDiagnostics()
+        upstreamDiagnostics.recordUpstreamError(response: ConsumeUpstreamResponse(
+            statusCode: 429,
+            headers: [],
+            body: Data("""
+            {"error":{"type":"\(longSafeCode)","code":"\(longSafeCode)"}}
+            """.utf8)
+        ))
+        var upstreamRing = upstreamDiagnostics.snapshot().errorRing
+        XCTAssertEqual(upstreamRing.count, 1)
+        XCTAssertEqual(upstreamRing[0]["error_type"] as? String, String(repeating: "a", count: 48))
+        XCTAssertEqual(upstreamRing[0]["error_code"] as? String, String(repeating: "a", count: 64))
+        XCTAssertEqual(upstreamRing[0]["truncated"] as? Bool, true)
+
+        upstreamDiagnostics.recordUpstreamError(response: ConsumeUpstreamResponse(
+            statusCode: 429,
+            headers: [("x-request-id", "oversized-request-id-that-must-not-appear")],
+            body: Data("""
+            {"error":{"message":"\(String(repeating: "a", count: 5 * 1024))","type":"rate_limit_exceeded","code":"rate_limit_exceeded"}}
+            """.utf8)
+        ))
+        upstreamRing = upstreamDiagnostics.snapshot().errorRing
+        XCTAssertEqual(upstreamRing.count, 2)
+        XCTAssertEqual(upstreamRing[1]["error_type"] as? String, "rate_limit_exceeded")
+        XCTAssertEqual(upstreamRing[1]["error_code"] as? String, "rate_limit_exceeded")
+        let oversizedCanonicalRequestID = try XCTUnwrap(upstreamRing[1]["canonical_request_id"] as? String)
+        XCTAssertTrue(oversizedCanonicalRequestID.hasPrefix("sha256:"))
+        XCTAssertEqual(oversizedCanonicalRequestID.utf8.count, 39)
+
+        upstreamDiagnostics.recordUpstreamError(response: ConsumeUpstreamResponse(
+            statusCode: 429,
+            headers: [],
+            body: Data("""
+            {"error":{"message":"\(String(repeating: "a", count: 70 * 1024))","type":"rate_limit_exceeded","code":"rate_limit_exceeded"}}
+            """.utf8)
+        ))
+        upstreamRing = upstreamDiagnostics.snapshot().errorRing
+        XCTAssertEqual(upstreamRing.count, 3)
+        XCTAssertEqual(upstreamRing[2]["error_type"] as? String, "upstream_error")
+        XCTAssertEqual(upstreamRing[2]["error_code"] as? String, "upstream_http_error")
+    }
+
     func testPhase2RejectsUnsafeTargetsFramingAndBrowserOrigins() throws {
         let token = try ConsumeLocalToken.generate()
         let runtime = consumeRuntime(token: token)

--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -7039,16 +7039,19 @@
     {
       "requirement_id": "SPEC-045-R006",
       "spec_id": "SPEC-045",
-      "state": "conformant",
+      "state": "pending",
       "implementation": [
         "phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift:struct ConsumeStatusCommand",
         "phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift:func statusPayload",
+        "phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift:final class ConsumeStatusDiagnostics",
         "phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift:struct ConsumeEndpointDescriptor",
         "phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift:struct ConsumeStatusClient"
       ],
       "tests": [
         "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testStatusCommandNoEndpointUsesRedactedError",
         "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testStatusHandlerRequiresAuthSetsNoStoreAndRedacts",
+        "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testStatusDiagnosticsRecordBoundedRedactedErrorsAndContact",
+        "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testStatusDiagnosticsBoundEntryCountAndFieldBytes",
         "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testDescriptorWriteIsUserPrivateAndStatusPayloadIsRedacted",
         "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase3NoBudgetStatusUsesNullBudgetAmounts"
       ],
@@ -7057,19 +7060,18 @@
       ],
       "evidence": [
         {
-          "artifact": "commit:dc63ecec59593235593b3de003e567e007ddcdc8",
-          "source": null,
-          "captured_at": "2026-08-24",
-          "expires_at": "2027-08-24"
-        },
-        {
           "artifact": "sha256:991c30ba0f34377ec66c993e27e2a3dd6b47705acc2799f5cf973d2ebd434161",
           "source": "journeys/evidence/local-consumer-endpoint-20260824T060103Z.spec-045-r001-spec-045-r002-spec-045-r003-spec-045-r004-spec-045-r005-spec-045-r006-spec-045-r007-spec-045-r008.journey-result.signed.json",
           "captured_at": "2026-08-24",
           "expires_at": "2027-08-24"
         }
       ],
-      "gap": null
+      "gap": {
+        "verdict": "UNKNOWN",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/927",
+        "rationale": "Status diagnostics now report bounded local/upstream error classes and last upstream contact instead of placeholders. Local regression coverage does not replace refreshed commit evidence and signed local-consumer endpoint journey evidence for the changed status implementation."
+      }
     },
     {
       "requirement_id": "SPEC-045-R007",

--- a/specs/README.md
+++ b/specs/README.md
@@ -53,7 +53,7 @@ it can no longer drift. Do not hand-edit the table; edit each spec's
 | SPEC-042 | Pool Control Plane and Trusted-Pool Manifest | 0.0.30 | draft | complete | pending: 12 | [SPEC-042-pool-control-plane.md](SPEC-042-pool-control-plane.md) |
 | SPEC-043 | Trusted Pool Creator Onboarding MVP | 0.1.0 | normative | complete | pending: 12 | [SPEC-043-trusted-pool-creator-onboarding.md](SPEC-043-trusted-pool-creator-onboarding.md) |
 | SPEC-044 | Malibu Model Catalog Economics | 0.1.1 | draft | complete | pending: 12 | [SPEC-044-malibu-model-catalog-economics.md](SPEC-044-malibu-model-catalog-economics.md) |
-| SPEC-045 | Local Consumer Endpoint Mode | 0.1.0 | draft | complete | conformant: 4, pending: 4 | [SPEC-045-local-consumer-endpoint-mode.md](SPEC-045-local-consumer-endpoint-mode.md) |
+| SPEC-045 | Local Consumer Endpoint Mode | 0.1.0 | draft | complete | conformant: 3, pending: 5 | [SPEC-045-local-consumer-endpoint-mode.md](SPEC-045-local-consumer-endpoint-mode.md) |
 | SPEC-046 | Provider BYOM Discovery | 0.1.2 | draft | complete | pending: 8 | [SPEC-046-provider-byom-discovery.md](SPEC-046-provider-byom-discovery.md) |
 | SPEC-047 | Network Model Admission | 0.1.2 | draft | complete | pending: 8 | [SPEC-047-network-model-admission.md](SPEC-047-network-model-admission.md) |
 <!-- AUTOGEN:spec-index END -->


### PR DESCRIPTION
## Summary

- Replaces placeholder SPEC-045 local endpoint status diagnostics with a bounded in-memory diagnostic ring.
- Records local error code classes, upstream SPEC-006 error type/code classes, hashed upstream request ids when available, and the last successful upstream HTTP contact timestamp.
- Keeps diagnostics redacted: no bearer tokens, local tokens, credential material, prompts, completions, upstream error messages, body fragments, or raw upstream request ids are exposed.

## Behavior

- `GET /v1/status` now reports `last_successful_upstream_contact_at` after a syntactically valid upstream response is received.
- `error_ring` now contains bounded local/upstream error classes instead of always returning an empty array.
- `HEAD` rejections remain bodyless but still add `local_endpoint_unsupported` to diagnostics.
- Upstream diagnostic parsing is bounded to 64 KiB; larger upstream error bodies record only generic upstream class material.
- Safe but long upstream class strings are truncated with `truncated: true`; unsafe class strings fall back to generic redacted classes.

## Conformance

- SPEC-045-R006 is demoted from `conformant` to `pending` because this branch changes the mapped `statusPayload` implementation and the historical signed journey/commit evidence no longer attests the current status diagnostics code.
- The new tests are mapped to SPEC-045-R006, but they are local regression coverage only.
- No signed journey artifacts are added, and this PR does not promote production readiness.

## Tests

- `swift test --filter 'ConsumeCommandTests/testStatusDiagnostics'` passed: 2 tests, 0 failures.
- `swift test --filter ConsumeCommandTests` passed: 129 tests, 0 failures.
- `python3 scripts/check_spec_governance.py --base-ref origin/main` passed.
- `python3 scripts/check_spec_pr_declaration.py --event /tmp/spec045-status-error-ring-event.json --base origin/main --head HEAD` passed.
- `git diff --check` passed.
- `jq empty specs/AUTHORITY.json && jq empty specs/CONFORMANCE.json` passed.
- Code review lane: 0 Critical, 0 High, 0 Medium, 0 Low, 0 Info.
- Security review lane: 0 Critical, 0 High, 0 Medium, 0 Low, 0 Info.
- Architecture/spec-boundary review lane: 0 Critical, 0 High, 0 Medium, 0 Low, 0 Info.

## Known Gaps

- Live NWConnection callback/deadline races are not tested here.
- Refreshed signed gateway journey evidence is not captured here.
- Full Swift suite was not run.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": ["SPEC-045"],
  "requirements": ["SPEC-045-R006", "SPEC-045-R007", "SPEC-045-R008"],
  "authority_domains": ["local-consumer-endpoint"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "swift test --filter 'ConsumeCommandTests/testStatusDiagnostics'",
    "swift test --filter ConsumeCommandTests",
    "python3 scripts/check_spec_governance.py --base-ref origin/main",
    "python3 scripts/check_spec_pr_declaration.py --event /tmp/spec045-status-error-ring-event.json --base origin/main --head HEAD",
    "git diff --check",
    "jq empty specs/AUTHORITY.json && jq empty specs/CONFORMANCE.json",
    "code/security/architecture review lanes"
  ],
  "journeys": ["not-required; no signed journey artifact added"]
}
SPEC-GOVERNANCE-DECLARATION-END
