### PR TITLE
fix(install): stop false rollback_failed on fresh first install (#1421)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,6 +183,7 @@ test-dist:
 	bash phase3-binary/dist/test/install_fresh_evidence.test.sh
 	bash phase3-binary/dist/test/install_recommend_retry.test.sh
 	bash phase3-binary/dist/test/install_upgrade_evidence_rollback.test.sh
+	bash phase3-binary/dist/test/install_recovery_bootout_settle.test.sh
 	bash phase3-binary/dist/test/install_launchd_migration.test.sh
 	bash phase3-binary/dist/test/install_lifecycle_state.test.sh
 	bash phase3-binary/dist/test/install_transaction_lock.test.sh

--- a/phase3-binary/Sources/macprovider-cli/ProviderLifecycleState.swift
+++ b/phase3-binary/Sources/macprovider-cli/ProviderLifecycleState.swift
@@ -261,7 +261,18 @@ struct ProviderLifecycleStateRecord: Codable, Equatable, Sendable {
 
         guard let previous else { return }
         if previous.state == .uninstalled {
-            guard writer == .installer, state == .installing else {
+            // A prior uninstall left an `uninstalled` tombstone. The installer is
+            // the only writer allowed to drive lifecycle out of that state:
+            // normally it records `installing` to begin a fresh install, but a
+            // reinstall whose cutover fails before it reaches the `installing`
+            // checkpoint must still be able to persist the `rollback_in_progress`
+            // intermediate state. Forbidding it made the installer's own rollback
+            // silently fail to record its intent on exactly a reinstall-after-
+            // uninstall -- the precondition for the wedge class recovery exists to
+            // clear (#1421). Every other writer, and every other target state,
+            // stays fail-closed.
+            guard writer == .installer,
+                  state == .installing || state == .rollbackInProgress else {
                 throw ProviderLifecycleStateError.invalidTransition(from: previous.state.rawValue, to: state.rawValue)
             }
         }

--- a/phase3-binary/Tests/macprovider-cliTests/ProviderLifecycleStateTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ProviderLifecycleStateTests.swift
@@ -166,6 +166,67 @@ final class ProviderLifecycleStateTests: XCTestCase {
         XCTAssertNotEqual(resumed.previousTransitionID, restarting.transitionID)
     }
 
+    func testInstallerRecordsRollbackFromUninstalledForFailedReinstall() throws {
+        // #1421: a reinstall after an uninstall tombstone whose cutover fails
+        // before the `installing` checkpoint must still be able to persist the
+        // `rollback_in_progress` intermediate state, so the installer's rollback
+        // records its intent instead of silently failing (the wedge precondition).
+        let fixture = try Fixture()
+        let store = ProviderLifecycleStateStore(url: fixture.recordURL)
+        _ = try store.transition(
+            to: .uninstalled,
+            reasonCode: "uninstall_services_stopped",
+            writer: .installer,
+            operationID: "uninstall-1"
+        )
+        let rolledBack = try store.transition(
+            to: .rollbackInProgress,
+            reasonCode: "install_admission_failed",
+            writer: .installer,
+            operationID: "reinstall-1"
+        )
+        XCTAssertEqual(rolledBack.state, .rollbackInProgress)
+        XCTAssertEqual(try store.current()?.state, .rollbackInProgress)
+    }
+
+    func testUninstalledStaysFailClosedForNonInstallerAndForeignTargets() throws {
+        // The fail-closed guard must still reject every non-installer writer out
+        // of `uninstalled`, and reject installer transitions to states other
+        // than `installing`/`rollback_in_progress`.
+        let fixture = try Fixture()
+        let store = ProviderLifecycleStateStore(url: fixture.recordURL)
+        _ = try store.transition(
+            to: .uninstalled,
+            reasonCode: "uninstall_services_stopped",
+            writer: .installer,
+            operationID: "uninstall-1"
+        )
+        XCTAssertThrowsError(
+            try store.transition(
+                to: .rollbackInProgress,
+                reasonCode: "update_rollback",
+                writer: .updater,
+                operationID: "update-1"
+            )
+        )
+        XCTAssertThrowsError(
+            try store.transition(
+                to: .startingProvider,
+                reasonCode: "serve_invoked",
+                writer: .serve,
+                operationID: "serve-1"
+            )
+        )
+        XCTAssertThrowsError(
+            try store.transition(
+                to: .pausedByOperator,
+                reasonCode: "operator_pause_confirmed",
+                writer: .installer,
+                operationID: "installer-1"
+            )
+        )
+    }
+
     func testPausedStartupCanRestorePauseAfterModelLoad() throws {
         let fixture = try Fixture()
         let store = ProviderLifecycleStateStore(url: fixture.recordURL)

--- a/phase3-binary/dist/install.sh
+++ b/phase3-binary/dist/install.sh
@@ -6118,6 +6118,22 @@ stop_loaded_service() {
     || recovery_failed "$failure_message has an unexpected launchd identity"
   recovery_launchctl bootout "$REC_LAUNCHD_DOMAIN/$service_label" >/dev/null 2>&1 \
     || recovery_failed "$failure_message could not be stopped"
+  # launchd keeps reporting a just-booted-out service as loaded for a short
+  # window while it tears the job down. Wait for the unload to settle so the
+  # callers' post-bootout "still loaded" assertions -- and any re-bootstrap of
+  # the same label further down -- observe the true final state instead of
+  # racing the teardown. Without this, a failed first install (nothing was
+  # loaded before it) would boot out its own just-created service and then
+  # immediately fail recovery with "provider service is active even though it
+  # was inactive before the failed install", turning a clean rollback into a
+  # reported rollback failure. Mirrors the repair-preflight quiesce settle loop.
+  for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
+    service_loaded "$service_label" || return 0
+    sleep 0.1
+  done
+  service_loaded "$service_label" \
+    && recovery_failed "$failure_message remained loaded after bootout"
+  return 0
 }
 
 # Before the durable cutover marker exists, the installer has not touched the
@@ -7476,7 +7492,11 @@ rollback_install_transaction() {
   INSTALL_TX_ROLLING_BACK=1
   record_lifecycle_state rollback_in_progress install_admission_failed \
     || log "WARNING: could not persist rollback lifecycle state before restoring the previous install"
-  log "Install did not pass admission; restoring the previous provider installation."
+  if [ "$EXISTING_INSTALL_WAS_PRESENT" -eq 1 ]; then
+    log "Install did not pass admission; restoring the previous provider installation."
+  else
+    log "Install did not pass admission; removing the staged files from this failed first install (no previous installation to restore)."
+  fi
   if [ -n "$MANUAL_PID" ] && pid_is_live_non_zombie "$MANUAL_PID"; then
     if ! stop_owned_manual_provider "$MANUAL_PID" "$INSTALL_DIR/macprovider-cli"; then
       log "ERROR: could not stop and prove death of the failed manual provider process; recovery data was preserved at $INSTALL_TX_BACKUP"
@@ -7487,8 +7507,22 @@ rollback_install_transaction() {
   verify_headless_recovery_trust "$INSTALL_TX_BACKUP" \
     || die 70 "headless rollback recovery did not match its root-owned trust receipt"
   if ! bash "$INSTALL_TX_BACKUP/recover.sh"; then
-    log "ERROR: automatic rollback failed; recovery data was preserved at $INSTALL_TX_BACKUP"
-    log "Run exactly: bash '$INSTALL_TX_BACKUP/recover.sh'"
+    if [ "$EXISTING_INSTALL_WAS_PRESENT" -eq 1 ]; then
+      log "ERROR: automatic rollback did not complete on this attempt; recovery data was preserved at $INSTALL_TX_BACKUP"
+    else
+      log "ERROR: cleanup of this failed first install did not complete on this attempt; recovery data was preserved at $INSTALL_TX_BACKUP"
+    fi
+    # The interrupted-install recovery agent armed before cutover retries this
+    # recovery automatically once this installer exits, and removes the recovery
+    # directory once it succeeds -- so the path below is only valid while it
+    # still exists. Do not disarm it here; automatic retry is the recovery net.
+    log "An interrupted-install recovery agent is armed and will retry automatically after this installer exits; it removes the recovery data once recovery succeeds."
+    if [ "$EXISTING_INSTALL_WAS_PRESENT" -eq 1 ]; then
+      log "If the provider is still not restored after that, run: macprovider-cli recover-update"
+    else
+      log "If cleanup has not completed after that, re-running the installer is safe and will retire this recovery data and finish it."
+    fi
+    log "While it still exists, the preserved recovery script can also be run directly: bash '$INSTALL_TX_BACKUP/recover.sh'"
     INSTALL_TX_ROLLING_BACK=0
     return 70
   fi
@@ -7508,7 +7542,11 @@ rollback_install_transaction() {
     INSTALL_TX_ROLLING_BACK=0
     return 70
   fi
-  log "Previous provider files and service state were restored and verified."
+  if [ "$EXISTING_INSTALL_WAS_PRESENT" -eq 1 ]; then
+    log "Previous provider files and service state were restored and verified."
+  else
+    log "Staged files from the failed first install were removed and verified; no previous provider installation existed to restore."
+  fi
   INSTALL_TX_ACTIVE=0
   INSTALL_TX_ROLLING_BACK=0
 }

--- a/phase3-binary/dist/test/install_recovery_bootout_settle.test.sh
+++ b/phase3-binary/dist/test/install_recovery_bootout_settle.test.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Issue #1421: launchd keeps reporting a just-booted-out service as loaded for a
+# short window while it tears the job down. recover.sh's stop_loaded_service
+# used to bootout and then let the caller assert "still loaded?" with no settle
+# wait, so a failed FIRST install (nothing was loaded before it) would boot out
+# its own just-created service and immediately trip
+#   "provider service is active even though it was inactive before the failed install"
+# -> recovery_failed -> "automatic rollback failed" on a clean rollback.
+#
+# stop_loaded_service must wait for the unload to settle after bootout, succeed
+# once the service actually unloads, and still fail cleanly (bounded, no hang)
+# if the service genuinely stays loaded.
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+INSTALL_SH="$REPO_ROOT/phase3-binary/dist/install.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+python3 - "$INSTALL_SH" > "$TMP/functions.sh" <<'PY'
+import sys
+
+names = ["recovery_failed", "service_loaded", "service_identity_matches", "stop_loaded_service"]
+lines = open(sys.argv[1], encoding="utf-8").read().splitlines()
+for name in names:
+    found = False
+    for index, line in enumerate(lines):
+        if not line.startswith(name + "()"):
+            continue
+        found = True
+        depth = 0
+        for body_line in lines[index:]:
+            print(body_line)
+            depth += body_line.count("{") - body_line.count("}")
+            if depth == 0:
+                break
+        break
+    if not found:
+        raise SystemExit(f"{name} not found")
+PY
+
+[ -s "$TMP/functions.sh" ] || { echo "failed to extract recover.sh helpers" >&2; exit 1; }
+
+LABEL="live.malibu.provider"
+PLIST="/Library/LaunchDaemons/live.malibu.provider.plist"
+PROGRAM="/Users/example/.local/bin/macprovider-cli"
+
+# Harness: mock recovery_launchctl. "print" reports the service as loaded (exit
+# 0 + a valid identity block matching PROGRAM/PLIST) for the first
+# PRINT_LOADED_CALLS invocations, then reports it unloaded (exit 1). "bootout"
+# is logged and succeeds. sleep is a no-op so the settle loop runs instantly.
+run_stop() {
+  print_loaded_calls="$1"
+  identity_program="$2"
+  arg_shape="${3:-6}"   # 6 = provider (2 alternates + message); 5 = legacy/watchdog (1 alternate + message)
+  : > "$TMP/calls.log"
+  printf '%s\n' "$print_loaded_calls" > "$TMP/print-remaining"
+  PATH="/usr/bin:/bin" \
+  CALLS_LOG="$TMP/calls.log" PRINT_REMAINING_FILE="$TMP/print-remaining" \
+  FUNCTION_PATH="$TMP/functions.sh" RECOVERY_DIR="$TMP" \
+  REC_LAUNCHD_DOMAIN="system" ARG_SHAPE="$arg_shape" \
+  IDENTITY_PROGRAM="$identity_program" IDENTITY_PATH="$PLIST" \
+  LABEL="$LABEL" PLIST="$PLIST" PROGRAM="$PROGRAM" \
+  bash -c '
+    set -uo pipefail
+    recovery_log() { printf "%s\n" "$*" >> "$CALLS_LOG.log"; }
+    sleep() { :; }
+    recovery_launchctl() {
+      verb="$1"
+      printf "%s\n" "$verb" >> "$CALLS_LOG"
+      case "$verb" in
+        print)
+          remaining="$(cat "$PRINT_REMAINING_FILE")"
+          if [ "$remaining" -gt 0 ]; then
+            printf "%s\n" "$((remaining - 1))" > "$PRINT_REMAINING_FILE"
+            printf "\tprogram = %s\n\tpath = %s\n" "$IDENTITY_PROGRAM" "$IDENTITY_PATH"
+            return 0
+          fi
+          return 1
+          ;;
+        bootout) return 0 ;;
+        *) return 0 ;;
+      esac
+    }
+    # shellcheck disable=SC1090
+    source "$FUNCTION_PATH"
+    if [ "$ARG_SHAPE" = "5" ]; then
+      # Legacy/watchdog call shape: one alternate program, then the message.
+      stop_loaded_service "$LABEL" "$PLIST" "$PROGRAM" "" "the legacy service"
+    else
+      stop_loaded_service "$LABEL" "$PLIST" "$PROGRAM" "" "" "the transaction provider service"
+    fi
+  '
+}
+
+bootout_count() { grep -cx bootout "$TMP/calls.log" || true; }
+
+# 1. RACE (the fix): service still reports loaded for a few polls after bootout,
+#    then unloads. stop_loaded_service must settle and succeed (exit 0), having
+#    booted out exactly once -- NOT trip recovery_failed.
+#    2 loaded calls consumed before the settle loop (service_loaded +
+#    service_identity_matches), then 3 more loaded settle polls, then unloaded.
+if ! run_stop 5 "$PROGRAM" >/dev/null 2>&1; then
+  echo "FAIL(race): stop_loaded_service reported failure while the service was still settling after bootout" >&2
+  exit 1
+fi
+if [ "$(bootout_count)" -ne 1 ]; then
+  echo "FAIL(race): expected exactly 1 bootout, saw $(bootout_count)" >&2
+  exit 1
+fi
+# Regression guard: the pre-fix stop_loaded_service returned as soon as it booted
+# out, leaving the service still reporting loaded (the settling window unspent),
+# so the caller's post-bootout "still loaded?" assertion in recover.sh tripped.
+# The fixed function must not return until the unload has actually settled.
+remaining_after="$(cat "$TMP/print-remaining")"
+if [ "$remaining_after" -ne 0 ]; then
+  echo "FAIL(race): stop_loaded_service returned before the service finished unloading ($remaining_after loaded polls unspent); the caller's post-bootout assertion would still trip" >&2
+  exit 1
+fi
+
+# 2. GENUINE FAILURE (preserved): service never unloads. stop_loaded_service
+#    must give up cleanly (exit 70) after the bounded settle loop, not hang.
+if run_stop 999 "$PROGRAM" >/dev/null 2>&1; then
+  echo "FAIL(stuck): stop_loaded_service reported success even though the service stayed loaded after bootout" >&2
+  exit 1
+fi
+rc=0
+run_stop 999 "$PROGRAM" >/dev/null 2>&1 || rc=$?
+if [ "$rc" -ne 70 ]; then
+  echo "FAIL(stuck): expected recovery_failed exit 70 for a service that never unloads, saw $rc" >&2
+  exit 1
+fi
+
+# 3. ALREADY UNLOADED (fast path): service not loaded from the start. Must
+#    return 0 without booting anything out.
+if ! run_stop 0 "$PROGRAM" >/dev/null 2>&1; then
+  echo "FAIL(fastpath): stop_loaded_service failed for an already-unloaded service" >&2
+  exit 1
+fi
+if [ "$(bootout_count)" -ne 0 ]; then
+  echo "FAIL(fastpath): expected 0 bootouts for an already-unloaded service, saw $(bootout_count)" >&2
+  exit 1
+fi
+
+# 4. IDENTITY MISMATCH (preserved): service loaded but with a foreign launchd
+#    identity. Must recovery_failed (exit 70) and never bootout.
+rc=0
+run_stop 5 "/opt/foreign/macprovider-cli" >/dev/null 2>&1 || rc=$?
+if [ "$rc" -ne 70 ]; then
+  echo "FAIL(identity): expected recovery_failed exit 70 on an unexpected launchd identity, saw $rc" >&2
+  exit 1
+fi
+if [ "$(bootout_count)" -ne 0 ]; then
+  echo "FAIL(identity): must not bootout a service whose identity did not match, saw $(bootout_count)" >&2
+  exit 1
+fi
+
+# 5. LEGACY/WATCHDOG 5-ARG SHAPE: the fix lives in the shared helper, which is
+#    also called with the 5-argument (one-alternate) shape for legacy/watchdog
+#    labels. The same settle-then-succeed behavior must hold there.
+if ! run_stop 5 "$PROGRAM" 5 >/dev/null 2>&1; then
+  echo "FAIL(5-arg): stop_loaded_service failed for the legacy/watchdog call shape while settling" >&2
+  exit 1
+fi
+if [ "$(bootout_count)" -ne 1 ]; then
+  echo "FAIL(5-arg): expected exactly 1 bootout for the legacy/watchdog shape, saw $(bootout_count)" >&2
+  exit 1
+fi
+if [ "$(cat "$TMP/print-remaining")" -ne 0 ]; then
+  echo "FAIL(5-arg): stop_loaded_service returned before the legacy/watchdog service finished unloading" >&2
+  exit 1
+fi
+
+echo "install_recovery_bootout_settle: OK"

--- a/phase3-binary/dist/test/install_upgrade_evidence_rollback.test.sh
+++ b/phase3-binary/dist/test/install_upgrade_evidence_rollback.test.sh
@@ -1248,7 +1248,14 @@ assert_recovery_preserved() {
   [ -x "$recovery/observe.sh" ]
   grep -F 'REC_INSTALL_RECOVERY_LABEL=live.malibu.provider-install-recovery' "$recovery/state.sh" >/dev/null
   grep -F 'fcntl.flock(lock_fd, fcntl.LOCK_EX)' "$recovery/observe.sh" >/dev/null
-  grep -F "Run exactly: bash '$recovery/recover.sh'" "$root/stderr.log" >/dev/null
+  # Issue #1421: when automatic rollback did not complete on this attempt the
+  # operator must still be pointed at a remedy that works. The preserved
+  # recover.sh path is surfaced (only valid while it exists, because the armed
+  # recovery agent retires the directory once it succeeds), alongside the
+  # durable `macprovider-cli recover-update` fallback that survives the
+  # directory being removed.
+  grep -F "bash '$recovery/recover.sh'" "$root/stderr.log" >/dev/null
+  grep -F 'macprovider-cli recover-update' "$root/stderr.log" >/dev/null
 }
 
 # Happy rollback: every old path and the active service are verified before the


### PR DESCRIPTION
Fixes #1421.

## What was reported
During 1.8.120 physical acceptance (#1396 finding 2), every failed install that
**reached service start** reported an automatic-rollback FAILURE even when the
rollback was clean, and the printed `recover.sh` remediation was often already
gone by the time an operator ran it. A benign `could not persist rollback
lifecycle state` warning was also observed.

## Root causes (verified against `main`, not the 1.8.117-era baseline the report was taken on)
1. **Bootout race.** `recover.sh`'s `stop_loaded_service` booted out a
   just-created service and the caller asserted `service_loaded` with **no settle
   wait**. launchd keeps reporting a booted-out service as loaded for a short
   window, so a failed *first* install (nothing was loaded before it) tripped
   `provider service is active even though it was inactive before the failed
   install` → `recover.sh` exit 70 → `automatic rollback failed` on a clean
   rollback. The installer's own repair-preflight path already polls up to 2s
   after bootout; `recover.sh` did not.
2. **Stale remediation.** On `recover.sh` failure, `rollback_install_transaction`
   printed `Run exactly: bash <dir>/recover.sh` and returned **without** disarming
   the interrupted-install recovery agent. That agent (`observe.sh`) takes the
   same install lock, re-runs `recover.sh` after the installer exits, and on
   success `rmtree`s the recovery dir — so the printed path went stale.
3. **Fresh-install wording.** A failed first install (`EXISTING_INSTALL_WAS_PRESENT=0`)
   used upgrade-shaped wording ("restoring the previous provider installation").
4. **Lifecycle guard.** The state machine only allowed `uninstalled → installing
   (installer)`. A reinstall-after-uninstall whose cutover fails *before* the
   `installing` checkpoint then tried `uninstalled → rollback_in_progress
   (installer)`, which was rejected — so the installer's rollback silently failed
   to persist its intent (the observed warning). NB: the report's "on every
   attempt, including successful ones" is not reproducible on `main` — the string
   lives only in the rollback path.

## The fix
- `stop_loaded_service`: bounded post-bootout settle loop (20×0.1s) mirroring the
  repair-preflight quiesce loop; fails closed if the service never unloads.
- `rollback_install_transaction`: branch wording on `EXISTING_INSTALL_WAS_PRESENT`;
  on `recover.sh` failure keep the recovery agent armed and print an accurate
  remedy (armed auto-retry; `recover-update` for upgrades / re-run installer for
  fresh; `recover.sh` path while it exists).
- `ProviderLifecycleState.swift`: extend the fail-closed guard to allow
  **installer-only** `uninstalled → {installing, rollback_in_progress}`. Every
  other writer and target state stays fail-closed.

## Tests
- New `install_recovery_bootout_settle.test.sh` — race settles+succeeds,
  never-unloads fails closed, already-unloaded fast path, foreign-identity
  no-bootout, 5-arg legacy shape. Proven to **fail** against the pre-fix helper.
  Wired into `make test-dist`.
- `ProviderLifecycleStateTests` — installer rollback-from-uninstalled allowed;
  non-installer / foreign-target stays fail-closed.
- Updated `install_upgrade_evidence_rollback.test.sh` for the new remediation.
- Full local suites green: settle test, upgrade rollback fault matrix,
  ProviderLifecycleStateTests (19), ProviderLifecycleShellConformanceTests (17),
  UninstallCommandTests (25), `swift build`.

## Audit (full combined diff, 3 lanes)
Code 0/0/0 · Security 0/0/0 · Architecture 0/0/0. Security lane explicitly
confirmed the guard change keeps every non-installer writer fenced and adds no
stale-writer overwrite path.

Carried LOWs (non-blocking):
- Remediation prints `macprovider-cli recover-update` unqualified (consistent
  with existing installer guidance; no injection/escalation — same operator,
  fixed string). Defense-in-depth absolute-path printing is a separate pattern.
- The fresh-install rollback wording branch is exercised via the shared code
  paths but not a dedicated fault-matrix case (the matrix harness is
  upgrade-shaped); the branch is a simple message selection.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "issue": "https://github.com/Augustas11/macprovider/issues/1421",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-001", "SPEC-020"],
  "requirements": ["SPEC-020-R004"],
  "authority_domains": ["provider-autoupdate", "native-app-lifecycle"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "phase3-binary/dist/test/install_recovery_bootout_settle.test.sh",
    "phase3-binary/dist/test/install_upgrade_evidence_rollback.test.sh",
    "phase3-binary/Tests/macprovider-cliTests/ProviderLifecycleStateTests.swift::testInstallerRecordsRollbackFromUninstalledForFailedReinstall",
    "phase3-binary/Tests/macprovider-cliTests/ProviderLifecycleStateTests.swift::testUninstalledStaysFailClosedForNonInstallerAndForeignTargets"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
