### PR TITLE
feat(governance): BYOM signed-journey evidence capture, builders, and validators (#1248)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ test-integration:
 test-dist:
 	PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v scripts.tests.test_upstream_watch
 	PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v scripts.tests.test_byom_contract_lock
+	PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v scripts.tests.test_byom_journey_evidence
 	node --test phase3-binary/app/Tests/MalibuTests/payout-signer-chain.test.mjs
 	bash scripts/test-production-exceptions.sh
 	bash scripts/test-coordinator-advertised-version-test.sh

--- a/audits/2026-09-08-byom-gates/AUDIT_1248_JOURNEY_EVIDENCE_PROMPT.md
+++ b/audits/2026-09-08-byom-gates/AUDIT_1248_JOURNEY_EVIDENCE_PROMPT.md
@@ -1,0 +1,32 @@
+# Audit — BYOM signed-journey evidence tooling (#1248, parent #1240)
+
+METHOD CONSTRAINT (read first): this is a first-party software-correctness and governance-proof review. Do NOT author or construct malformed/adversarial payloads. Evaluate by reading source and running the EXISTING tests (`PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts.tests.test_byom_journey_evidence`, `python3 scripts/check_spec_governance.py`). Describe any gap abstractly (field + condition) in prose.
+
+Review the COMPLETE diff of this branch as it will land: `git diff origin/main...HEAD` (4 commits on `feat/1248-byom-journey-evidence`). Review every file.
+
+## What the change does
+Epic gate #1248 requires `JOURNEY-PROVIDER-BYOM-DISCOVERY` and `JOURNEY-NETWORK-MODEL-ADMISSION` signed evidence through the repo governance path before SPEC-046/047 conformance promotion. Today those journeys have contracts in `journeys/*.md` but no capture/build tooling and no governance registration. This branch adds:
+- `scripts/byom_journey_evidence.py` — shared contract: journey tables, redaction scanner, run-manifest → redacted evidence, evidence → journey-result payload.
+- `scripts/capture-byom-journey-evidence.py`, `scripts/build-byom-discovery-journey-result.py`, `scripts/build-network-model-admission-journey-result.py`.
+- Registration of both journey ids and their step ids / requirement mapping / evidence schemas in `scripts/check_spec_governance.py`.
+- Golden fixtures + 36 unit tests (`scripts/tests/test_byom_journey_evidence.py`), wired into `make test-dist`.
+- `docs/runbooks/byom-journey-evidence.md` operator sequence (capture → build → sign with the acceptance key → preflight → promote → reconcile).
+It does NOT touch `specs/CONFORMANCE.json` states or evidence, nor the SPEC texts, and does not sign anything.
+
+## Invariants to verify (challenge them)
+- Step ids and execution modes come verbatim from `journeys/JOURNEY-PROVIDER-BYOM-DISCOVERY.md` and `journeys/JOURNEY-NETWORK-MODEL-ADMISSION.md`; a manifest missing ANY normative step must be rejected (a partial hermetic run cannot yield promotable evidence).
+- Per-step → requirement-id mapping is derived from SPEC-046 §3 / SPEC-047 §3; the union must cover all eight requirements per spec or capture fails. Check the mapping is faithful, not padded.
+- `observations.money_path_zero_rows` (ten coordinator tables) must be integer 0 each; `False`/strings/missing must be rejected.
+- Redaction: evidence must fail closed on any URL, absolute path, token-shaped string, or hostname; digests only, never captured CLI documents.
+- Nothing here can promote a requirement or write evidence rows without a valid signature verified against `security/acceptance-candidate-signing-public.pem` via the existing `promote-signed-journey-result.py` path; the new builders must not create a bypass.
+- No secrets, no key material, no new dependencies (stdlib only), noninteractive for CI.
+- `check_spec_governance.py` changes must not weaken validation of the pre-existing journeys (run the neighbouring `scripts.tests.test_*journey*` suites).
+
+## Lanes to report (this pass is: {{LANE}})
+Report findings as CRITICAL / HIGH / MEDIUM / LOW / INFO. The merge bar is 0 CRITICAL, 0 HIGH, 0 MEDIUM.
+
+- CODE: correctness of manifest→evidence→payload transforms; schema validity against `JOURNEY_RESULT_PAYLOAD_SCHEMA`; error paths; test adequacy (do the 36 tests actually exercise rejection paths, or only happy paths?); Makefile wiring.
+- SECURITY: redaction completeness; any path by which unsigned or partial evidence becomes promotable; signature/key-id/fingerprint handling in the builders; injection via manifest fields into governance output; secret handling in the runbook.
+- ARCHITECTURE: single source of truth for step ids / requirement mappings (duplicated between `byom_journey_evidence.py` and `check_spec_governance.py`?); consistency with the sibling builders (prebeta, local-consumer-endpoint); whether `environment.class` (hermetic-loopback vs physical-provider) is the right seam; drift between journey contracts and tooling.
+
+End with a line `VERDICT: <N> CRITICAL / <N> HIGH / <N> MEDIUM / <N> LOW / <N> INFO`. Be specific: cite file:line. Do not invent issues to fill a lane.

--- a/audits/2026-09-08-byom-gates/AUDIT_1248_JOURNEY_EVIDENCE_R1.md
+++ b/audits/2026-09-08-byom-gates/AUDIT_1248_JOURNEY_EVIDENCE_R1.md
@@ -120,4 +120,7 @@ No SPEC file and no `specs/CONFORMANCE.json` row was touched by this pass.
 VERDICT: 0 CRITICAL / 0 HIGH / 0 MEDIUM / 0 LOW / 0 INFO (architecture lane, R1
 findings resolved)
 
-code-reviewer and security-reviewer lanes: pending
+code-reviewer and security-reviewer lanes: run in R2. All three R2 lanes
+(architecture, security, code review), their two MEDIUM findings, and the
+resolutions are recorded in
+`audits/2026-09-08-byom-gates/AUDIT_1248_JOURNEY_EVIDENCE_R2.md`.

--- a/audits/2026-09-08-byom-gates/AUDIT_1248_JOURNEY_EVIDENCE_R1.md
+++ b/audits/2026-09-08-byom-gates/AUDIT_1248_JOURNEY_EVIDENCE_R1.md
@@ -1,0 +1,123 @@
+# AUDIT 1248 — BYOM signed-journey evidence tooling — R1
+
+**Date:** 2026-09-08 · **Branch:** `feat/1248-byom-journey-evidence` ·
+**Issue:** #1248 (parent epic #1240) · **Specs:** SPEC-046, SPEC-047
+
+Prompt: `audits/2026-09-08-byom-gates/AUDIT_1248_JOURNEY_EVIDENCE_PROMPT.md`.
+Scope: the full branch diff `origin/main...HEAD` for the capture → build →
+governance pipeline (`scripts/byom_journey_evidence.py`,
+`scripts/capture-byom-journey-evidence.py`, the two builders,
+`scripts/check_spec_governance.py` registration, the unit suite and golden
+fixtures, and `docs/runbooks/byom-journey-evidence.md`).
+
+Architecture lane verdict on R1 input: **0 CRITICAL / 0 HIGH / 3 MEDIUM / 0 LOW /
+0 INFO**. All three MEDIUMs are resolved below.
+
+## MEDIUM 1 — Builder could overclaim from hand-authored redacted evidence
+
+**Finding.** The builder selected promotable requirements from the top-level
+`evidence.requirement_ids` and checked only that the named steps existed. It did
+not revalidate each step's `requirement_ids` nor recompute the union, so redacted
+evidence written by hand (rather than emitted by capture) could declare a
+requirement its steps never exercised and still reach the signer.
+
+**Resolution.** One shared evidence-step validator, used by both sides.
+
+- `scripts/byom_journey_evidence.py:468` — `validate_evidence_steps()` is now the
+  only step validator. It requires the exact step-key set for the journey
+  (unknown id, duplicate id, and missing id all fail), requires `status == "pass"`
+  and `artifacts == [artifact_id]`, validates every per-step requirement id
+  against `JourneyContract.allowed_step_requirement_ids()`, revalidates the
+  captured-document digest entries, recomputes the union of the per-step
+  requirement ids, and fails unless that union covers every promotable
+  requirement (all eight per journey).
+- `scripts/byom_journey_evidence.py:567` — capture's `_require_manifest_steps()`
+  now only maps run-manifest steps to evidence steps (digesting the captured
+  documents) and delegates every contract check to the shared validator at
+  `scripts/byom_journey_evidence.py:597`. No duplicated validation logic remains.
+- `scripts/byom_journey_evidence.py:761` — `build_journey_result_payload()` runs
+  the same validator over the committed evidence, then requires the top-level
+  `evidence.requirement_ids` to be unique and to equal the recomputed union
+  (`scripts/byom_journey_evidence.py:768`) before `parse_requirement_ids()` can
+  select anything. The signed payload's steps are projected from the validated
+  steps at `scripts/byom_journey_evidence.py:809`.
+
+**Rejection tests** (all fail against the pre-fix module):
+`scripts/tests/test_byom_journey_evidence.py:469` extra step,
+`:477` missing step, `:483` per-step id outside the allowed set,
+`:489` top-level ids ≠ union, `:497` top-level ids padded with a foreign id,
+`:503` evidence that stops covering every mapped requirement.
+
+## MEDIUM 2 — Captured CLI documents were scanned for credentials only
+
+**Finding.** `_digest_document()` ran only `reject_secret_like_text()` over the
+captured CLI JSON, while the module's redaction contract and `assert_redacted()`
+fail closed on URLs, absolute and `~/`-relative paths, hostnames, IP literals,
+`localhost`, and credentials. The document digest is what the signed result binds
+to, so the redaction claim was weaker than advertised for exactly those bytes.
+
+**Resolution.** `scripts/byom_journey_evidence.py:459` now applies the full
+`reject_unredacted_text()` scan to every captured document before digesting it.
+
+**Allowlist decision: none — fail closed.** No raw-document field is exempted.
+The committed golden fixtures under
+`scripts/tests/fixtures/byom_journeys/*/captures/` carry no URL, path, hostname,
+or IP, and the CLI documents these journeys capture (discovery listings,
+evaluation verdicts, offer dry-runs, admission status, withdrawal, catalog
+economics) do not need one. A document that legitimately contains an endpoint or
+a local path is a document the operator redacts before capture; capture refuses
+the whole run otherwise. This is stated in the code comment at
+`scripts/byom_journey_evidence.py:452` and in the runbook's redaction posture at
+`docs/runbooks/byom-journey-evidence.md:47`.
+
+**Rejection tests:** `scripts/tests/test_byom_journey_evidence.py:211` URL,
+`:217` absolute path, `:223` hostname, `:229` IPv4 literal, `:235` localhost —
+alongside the pre-existing credential case at `:192`.
+
+## MEDIUM 3 — Runbook signing command did not match the signer CLI
+
+**Finding.** Step 6 showed a positional unsigned-payload argument and described
+`MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM` as `<path-or-env-indirect>`, but
+`scripts/sign-journey-result.py:153` requires `--input` and `read_private_key()`
+(`scripts/sign-journey-result.py:66`) reads the variable as PEM contents. The
+sequence was not executable as written.
+
+**Resolution.** `docs/runbooks/byom-journey-evidence.md:159` now states that the
+env var carries the PEM contents — not a path and not the name of another
+variable — and matches how the sibling `promote-signed-*-journey.yml` workflows
+set it; the command at `docs/runbooks/byom-journey-evidence.md:168` uses `--input`
+and notes that `--output` must resolve under `journeys/evidence/`. While checking
+the sequence end to end, Step 7 was also found to omit the required `--base-ref`
+of `scripts/promote-signed-journey-result.py`; it is added at
+`docs/runbooks/byom-journey-evidence.md:184`.
+
+**Executed against the golden fixtures** (non-signing steps, in a scratch
+repository; nothing promoted):
+
+- Step 3 capture, discovery and admission — both wrote the redacted artifact.
+- Step 4 build, both builders — the discovery payload covered
+  `SPEC-046-R001..R008` across all 10 steps.
+- Step 5 preflight — `1 requirement(s) match current selectors at ae8c847b`.
+- Step 6 argument shape — with the key env var unset the signer parsed
+  `--input`/`--output`, validated the payload, and failed only at
+  `protected signing key env var is required`.
+- Step 7 argument shape — the documented flag set was accepted and failed only on
+  the deliberately absent envelope file.
+
+## Verification
+
+| Gate | Result |
+|---|---|
+| `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts.tests.test_byom_journey_evidence` | 47 tests, OK (36 → 47) |
+| `python3 scripts/check_spec_governance.py` | SPEC governance validation passed |
+| `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts.tests.test_spec_governance scripts.tests.test_journey_result_tools scripts.tests.test_provider_prebeta_journey_result scripts.tests.test_local_consumer_endpoint_journey_result` | 121 tests, OK |
+| `python3 scripts/gen_spec_index.py --lint` | ok: specs/ root is canonical-only (51 tracked) |
+
+No SPEC file and no `specs/CONFORMANCE.json` row was touched by this pass.
+
+## Verdict
+
+VERDICT: 0 CRITICAL / 0 HIGH / 0 MEDIUM / 0 LOW / 0 INFO (architecture lane, R1
+findings resolved)
+
+code-reviewer and security-reviewer lanes: pending

--- a/audits/2026-09-08-byom-gates/AUDIT_1248_JOURNEY_EVIDENCE_R2.md
+++ b/audits/2026-09-08-byom-gates/AUDIT_1248_JOURNEY_EVIDENCE_R2.md
@@ -1,0 +1,224 @@
+# AUDIT 1248 — BYOM signed-journey evidence tooling — R2
+
+**Date:** 2026-09-08 · **Branch:** `feat/1248-byom-journey-evidence` ·
+**Issue:** #1248 (parent epic #1240) · **Specs:** SPEC-046, SPEC-047
+
+Prompt: `audits/2026-09-08-byom-gates/AUDIT_1248_JOURNEY_EVIDENCE_PROMPT.md`.
+R1 record: `audits/2026-09-08-byom-gates/AUDIT_1248_JOURNEY_EVIDENCE_R1.md`.
+Scope: the full branch diff `origin/main...HEAD` (five commits, rebased onto
+`3d97de18`), re-run after the R1 fixes.
+
+## Lane verdicts on R2 input
+
+| Lane | Verdict |
+|---|---|
+| architecture | 0 CRITICAL / 0 HIGH / 1 MEDIUM / 1 LOW / 0 INFO |
+| security | 0 CRITICAL / 0 HIGH / 1 MEDIUM / 0 LOW / 0 INFO |
+| code review | 0 CRITICAL / 0 HIGH / 2 MEDIUM / 0 LOW / 0 INFO |
+
+All three lanes verified the R1 resolutions (shared `validate_evidence_steps()`
+used by capture and both builders, the full redaction scan over captured
+documents before digesting, and the runbook signing/promote commands) and did not
+re-report them. All three lanes also confirmed there is no unsigned-promotion
+bypass: the builders emit unsigned payloads only, and promotion still requires a
+verified acceptance signature.
+
+The three lanes converge on two distinct findings. The architecture lane's LOW is
+the same defect as MEDIUM B, so closing B closes it.
+
+## MEDIUM A — Redaction scanner was narrower than its advertised fail-closed contract
+
+**Finding.** The module comment and the runbook both promise the evidence fails
+closed on *any* hostname and on anything shaped like a credential. Two rules did
+not hold up:
+
+- Hostname detection was a fixed suffix allowlist —
+  `com|net|org|io|ai|app|dev|cloud|tech|local|internal`. A DNS-looking hostname
+  with any other suffix (`provider-mac.xyz`, `pool.example.co.uk`,
+  `provider-mac.lan`, `mac-mini.home`, `provider-mac.corp`) passed both
+  `assert_redacted()` and the captured-document scan in `_digest_document()`.
+- The credential patterns were narrower than the sibling governance scanner in
+  `scripts/check_spec_governance.py`. Most concretely, the BYOM `sk-` shape was
+  `\bsk-[A-Za-z0-9]{20,}\b` while the sibling already covered
+  `\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}\b`, so `sk-proj-…` and any `sk-` token
+  carrying `_` or `-` passed. The sibling also applied its whole pattern set
+  case-insensitively; BYOM did not.
+- Only the IPv6 *loopback* literal `::1` was detected; other IPv6 literals were not.
+
+**Resolution — one shape-based rule plus one explicit, tested allowlist.**
+
+*Single source of truth for credential shapes.*
+`scripts/check_spec_governance.py:271` now defines
+`CREDENTIAL_SHAPE_PATTERN_FRAGMENTS`, the shapes credential material takes
+independent of the field carrying it.
+`LOCAL_CONSUMER_ENDPOINT_FORBIDDEN_METADATA_RE`
+(`scripts/check_spec_governance.py:291`) is recomposed from its own
+credential-bearing field-name fragments
+(`scripts/check_spec_governance.py:281`) plus that shared tuple, so its behaviour
+is unchanged. `scripts/byom_journey_evidence.py:128` compiles the same fragments
+(case-insensitively) and appends only the two BYOM-specific extras that have no
+sibling counterpart (`authorization: bearer …` at the tighter 8-character
+threshold, and `provider-token-…`). The BYOM scanner can no longer drift narrower
+than the sibling.
+
+*Hostname rule.* `scripts/byom_journey_evidence.py:83` replaces the suffix list
+with `DNS_HOSTNAME_RE`: one or more `label.` groups followed by a purely
+alphabetic final label of 2–63 characters, with lookarounds that stop a match from
+starting or ending mid-token. Any TLD is rejected.
+`scripts/byom_journey_evidence.py:338` applies it per match through
+`reject_hostname_like_text()`, which is reached from `reject_unredacted_text()`
+(`scripts/byom_journey_evidence.py:345`) and therefore from both
+`assert_redacted()` and the captured-document scan.
+
+*IP literals.* `scripts/byom_journey_evidence.py:89` adds `IPV6_LITERAL_RE`
+covering the full and compressed IPv6 forms (the previous `::1`-only rule is a
+subset of it); the IPv4 rule is unchanged. URLs, absolute paths and `~/` paths
+were already covered and remain so
+(`scripts/byom_journey_evidence.py:117`).
+
+**Allowlist decision — exactly one value shape, applied per match.**
+`HOSTNAME_ALLOWLISTED_VALUE_SHAPES` (`scripts/byom_journey_evidence.py:111`)
+admits a repository source **file name**, `<name>.<known-extension>`. That is the
+only DNS-shaped value the contract legitimately emits: the evidence records
+`harness.name` verbatim (`test/e2e/byom/run-cli-onboarding-e2e.py` in the golden
+fixtures), and a file name is indistinguishable from a two-label hostname by
+shape. An unlisted extension still fails closed
+(`scripts/tests/test_byom_journey_evidence.py:898`).
+
+Every other value shape the audit called out needs no allowlist entry, because it
+is not DNS-shaped under the new rule and never reaches the allowlist: schema ids
+end in `v1`/`v<N>` (`macprovider.provider-byom-discovery-evidence.v1`,
+`provider_byom_discovery.v1`), step ids and requirement ids carry no dot
+(`step-01-discover-mlx-cache`, `SPEC-046-R008`), `SnapshotManifestV1` carries no
+dot, and semantic and CLI versions end in a numeric label (`1.8.117`, `v1.2.3`,
+`0.0.0-fixture`). This was verified empirically over the committed golden
+fixtures before the rule was chosen, and is now pinned by
+`scripts/tests/test_byom_journey_evidence.py:865`.
+
+**Rejection tests** (all fail against the pre-fix module):
+`scripts/tests/test_byom_journey_evidence.py:257` and `:266` — the six hostname
+suffixes outside the old fixed list, in a manifest assertion and in captured
+document bytes; `:275` — IPv6 literals in captured documents; `:293` and `:302` —
+the six token shapes the governance sibling covered and BYOM did not, in an
+assertion and in captured document bytes; `:807` and `:821` — the direct scanner
+sweep over hostnames, URLs, paths and IP literals; `:848` — the token-shape
+sweep; `:898` — an unlisted file extension.
+
+**Positive tests:** `scripts/tests/test_byom_journey_evidence.py:310` proves the
+legitimate shapes survive a real capture end to end; `:865` asserts the full list
+of legitimate value shapes is accepted by the scanner; `:836`/`:846` assert
+structurally that the BYOM credential set is a superset of
+`CREDENTIAL_SHAPE_PATTERN_FRAGMENTS` and that the governance sibling composes the
+same fragments, so the two cannot drift apart silently.
+
+## MEDIUM B — Governance verifier did not re-validate the referenced evidence artifact
+
+**Finding.** The builder validated committed redacted evidence deeply, but the
+BYOM governance validators checked only the signed payload's own fields plus the
+artifact id and source prefix. The generic artifact loop bound the artifact bytes
+to the declared `sha256`, and nothing re-opened the artifact. Since
+`scripts/sign-journey-result.py` signs whatever payload it is handed, a
+hand-authored BYOM payload with a valid acceptance signature could reach promotion
+without ever passing the builder's checks — unlike the prebeta and local-consumer
+journeys, which both re-open their hash-bound source.
+
+**Resolution.** `_validate_byom_journey_source()` at
+`scripts/check_spec_governance.py:2729`, the BYOM counterpart of
+`_validate_local_consumer_endpoint_source()`. It re-opens the referenced
+`*.redacted.json`, then re-runs the **shared** contract rather than
+reimplementing it:
+
+- `assert_redacted()` — the full redaction scan over the artifact.
+- schema version, journey id, execution mode, and `environment.class` against the
+  journey contract.
+- `validate_evidence_steps()` — the same validator capture and the builders use,
+  which recomputes the requirement union from the per-step ids.
+- `validate_evidence_observations()` — the required-true / required-false names
+  and the money-path zero-row rule. (This helper was previously named
+  `_require_manifest_observations`; it is renamed and documented at
+  `scripts/byom_journey_evidence.py:642` because governance is now a third
+  caller. No behaviour changed.)
+- the artifact's declared `requirement_ids` must be unique and equal the
+  recomputed step union.
+
+It then compares the signed payload against the validated source: the signed
+requirement ids must all be covered by the recomputed union; the signed step
+projection (`id`, `status`, `assertion`, `artifacts`) must equal the source's;
+and `observations`, `run_id`, `captured_at`, `expires_at`, `repository`,
+`operator`, `environment`, `result` and `redaction` must match the source
+exactly.
+
+The circular-import problem — `scripts/byom_journey_evidence.py` imports the
+journey constants from `scripts/check_spec_governance.py` — is handled by the
+lazy loader `_byom_evidence_module()` at
+`scripts/check_spec_governance.py:2702`, which resolves the sibling by file
+location and binds the child to this exact module object rather than executing a
+second copy.
+
+**Callers.** `_validate_byom_journey_artifacts()`
+(`scripts/check_spec_governance.py:2819`) invokes it for the artifact whose id is
+the journey's reviewed artifact, and now takes `journey_id`, `signed`, and a
+keyword-only `root`. Both BYOM validators pass them
+(`scripts/check_spec_governance.py:2896` discovery,
+`scripts/check_spec_governance.py:2947` admission), and
+`_validate_signed_journey_result()` threads `root=root` into both at
+`scripts/check_spec_governance.py:3282` and `:3293`. `root` defaults to `None`
+so direct unit calls that only exercise the payload rules keep working, exactly
+as `_validate_local_consumer_endpoint_journey_result()` already does.
+
+**Rejection tests** (`scripts/tests/test_byom_journey_evidence.py:902`,
+`BYOMJourneyGovernanceSourceTests` — each builds real evidence from the golden
+discovery fixture, writes it under a scratch `journeys/evidence/`, and projects
+the signed payload from it):
+
+- `:983` — a payload projected honestly from its source passes with no errors.
+- `:986` — a signed requirement id the source does not cover is rejected.
+- `:992` — source `requirement_ids` padded beyond the step union is rejected.
+- `:999` and `:1005` — a signed step whose assertion disagrees with the source,
+  and a dropped step, are both rejected.
+- `:1011` — a tampered signed observation is rejected.
+- `:1017` — a tampered source observation is rejected by the shared rule.
+- `:1024` — a source step id outside the contract is rejected.
+- `:1031` — source evidence that is no longer redacted is rejected.
+- `:1038` — a signed operator role that disagrees with the source is rejected.
+- `:1044` — an absent source artifact is rejected.
+
+**End-to-end proof.** The two real builder outputs produced from the golden
+fixtures (see Verification) were passed through both BYOM governance validators
+with `root` set: both returned zero errors, and mutating one step's assertion in
+the signed payload produced
+`evidence[0].signed.artifacts[0].source.steps: signed steps must match the source
+evidence steps`.
+
+## LOW (architecture lane) — governance does not re-open BYOM redacted evidence
+
+Same defect as MEDIUM B, and closed by the same change.
+
+## Verification
+
+| Gate | Result |
+|---|---|
+| `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts.tests.test_byom_journey_evidence` | 70 tests, OK (47 → 70) |
+| `python3 scripts/check_spec_governance.py` | SPEC governance validation passed |
+| `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts.tests.test_spec_governance scripts.tests.test_journey_result_tools scripts.tests.test_provider_prebeta_journey_result scripts.tests.test_local_consumer_endpoint_journey_result scripts.tests.test_byom_contract_lock` | 127 tests, OK |
+| `python3 scripts/gen_spec_index.py --lint` | ok: specs/ root is canonical-only (51 tracked) |
+
+**Runbook operator sequence against the golden fixtures** (non-signing steps, in a
+scratch repository; nothing promoted). This is the check that the tightened
+scanner does not reject the committed goldens:
+
+- Step 3 capture, both journeys — both wrote their redacted artifact; no hostname,
+  IP, path or credential rejection.
+- Step 4 build, both builders — discovery covered `SPEC-046-R001..R008` across 10
+  steps; admission covered `SPEC-047-R001..R008` across 12 steps.
+- Step 5 preflight — `2 requirement(s) match current selectors at 51f855a4`.
+- Governance re-validation of both builder outputs with `root` set — zero errors;
+  a tampered step is rejected.
+
+No SPEC file and no `specs/CONFORMANCE.json` row was touched by this pass.
+
+## Verdict
+
+VERDICT: 0 CRITICAL / 0 HIGH / 0 MEDIUM / 0 LOW / 0 INFO (R2 findings resolved)
+
+R3 re-run: pending

--- a/audits/2026-09-08-byom-gates/AUDIT_1248_JOURNEY_EVIDENCE_R3.md
+++ b/audits/2026-09-08-byom-gates/AUDIT_1248_JOURNEY_EVIDENCE_R3.md
@@ -1,0 +1,17 @@
+# Audit record R3 — BYOM signed-journey evidence tooling (#1248)
+
+Third codex pass on the branch rebased onto `origin/main` `49e71210`, 2026-09-08. R1/R2 resolutions were verified by all three lanes.
+
+| Lane | Verdict | Findings |
+|---|---|---|
+| architect | 0 C / 0 H / 0 M / 0 L / 0 I | Clean; R2 resolutions confirmed. |
+| security-reviewer | 0 C / 0 H / 0 M / 2 L / 0 I | LOW: raw document paths accepted absolute paths outside the manifest dir (digest/byte-count only, no bypass); LOW: shape-based hostname rule still cannot flag single-label hosts — inherent to any DNS-shape rule, carried. |
+| code-reviewer | 0 C / 0 H / 1 M / 0 L / 0 I | MEDIUM: `_digest_document()` recorded the manifest-declared `schema` without checking the parsed captured JSON, so signed evidence could claim a step was backed by one CLI schema while the digested bytes were another document. |
+
+## Resolution (commit after this record)
+
+- **MEDIUM (schema trust):** `_digest_document()` now keeps the parsed value, requires a JSON object, and requires its top-level `schema` to equal the manifest entry's `schema`; tests `test_rejects_captured_document_whose_schema_differs_from_the_manifest`, `..._without_a_top_level_schema`, `..._that_is_not_a_json_object`.
+- **LOW (path confinement):** document paths must be manifest-relative, no `..`, and must resolve under the manifest directory; tests `test_rejects_captured_document_with_an_absolute_path`, `..._path_escaping_the_manifest_directory`.
+- **LOW (single-label hostnames):** carried. The scanner flags any `label.label…tld` shape, URLs, IPv4/IPv6 literals, localhost, absolute/home paths, and credential shapes; a bare single-label host name is indistinguishable from an ordinary word and is covered by the operator redaction review step in the runbook.
+
+R4 re-run: see `AUDIT_1248_JOURNEY_EVIDENCE_R4.md`.

--- a/audits/2026-09-08-byom-gates/AUDIT_1248_JOURNEY_EVIDENCE_R4.md
+++ b/audits/2026-09-08-byom-gates/AUDIT_1248_JOURNEY_EVIDENCE_R4.md
@@ -1,0 +1,17 @@
+# Audit record R4 — BYOM signed-journey evidence tooling (#1248)
+
+Fourth codex pass, branch on `origin/main` `49e71210`, 2026-09-08. R3 resolutions (captured-document schema check, manifest-relative path confinement) verified by all three lanes.
+
+| Lane | Verdict | Findings |
+|---|---|---|
+| architect | 0 C / 0 H / 0 M / 2 L / 0 I | LOW: captured CLI documents parsed with plain `json.loads` (duplicate keys last-wins) while committed evidence uses the duplicate-rejecting hook; LOW: single-label hostnames (carried). |
+| security-reviewer | 0 C / 0 H / 0 M / 2 L / 0 I | Same two LOWs. |
+| code-reviewer | 0 C / 0 H / 1 M / 1 L / 0 I | MEDIUM: the generic signed-result schema permits optional fields (`harness`, `config_before`, `candidate`, `candidate_identity`, `eip712`, `signer`) that BYOM source re-validation never binds to the evidence, so a hand-signed BYOM payload could carry unbound, unscanned data; LOW: single-label hostnames (carried). |
+
+## Resolution (commit after this record)
+
+- **MEDIUM (unbound optional keys):** `BYOM_JOURNEY_RESULT_PAYLOAD_KEYS` in `scripts/byom_journey_evidence.py` is the single closed key set; the builder asserts its own output equals it, and `_validate_byom_journey_source` in `scripts/check_spec_governance.py` rejects any signed BYOM payload whose key set is not exactly that set (extra or missing) before source comparison. Tests: `test_rejects_signed_payload_carrying_generic_optional_fields` (six optional keys), `test_rejects_signed_payload_missing_a_builder_key`. The governance-source test helper now emits the real signed shape (with `schema_version`, as the signer requires).
+- **LOW (duplicate JSON keys):** `_digest_document()` parses captured documents with `object_pairs_hook=_unique_json_object` and fails closed on `DuplicateJSONKeyError`; test `test_rejects_captured_document_with_duplicate_json_keys`.
+- **LOW (single-label hostnames):** carried by design (see R3).
+
+R5 re-run: see `AUDIT_1248_JOURNEY_EVIDENCE_R5.md`.

--- a/audits/2026-09-08-byom-gates/AUDIT_1248_JOURNEY_EVIDENCE_R5.md
+++ b/audits/2026-09-08-byom-gates/AUDIT_1248_JOURNEY_EVIDENCE_R5.md
@@ -1,0 +1,17 @@
+# Audit record R5 — BYOM signed-journey evidence tooling (#1248)
+
+Fifth codex pass, branch on `origin/main` `8e04e035`, 2026-09-08. R4 resolutions (closed payload key set, duplicate-key rejection) verified by all three lanes.
+
+| Lane | Verdict | Findings |
+|---|---|---|
+| architect | 0 C / 0 H / 0 M / 1 L / 0 I | LOW: single-label hostnames (carried). |
+| security-reviewer | 0 C / 0 H / 0 M / 2 L / 0 I | LOW: captured-document redaction scanned serialized JSON text only, so JSON string escapes could hide a URL/path/hostname from the regexes; LOW: single-label hostnames (carried). |
+| code-reviewer | 0 C / 0 H / 1 M / 1 L / 0 I | MEDIUM: `_validate_byom_journey_artifacts` only required the primary artifact id to be present, so a hand-signed BYOM payload could carry additional hash-bound artifact records (or extra fields on the one record) that nothing compares to the builder projection; LOW: single-label hostnames (carried). |
+
+## Resolution (commit after this record)
+
+- **MEDIUM (unbound artifact records):** BYOM validators now mirror the sibling journeys exactly: `signed.artifacts` must be exactly one object with exactly `{id, sha256, source}`, `id` equal to the reviewed artifact, `source` under the journey prefix; only then is the source re-validated. Tests `test_rejects_signed_payload_with_an_extra_artifact_record`, `test_rejects_signed_artifact_record_with_an_extra_field`. With keys, steps, observations, metadata, and artifacts all pinned to the builder projection, no field of a signed BYOM payload is left unbound to the source evidence.
+- **LOW (escaped values):** `_digest_document()` now also walks the decoded JSON values through the shared redaction scan; test `test_rejects_captured_document_hiding_a_url_behind_json_escapes`.
+- **LOW (single-label hostnames):** carried by design (see R3).
+
+R6 closure re-run: see `AUDIT_1248_JOURNEY_EVIDENCE_R6.md`.

--- a/audits/2026-09-08-byom-gates/AUDIT_1248_JOURNEY_EVIDENCE_R6.md
+++ b/audits/2026-09-08-byom-gates/AUDIT_1248_JOURNEY_EVIDENCE_R6.md
@@ -1,0 +1,16 @@
+# Audit record R6 — BYOM signed-journey evidence tooling (#1248)
+
+Sixth codex pass, branch on `origin/main` `8e04e035`, 2026-09-08. R5 resolutions (single builder artifact record, decoded-value scan) verified by all three lanes.
+
+| Lane | Verdict | Findings |
+|---|---|---|
+| architect | 0 C / 0 H / 0 M / 0 L / 0 I | Clean. |
+| security-reviewer | 0 C / 0 H / 0 M / 0 L / 0 I | Clean. |
+| code-reviewer | 0 C / 0 H / 1 M / 0 L / 0 I | MEDIUM: the file-name allowlist (`.go/.json/.md/.py/.sh/...`) was applied globally by the hostname scanner, so a DNS-shaped token whose final label is also a file extension (`provider-mac.sh`, `coordinator.md`) passed in any assertion or captured value, contradicting the "any DNS-shaped token" contract. |
+
+## Resolution (commit after this record)
+
+- **MEDIUM (global allowlist):** the global allowlist is removed; `reject_hostname_like_text` rejects every DNS-shaped token. Repository source file names are accepted only at the structurally validated JSON paths in `REPO_SOURCE_FILE_FIELDS` (`$.harness.name`), through `reject_unredacted_repo_source_file`, which still runs the secret/URL/path scans and requires a repository-relative file name with a known extension and no `..`. Tests: `test_file_name_shapes_are_hostnames_everywhere_except_the_harness_name_field`, `test_harness_name_field_still_requires_a_repository_source_file_name`, `test_a_file_name_shape_in_a_captured_document_value_fails_closed`; the capture-level acceptance test no longer places a file name inside a step assertion (that is now correctly rejected). Runbook redaction posture updated.
+- Single-label hostnames LOW: carried by design (R3); not re-reported by any R6 lane.
+
+R7 closure re-run: see `AUDIT_1248_JOURNEY_EVIDENCE_R7.md`.

--- a/audits/2026-09-08-byom-gates/AUDIT_1248_JOURNEY_EVIDENCE_R7.md
+++ b/audits/2026-09-08-byom-gates/AUDIT_1248_JOURNEY_EVIDENCE_R7.md
@@ -1,0 +1,25 @@
+# Audit record R7 — BYOM signed-journey evidence tooling (#1248) — CLOSURE
+
+Seventh codex pass, branch on `origin/main` `8e04e035`, 2026-09-08. R6 resolution (hostname exemption scoped to `$.harness.name`, no global allowlist) verified by all three lanes.
+
+| Lane | Verdict |
+|---|---|
+| code-reviewer | 0 CRITICAL / 0 HIGH / 0 MEDIUM / 0 LOW / 0 INFO |
+| security-reviewer | 0 CRITICAL / 0 HIGH / 0 MEDIUM / 0 LOW / 0 INFO |
+| architect | 0 CRITICAL / 0 HIGH / 0 MEDIUM / 0 LOW / 0 INFO |
+
+Gate met. Carried by design (documented in R3, not re-reported since R5): single-label hostnames are not DNS-shaped and remain an operator redaction-review item in the runbook.
+
+## Round summary
+
+| Round | MEDIUM | Theme |
+|---|---|---|
+| R1 | 3 | builder trusted hand-authored evidence; captured docs scanned for credentials only; runbook signing command wrong |
+| R2 | 2 | scanner narrower than the "any hostname / token-shaped" contract; governance did not re-open the source artifact |
+| R3 | 1 | manifest-declared document schema not checked against parsed JSON |
+| R4 | 1 | extra generic optional keys in a signed payload unbound to the source |
+| R5 | 1 | extra artifact records unbound to the source |
+| R6 | 1 | file-name allowlist applied globally by the hostname scanner |
+| R7 | 0 | closure |
+
+Lesson recorded: BYOM validators should have started from "signed payload is exactly the builder's closed projection" (sibling-validator parity) rather than field-by-field comparison; R5 made that structural and no further finding in that class appeared.

--- a/docs/runbooks/byom-disablement-rollback.md
+++ b/docs/runbooks/byom-disablement-rollback.md
@@ -127,4 +127,10 @@ directions.
 3. This disablement/rollback map reviewed and current.
 4. Coordinator admission endpoints deployed from a tag (Go).
 5. Malibu.app + CLI release cut passing provider-CLI-release-verification.
-6. Signed journey evidence where the governance process requires it.
+6. Signed journey evidence where the governance process requires it:
+   `JOURNEY-PROVIDER-BYOM-DISCOVERY` (SPEC-046) and
+   `JOURNEY-NETWORK-MODEL-ADMISSION` (SPEC-047), captured, built, signed,
+   preflighted, and promoted through
+   `docs/runbooks/byom-journey-evidence.md`. Signing needs the operator
+   acceptance key; conformance rows change only via
+   `scripts/promote-signed-journey-result.py`, never by hand.

--- a/docs/runbooks/byom-journey-evidence.md
+++ b/docs/runbooks/byom-journey-evidence.md
@@ -55,11 +55,13 @@ the TLD. Credential shapes are compiled from `CREDENTIAL_SHAPE_PATTERN_FRAGMENTS
 in `scripts/check_spec_governance.py`, so this scanner can never be narrower than
 the sibling signed-journey scanner.
 
-The one allowlist is `HOSTNAME_ALLOWLISTED_VALUE_SHAPES` in
-`scripts/byom_journey_evidence.py`: a repository source **file name**
+There is no global allowlist. A repository source **file name**
 (`run-cli-onboarding-e2e.py`, `run-manifest.json`) is `<name>.<ext>` and therefore
-DNS-shaped by coincidence, and the evidence records `harness.name` verbatim. An
-unlisted extension still fails closed. Every other value the contract emits —
+DNS-shaped by coincidence; it is accepted only at the structurally validated
+`harness.name` field (`REPO_SOURCE_FILE_FIELDS` / `REPO_SOURCE_FILE_NAME_RE` in
+`scripts/byom_journey_evidence.py`). The same token in a step assertion or a
+captured document value is a hostname and fails closed, and an unlisted
+extension fails closed even in `harness.name`. Every other value the contract emits —
 evidence and document schema ids, step ids, requirement ids, run ids, CLI and
 semantic versions — ends in a label that is not purely alphabetic and so never
 reaches the allowlist at all.

--- a/docs/runbooks/byom-journey-evidence.md
+++ b/docs/runbooks/byom-journey-evidence.md
@@ -1,0 +1,203 @@
+# BYOM Signed-Journey Evidence
+
+**Epic:** #1240 · **Gate:** #1248 (BYOM v0.1 promotion requires signed journey
+evidence, not prose) · **Specs:** SPEC-046, SPEC-047
+
+#1248 requires `JOURNEY-PROVIDER-BYOM-DISCOVERY` evidence for local discovery and
+`JOURNEY-NETWORK-MODEL-ADMISSION` evidence before any network-admission claim,
+and requires that the evidence reach `specs/CONFORMANCE.json` only through the
+repository governance path. This runbook is the exact operator sequence.
+
+Nothing here promotes anything on its own. Capture and build are reproducible and
+noninteractive; **signing is the operator step** and needs the acceptance signing
+key that only the release operator holds.
+
+## What the two journeys are
+
+| Journey | Spec | Journey contract | Steps | Evidence artifact |
+|---|---|---|---|---|
+| `JOURNEY-PROVIDER-BYOM-DISCOVERY` | SPEC-046 (R001–R008) | `journeys/JOURNEY-PROVIDER-BYOM-DISCOVERY.md` | `step-01-discover-mlx-cache` … `step-10-local-state-ladder` | `journeys/evidence/provider-byom-discovery-*.redacted.json` |
+| `JOURNEY-NETWORK-MODEL-ADMISSION` | SPEC-047 (R001–R008) | `journeys/JOURNEY-NETWORK-MODEL-ADMISSION.md` | `step-01-offer-dry-run` … `step-12-redaction-review` | `journeys/evidence/network-model-admission-*.redacted.json` |
+
+The step ids, the required-`true` / required-`false` observation names, the
+evidence schema strings, and the evidence path prefixes are the normative lists in
+those two journey contracts. They are mirrored in `scripts/check_spec_governance.py`
+(`PROVIDER_BYOM_DISCOVERY_*`, `NETWORK_MODEL_ADMISSION_*`) and enforced on both the
+capture side and the governance side. Do not invent a step id: an unlisted step id
+is rejected, and a missing one is rejected.
+
+Each step also declares the SPEC requirement ids it exercises. The allowed set per
+step comes from the requirement subjects in SPEC-046 §3 / SPEC-047 §3 (plus the
+release-evidence requirement, `SPEC-046-R008` / `SPEC-047-R008`, which the journey
+proves as a whole). The union across all steps must cover every requirement mapped
+to the journey, or capture fails.
+
+`environment.class` records how the run was executed:
+
+- `hermetic-loopback` — the harness at `test/e2e/byom/run-cli-onboarding-e2e.py`
+  (`make test-byom-e2e`).
+- `physical-provider` — a real Mac run per
+  `test/e2e/byom/CANDIDATE-E2E-RUNBOOK.md`.
+
+## Redaction posture
+
+The capture tool fails closed. It refuses to emit evidence that contains a URL, an
+absolute or `~/`-relative path, a hostname, an IP literal, a `localhost`
+reference, or anything shaped like a credential, in either a key or a value. It
+also refuses to record a captured CLI document that still contains a credential.
+
+Captured CLI JSON documents are **never** copied into the repository. Only their
+SHA-256 digest, byte count, declared schema, and a short id are recorded. Keep the
+raw documents in operator-local storage; the digests are what bind the signed
+result to them.
+
+## Step 1 — run the journey and collect CLI documents
+
+Hermetic:
+
+```bash
+make test-byom-e2e
+```
+
+Physical provider Mac: follow `test/e2e/byom/CANDIDATE-E2E-RUNBOOK.md`.
+
+Save each `--json` document the run produced (discovery, evaluation, offer
+dry-run, admission status, withdrawal, catalog economics) into one local
+directory, e.g. `~/byom-run/captures/`. For the admission journey, also read the
+money-path row counts directly from the coordinator's own tables (ledger,
+settlement, payout, request log) — not from a quiet API.
+
+## Step 2 — write the run manifest
+
+Create `~/byom-run/run-manifest.json` using schema
+`macprovider.byom-journey-run.v1`. Copy the shape from the committed golden
+fixtures:
+
+- `scripts/tests/fixtures/byom_journeys/discovery/run-manifest.json`
+- `scripts/tests/fixtures/byom_journeys/admission/run-manifest.json`
+
+Required keys: `schema_version`, `journey_id`, `run_id`, `environment_class`,
+`cli_version`, `harness` (`{name, status}`), `steps`, `observations`. Each step is
+`{id, status, assertion, requirement_ids, documents}`, and each document is
+`{id, schema, path}` where `path` is relative to the manifest file. Document paths
+stay local; they are digested, not published.
+
+The admission manifest must additionally carry
+`observations.money_path_zero_rows` with every one of these tables set to the
+integer `0` (SPEC-047-R003):
+
+```
+ledger_operator_credits      ledger_payout_ready        ledger_quarantine_resolutions
+ledger_request_credits       payout_attempts            request_log
+settlement_attempt_outputs   settlement_receipt_verdicts
+settlement_route_snapshots   spec022_payable_request_credits
+```
+
+## Step 3 — capture the redacted evidence
+
+```bash
+python3 scripts/capture-byom-journey-evidence.py \
+  --journey discovery \
+  --run-manifest ~/byom-run/run-manifest.json \
+  --output journeys/evidence/provider-byom-discovery-<UTC>.redacted.json \
+  --source-sha "$(git rev-parse HEAD)" \
+  --operator-role release-operator \
+  --operator-identity-fingerprint <sha256-hex> \
+  --hardware-profile <redacted-profile-label> \
+  --candidate <candidate-build-label> \
+  --summary "<one line>"
+```
+
+Use `--journey admission` and the `network-model-admission-` output prefix for the
+admission journey. Add `--run-hermetic-harness` to have the tool run
+`test/e2e/byom/run-cli-onboarding-e2e.py` first and refuse to capture unless it
+passes.
+
+Review the emitted artifact by eye, then commit it through a normal PR. The
+evidence artifact must be committed before the next step, because the builder
+verifies its bytes against the commit that contains it.
+
+## Step 4 — build the unsigned journey-result payload
+
+```bash
+python3 scripts/build-byom-discovery-journey-result.py \
+  journeys/evidence/provider-byom-discovery-<UTC>.redacted.json \
+  --output /tmp/byom-discovery-journey-result.unsigned.json \
+  --source-sha <candidate-source-commit> \
+  --evidence-sha <commit-containing-the-evidence> \
+  --requirement-ids SPEC-046-R001,...
+```
+
+`scripts/build-network-model-admission-journey-result.py` is the admission
+counterpart. Both refuse to promote a requirement that is not mapped to their
+journey, not still `pending`, or not covered by the evidence. Omit
+`--requirement-ids` to cover everything the evidence covers.
+
+The unsigned payload is runner-temp state. Do not commit it.
+
+## Step 5 — preflight (still no signature)
+
+```bash
+python3 scripts/preflight-signed-journey-promotion.py \
+  --source-sha <candidate-source-commit> \
+  --requirement-ids SPEC-046-R001,... \
+  --journey-id JOURNEY-PROVIDER-BYOM-DISCOVERY
+```
+
+This rejects a stale promotion: the requirement must still be `pending`, must be
+mapped to the journey, and its `implementation`/`tests` selectors must still
+resolve at `--source-sha`. Fix drift here rather than after signing.
+
+## Step 6 — sign (operator key required)
+
+**This is the only step that needs the acceptance signing key**, and it is the
+only step an agent must not perform on the operator's behalf.
+
+```bash
+MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM=<path-or-env-indirect> \
+python3 scripts/sign-journey-result.py \
+  /tmp/byom-discovery-journey-result.unsigned.json \
+  --output journeys/evidence/provider-byom-discovery-<UTC>.<requirement-slug>.journey-result.signed.json
+```
+
+The signature is `ecdsa-p256-sha256` under key id
+`macprovider-acceptance-p256-v1`, verified against
+`security/acceptance-candidate-signing-public.pem`. Never print, echo, copy, or
+commit the private key. Prefer running this in the `production-release`
+environment the sibling promotion workflows use, so the key never lands on a
+laptop.
+
+## Step 7 — promote and reconcile conformance
+
+```bash
+python3 scripts/promote-signed-journey-result.py \
+  journeys/evidence/provider-byom-discovery-<UTC>.<requirement-slug>.journey-result.signed.json \
+  --requirement-ids SPEC-046-R001,...
+
+python3 scripts/check_spec_governance.py --base-ref origin/main
+```
+
+Promotion is what writes the `sha256:`/`source` evidence entry into
+`specs/CONFORMANCE.json` and moves the requirement out of `pending`. Do not edit
+`specs/CONFORMANCE.json` states or evidence by hand — a hand-edited row is exactly
+the prose-only promotion #1248 forbids.
+
+Then open a PR containing the redacted evidence, the signed envelope, and the
+conformance change, and let `spec-index / check` run.
+
+## Verification while iterating
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v scripts.tests.test_byom_journey_evidence
+python3 scripts/check_spec_governance.py
+make test-byom-e2e
+```
+
+The unit suite also runs inside `make test-dist`.
+
+## Related
+
+- `docs/runbooks/byom-disablement-rollback.md` — promotion checklist and the
+  disable switch for every BYOM surface.
+- `test/e2e/byom/README.md`, `test/e2e/byom/CANDIDATE-E2E-RUNBOOK.md` — how to
+  produce the runs this evidence describes.

--- a/docs/runbooks/byom-journey-evidence.md
+++ b/docs/runbooks/byom-journey-evidence.md
@@ -43,8 +43,11 @@ to the journey, or capture fails.
 
 The capture tool fails closed. It refuses to emit evidence that contains a URL, an
 absolute or `~/`-relative path, a hostname, an IP literal, a `localhost`
-reference, or anything shaped like a credential, in either a key or a value. It
-also refuses to record a captured CLI document that still contains a credential.
+reference, or anything shaped like a credential, in either a key or a value. The
+same fail-closed scan runs over every captured CLI document before it is digested,
+because the digest is what the signed result binds to. There is no allowlist: a
+document that legitimately contains an endpoint or a local path is one you redact
+before capture, or capture refuses the whole run.
 
 Captured CLI JSON documents are **never** copied into the repository. Only their
 SHA-256 digest, byte count, declared schema, and a short id are recorded. Keep the
@@ -153,14 +156,21 @@ resolve at `--source-sha`. Fix drift here rather than after signing.
 **This is the only step that needs the acceptance signing key**, and it is the
 only step an agent must not perform on the operator's behalf.
 
+`MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM` must already hold the **PEM contents** of
+the acceptance signing key — `read_private_key()` reads the variable itself, not a
+path to a key file and not the name of another variable. In the
+`production-release` environment it comes straight from the repository secret of
+the same name, exactly as the sibling `promote-signed-*-journey.yml` workflows set
+it.
+
 ```bash
-MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM=<path-or-env-indirect> \
 python3 scripts/sign-journey-result.py \
-  /tmp/byom-discovery-journey-result.unsigned.json \
+  --input /tmp/byom-discovery-journey-result.unsigned.json \
   --output journeys/evidence/provider-byom-discovery-<UTC>.<requirement-slug>.journey-result.signed.json
 ```
 
-The signature is `ecdsa-p256-sha256` under key id
+`--input` and `--output` are both required, and `--output` must resolve under
+`journeys/evidence/`. The signature is `ecdsa-p256-sha256` under key id
 `macprovider-acceptance-p256-v1`, verified against
 `security/acceptance-candidate-signing-public.pem`. Never print, echo, copy, or
 commit the private key. Prefer running this in the `production-release`
@@ -171,8 +181,9 @@ laptop.
 
 ```bash
 python3 scripts/promote-signed-journey-result.py \
-  journeys/evidence/provider-byom-discovery-<UTC>.<requirement-slug>.journey-result.signed.json \
-  --requirement-ids SPEC-046-R001,...
+  --base-ref origin/main \
+  --requirement-ids SPEC-046-R001,... \
+  journeys/evidence/provider-byom-discovery-<UTC>.<requirement-slug>.journey-result.signed.json
 
 python3 scripts/check_spec_governance.py --base-ref origin/main
 ```

--- a/docs/runbooks/byom-journey-evidence.md
+++ b/docs/runbooks/byom-journey-evidence.md
@@ -42,12 +42,36 @@ to the journey, or capture fails.
 ## Redaction posture
 
 The capture tool fails closed. It refuses to emit evidence that contains a URL, an
-absolute or `~/`-relative path, a hostname, an IP literal, a `localhost`
+absolute or `~/`-relative path, a hostname, an IPv4 or IPv6 literal, a `localhost`
 reference, or anything shaped like a credential, in either a key or a value. The
 same fail-closed scan runs over every captured CLI document before it is digested,
-because the digest is what the signed result binds to. There is no allowlist: a
-document that legitimately contains an endpoint or a local path is one you redact
-before capture, or capture refuses the whole run.
+because the digest is what the signed result binds to. A document that legitimately
+contains an endpoint or a local path is one you redact before capture, or capture
+refuses the whole run.
+
+The hostname rule is shape-based, not a suffix list: **any** DNS-shaped token —
+one or more `label.` groups ending in an alphabetic label — is rejected, whatever
+the TLD. Credential shapes are compiled from `CREDENTIAL_SHAPE_PATTERN_FRAGMENTS`
+in `scripts/check_spec_governance.py`, so this scanner can never be narrower than
+the sibling signed-journey scanner.
+
+The one allowlist is `HOSTNAME_ALLOWLISTED_VALUE_SHAPES` in
+`scripts/byom_journey_evidence.py`: a repository source **file name**
+(`run-cli-onboarding-e2e.py`, `run-manifest.json`) is `<name>.<ext>` and therefore
+DNS-shaped by coincidence, and the evidence records `harness.name` verbatim. An
+unlisted extension still fails closed. Every other value the contract emits —
+evidence and document schema ids, step ids, requirement ids, run ids, CLI and
+semantic versions — ends in a label that is not purely alphabetic and so never
+reaches the allowlist at all.
+
+Governance does not take the signed payload's word for any of this.
+`_validate_byom_journey_source()` in `scripts/check_spec_governance.py` re-opens
+the referenced redacted evidence and re-runs the same shared contract — the
+redaction scan, `validate_evidence_steps()`, and `validate_evidence_observations()`
+(money-path zero rows included) — then compares the signed requirement ids, step
+projection, observations, and metadata against it. A hand-authored payload with a
+valid acceptance signature is rejected if it disagrees with its own source
+artifact.
 
 Captured CLI JSON documents are **never** copied into the repository. Only their
 SHA-256 digest, byte count, declared schema, and a short id are recorded. Keep the

--- a/scripts/build-byom-discovery-journey-result.py
+++ b/scripts/build-byom-discovery-journey-result.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Build an unsigned JOURNEY-PROVIDER-BYOM-DISCOVERY journey-result payload.
+
+Input is the redacted evidence artifact written by
+`scripts/capture-byom-journey-evidence.py --journey discovery`. Output is the
+unsigned payload that `scripts/sign-journey-result.py` signs with the operator
+acceptance key; this script never touches signing material.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from byom_journey_evidence import DISCOVERY_CONTRACT, run_builder_cli  # noqa: E402
+
+
+def main(argv: list[str] | None = None) -> int:
+    return run_builder_cli(DISCOVERY_CONTRACT, argv, "build-byom-discovery-journey-result")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build-network-model-admission-journey-result.py
+++ b/scripts/build-network-model-admission-journey-result.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Build an unsigned JOURNEY-NETWORK-MODEL-ADMISSION journey-result payload.
+
+Input is the redacted evidence artifact written by
+`scripts/capture-byom-journey-evidence.py --journey admission`, including the
+SPEC-047-R003 money-path zero-row assertions. Output is the unsigned payload that
+`scripts/sign-journey-result.py` signs with the operator acceptance key; this
+script never touches signing material.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from byom_journey_evidence import ADMISSION_CONTRACT, run_builder_cli  # noqa: E402
+
+
+def main(argv: list[str] | None = None) -> int:
+    return run_builder_cli(ADMISSION_CONTRACT, argv, "build-network-model-admission-journey-result")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/byom_journey_evidence.py
+++ b/scripts/byom_journey_evidence.py
@@ -476,7 +476,17 @@ def _digest_document(manifest_dir: Path, entry: Any, step_id: str, index: int) -
     schema = require_string(document.get("schema"), DOCUMENT_SCHEMA_RE, f"{location}.schema")
     raw_path = require_string(document.get("path"), None, f"{location}.path")
     candidate = Path(raw_path)
-    path = candidate if candidate.is_absolute() else (manifest_dir / candidate)
+    # Raw CLI documents live beside the run manifest; the operator contract says
+    # paths are manifest-relative, so an absolute path or a parent traversal is a
+    # manifest-authoring error, not a file to go and hash.
+    if candidate.is_absolute() or ".." in candidate.parts:
+        fail(f"{location}.path must be relative to the run manifest directory")
+    manifest_root = manifest_dir.resolve()
+    path = (manifest_root / candidate).resolve()
+    try:
+        path.relative_to(manifest_root)
+    except ValueError:
+        fail(f"{location}.path must stay under the run manifest directory")
     if path.is_symlink() or not path.is_file():
         fail(f"{location}.path is absent or unsafe")
     try:
@@ -488,9 +498,21 @@ def _digest_document(manifest_dir: Path, entry: Any, step_id: str, index: int) -
     except UnicodeDecodeError:
         fail(f"{location}.path must be a UTF-8 CLI JSON document")
     try:
-        json.loads(decoded)
+        parsed = json.loads(decoded)
     except json.JSONDecodeError as exc:
         fail(f"{location}.path must be a JSON document: {exc}")
+    # The raw document is never committed, so this is the only point at which
+    # the manifest's claimed schema can be checked against what was actually
+    # digested. A signed step must not claim `model_admission_status.v1` backing
+    # while the bytes under the digest are some other document.
+    if not isinstance(parsed, dict):
+        fail(f"{location}.path must be a JSON object document")
+    actual_schema = parsed.get("schema")
+    if not isinstance(actual_schema, str) or actual_schema != schema:
+        fail(
+            f"{location}.schema {schema!r} does not match the captured document's "
+            f"top-level schema {actual_schema!r}"
+        )
     # The document itself is never embedded, but its digest is what the signed
     # journey-result binds to, so the redaction claim has to hold for the bytes we
     # digest: a captured document that still carries a URL, an absolute or

--- a/scripts/byom_journey_evidence.py
+++ b/scripts/byom_journey_evidence.py
@@ -523,6 +523,9 @@ def _digest_document(manifest_dir: Path, entry: Any, step_id: str, index: int) -
     # for raw-document fields -- a CLI document that legitimately needs an
     # endpoint or a path in it is a document the operator redacts before capture.
     reject_unredacted_text(decoded, f"{location}.path")
+    # JSON string escapes (\u002f, \u002e, ...) can hide a URL, path, or hostname
+    # from the serialized-text scan, so the decoded values are scanned as well.
+    _walk_redaction(parsed, f"{location}.document")
     return {
         "id": document_id,
         "schema": schema,

--- a/scripts/byom_journey_evidence.py
+++ b/scripts/byom_journey_evidence.py
@@ -1,0 +1,814 @@
+#!/usr/bin/env python3
+"""Shared contract for the two BYOM signed-journey evidence pipelines.
+
+`JOURNEY-PROVIDER-BYOM-DISCOVERY` (SPEC-046) and `JOURNEY-NETWORK-MODEL-ADMISSION`
+(SPEC-047) share one capture-then-build shape, so the step tables, redaction
+rules, run-manifest contract, and payload projection live here and are consumed by
+`capture-byom-journey-evidence.py`, `build-byom-discovery-journey-result.py`, and
+`build-network-model-admission-journey-result.py`.
+
+Nothing in this module signs or promotes anything. It only produces the redacted
+evidence artifact and the unsigned journey-result payload; the acceptance signing
+key stays an operator secret used by `sign-journey-result.py`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from copy import deepcopy
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from check_spec_governance import (
+    BYOM_JOURNEY_ENVIRONMENT_CLASSES,
+    DuplicateJSONKeyError,
+    JOURNEY_RESULT_PAYLOAD_SCHEMA,
+    NETWORK_MODEL_ADMISSION_ARTIFACT_ID,
+    NETWORK_MODEL_ADMISSION_EVIDENCE_PREFIX,
+    NETWORK_MODEL_ADMISSION_EVIDENCE_SCHEMA,
+    NETWORK_MODEL_ADMISSION_EXECUTION_MODE,
+    NETWORK_MODEL_ADMISSION_FALSE_OBSERVATIONS,
+    NETWORK_MODEL_ADMISSION_JOURNEY_ID,
+    NETWORK_MODEL_ADMISSION_MONEY_PATH_TABLES,
+    NETWORK_MODEL_ADMISSION_PROMOTABLE_REQUIREMENT_IDS,
+    NETWORK_MODEL_ADMISSION_STEP_ID_ORDER,
+    NETWORK_MODEL_ADMISSION_STEP_REQUIREMENT_IDS,
+    NETWORK_MODEL_ADMISSION_TRUE_OBSERVATIONS,
+    PROVIDER_BYOM_DISCOVERY_ARTIFACT_ID,
+    PROVIDER_BYOM_DISCOVERY_EVIDENCE_PREFIX,
+    PROVIDER_BYOM_DISCOVERY_EVIDENCE_SCHEMA,
+    PROVIDER_BYOM_DISCOVERY_EXECUTION_MODE,
+    PROVIDER_BYOM_DISCOVERY_FALSE_OBSERVATIONS,
+    PROVIDER_BYOM_DISCOVERY_JOURNEY_ID,
+    PROVIDER_BYOM_DISCOVERY_PROMOTABLE_REQUIREMENT_IDS,
+    PROVIDER_BYOM_DISCOVERY_STEP_ID_ORDER,
+    PROVIDER_BYOM_DISCOVERY_STEP_REQUIREMENT_IDS,
+    PROVIDER_BYOM_DISCOVERY_TRUE_OBSERVATIONS,
+    ValidationResult,
+    _load_json,
+    _unique_json_object,
+)
+
+
+RUN_MANIFEST_SCHEMA = "macprovider.byom-journey-run.v1"
+REPOSITORY = "Augustas11/macprovider"
+DEFAULT_EVIDENCE_LIFETIME_DAYS = 30
+
+REQUIREMENT_RE = re.compile(r"^SPEC-[0-9]{3}-R[0-9]{3}$")
+COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+DATETIME_Z_RE = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")
+DATE_RE = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}$")
+SAFE_LABEL_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:@+-]{0,127}$")
+DOCUMENT_SCHEMA_RE = re.compile(r"^[a-z][a-z0-9_]*\.v[0-9]+$")
+REPO_RELATIVE_FILE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*(?:/[A-Za-z0-9][A-Za-z0-9._-]*)*$")
+
+# Redaction is fail-closed: the emitted evidence must not carry a URL, an
+# absolute or home-relative path, a hostname, an IP literal, or anything shaped
+# like a credential. Captured CLI documents are digested, never embedded, so the
+# operator's raw endpoints and paths never reach the repository.
+FORBIDDEN_VALUE_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("a url", re.compile(r"(?i)[a-z][a-z0-9+.-]*://")),
+    ("an absolute path", re.compile(r"(?:^|[\s\"'=,;(\[])(?:/[A-Za-z0-9._~-]+){2,}")),
+    ("a home-relative path", re.compile(r"(?:^|[\s\"'=,;(\[])~/")),
+    ("an ipv4 literal", re.compile(r"\b[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\b")),
+    ("an ipv6 loopback literal", re.compile(r"(?:^|[^0-9A-Fa-f:])::1(?:[^0-9A-Fa-f:]|$)")),
+    ("a localhost reference", re.compile(r"(?i)\blocalhost\b")),
+    (
+        "a hostname",
+        re.compile(
+            r"(?i)\b[a-z0-9](?:[a-z0-9-]*[a-z0-9])?"
+            r"(?:\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)*"
+            r"\.(?:com|net|org|io|ai|app|dev|cloud|tech|local|internal)\b"
+        ),
+    ),
+)
+FORBIDDEN_SECRET_VALUE_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----"),
+    re.compile(r"(?i)\bauthorization\s*:\s*bearer\s+(?!redacted\b)[A-Za-z0-9._~+/=-]{8,}"),
+    re.compile(r"(?i)\bbearer\s+(?!redacted\b)[A-Za-z0-9._~+/=-]{20,}"),
+    re.compile(r"\bghp_[A-Za-z0-9_]{20,}\b"),
+    re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}\b"),
+    re.compile(r"\bsk-[A-Za-z0-9]{20,}\b"),
+    re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{20,}\b"),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+    re.compile(r"\bmp_[A-Za-z0-9_-]{16,}\b"),
+    re.compile(r"\bprovider-token-[A-Za-z0-9_-]{8,}\b"),
+)
+FORBIDDEN_KEY_FRAGMENTS: tuple[str, ...] = (
+    "absolute_path",
+    "authorization_header",
+    "base_url",
+    "bearer_token",
+    "endpoint_origin",
+    "endpoint_url",
+    "hostname",
+    "ip_address",
+    "private_key",
+    "provider_token",
+    "raw_secret",
+    "raw_token",
+    "secret_key",
+    "socket_path",
+)
+
+
+class BYOMEvidenceError(Exception):
+    """Raised when captured input fails the closed evidence contract."""
+
+
+class JourneyContract:
+    """Everything one BYOM journey needs, sourced from the governance module."""
+
+    def __init__(
+        self,
+        *,
+        selector: str,
+        journey_id: str,
+        execution_mode: str,
+        evidence_schema: str,
+        evidence_prefix: str,
+        artifact_id: str,
+        step_id_order: tuple[str, ...],
+        step_requirement_ids: dict[str, set[str]],
+        promotable_requirement_ids: set[str],
+        true_observations: set[str],
+        false_observations: set[str],
+        release_evidence_requirement_id: str,
+        money_path_tables: tuple[str, ...] = (),
+    ) -> None:
+        self.selector = selector
+        self.journey_id = journey_id
+        self.execution_mode = execution_mode
+        self.evidence_schema = evidence_schema
+        self.evidence_prefix = evidence_prefix
+        self.artifact_id = artifact_id
+        self.step_id_order = step_id_order
+        self.step_requirement_ids = step_requirement_ids
+        self.promotable_requirement_ids = promotable_requirement_ids
+        self.true_observations = true_observations
+        self.false_observations = false_observations
+        self.release_evidence_requirement_id = release_evidence_requirement_id
+        self.money_path_tables = money_path_tables
+
+    def allowed_step_requirement_ids(self, step_id: str) -> set[str]:
+        # The release-evidence requirement is what the journey as a whole proves,
+        # so it is admissible on any step; every other id must be the requirement
+        # subject that step actually exercises.
+        return self.step_requirement_ids[step_id] | {self.release_evidence_requirement_id}
+
+
+DISCOVERY_CONTRACT = JourneyContract(
+    selector="discovery",
+    journey_id=PROVIDER_BYOM_DISCOVERY_JOURNEY_ID,
+    execution_mode=PROVIDER_BYOM_DISCOVERY_EXECUTION_MODE,
+    evidence_schema=PROVIDER_BYOM_DISCOVERY_EVIDENCE_SCHEMA,
+    evidence_prefix=PROVIDER_BYOM_DISCOVERY_EVIDENCE_PREFIX,
+    artifact_id=PROVIDER_BYOM_DISCOVERY_ARTIFACT_ID,
+    step_id_order=PROVIDER_BYOM_DISCOVERY_STEP_ID_ORDER,
+    step_requirement_ids=PROVIDER_BYOM_DISCOVERY_STEP_REQUIREMENT_IDS,
+    promotable_requirement_ids=set(PROVIDER_BYOM_DISCOVERY_PROMOTABLE_REQUIREMENT_IDS),
+    true_observations=PROVIDER_BYOM_DISCOVERY_TRUE_OBSERVATIONS,
+    false_observations=PROVIDER_BYOM_DISCOVERY_FALSE_OBSERVATIONS,
+    release_evidence_requirement_id="SPEC-046-R008",
+)
+ADMISSION_CONTRACT = JourneyContract(
+    selector="admission",
+    journey_id=NETWORK_MODEL_ADMISSION_JOURNEY_ID,
+    execution_mode=NETWORK_MODEL_ADMISSION_EXECUTION_MODE,
+    evidence_schema=NETWORK_MODEL_ADMISSION_EVIDENCE_SCHEMA,
+    evidence_prefix=NETWORK_MODEL_ADMISSION_EVIDENCE_PREFIX,
+    artifact_id=NETWORK_MODEL_ADMISSION_ARTIFACT_ID,
+    step_id_order=NETWORK_MODEL_ADMISSION_STEP_ID_ORDER,
+    step_requirement_ids=NETWORK_MODEL_ADMISSION_STEP_REQUIREMENT_IDS,
+    promotable_requirement_ids=set(NETWORK_MODEL_ADMISSION_PROMOTABLE_REQUIREMENT_IDS),
+    true_observations=NETWORK_MODEL_ADMISSION_TRUE_OBSERVATIONS,
+    false_observations=NETWORK_MODEL_ADMISSION_FALSE_OBSERVATIONS,
+    release_evidence_requirement_id="SPEC-047-R008",
+    money_path_tables=NETWORK_MODEL_ADMISSION_MONEY_PATH_TABLES,
+)
+CONTRACTS: dict[str, JourneyContract] = {
+    DISCOVERY_CONTRACT.selector: DISCOVERY_CONTRACT,
+    DISCOVERY_CONTRACT.journey_id: DISCOVERY_CONTRACT,
+    ADMISSION_CONTRACT.selector: ADMISSION_CONTRACT,
+    ADMISSION_CONTRACT.journey_id: ADMISSION_CONTRACT,
+}
+
+
+def contract_for(selector: str) -> JourneyContract:
+    try:
+        return CONTRACTS[selector]
+    except KeyError:
+        raise BYOMEvidenceError(f"unknown journey selector: {selector!r}") from None
+
+
+def fail(message: str) -> None:
+    raise BYOMEvidenceError(message)
+
+
+def require_object(value: Any, location: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        fail(f"{location} must be an object")
+    return value
+
+
+def require_list(value: Any, location: str) -> list[Any]:
+    if not isinstance(value, list):
+        fail(f"{location} must be an array")
+    return value
+
+
+def require_string(value: Any, pattern: re.Pattern[str] | None, location: str) -> str:
+    if not isinstance(value, str) or not value:
+        fail(f"{location} must be a non-empty string")
+    if pattern is not None and not pattern.fullmatch(value):
+        fail(f"{location} has invalid format")
+    return value
+
+
+def require_exact_keys(value: dict[str, Any], required: set[str], allowed: set[str], location: str) -> None:
+    observed = set(value)
+    missing = sorted(required - observed)
+    if missing:
+        fail(f"{location} is missing required key(s): {', '.join(missing)}")
+    unexpected = sorted(observed - allowed)
+    if unexpected:
+        fail(f"{location} has unexpected key(s): {', '.join(unexpected)}")
+
+
+def load_json_object(path: Path, label: str) -> dict[str, Any]:
+    result = ValidationResult()
+    value = _load_json(path, result)
+    if result.errors:
+        fail(f"{label} rejected: " + "; ".join(result.errors))
+    if not isinstance(value, dict):
+        fail(f"{label} must be a JSON object")
+    return value
+
+
+def load_json_object_bytes(path: Path, label: str) -> tuple[dict[str, Any], bytes]:
+    try:
+        payload = path.read_bytes()
+        value = json.loads(payload.decode("utf-8"), object_pairs_hook=_unique_json_object)
+    except DuplicateJSONKeyError as exc:
+        fail(f"{label} has a duplicate JSON object key: {exc.args[0]!r}")
+    except (UnicodeDecodeError, json.JSONDecodeError, OSError) as exc:
+        fail(f"{label} rejected: {exc}")
+    if not isinstance(value, dict):
+        fail(f"{label} must be a JSON object")
+    return value, payload
+
+
+def write_json_atomically(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(value, indent=2, sort_keys=False) + "\n"
+    with tempfile.NamedTemporaryFile(
+        "w", encoding="utf-8", dir=path.parent, prefix=f".{path.name}.", delete=False
+    ) as handle:
+        temporary = Path(handle.name)
+        handle.write(payload)
+    try:
+        if path.exists() and path.is_symlink():
+            fail(f"output must not be a symlink: {path}")
+        temporary.replace(path)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+
+
+def reject_forbidden_keys(value: Any, location: str = "$") -> None:
+    if isinstance(value, dict):
+        for key, item in value.items():
+            lowered = key.lower()
+            for fragment in FORBIDDEN_KEY_FRAGMENTS:
+                if fragment in lowered and not (lowered.endswith("_redacted") and item is True):
+                    fail(f"{location}.{key} uses a forbidden secret-bearing field name")
+            reject_forbidden_keys(item, f"{location}.{key}")
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            reject_forbidden_keys(item, f"{location}[{index}]")
+
+
+def reject_secret_like_text(text: str, location: str) -> None:
+    for pattern in FORBIDDEN_SECRET_VALUE_PATTERNS:
+        if pattern.search(text):
+            fail(f"{location} contains a credential-like value")
+
+
+def reject_unredacted_text(text: str, location: str) -> None:
+    reject_secret_like_text(text, location)
+    for label, pattern in FORBIDDEN_VALUE_PATTERNS:
+        if pattern.search(text):
+            fail(f"{location} contains {label}; evidence must stay redacted")
+
+
+def assert_redacted(value: Any, location: str = "$") -> None:
+    """Fail closed on any URL, path, hostname, IP, or credential in the evidence."""
+    reject_forbidden_keys(value, location)
+    _walk_redaction(value, location)
+
+
+def _walk_redaction(value: Any, location: str) -> None:
+    if isinstance(value, dict):
+        for key, item in value.items():
+            reject_unredacted_text(key, f"{location} key {key!r}")
+            _walk_redaction(item, f"{location}.{key}")
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            _walk_redaction(item, f"{location}[{index}]")
+    elif isinstance(value, str):
+        reject_unredacted_text(value, location)
+
+
+def repository_relative(root: Path, value: str, label: str) -> str:
+    root = root.resolve()
+    candidate = Path(value)
+    if candidate.is_absolute():
+        fail(f"{label} must be repository-relative")
+    normalized = candidate.as_posix()
+    if normalized.startswith("../") or "/../" in normalized or normalized in ("..", "."):
+        fail(f"{label} must not contain parent traversal")
+    resolved = (root / normalized).resolve(strict=False)
+    try:
+        resolved.relative_to(root)
+    except ValueError:
+        fail(f"{label} must stay inside the repository")
+    return normalized
+
+
+def require_evidence_source(root: Path, contract: JourneyContract, source: str) -> tuple[str, Path]:
+    root = root.resolve()
+    normalized = repository_relative(root, source, "redacted evidence source")
+    if not normalized.startswith(contract.evidence_prefix) or not normalized.endswith(".redacted.json"):
+        fail(f"redacted evidence source must be {contract.evidence_prefix}*.redacted.json")
+    candidate = root
+    for component in Path(normalized).parts:
+        candidate = candidate / component
+        if candidate.is_symlink():
+            fail(f"redacted evidence source is absent or unsafe: {normalized}")
+    path = root / normalized
+    if not path.is_file():
+        fail(f"redacted evidence source is absent or unsafe: {normalized}")
+    return normalized, path
+
+
+def require_reachable_commit(root: Path, commit: str, label: str) -> None:
+    completed = subprocess.run(
+        ["git", "cat-file", "-e", f"{commit}^{{commit}}"],
+        cwd=root,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    if completed.returncode != 0:
+        fail(f"{label} is not a reachable commit")
+
+
+def require_ancestor_commit(root: Path, ancestor: str, descendant: str) -> None:
+    completed = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", ancestor, descendant],
+        cwd=root,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    if completed.returncode != 0:
+        fail("--source-sha must be an ancestor of --evidence-sha")
+
+
+def require_git_file_matches(root: Path, commit: str, source: str, expected: bytes) -> None:
+    completed = subprocess.run(["git", "show", f"{commit}:{source}"], cwd=root, capture_output=True, check=False)
+    if completed.returncode != 0:
+        fail("redacted evidence source must exist at --evidence-sha")
+    if completed.stdout != expected:
+        fail("redacted evidence source bytes must match --evidence-sha")
+
+
+def parse_requirement_ids(raw: str | None, covered: list[str], contract: JourneyContract) -> list[str]:
+    if raw is None:
+        selected = list(covered)
+    else:
+        selected = [item.strip() for item in raw.split(",") if item.strip()]
+    if not selected:
+        fail("requirement_ids must not be empty")
+    if len(set(selected)) != len(selected):
+        fail("requirement_ids must be unique")
+    invalid = [item for item in selected if not REQUIREMENT_RE.fullmatch(item)]
+    if invalid:
+        fail(f"invalid requirement id(s): {', '.join(invalid)}")
+    overclaimed = [item for item in selected if item not in covered]
+    if overclaimed:
+        fail(f"requirement ids must be covered by evidence.requirement_ids: {', '.join(sorted(overclaimed))}")
+    forbidden = [item for item in selected if item not in contract.promotable_requirement_ids]
+    if forbidden:
+        fail(f"{contract.journey_id} cannot promote {', '.join(sorted(forbidden))}")
+    return selected
+
+
+def load_mapped_pending_requirements(root: Path, contract: JourneyContract) -> set[str]:
+    conformance = load_json_object(root / "specs" / "CONFORMANCE.json", "spec conformance")
+    requirements = require_list(conformance.get("requirements"), "specs/CONFORMANCE.json requirements")
+    mapped: set[str] = set()
+    for row in requirements:
+        if not isinstance(row, dict):
+            continue
+        journeys = row.get("journeys")
+        if isinstance(journeys, list) and contract.journey_id in journeys and row.get("state") == "pending":
+            requirement_id = row.get("requirement_id")
+            if isinstance(requirement_id, str):
+                mapped.add(requirement_id)
+    return mapped
+
+
+def _digest_document(manifest_dir: Path, entry: Any, step_id: str, index: int) -> dict[str, Any]:
+    location = f"{step_id}.documents[{index}]"
+    document = require_object(entry, location)
+    require_exact_keys(document, {"id", "schema", "path"}, {"id", "schema", "path"}, location)
+    document_id = require_string(document.get("id"), SAFE_LABEL_RE, f"{location}.id")
+    schema = require_string(document.get("schema"), DOCUMENT_SCHEMA_RE, f"{location}.schema")
+    raw_path = require_string(document.get("path"), None, f"{location}.path")
+    candidate = Path(raw_path)
+    path = candidate if candidate.is_absolute() else (manifest_dir / candidate)
+    if path.is_symlink() or not path.is_file():
+        fail(f"{location}.path is absent or unsafe")
+    try:
+        payload = path.read_bytes()
+    except OSError as exc:
+        fail(f"{location}.path cannot be read: {exc}")
+    try:
+        decoded = payload.decode("utf-8")
+    except UnicodeDecodeError:
+        fail(f"{location}.path must be a UTF-8 CLI JSON document")
+    try:
+        json.loads(decoded)
+    except json.JSONDecodeError as exc:
+        fail(f"{location}.path must be a JSON document: {exc}")
+    # The document itself is never embedded, but a captured document that still
+    # carries a credential must not be archived at all.
+    reject_secret_like_text(decoded, f"{location}.path")
+    return {
+        "id": document_id,
+        "schema": schema,
+        "sha256": hashlib.sha256(payload).hexdigest(),
+        "bytes": len(payload),
+    }
+
+
+def _require_manifest_steps(manifest_dir: Path, contract: JourneyContract, value: Any) -> list[dict[str, Any]]:
+    steps = require_list(value, "steps")
+    by_id: dict[str, dict[str, Any]] = {}
+    covered: set[str] = set()
+    for index, item in enumerate(steps):
+        location = f"steps[{index}]"
+        step = require_object(item, location)
+        require_exact_keys(
+            step,
+            {"id", "status", "assertion", "requirement_ids", "documents"},
+            {"id", "status", "assertion", "requirement_ids", "documents"},
+            location,
+        )
+        step_id = require_string(step.get("id"), None, f"{location}.id")
+        if step_id not in contract.step_requirement_ids:
+            fail(f"unknown {contract.journey_id} step id: {step_id}")
+        if step_id in by_id:
+            fail(f"duplicate step id: {step_id}")
+        if step.get("status") != "pass":
+            fail(f"{step_id}.status must equal 'pass'")
+        assertion = require_string(step.get("assertion"), None, f"{step_id}.assertion")
+        requirement_ids = require_list(step.get("requirement_ids"), f"{step_id}.requirement_ids")
+        if not requirement_ids:
+            fail(f"{step_id}.requirement_ids must not be empty")
+        allowed = contract.allowed_step_requirement_ids(step_id)
+        normalized_requirements: list[str] = []
+        for requirement_index, requirement in enumerate(requirement_ids):
+            requirement_id = require_string(
+                requirement, REQUIREMENT_RE, f"{step_id}.requirement_ids[{requirement_index}]"
+            )
+            if requirement_id not in allowed:
+                fail(
+                    f"{step_id}.requirement_ids: {requirement_id} is not a requirement this step "
+                    f"exercises; allowed: {', '.join(sorted(allowed))}"
+                )
+            if requirement_id in normalized_requirements:
+                fail(f"{step_id}.requirement_ids must be unique")
+            normalized_requirements.append(requirement_id)
+        covered.update(normalized_requirements)
+        documents = require_list(step.get("documents"), f"{step_id}.documents")
+        if not documents:
+            fail(f"{step_id}.documents must reference at least one captured CLI JSON document")
+        digested = [
+            _digest_document(manifest_dir, document, step_id, document_index)
+            for document_index, document in enumerate(documents)
+        ]
+        document_ids = [document["id"] for document in digested]
+        if len(set(document_ids)) != len(document_ids):
+            fail(f"{step_id}.documents ids must be unique")
+        by_id[step_id] = {
+            "id": step_id,
+            "status": "pass",
+            "assertion": assertion,
+            "artifacts": [contract.artifact_id],
+            "requirement_ids": sorted(normalized_requirements),
+            "documents": digested,
+        }
+    missing = [step_id for step_id in contract.step_id_order if step_id not in by_id]
+    if missing:
+        fail(f"missing {contract.journey_id} step(s): {', '.join(missing)}")
+    uncovered = sorted(contract.promotable_requirement_ids - covered)
+    if uncovered:
+        fail(f"steps do not cover every mapped requirement: {', '.join(uncovered)}")
+    return [by_id[step_id] for step_id in contract.step_id_order]
+
+
+def _require_manifest_observations(contract: JourneyContract, value: Any) -> dict[str, Any]:
+    observations = require_object(value, "observations")
+    required = set(contract.true_observations) | set(contract.false_observations)
+    allowed = set(required)
+    if contract.money_path_tables:
+        allowed.add("money_path_zero_rows")
+        required.add("money_path_zero_rows")
+    require_exact_keys(observations, required, allowed, "observations")
+    for field in sorted(contract.true_observations):
+        if observations.get(field) is not True:
+            fail(f"observations.{field} must be true")
+    for field in sorted(contract.false_observations):
+        if observations.get(field) is not False:
+            fail(f"observations.{field} must be false")
+    normalized = {field: observations[field] for field in sorted(contract.true_observations | contract.false_observations)}
+    if contract.money_path_tables:
+        money_path = require_object(observations.get("money_path_zero_rows"), "observations.money_path_zero_rows")
+        require_exact_keys(
+            money_path,
+            set(contract.money_path_tables),
+            set(contract.money_path_tables),
+            "observations.money_path_zero_rows",
+        )
+        for table in contract.money_path_tables:
+            count = money_path.get(table)
+            if isinstance(count, bool) or not isinstance(count, int) or count != 0:
+                fail(f"observations.money_path_zero_rows.{table} must be the integer 0")
+        normalized["money_path_zero_rows"] = {table: 0 for table in contract.money_path_tables}
+    return normalized
+
+
+def _parse_captured_at(raw: str | None) -> str:
+    if raw is None:
+        return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return require_string(raw, DATETIME_Z_RE, "--captured-at")
+
+
+def _parse_expires_at(raw: str | None, captured_at: str) -> str:
+    if raw is None:
+        captured = datetime.strptime(captured_at, "%Y-%m-%dT%H:%M:%SZ").date()
+        return (captured + timedelta(days=DEFAULT_EVIDENCE_LIFETIME_DAYS)).isoformat()
+    expires_at = require_string(raw, DATE_RE, "--expires-at")
+    if date.fromisoformat(expires_at) < date.today():
+        fail("--expires-at must not be in the past")
+    return expires_at
+
+
+def build_evidence(
+    root: Path,
+    contract: JourneyContract,
+    manifest_path: Path,
+    *,
+    source_sha: str,
+    operator_role: str,
+    operator_identity_fingerprint: str,
+    hardware_profile: str,
+    candidate: str,
+    captured_at: str | None,
+    expires_at: str | None,
+    summary: str,
+) -> dict[str, Any]:
+    require_string(source_sha, COMMIT_RE, "--source-sha")
+    require_reachable_commit(root, source_sha, "--source-sha")
+    manifest = load_json_object(manifest_path, "run manifest")
+    require_exact_keys(
+        manifest,
+        {"schema_version", "journey_id", "run_id", "environment_class", "cli_version", "harness", "steps", "observations"},
+        {"schema_version", "journey_id", "run_id", "environment_class", "cli_version", "harness", "steps", "observations"},
+        "run manifest",
+    )
+    if manifest.get("schema_version") != RUN_MANIFEST_SCHEMA:
+        fail(f"run manifest schema_version must equal {RUN_MANIFEST_SCHEMA!r}")
+    if manifest.get("journey_id") != contract.journey_id:
+        fail(f"run manifest journey_id must equal {contract.journey_id!r}")
+    run_id = require_string(manifest.get("run_id"), SAFE_LABEL_RE, "run_id")
+    environment_class = require_string(manifest.get("environment_class"), None, "environment_class")
+    if environment_class not in BYOM_JOURNEY_ENVIRONMENT_CLASSES:
+        fail(f"environment_class must be one of {sorted(BYOM_JOURNEY_ENVIRONMENT_CLASSES)}")
+    cli_version = require_string(manifest.get("cli_version"), SAFE_LABEL_RE, "cli_version")
+
+    harness = require_object(manifest.get("harness"), "harness")
+    require_exact_keys(harness, {"name", "status"}, {"name", "status"}, "harness")
+    harness_name = require_string(harness.get("name"), REPO_RELATIVE_FILE_RE, "harness.name")
+    repository_relative(root, harness_name, "harness.name")
+    if harness.get("status") != "pass":
+        fail("harness.status must equal 'pass'")
+
+    steps = _require_manifest_steps(manifest_path.parent.resolve(), contract, manifest.get("steps"))
+    observations = _require_manifest_observations(contract, manifest.get("observations"))
+    requirement_ids = sorted({item for step in steps for item in step["requirement_ids"]})
+
+    captured = _parse_captured_at(captured_at)
+    evidence = {
+        "schema_version": contract.evidence_schema,
+        "journey_id": contract.journey_id,
+        "run_id": run_id,
+        "execution_mode": contract.execution_mode,
+        "requirement_ids": requirement_ids,
+        "repository": {"name": REPOSITORY, "commit": source_sha},
+        "captured_at": captured,
+        "expires_at": _parse_expires_at(expires_at, captured),
+        "operator": {
+            "role": require_string(operator_role, SAFE_LABEL_RE, "--operator-role"),
+            "identity_fingerprint": require_string(
+                operator_identity_fingerprint, SHA256_RE, "--operator-identity-fingerprint"
+            ),
+        },
+        "environment": {
+            "class": environment_class,
+            "hardware_profile": require_string(hardware_profile, SAFE_LABEL_RE, "--hardware-profile"),
+            "candidate": require_string(candidate, SAFE_LABEL_RE, "--candidate"),
+        },
+        "harness": {"name": harness_name, "status": "pass", "cli_version": cli_version},
+        "result": {"status": "pass", "summary": require_string(summary, None, "--summary")},
+        "steps": steps,
+        "observations": observations,
+        "redaction": {
+            "secrets_redacted": True,
+            "operator_identity_redacted": True,
+            "local_account_names_redacted": True,
+        },
+    }
+    assert_redacted(evidence)
+    return evidence
+
+
+def build_journey_result_payload(
+    root: Path,
+    contract: JourneyContract,
+    source: str,
+    *,
+    source_sha: str,
+    evidence_sha: str,
+    requirement_ids: str | None,
+) -> dict[str, Any]:
+    require_string(source_sha, COMMIT_RE, "--source-sha")
+    require_string(evidence_sha, COMMIT_RE, "--evidence-sha")
+    normalized_source, path = require_evidence_source(root, contract, source)
+    evidence, evidence_bytes = load_json_object_bytes(path, "BYOM redacted evidence")
+    assert_redacted(evidence)
+    if evidence.get("schema_version") != contract.evidence_schema:
+        fail(f"schema_version must equal {contract.evidence_schema!r}")
+    if evidence.get("journey_id") != contract.journey_id:
+        fail(f"journey_id must equal {contract.journey_id!r}")
+    if evidence.get("execution_mode") != contract.execution_mode:
+        fail(f"execution_mode must equal {contract.execution_mode!r}")
+
+    require_reachable_commit(root, source_sha, "--source-sha")
+    require_reachable_commit(root, evidence_sha, "--evidence-sha")
+    require_ancestor_commit(root, source_sha, evidence_sha)
+    repository = require_object(evidence.get("repository"), "repository")
+    if repository.get("name") != REPOSITORY:
+        fail(f"repository.name must equal {REPOSITORY!r}")
+    if require_string(repository.get("commit"), COMMIT_RE, "repository.commit") != source_sha:
+        fail("repository.commit must exactly match --source-sha")
+    require_git_file_matches(root, evidence_sha, normalized_source, evidence_bytes)
+
+    covered = require_list(evidence.get("requirement_ids"), "requirement_ids")
+    covered_ids = [require_string(item, REQUIREMENT_RE, "requirement_ids[]") for item in covered]
+    selected = parse_requirement_ids(requirement_ids, covered_ids, contract)
+    mapped = load_mapped_pending_requirements(root, contract)
+    not_mapped = [item for item in selected if item not in mapped]
+    if not_mapped:
+        fail(
+            f"requirement_ids must be pending and mapped to {contract.journey_id}: "
+            + ", ".join(sorted(not_mapped))
+        )
+
+    captured_at = require_string(evidence.get("captured_at"), DATETIME_Z_RE, "captured_at")
+    expires_at = require_string(evidence.get("expires_at"), DATE_RE, "expires_at")
+    if date.fromisoformat(expires_at) < date.today():
+        fail("expires_at must not be in the past")
+
+    operator = deepcopy(require_object(evidence.get("operator"), "operator"))
+    require_string(operator.get("role"), SAFE_LABEL_RE, "operator.role")
+    require_string(operator.get("identity_fingerprint"), SHA256_RE, "operator.identity_fingerprint")
+    environment = deepcopy(require_object(evidence.get("environment"), "environment"))
+    require_exact_keys(
+        environment, {"class", "hardware_profile", "candidate"}, {"class", "hardware_profile", "candidate"}, "environment"
+    )
+    if environment.get("class") not in BYOM_JOURNEY_ENVIRONMENT_CLASSES:
+        fail(f"environment.class must be one of {sorted(BYOM_JOURNEY_ENVIRONMENT_CLASSES)}")
+
+    run_result = deepcopy(require_object(evidence.get("result"), "result"))
+    if run_result.get("status") != "pass":
+        fail("result.status must equal 'pass'")
+    require_exact_keys(run_result, {"status"}, {"status", "summary"}, "result")
+
+    observations = _require_manifest_observations(contract, evidence.get("observations"))
+    redaction = deepcopy(require_object(evidence.get("redaction"), "redaction"))
+    for field in ("secrets_redacted", "operator_identity_redacted", "local_account_names_redacted"):
+        if redaction.get(field) is not True:
+            fail(f"redaction.{field} must be true")
+
+    evidence_steps = require_list(evidence.get("steps"), "steps")
+    by_id: dict[str, dict[str, Any]] = {}
+    for index, item in enumerate(evidence_steps):
+        step = require_object(item, f"steps[{index}]")
+        step_id = require_string(step.get("id"), None, f"steps[{index}].id")
+        if step_id not in contract.step_requirement_ids:
+            fail(f"unknown {contract.journey_id} step id: {step_id}")
+        if step_id in by_id:
+            fail(f"duplicate step id: {step_id}")
+        if step.get("status") != "pass":
+            fail(f"{step_id}.status must equal 'pass'")
+        assertion = require_string(step.get("assertion"), None, f"{step_id}.assertion")
+        artifacts = step.get("artifacts")
+        if artifacts != [contract.artifact_id]:
+            fail(f"{step_id}.artifacts must reference {contract.artifact_id}")
+        documents = require_list(step.get("documents"), f"{step_id}.documents")
+        if not documents:
+            fail(f"{step_id}.documents must reference at least one captured CLI JSON document")
+        for document_index, document in enumerate(documents):
+            location = f"{step_id}.documents[{document_index}]"
+            entry = require_object(document, location)
+            require_exact_keys(entry, {"id", "schema", "sha256", "bytes"}, {"id", "schema", "sha256", "bytes"}, location)
+            require_string(entry.get("sha256"), SHA256_RE, f"{location}.sha256")
+        # Steps in the signed payload carry only the governance-closed keys; the
+        # per-step requirement ids and captured-document digests stay in the
+        # hash-bound evidence artifact.
+        by_id[step_id] = {
+            "id": step_id,
+            "status": "pass",
+            "assertion": assertion,
+            "artifacts": [contract.artifact_id],
+        }
+    missing = [step_id for step_id in contract.step_id_order if step_id not in by_id]
+    if missing:
+        fail(f"missing {contract.journey_id} step(s): {', '.join(missing)}")
+
+    return {
+        "schema_version": JOURNEY_RESULT_PAYLOAD_SCHEMA,
+        "journey_id": contract.journey_id,
+        "requirement_ids": selected,
+        "repository": {"name": REPOSITORY, "commit": source_sha},
+        "captured_at": captured_at,
+        "expires_at": expires_at,
+        "operator": operator,
+        "environment": environment,
+        "artifacts": [
+            {
+                "id": contract.artifact_id,
+                "sha256": hashlib.sha256(evidence_bytes).hexdigest(),
+                "source": normalized_source,
+            }
+        ],
+        "result": run_result,
+        "steps": [by_id[step_id] for step_id in contract.step_id_order],
+        "redaction": redaction,
+        "run_id": require_string(evidence.get("run_id"), SAFE_LABEL_RE, "run_id"),
+        "execution_mode": contract.execution_mode,
+        "observations": observations,
+    }
+
+
+def run_builder_cli(contract: JourneyContract, argv: list[str] | None, program: str) -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(description=f"Build an unsigned {contract.journey_id} journey-result payload.")
+    parser.add_argument("redacted_evidence_source", help=f"{contract.evidence_prefix}*.redacted.json")
+    parser.add_argument("--root", default=".", help="repository root")
+    parser.add_argument("--output", required=True, help="unsigned journey-result payload output path")
+    parser.add_argument("--source-sha", required=True, help="source/build commit captured by the evidence")
+    parser.add_argument("--evidence-sha", required=True, help="commit containing the redacted evidence")
+    parser.add_argument("--requirement-ids", default=None, help="comma-separated requirement IDs to cover")
+    args = parser.parse_args(argv)
+
+    root = Path(args.root).resolve()
+    output = Path(args.output)
+    if not output.is_absolute():
+        output = root / output
+    try:
+        payload = build_journey_result_payload(
+            root,
+            contract,
+            args.redacted_evidence_source,
+            source_sha=args.source_sha,
+            evidence_sha=args.evidence_sha,
+            requirement_ids=args.requirement_ids,
+        )
+        write_json_atomically(output, payload)
+    except BYOMEvidenceError as exc:
+        print(f"{program}: {exc}", file=sys.stderr)
+        return 1
+    print(f"{program}: wrote {output}")
+    return 0

--- a/scripts/byom_journey_evidence.py
+++ b/scripts/byom_journey_evidence.py
@@ -498,7 +498,9 @@ def _digest_document(manifest_dir: Path, entry: Any, step_id: str, index: int) -
     except UnicodeDecodeError:
         fail(f"{location}.path must be a UTF-8 CLI JSON document")
     try:
-        parsed = json.loads(decoded)
+        parsed = json.loads(decoded, object_pairs_hook=_unique_json_object)
+    except DuplicateJSONKeyError as exc:
+        fail(f"{location}.path must not contain duplicate JSON keys: {exc}")
     except json.JSONDecodeError as exc:
         fail(f"{location}.path must be a JSON document: {exc}")
     # The raw document is never committed, so this is the only point at which
@@ -886,7 +888,7 @@ def build_journey_result_payload(
         for step in validated_steps
     ]
 
-    return {
+    payload = {
         "schema_version": JOURNEY_RESULT_PAYLOAD_SCHEMA,
         "journey_id": contract.journey_id,
         "requirement_ids": selected,
@@ -909,6 +911,36 @@ def build_journey_result_payload(
         "execution_mode": contract.execution_mode,
         "observations": observations,
     }
+    if set(payload) != BYOM_JOURNEY_RESULT_PAYLOAD_KEYS:
+        fail("builder payload keys drifted from BYOM_JOURNEY_RESULT_PAYLOAD_KEYS")
+    return payload
+
+
+# The closed key set of a BYOM journey-result payload. The builder emits exactly
+# these keys, and governance requires a signed BYOM payload to carry exactly
+# these keys: the generic signed-result schema permits optional fields such as
+# `harness`, `config_before`, `candidate`, or `eip712`, but nothing binds those to
+# the redacted evidence, so a hand-signed BYOM payload must not be able to smuggle
+# them past source re-validation.
+BYOM_JOURNEY_RESULT_PAYLOAD_KEYS = frozenset(
+    {
+        "schema_version",
+        "journey_id",
+        "requirement_ids",
+        "repository",
+        "captured_at",
+        "expires_at",
+        "operator",
+        "environment",
+        "artifacts",
+        "result",
+        "steps",
+        "redaction",
+        "run_id",
+        "execution_mode",
+        "observations",
+    }
+)
 
 
 def run_builder_cli(contract: JourneyContract, argv: list[str] | None, program: str) -> int:

--- a/scripts/byom_journey_evidence.py
+++ b/scripts/byom_journey_evidence.py
@@ -449,9 +449,14 @@ def _digest_document(manifest_dir: Path, entry: Any, step_id: str, index: int) -
         json.loads(decoded)
     except json.JSONDecodeError as exc:
         fail(f"{location}.path must be a JSON document: {exc}")
-    # The document itself is never embedded, but a captured document that still
-    # carries a credential must not be archived at all.
-    reject_secret_like_text(decoded, f"{location}.path")
+    # The document itself is never embedded, but its digest is what the signed
+    # journey-result binds to, so the redaction claim has to hold for the bytes we
+    # digest: a captured document that still carries a URL, an absolute or
+    # home-relative path, a hostname, an IP literal, a localhost reference, or a
+    # credential must not be archived at all. There is deliberately no allowlist
+    # for raw-document fields -- a CLI document that legitimately needs an
+    # endpoint or a path in it is a document the operator redacts before capture.
+    reject_unredacted_text(decoded, f"{location}.path")
     return {
         "id": document_id,
         "schema": schema,
@@ -460,20 +465,32 @@ def _digest_document(manifest_dir: Path, entry: Any, step_id: str, index: int) -
     }
 
 
-def _require_manifest_steps(manifest_dir: Path, contract: JourneyContract, value: Any) -> list[dict[str, Any]]:
-    steps = require_list(value, "steps")
+def validate_evidence_steps(
+    contract: JourneyContract, value: Any, *, location: str = "steps"
+) -> tuple[list[dict[str, Any]], list[str]]:
+    """Validate redacted-evidence steps against one journey contract.
+
+    This is the only step validator. Capture runs it on the steps it derives from
+    the run manifest, and the journey-result builders run it again on the
+    committed redacted evidence, so hand-authored evidence cannot claim a
+    requirement its steps do not actually exercise. It requires the exact step-key
+    set for the journey, validates every per-step requirement id against
+    `allowed_step_requirement_ids()`, and returns the steps in contract order plus
+    the recomputed union of those requirement ids.
+    """
+    steps = require_list(value, location)
     by_id: dict[str, dict[str, Any]] = {}
     covered: set[str] = set()
     for index, item in enumerate(steps):
-        location = f"steps[{index}]"
-        step = require_object(item, location)
+        step_location = f"{location}[{index}]"
+        step = require_object(item, step_location)
         require_exact_keys(
             step,
-            {"id", "status", "assertion", "requirement_ids", "documents"},
-            {"id", "status", "assertion", "requirement_ids", "documents"},
-            location,
+            {"id", "status", "assertion", "artifacts", "requirement_ids", "documents"},
+            {"id", "status", "assertion", "artifacts", "requirement_ids", "documents"},
+            step_location,
         )
-        step_id = require_string(step.get("id"), None, f"{location}.id")
+        step_id = require_string(step.get("id"), None, f"{step_location}.id")
         if step_id not in contract.step_requirement_ids:
             fail(f"unknown {contract.journey_id} step id: {step_id}")
         if step_id in by_id:
@@ -481,6 +498,8 @@ def _require_manifest_steps(manifest_dir: Path, contract: JourneyContract, value
         if step.get("status") != "pass":
             fail(f"{step_id}.status must equal 'pass'")
         assertion = require_string(step.get("assertion"), None, f"{step_id}.assertion")
+        if step.get("artifacts") != [contract.artifact_id]:
+            fail(f"{step_id}.artifacts must reference {contract.artifact_id}")
         requirement_ids = require_list(step.get("requirement_ids"), f"{step_id}.requirement_ids")
         if not requirement_ids:
             fail(f"{step_id}.requirement_ids must not be empty")
@@ -502,11 +521,30 @@ def _require_manifest_steps(manifest_dir: Path, contract: JourneyContract, value
         documents = require_list(step.get("documents"), f"{step_id}.documents")
         if not documents:
             fail(f"{step_id}.documents must reference at least one captured CLI JSON document")
-        digested = [
-            _digest_document(manifest_dir, document, step_id, document_index)
-            for document_index, document in enumerate(documents)
-        ]
-        document_ids = [document["id"] for document in digested]
+        normalized_documents: list[dict[str, Any]] = []
+        for document_index, document in enumerate(documents):
+            document_location = f"{step_id}.documents[{document_index}]"
+            entry = require_object(document, document_location)
+            require_exact_keys(
+                entry,
+                {"id", "schema", "sha256", "bytes"},
+                {"id", "schema", "sha256", "bytes"},
+                document_location,
+            )
+            size = entry.get("bytes")
+            if isinstance(size, bool) or not isinstance(size, int) or size <= 0:
+                fail(f"{document_location}.bytes must be a positive integer")
+            normalized_documents.append(
+                {
+                    "id": require_string(entry.get("id"), SAFE_LABEL_RE, f"{document_location}.id"),
+                    "schema": require_string(
+                        entry.get("schema"), DOCUMENT_SCHEMA_RE, f"{document_location}.schema"
+                    ),
+                    "sha256": require_string(entry.get("sha256"), SHA256_RE, f"{document_location}.sha256"),
+                    "bytes": size,
+                }
+            )
+        document_ids = [document["id"] for document in normalized_documents]
         if len(set(document_ids)) != len(document_ids):
             fail(f"{step_id}.documents ids must be unique")
         by_id[step_id] = {
@@ -515,7 +553,7 @@ def _require_manifest_steps(manifest_dir: Path, contract: JourneyContract, value
             "assertion": assertion,
             "artifacts": [contract.artifact_id],
             "requirement_ids": sorted(normalized_requirements),
-            "documents": digested,
+            "documents": normalized_documents,
         }
     missing = [step_id for step_id in contract.step_id_order if step_id not in by_id]
     if missing:
@@ -523,7 +561,40 @@ def _require_manifest_steps(manifest_dir: Path, contract: JourneyContract, value
     uncovered = sorted(contract.promotable_requirement_ids - covered)
     if uncovered:
         fail(f"steps do not cover every mapped requirement: {', '.join(uncovered)}")
-    return [by_id[step_id] for step_id in contract.step_id_order]
+    return [by_id[step_id] for step_id in contract.step_id_order], sorted(covered)
+
+
+def _require_manifest_steps(
+    manifest_dir: Path, contract: JourneyContract, value: Any
+) -> tuple[list[dict[str, Any]], list[str]]:
+    """Digest the manifest's captured documents, then apply the shared step validator."""
+    steps = require_list(value, "steps")
+    candidates: list[dict[str, Any]] = []
+    for index, item in enumerate(steps):
+        location = f"steps[{index}]"
+        step = require_object(item, location)
+        require_exact_keys(
+            step,
+            {"id", "status", "assertion", "requirement_ids", "documents"},
+            {"id", "status", "assertion", "requirement_ids", "documents"},
+            location,
+        )
+        step_id = require_string(step.get("id"), None, f"{location}.id")
+        documents = require_list(step.get("documents"), f"{step_id}.documents")
+        candidates.append(
+            {
+                "id": step_id,
+                "status": step.get("status"),
+                "assertion": step.get("assertion"),
+                "artifacts": [contract.artifact_id],
+                "requirement_ids": step.get("requirement_ids"),
+                "documents": [
+                    _digest_document(manifest_dir, document, step_id, document_index)
+                    for document_index, document in enumerate(documents)
+                ],
+            }
+        )
+    return validate_evidence_steps(contract, candidates)
 
 
 def _require_manifest_observations(contract: JourneyContract, value: Any) -> dict[str, Any]:
@@ -613,9 +684,10 @@ def build_evidence(
     if harness.get("status") != "pass":
         fail("harness.status must equal 'pass'")
 
-    steps = _require_manifest_steps(manifest_path.parent.resolve(), contract, manifest.get("steps"))
+    steps, requirement_ids = _require_manifest_steps(
+        manifest_path.parent.resolve(), contract, manifest.get("steps")
+    )
     observations = _require_manifest_observations(contract, manifest.get("observations"))
-    requirement_ids = sorted({item for step in steps for item in step["requirement_ids"]})
 
     captured = _parse_captured_at(captured_at)
     evidence = {
@@ -683,8 +755,19 @@ def build_journey_result_payload(
         fail("repository.commit must exactly match --source-sha")
     require_git_file_matches(root, evidence_sha, normalized_source, evidence_bytes)
 
-    covered = require_list(evidence.get("requirement_ids"), "requirement_ids")
-    covered_ids = [require_string(item, REQUIREMENT_RE, "requirement_ids[]") for item in covered]
+    # Committed redacted evidence is input, not truth: re-run the same step
+    # validator capture used and recompute the requirement union from the steps
+    # rather than trusting the top-level list a hand-authored artifact declares.
+    validated_steps, covered_ids = validate_evidence_steps(contract, evidence.get("steps"))
+    declared = require_list(evidence.get("requirement_ids"), "requirement_ids")
+    declared_ids = [require_string(item, REQUIREMENT_RE, "requirement_ids[]") for item in declared]
+    if len(set(declared_ids)) != len(declared_ids):
+        fail("requirement_ids must be unique")
+    if sorted(declared_ids) != covered_ids:
+        fail(
+            "requirement_ids must equal the union of the evidence step requirement ids: "
+            f"expected {', '.join(covered_ids)}"
+        )
     selected = parse_requirement_ids(requirement_ids, covered_ids, contract)
     mapped = load_mapped_pending_requirements(root, contract)
     not_mapped = [item for item in selected if item not in mapped]
@@ -720,41 +803,18 @@ def build_journey_result_payload(
         if redaction.get(field) is not True:
             fail(f"redaction.{field} must be true")
 
-    evidence_steps = require_list(evidence.get("steps"), "steps")
-    by_id: dict[str, dict[str, Any]] = {}
-    for index, item in enumerate(evidence_steps):
-        step = require_object(item, f"steps[{index}]")
-        step_id = require_string(step.get("id"), None, f"steps[{index}].id")
-        if step_id not in contract.step_requirement_ids:
-            fail(f"unknown {contract.journey_id} step id: {step_id}")
-        if step_id in by_id:
-            fail(f"duplicate step id: {step_id}")
-        if step.get("status") != "pass":
-            fail(f"{step_id}.status must equal 'pass'")
-        assertion = require_string(step.get("assertion"), None, f"{step_id}.assertion")
-        artifacts = step.get("artifacts")
-        if artifacts != [contract.artifact_id]:
-            fail(f"{step_id}.artifacts must reference {contract.artifact_id}")
-        documents = require_list(step.get("documents"), f"{step_id}.documents")
-        if not documents:
-            fail(f"{step_id}.documents must reference at least one captured CLI JSON document")
-        for document_index, document in enumerate(documents):
-            location = f"{step_id}.documents[{document_index}]"
-            entry = require_object(document, location)
-            require_exact_keys(entry, {"id", "schema", "sha256", "bytes"}, {"id", "schema", "sha256", "bytes"}, location)
-            require_string(entry.get("sha256"), SHA256_RE, f"{location}.sha256")
-        # Steps in the signed payload carry only the governance-closed keys; the
-        # per-step requirement ids and captured-document digests stay in the
-        # hash-bound evidence artifact.
-        by_id[step_id] = {
-            "id": step_id,
+    # Steps in the signed payload carry only the governance-closed keys; the
+    # per-step requirement ids and captured-document digests stay in the
+    # hash-bound evidence artifact.
+    steps_payload = [
+        {
+            "id": step["id"],
             "status": "pass",
-            "assertion": assertion,
+            "assertion": step["assertion"],
             "artifacts": [contract.artifact_id],
         }
-    missing = [step_id for step_id in contract.step_id_order if step_id not in by_id]
-    if missing:
-        fail(f"missing {contract.journey_id} step(s): {', '.join(missing)}")
+        for step in validated_steps
+    ]
 
     return {
         "schema_version": JOURNEY_RESULT_PAYLOAD_SCHEMA,
@@ -773,7 +833,7 @@ def build_journey_result_payload(
             }
         ],
         "result": run_result,
-        "steps": [by_id[step_id] for step_id in contract.step_id_order],
+        "steps": steps_payload,
         "redaction": redaction,
         "run_id": require_string(evidence.get("run_id"), SAFE_LABEL_RE, "run_id"),
         "execution_mode": contract.execution_mode,

--- a/scripts/byom_journey_evidence.py
+++ b/scripts/byom_journey_evidence.py
@@ -27,6 +27,7 @@ from typing import Any
 
 from check_spec_governance import (
     BYOM_JOURNEY_ENVIRONMENT_CLASSES,
+    CREDENTIAL_SHAPE_PATTERN_FRAGMENTS,
     DuplicateJSONKeyError,
     JOURNEY_RESULT_PAYLOAD_SCHEMA,
     NETWORK_MODEL_ADMISSION_ARTIFACT_ID,
@@ -73,33 +74,62 @@ REPO_RELATIVE_FILE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*(?:/[A-Za-z0-9][
 # absolute or home-relative path, a hostname, an IP literal, or anything shaped
 # like a credential. Captured CLI documents are digested, never embedded, so the
 # operator's raw endpoints and paths never reach the repository.
+#
+# The hostname rule is shape-based, not a suffix allowlist: anything that looks
+# like DNS -- one or more `label.` groups followed by an alphabetic final label --
+# is rejected, whatever the TLD. A handful of legitimate evidence values are
+# DNS-shaped by coincidence, and they are handled by the explicit
+# `HOSTNAME_ALLOWLISTED_VALUE_SHAPES` below rather than by weakening the rule.
+DNS_HOSTNAME_RE = re.compile(
+    r"(?i)(?<![A-Za-z0-9_.-])"
+    r"(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+"
+    r"[A-Za-z]{2,63}"
+    r"(?![A-Za-z0-9_-])"
+)
+IPV6_LITERAL_RE = re.compile(
+    r"(?<![0-9A-Za-z:])"
+    r"(?:"
+    r"(?:[0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4}"
+    r"|(?:[0-9A-Fa-f]{1,4}:){1,7}:"
+    r"|(?:[0-9A-Fa-f]{1,4}:){1,6}:[0-9A-Fa-f]{1,4}"
+    r"|(?:[0-9A-Fa-f]{1,4}:){1,5}(?::[0-9A-Fa-f]{1,4}){1,2}"
+    r"|(?:[0-9A-Fa-f]{1,4}:){1,4}(?::[0-9A-Fa-f]{1,4}){1,3}"
+    r"|(?:[0-9A-Fa-f]{1,4}:){1,3}(?::[0-9A-Fa-f]{1,4}){1,4}"
+    r"|(?:[0-9A-Fa-f]{1,4}:){1,2}(?::[0-9A-Fa-f]{1,4}){1,5}"
+    r"|[0-9A-Fa-f]{1,4}:(?::[0-9A-Fa-f]{1,4}){1,6}"
+    r"|:(?::[0-9A-Fa-f]{1,4}){1,7}"
+    r")"
+    r"(?![0-9A-Za-z:])"
+)
+# The only DNS-shaped strings this evidence is allowed to carry. A repository
+# source file name (`run-cli-onboarding-e2e.py`, `run-manifest.json`) is
+# `<name>.<ext>`, which is indistinguishable from a two-label hostname by shape,
+# and the evidence records `harness.name` verbatim. Every other value the contract
+# emits -- evidence and document schema ids (`...-evidence.v1`, `..._status.v1`),
+# step ids, requirement ids, run ids, CLI/semantic versions -- ends in a label
+# that is not purely alphabetic, so it never reaches this allowlist at all.
+HOSTNAME_ALLOWLISTED_VALUE_SHAPES: tuple[re.Pattern[str], ...] = (
+    re.compile(
+        r"(?i)^[A-Za-z0-9][A-Za-z0-9._-]*"
+        r"\.(?:go|json|jsonl|md|mjs|py|sh|swift|toml|ts|txt|yaml|yml)$"
+    ),
+)
 FORBIDDEN_VALUE_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     ("a url", re.compile(r"(?i)[a-z][a-z0-9+.-]*://")),
     ("an absolute path", re.compile(r"(?:^|[\s\"'=,;(\[])(?:/[A-Za-z0-9._~-]+){2,}")),
     ("a home-relative path", re.compile(r"(?:^|[\s\"'=,;(\[])~/")),
     ("an ipv4 literal", re.compile(r"\b[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\b")),
-    ("an ipv6 loopback literal", re.compile(r"(?:^|[^0-9A-Fa-f:])::1(?:[^0-9A-Fa-f:]|$)")),
+    ("an ipv6 literal", IPV6_LITERAL_RE),
     ("a localhost reference", re.compile(r"(?i)\blocalhost\b")),
-    (
-        "a hostname",
-        re.compile(
-            r"(?i)\b[a-z0-9](?:[a-z0-9-]*[a-z0-9])?"
-            r"(?:\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)*"
-            r"\.(?:com|net|org|io|ai|app|dev|cloud|tech|local|internal)\b"
-        ),
-    ),
 )
-FORBIDDEN_SECRET_VALUE_PATTERNS: tuple[re.Pattern[str], ...] = (
-    re.compile(r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----"),
+# Credential shapes come from the governance module so this scanner can never be
+# narrower than the sibling signed-journey scanner; the two extras below are
+# BYOM-specific and have no counterpart there.
+FORBIDDEN_SECRET_VALUE_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(fragment, re.IGNORECASE) for fragment in CREDENTIAL_SHAPE_PATTERN_FRAGMENTS
+) + (
     re.compile(r"(?i)\bauthorization\s*:\s*bearer\s+(?!redacted\b)[A-Za-z0-9._~+/=-]{8,}"),
-    re.compile(r"(?i)\bbearer\s+(?!redacted\b)[A-Za-z0-9._~+/=-]{20,}"),
-    re.compile(r"\bghp_[A-Za-z0-9_]{20,}\b"),
-    re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}\b"),
-    re.compile(r"\bsk-[A-Za-z0-9]{20,}\b"),
-    re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{20,}\b"),
-    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
-    re.compile(r"\bmp_[A-Za-z0-9_-]{16,}\b"),
-    re.compile(r"\bprovider-token-[A-Za-z0-9_-]{8,}\b"),
+    re.compile(r"(?i)\bprovider-token-[A-Za-z0-9_-]{8,}\b"),
 )
 FORBIDDEN_KEY_FRAGMENTS: tuple[str, ...] = (
     "absolute_path",
@@ -301,11 +331,23 @@ def reject_secret_like_text(text: str, location: str) -> None:
             fail(f"{location} contains a credential-like value")
 
 
+def _is_allowlisted_hostname_shape(candidate: str) -> bool:
+    return any(pattern.fullmatch(candidate) for pattern in HOSTNAME_ALLOWLISTED_VALUE_SHAPES)
+
+
+def reject_hostname_like_text(text: str, location: str) -> None:
+    """Fail closed on any DNS-shaped token that is not an allowlisted value shape."""
+    for match in DNS_HOSTNAME_RE.finditer(text):
+        if not _is_allowlisted_hostname_shape(match.group(0)):
+            fail(f"{location} contains a hostname; evidence must stay redacted")
+
+
 def reject_unredacted_text(text: str, location: str) -> None:
     reject_secret_like_text(text, location)
     for label, pattern in FORBIDDEN_VALUE_PATTERNS:
         if pattern.search(text):
             fail(f"{location} contains {label}; evidence must stay redacted")
+    reject_hostname_like_text(text, location)
 
 
 def assert_redacted(value: Any, location: str = "$") -> None:
@@ -597,7 +639,13 @@ def _require_manifest_steps(
     return validate_evidence_steps(contract, candidates)
 
 
-def _require_manifest_observations(contract: JourneyContract, value: Any) -> dict[str, Any]:
+def validate_evidence_observations(contract: JourneyContract, value: Any) -> dict[str, Any]:
+    """Validate and normalize the observation block, including the money-path zero rows.
+
+    Shared by capture, the builders, and the governance source re-validation so the
+    required-true/required-false names and the money-path zero-row rule have one
+    implementation.
+    """
     observations = require_object(value, "observations")
     required = set(contract.true_observations) | set(contract.false_observations)
     allowed = set(required)
@@ -687,7 +735,7 @@ def build_evidence(
     steps, requirement_ids = _require_manifest_steps(
         manifest_path.parent.resolve(), contract, manifest.get("steps")
     )
-    observations = _require_manifest_observations(contract, manifest.get("observations"))
+    observations = validate_evidence_observations(contract, manifest.get("observations"))
 
     captured = _parse_captured_at(captured_at)
     evidence = {
@@ -797,7 +845,7 @@ def build_journey_result_payload(
         fail("result.status must equal 'pass'")
     require_exact_keys(run_result, {"status"}, {"status", "summary"}, "result")
 
-    observations = _require_manifest_observations(contract, evidence.get("observations"))
+    observations = validate_evidence_observations(contract, evidence.get("observations"))
     redaction = deepcopy(require_object(evidence.get("redaction"), "redaction"))
     for field in ("secrets_redacted", "operator_identity_redacted", "local_account_names_redacted"):
         if redaction.get(field) is not True:

--- a/scripts/byom_journey_evidence.py
+++ b/scripts/byom_journey_evidence.py
@@ -78,8 +78,9 @@ REPO_RELATIVE_FILE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*(?:/[A-Za-z0-9][
 # The hostname rule is shape-based, not a suffix allowlist: anything that looks
 # like DNS -- one or more `label.` groups followed by an alphabetic final label --
 # is rejected, whatever the TLD. A handful of legitimate evidence values are
-# DNS-shaped by coincidence, and they are handled by the explicit
-# `HOSTNAME_ALLOWLISTED_VALUE_SHAPES` below rather than by weakening the rule.
+# DNS-shaped by coincidence (repository source file names); they are permitted
+# only in the structurally validated `REPO_SOURCE_FILE_FIELDS` below, never by a
+# global allowlist, so `provider-mac.sh` in free text still fails closed.
 DNS_HOSTNAME_RE = re.compile(
     r"(?i)(?<![A-Za-z0-9_.-])"
     r"(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+"
@@ -101,19 +102,21 @@ IPV6_LITERAL_RE = re.compile(
     r")"
     r"(?![0-9A-Za-z:])"
 )
-# The only DNS-shaped strings this evidence is allowed to carry. A repository
-# source file name (`run-cli-onboarding-e2e.py`, `run-manifest.json`) is
-# `<name>.<ext>`, which is indistinguishable from a two-label hostname by shape,
-# and the evidence records `harness.name` verbatim. Every other value the contract
-# emits -- evidence and document schema ids (`...-evidence.v1`, `..._status.v1`),
-# step ids, requirement ids, run ids, CLI/semantic versions -- ends in a label
-# that is not purely alphabetic, so it never reaches this allowlist at all.
-HOSTNAME_ALLOWLISTED_VALUE_SHAPES: tuple[re.Pattern[str], ...] = (
-    re.compile(
-        r"(?i)^[A-Za-z0-9][A-Za-z0-9._-]*"
-        r"\.(?:go|json|jsonl|md|mjs|py|sh|swift|toml|ts|txt|yaml|yml)$"
-    ),
+# Repository source file names (`test/e2e/byom/run-cli-onboarding-e2e.py`,
+# `run-manifest.json`) are `<name>.<ext>` and therefore DNS-shaped by
+# coincidence. They are accepted ONLY at the JSON paths in
+# `REPO_SOURCE_FILE_FIELDS`, which capture validates structurally; the global
+# hostname rule has no allowlist, so a `.sh`/`.md`/`.py`-suffixed token in an
+# assertion or a captured value is still a hostname and fails closed. Every
+# other value the contract emits -- evidence and document schema ids
+# (`...-evidence.v1`, `..._status.v1`), step ids, requirement ids, run ids,
+# CLI/semantic versions -- ends in a label that is not purely alphabetic, so it
+# is not DNS-shaped at all.
+REPO_SOURCE_FILE_NAME_RE = re.compile(
+    r"(?i)^[A-Za-z0-9][A-Za-z0-9._-]*(?:/[A-Za-z0-9][A-Za-z0-9._-]*)*"
+    r"\.(?:go|json|jsonl|md|mjs|py|sh|swift|toml|ts|txt|yaml|yml)$"
 )
+REPO_SOURCE_FILE_FIELDS = frozenset({"$.harness.name"})
 FORBIDDEN_VALUE_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     ("a url", re.compile(r"(?i)[a-z][a-z0-9+.-]*://")),
     ("an absolute path", re.compile(r"(?:^|[\s\"'=,;(\[])(?:/[A-Za-z0-9._~-]+){2,}")),
@@ -331,15 +334,24 @@ def reject_secret_like_text(text: str, location: str) -> None:
             fail(f"{location} contains a credential-like value")
 
 
-def _is_allowlisted_hostname_shape(candidate: str) -> bool:
-    return any(pattern.fullmatch(candidate) for pattern in HOSTNAME_ALLOWLISTED_VALUE_SHAPES)
-
-
 def reject_hostname_like_text(text: str, location: str) -> None:
-    """Fail closed on any DNS-shaped token that is not an allowlisted value shape."""
-    for match in DNS_HOSTNAME_RE.finditer(text):
-        if not _is_allowlisted_hostname_shape(match.group(0)):
-            fail(f"{location} contains a hostname; evidence must stay redacted")
+    """Fail closed on any DNS-shaped token; there is no value-shape allowlist."""
+    if DNS_HOSTNAME_RE.search(text):
+        fail(f"{location} contains a hostname; evidence must stay redacted")
+
+
+def reject_unredacted_repo_source_file(value: str, location: str) -> None:
+    """Scoped rule for the repository source file-name fields.
+
+    Runs every scan except the hostname rule, then requires the whole value to be
+    a repository-relative source file name with a known extension.
+    """
+    reject_secret_like_text(value, location)
+    for label, pattern in FORBIDDEN_VALUE_PATTERNS:
+        if pattern.search(value):
+            fail(f"{location} contains {label}; evidence must stay redacted")
+    if ".." in Path(value).parts or not REPO_SOURCE_FILE_NAME_RE.fullmatch(value):
+        fail(f"{location} must be a repository-relative source file name")
 
 
 def reject_unredacted_text(text: str, location: str) -> None:
@@ -365,7 +377,10 @@ def _walk_redaction(value: Any, location: str) -> None:
         for index, item in enumerate(value):
             _walk_redaction(item, f"{location}[{index}]")
     elif isinstance(value, str):
-        reject_unredacted_text(value, location)
+        if location in REPO_SOURCE_FILE_FIELDS:
+            reject_unredacted_repo_source_file(value, location)
+        else:
+            reject_unredacted_text(value, location)
 
 
 def repository_relative(root: Path, value: str, label: str) -> str:

--- a/scripts/capture-byom-journey-evidence.py
+++ b/scripts/capture-byom-journey-evidence.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Capture redacted BYOM signed-journey evidence for SPEC-046 / SPEC-047.
+
+The run manifest (`macprovider.byom-journey-run.v1`) records, per normative
+journey step, the pass/fail verdict, the requirement ids that step exercises, and
+the captured CLI JSON documents. This script digests those documents, enforces the
+step and requirement tables from `journeys/JOURNEY-*.md` and the SPECs, refuses any
+unredacted URL, path, hostname, IP, or credential, and writes the redacted evidence
+artifact that `build-*-journey-result.py` later projects into a journey-result.
+
+The captured CLI documents themselves are never copied into the repository; only
+their SHA-256 digests and byte counts are recorded.
+
+This script signs nothing. Promotion still needs the operator acceptance signing
+key via `scripts/sign-journey-result.py`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from byom_journey_evidence import (  # noqa: E402
+    ADMISSION_CONTRACT,
+    BYOMEvidenceError,
+    DISCOVERY_CONTRACT,
+    build_evidence,
+    contract_for,
+    repository_relative,
+    write_json_atomically,
+)
+
+
+HARNESS_PATH = "test/e2e/byom/run-cli-onboarding-e2e.py"
+
+
+def die(message: str) -> None:
+    print(f"capture-byom-journey-evidence: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def run_hermetic_harness(root: Path) -> None:
+    harness = root / HARNESS_PATH
+    if not harness.is_file() or harness.is_symlink():
+        die(f"hermetic harness is absent or unsafe: {HARNESS_PATH}")
+    completed = subprocess.run(
+        [sys.executable, str(harness)],
+        cwd=str(root),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        # The harness prints loopback origins and temp paths; surface only the
+        # verdict so this script's own output stays redaction-safe.
+        die(f"hermetic BYOM harness failed with exit code {completed.returncode}")
+    print("capture-byom-journey-evidence: hermetic BYOM harness passed")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--journey",
+        required=True,
+        choices=(DISCOVERY_CONTRACT.selector, ADMISSION_CONTRACT.selector),
+        help="which BYOM journey this run covers",
+    )
+    parser.add_argument("--root", default=".", help="repository root")
+    parser.add_argument("--run-manifest", required=True, help="closed JSON run manifest for the executed journey")
+    parser.add_argument("--output", required=True, help="redacted evidence output path under journeys/evidence/")
+    parser.add_argument("--source-sha", required=True, help="candidate source commit the run exercised")
+    parser.add_argument("--operator-role", required=True)
+    parser.add_argument("--operator-identity-fingerprint", required=True, help="sha256 hex fingerprint")
+    parser.add_argument("--hardware-profile", required=True)
+    parser.add_argument("--candidate", required=True, help="candidate build/release label")
+    parser.add_argument("--summary", required=True, help="one-line result summary")
+    parser.add_argument("--captured-at", default=None, help="UTC capture timestamp, e.g. 2026-09-08T00:00:00Z")
+    parser.add_argument("--expires-at", default=None, help="evidence expiry date, defaults to capture date + 30 days")
+    parser.add_argument(
+        "--run-hermetic-harness",
+        action="store_true",
+        help=f"run {HARNESS_PATH} first and refuse to capture unless it passes",
+    )
+    args = parser.parse_args(argv)
+
+    root = Path(args.root).resolve()
+    if args.run_hermetic_harness:
+        run_hermetic_harness(root)
+
+    try:
+        contract = contract_for(args.journey)
+        output = repository_relative(root, args.output, "--output")
+        if not output.startswith(contract.evidence_prefix) or not output.endswith(".redacted.json"):
+            die(f"--output must be {contract.evidence_prefix}*.redacted.json")
+        evidence = build_evidence(
+            root,
+            contract,
+            Path(args.run_manifest).resolve(),
+            source_sha=args.source_sha,
+            operator_role=args.operator_role,
+            operator_identity_fingerprint=args.operator_identity_fingerprint,
+            hardware_profile=args.hardware_profile,
+            candidate=args.candidate,
+            captured_at=args.captured_at,
+            expires_at=args.expires_at,
+            summary=args.summary,
+        )
+        write_json_atomically(root / output, evidence)
+    except BYOMEvidenceError as exc:
+        die(str(exc))
+    print(f"capture-byom-journey-evidence: wrote {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_spec_governance.py
+++ b/scripts/check_spec_governance.py
@@ -2839,31 +2839,30 @@ def _validate_byom_journey_artifacts(
     *,
     root: Path | None = None,
 ) -> None:
-    observed: set[str] = set()
-    for index, artifact in enumerate(artifacts):
-        if not isinstance(artifact, dict):
-            continue
-        artifact_id = artifact.get("id")
-        if isinstance(artifact_id, str):
-            observed.add(artifact_id)
-        source = artifact.get("source")
-        if not isinstance(source, str) or not source.startswith(prefix) or not source.endswith(".redacted.json"):
-            result.error(
-                f"{location}.signed.artifacts[{index}].source",
-                f"must match {prefix}*.redacted.json",
-            )
-            continue
-        if root is not None and artifact_id == primary_artifact_id:
-            _validate_byom_journey_source(
-                root,
-                artifact,
-                signed,
-                journey_id,
-                f"{location}.signed.artifacts[{index}]",
-                result,
-            )
-    if primary_artifact_id not in observed:
-        result.error(f"{location}.signed.artifacts", f"must include the reviewed artifact {primary_artifact_id!r}")
+    # Mirror the sibling journey validators: the BYOM builder emits exactly one
+    # hash-bound redacted-evidence artifact with exactly {id, sha256, source}, so a
+    # signed payload carrying any other artifact record -- or any extra field on
+    # the one record -- is not a builder projection and must not promote.
+    if len(artifacts) != 1 or not isinstance(artifacts[0], dict):
+        result.error(
+            f"{location}.signed.artifacts",
+            f"{journey_id} journey-result must contain exactly one redacted evidence artifact",
+        )
+        return
+    artifact = artifacts[0]
+    artifact_location = f"{location}.signed.artifacts[0]"
+    if set(artifact) != {"id", "sha256", "source"}:
+        result.error(artifact_location, "must carry exactly the builder artifact fields id, sha256, source")
+        return
+    if artifact.get("id") != primary_artifact_id:
+        result.error(f"{artifact_location}.id", f"must equal the reviewed artifact {primary_artifact_id!r}")
+        return
+    source = artifact.get("source")
+    if not isinstance(source, str) or not source.startswith(prefix) or not source.endswith(".redacted.json"):
+        result.error(f"{artifact_location}.source", f"must match {prefix}*.redacted.json")
+        return
+    if root is not None:
+        _validate_byom_journey_source(root, artifact, signed, journey_id, artifact_location, result)
 
 
 def _validate_provider_byom_discovery_journey_result(

--- a/scripts/check_spec_governance.py
+++ b/scripts/check_spec_governance.py
@@ -262,25 +262,36 @@ LOCAL_CONSUMER_ENDPOINT_CANDIDATE_IDENTITY_SDK_NAMES = {
     "openai-python",
     "openai-ruby",
 }
+# The shapes credential *material* takes, independent of the field carrying it.
+# This is the single source of truth for token-shaped detection on the signed
+# journey surfaces: the local-consumer metadata scanner below composes it with its
+# own credential-bearing field-name fragments, and
+# `scripts/byom_journey_evidence.py` compiles the same fragments, so the BYOM
+# redaction scanner can never drift narrower than this one.
+CREDENTIAL_SHAPE_PATTERN_FRAGMENTS: tuple[str, ...] = (
+    r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----",
+    r"\bbearer\s+(?!redacted\b)[A-Za-z0-9._~+/=-]{20,}",
+    r"\bghp_[A-Za-z0-9_]{20,}\b",
+    r"\bgithub_pat_[A-Za-z0-9_]{20,}\b",
+    r"\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}\b",
+    r"\bxox[baprs]-[A-Za-z0-9-]{20,}\b",
+    r"\bAKIA[0-9A-Z]{16}\b",
+    r"\bmp_[A-Za-z0-9_-]{16,}\b",
+)
+LOCAL_CONSUMER_ENDPOINT_FORBIDDEN_FIELD_NAME_FRAGMENTS: tuple[str, ...] = (
+    r"\bauthorization\s*[:=]",
+    r"\blocal[_-]?token\s*[:=]",
+    r"\bapi[_-]?key\s*[:=]",
+    r"\bx-api-key\s*[:=]",
+    r"\bbuyer[_-]?credential\s*[:=]",
+    r"\bupstream[_-]?credential\s*[:=]",
+    r"\braw[_ -]?prompt\s*[:=]",
+    r"\braw[_ -]?completion\s*[:=]",
+)
 LOCAL_CONSUMER_ENDPOINT_FORBIDDEN_METADATA_RE = re.compile(
-    r"(?i)("
-    r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----|"
-    r"\bauthorization\s*[:=]|"
-    r"\bbearer\s+(?!redacted\b)[A-Za-z0-9._~+/=-]{20,}|"
-    r"\blocal[_-]?token\s*[:=]|"
-    r"\bapi[_-]?key\s*[:=]|"
-    r"\bx-api-key\s*[:=]|"
-    r"\bbuyer[_-]?credential\s*[:=]|"
-    r"\bupstream[_-]?credential\s*[:=]|"
-    r"\braw[_ -]?prompt\s*[:=]|"
-    r"\braw[_ -]?completion\s*[:=]|"
-    r"\bghp_[A-Za-z0-9_]{20,}\b|"
-    r"\bgithub_pat_[A-Za-z0-9_]{20,}\b|"
-    r"\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}\b|"
-    r"\bxox[baprs]-[A-Za-z0-9-]{20,}\b|"
-    r"\bAKIA[0-9A-Z]{16}\b|"
-    r"\bmp_[A-Za-z0-9_-]{16,}\b"
-    r")"
+    "(?i)("
+    + "|".join(LOCAL_CONSUMER_ENDPOINT_FORBIDDEN_FIELD_NAME_FRAGMENTS + CREDENTIAL_SHAPE_PATTERN_FRAGMENTS)
+    + ")"
 )
 LOCAL_CONSUMER_ENDPOINT_STEP_ID_ORDER = (
     "step-01-capture-local-endpoint",
@@ -2685,12 +2696,136 @@ def _validate_byom_journey_requirement_ids(
         result.error(f"{location}.signed.requirement_ids", f"{label} journey-result cannot promote {requirement_id}")
 
 
+_BYOM_EVIDENCE_MODULE: Any = None
+
+
+def _byom_evidence_module() -> Any:
+    """Load the BYOM evidence contract module lazily.
+
+    `scripts/byom_journey_evidence.py` imports this module for the journey
+    constants, so the import has to stay function-local. That module owns the
+    shared step, observation, and redaction rules, and governance re-runs exactly
+    those rules over the referenced evidence artifact instead of reimplementing
+    them.
+    """
+    global _BYOM_EVIDENCE_MODULE
+    if _BYOM_EVIDENCE_MODULE is None:
+        scripts_dir = str(Path(__file__).resolve().parent)
+        inserted = scripts_dir not in sys.path
+        if inserted:
+            sys.path.insert(0, scripts_dir)
+        # Bind the child module to this exact module object rather than letting it
+        # execute a second copy of this file under the bare name.
+        sys.modules.setdefault("check_spec_governance", sys.modules[__name__])
+        try:
+            import byom_journey_evidence
+        finally:
+            if inserted:
+                sys.path.remove(scripts_dir)
+        _BYOM_EVIDENCE_MODULE = byom_journey_evidence
+    return _BYOM_EVIDENCE_MODULE
+
+
+def _validate_byom_journey_source(
+    root: Path,
+    artifact: dict[str, Any],
+    signed: dict[str, Any],
+    journey_id: str,
+    location: str,
+    result: ValidationResult,
+) -> None:
+    """Re-validate the redacted evidence a BYOM signed payload names as its source.
+
+    The builder validates committed evidence deeply, but a hand-authored payload
+    can still carry a valid acceptance signature, so promotion must not trust the
+    signed projection on its own. This re-opens the hash-bound artifact and re-runs
+    the same shared contract -- the redaction scan, `validate_evidence_steps`, and
+    `validate_evidence_observations` (money-path zero rows included) -- then
+    compares the signed requirement ids and step projection against it. It is the
+    BYOM counterpart of `_validate_local_consumer_endpoint_source()`.
+    """
+    source = artifact.get("source")
+    if not isinstance(source, str):
+        return
+    path = _repository_path(root, source, f"{location}.source", result)
+    if path is None:
+        return
+    module = _byom_evidence_module()
+    try:
+        contract = module.contract_for(journey_id)
+        evidence = module.load_json_object(path, "BYOM redacted evidence")
+        module.assert_redacted(evidence)
+        if evidence.get("schema_version") != contract.evidence_schema:
+            module.fail(f"schema_version must equal {contract.evidence_schema!r}")
+        if evidence.get("journey_id") != contract.journey_id:
+            module.fail(f"journey_id must equal {contract.journey_id!r}")
+        if evidence.get("execution_mode") != contract.execution_mode:
+            module.fail(f"execution_mode must equal {contract.execution_mode!r}")
+        environment = module.require_object(evidence.get("environment"), "environment")
+        if environment.get("class") not in BYOM_JOURNEY_ENVIRONMENT_CLASSES:
+            module.fail(f"environment.class must be one of {sorted(BYOM_JOURNEY_ENVIRONMENT_CLASSES)}")
+        source_steps, covered_ids = module.validate_evidence_steps(contract, evidence.get("steps"))
+        source_observations = module.validate_evidence_observations(contract, evidence.get("observations"))
+        declared_ids = [
+            module.require_string(item, module.REQUIREMENT_RE, "requirement_ids[]")
+            for item in module.require_list(evidence.get("requirement_ids"), "requirement_ids")
+        ]
+        if len(set(declared_ids)) != len(declared_ids) or sorted(declared_ids) != covered_ids:
+            module.fail(
+                "requirement_ids must equal the union of the evidence step requirement ids: "
+                + ", ".join(covered_ids)
+            )
+    except module.BYOMEvidenceError as exc:
+        result.error(f"{location}.source", str(exc))
+        return
+
+    signed_requirement_ids = [item for item in (signed.get("requirement_ids") or []) if isinstance(item, str)]
+    overclaimed = sorted(set(signed_requirement_ids) - set(covered_ids))
+    if overclaimed:
+        result.error(
+            f"{location}.source.requirement_ids",
+            f"must cover every signed requirement ID: {overclaimed}",
+        )
+
+    expected_steps = [
+        {
+            "id": step["id"],
+            "status": "pass",
+            "assertion": step["assertion"],
+            "artifacts": step["artifacts"],
+        }
+        for step in source_steps
+    ]
+    signed_steps = [
+        {
+            "id": step.get("id"),
+            "status": step.get("status"),
+            "assertion": step.get("assertion"),
+            "artifacts": step.get("artifacts"),
+        }
+        for step in signed.get("steps", [])
+        if isinstance(step, dict)
+    ]
+    if signed_steps != expected_steps:
+        result.error(f"{location}.source.steps", "signed steps must match the source evidence steps")
+
+    if signed.get("observations") != source_observations:
+        result.error(f"{location}.source.observations", "signed observations must match the source evidence")
+    for field_name in ("run_id", "captured_at", "expires_at", "repository", "operator", "environment", "result", "redaction"):
+        if signed.get(field_name) != evidence.get(field_name):
+            result.error(f"{location}.source.{field_name}", "signed payload must match the source evidence")
+
+
 def _validate_byom_journey_artifacts(
     artifacts: list[Any],
     primary_artifact_id: str,
     prefix: str,
+    journey_id: str,
+    signed: dict[str, Any],
     location: str,
     result: ValidationResult,
+    *,
+    root: Path | None = None,
 ) -> None:
     observed: set[str] = set()
     for index, artifact in enumerate(artifacts):
@@ -2705,6 +2840,16 @@ def _validate_byom_journey_artifacts(
                 f"{location}.signed.artifacts[{index}].source",
                 f"must match {prefix}*.redacted.json",
             )
+            continue
+        if root is not None and artifact_id == primary_artifact_id:
+            _validate_byom_journey_source(
+                root,
+                artifact,
+                signed,
+                journey_id,
+                f"{location}.signed.artifacts[{index}]",
+                result,
+            )
     if primary_artifact_id not in observed:
         result.error(f"{location}.signed.artifacts", f"must include the reviewed artifact {primary_artifact_id!r}")
 
@@ -2717,6 +2862,8 @@ def _validate_provider_byom_discovery_journey_result(
     steps: list[Any],
     location: str,
     result: ValidationResult,
+    *,
+    root: Path | None = None,
 ) -> None:
     if signed.get("journey_id") != PROVIDER_BYOM_DISCOVERY_JOURNEY_ID:
         result.error(f"{location}.signed.journey_id", f"must equal {PROVIDER_BYOM_DISCOVERY_JOURNEY_ID!r}")
@@ -2742,8 +2889,11 @@ def _validate_provider_byom_discovery_journey_result(
         artifacts,
         PROVIDER_BYOM_DISCOVERY_ARTIFACT_ID,
         PROVIDER_BYOM_DISCOVERY_EVIDENCE_PREFIX,
+        PROVIDER_BYOM_DISCOVERY_JOURNEY_ID,
+        signed,
         location,
         result,
+        root=root,
     )
     _validate_byom_journey_observations(
         signed,
@@ -2763,6 +2913,8 @@ def _validate_network_model_admission_journey_result(
     steps: list[Any],
     location: str,
     result: ValidationResult,
+    *,
+    root: Path | None = None,
 ) -> None:
     if signed.get("journey_id") != NETWORK_MODEL_ADMISSION_JOURNEY_ID:
         result.error(f"{location}.signed.journey_id", f"must equal {NETWORK_MODEL_ADMISSION_JOURNEY_ID!r}")
@@ -2788,8 +2940,11 @@ def _validate_network_model_admission_journey_result(
         artifacts,
         NETWORK_MODEL_ADMISSION_ARTIFACT_ID,
         NETWORK_MODEL_ADMISSION_EVIDENCE_PREFIX,
+        NETWORK_MODEL_ADMISSION_JOURNEY_ID,
+        signed,
         location,
         result,
+        root=root,
     )
     observations = _validate_byom_journey_observations(
         signed,
@@ -3124,6 +3279,7 @@ def _validate_signed_journey_result(
             steps,
             location,
             result,
+            root=root,
         )
     if journey_id == NETWORK_MODEL_ADMISSION_JOURNEY_ID:
         _validate_network_model_admission_journey_result(
@@ -3134,6 +3290,7 @@ def _validate_signed_journey_result(
             steps,
             location,
             result,
+            root=root,
         )
 
     return len(result.errors) == before

--- a/scripts/check_spec_governance.py
+++ b/scripts/check_spec_governance.py
@@ -303,6 +303,148 @@ LOCAL_CONSUMER_ENDPOINT_EVIDENCE_REQUIREMENT_IDS = {
     "SPEC-045-R007",
     "SPEC-045-R008",
 }
+PROVIDER_BYOM_DISCOVERY_JOURNEY_ID = "JOURNEY-PROVIDER-BYOM-DISCOVERY"
+PROVIDER_BYOM_DISCOVERY_EXECUTION_MODE = "local-provider-discovery"
+PROVIDER_BYOM_DISCOVERY_ARTIFACT_ID = "redacted-provider-byom-discovery"
+PROVIDER_BYOM_DISCOVERY_EVIDENCE_SCHEMA = "macprovider.provider-byom-discovery-evidence.v1"
+PROVIDER_BYOM_DISCOVERY_EVIDENCE_PREFIX = "journeys/evidence/provider-byom-discovery-"
+# Step ids are the normative list in journeys/JOURNEY-PROVIDER-BYOM-DISCOVERY.md
+# ("Required Steps"); they are not invented here.
+PROVIDER_BYOM_DISCOVERY_STEP_ID_ORDER = (
+    "step-01-discover-mlx-cache",
+    "step-02-discover-loopback-runtime",
+    "step-03-discover-opaque-endpoint",
+    "step-04-reject-non-loopback",
+    "step-05-handle-adapter-failure",
+    "step-06-evaluate-candidate",
+    "step-07-no-production-mutation",
+    "step-08-redaction-review",
+    "step-09-state-boundary",
+    "step-10-local-state-ladder",
+)
+PROVIDER_BYOM_DISCOVERY_STEP_IDS = set(PROVIDER_BYOM_DISCOVERY_STEP_ID_ORDER)
+PROVIDER_BYOM_DISCOVERY_PROMOTABLE_REQUIREMENT_IDS = {
+    f"SPEC-046-R{index:03d}" for index in range(1, 9)
+}
+# SPEC-046-R008 is the release-evidence requirement the whole journey proves, so
+# it is admissible on every step; the other ids are the requirement subjects each
+# step actually exercises (SPEC-046 §3 requirement headings).
+PROVIDER_BYOM_DISCOVERY_STEP_REQUIREMENT_IDS = {
+    "step-01-discover-mlx-cache": {"SPEC-046-R001", "SPEC-046-R002", "SPEC-046-R003"},
+    "step-02-discover-loopback-runtime": {"SPEC-046-R001", "SPEC-046-R002", "SPEC-046-R003"},
+    "step-03-discover-opaque-endpoint": {"SPEC-046-R002", "SPEC-046-R003", "SPEC-046-R004"},
+    "step-04-reject-non-loopback": {"SPEC-046-R002", "SPEC-046-R007"},
+    "step-05-handle-adapter-failure": {"SPEC-046-R002", "SPEC-046-R004"},
+    "step-06-evaluate-candidate": {"SPEC-046-R001", "SPEC-046-R005"},
+    "step-07-no-production-mutation": {"SPEC-046-R006"},
+    "step-08-redaction-review": {"SPEC-046-R007"},
+    "step-09-state-boundary": {"SPEC-046-R003"},
+    "step-10-local-state-ladder": {"SPEC-046-R003"},
+}
+PROVIDER_BYOM_DISCOVERY_TRUE_OBSERVATIONS = {
+    "adapter_failure_warned",
+    "candidate_evaluated",
+    "loopback_runtime_discovered",
+    "local_state_ladder_verified",
+    "mlx_cache_discovered",
+    "non_loopback_rejected",
+    "opaque_endpoint_candidate_discovered",
+    "redacted_artifacts_reviewed",
+    "state_boundary_preserved",
+}
+PROVIDER_BYOM_DISCOVERY_FALSE_OBSERVATIONS = {
+    "buyer_traffic_sent",
+    "provider_credit_created",
+    "raw_completion_logged",
+    "raw_prompt_logged",
+    "runtime_installed",
+    "weights_downloaded",
+}
+NETWORK_MODEL_ADMISSION_JOURNEY_ID = "JOURNEY-NETWORK-MODEL-ADMISSION"
+NETWORK_MODEL_ADMISSION_EXECUTION_MODE = "provider-byom-network-admission"
+NETWORK_MODEL_ADMISSION_ARTIFACT_ID = "redacted-network-model-admission"
+NETWORK_MODEL_ADMISSION_EVIDENCE_SCHEMA = "macprovider.network-model-admission-evidence.v1"
+NETWORK_MODEL_ADMISSION_EVIDENCE_PREFIX = "journeys/evidence/network-model-admission-"
+# Step ids are the normative list in journeys/JOURNEY-NETWORK-MODEL-ADMISSION.md
+# ("Required Steps"); they are not invented here.
+NETWORK_MODEL_ADMISSION_STEP_ID_ORDER = (
+    "step-01-offer-dry-run",
+    "step-02-submit-signed-offer",
+    "step-03-reject-opaque-endpoint",
+    "step-04-sandbox-probe-only",
+    "step-05-network-visible-unpriced",
+    "step-06-catalog-matched-not-settlement",
+    "step-07-revocation-on-drift",
+    "step-08-withdrawal",
+    "step-09-settlement-capable-case",
+    "step-10-admission-status-presentation",
+    "step-11-transition-validity",
+    "step-12-redaction-review",
+)
+NETWORK_MODEL_ADMISSION_STEP_IDS = set(NETWORK_MODEL_ADMISSION_STEP_ID_ORDER)
+NETWORK_MODEL_ADMISSION_PROMOTABLE_REQUIREMENT_IDS = {
+    f"SPEC-047-R{index:03d}" for index in range(1, 9)
+}
+# SPEC-047-R008 is the release-evidence requirement the whole journey proves, so
+# it is admissible on every step; the other ids are the requirement subjects each
+# step actually exercises (SPEC-047 §3 requirement headings).
+NETWORK_MODEL_ADMISSION_STEP_REQUIREMENT_IDS = {
+    "step-01-offer-dry-run": {"SPEC-047-R002"},
+    "step-02-submit-signed-offer": {"SPEC-047-R002", "SPEC-047-R007"},
+    "step-03-reject-opaque-endpoint": {"SPEC-047-R003", "SPEC-047-R007"},
+    "step-04-sandbox-probe-only": {"SPEC-047-R001", "SPEC-047-R003", "SPEC-047-R005", "SPEC-047-R007"},
+    "step-05-network-visible-unpriced": {"SPEC-047-R004", "SPEC-047-R005"},
+    "step-06-catalog-matched-not-settlement": {"SPEC-047-R003", "SPEC-047-R004"},
+    "step-07-revocation-on-drift": {"SPEC-047-R006"},
+    "step-08-withdrawal": {"SPEC-047-R006"},
+    "step-09-settlement-capable-case": {"SPEC-047-R003", "SPEC-047-R005"},
+    "step-10-admission-status-presentation": {"SPEC-047-R002", "SPEC-047-R004"},
+    "step-11-transition-validity": {"SPEC-047-R001", "SPEC-047-R006"},
+    "step-12-redaction-review": {"SPEC-047-R007"},
+}
+NETWORK_MODEL_ADMISSION_TRUE_OBSERVATIONS = {
+    "catalog_matched_not_settlement_verified",
+    "default_buyer_invisibility_verified",
+    "dry_run_did_not_submit",
+    "network_visible_unpriced_disclosed",
+    "earning_path_disclosure_verified",
+    "provider_signature_verified",
+    "rejected_opaque_endpoint_verified",
+    "revocation_on_drift_verified",
+    "sandbox_probe_only_blocked_from_paid_routing",
+    "synthetic_probe_used_provider_channel",
+    "settlement_capable_case_verified",
+    "transition_matrix_enforced",
+    "rejected_reoffer_required_fresh_evidence",
+    "withdrawn_reoffer_required_fresh_evidence",
+    "revoked_reoffer_required_fresh_evidence",
+    "withdrawal_verified",
+}
+NETWORK_MODEL_ADMISSION_FALSE_OBSERVATIONS = {
+    "non_settlement_state_created_provider_credit",
+    "provider_price_treated_as_catalog_rate",
+    "raw_completion_logged",
+    "raw_prompt_logged",
+    "secret_field_persisted",
+}
+# SPEC-047-R003 forbids any settlement, ledger, payout, or request-log row for a
+# non-settlement BYOM lifecycle. These are the coordinator tables read directly
+# for the #1248 money-path assertion; every count must be exactly zero.
+NETWORK_MODEL_ADMISSION_MONEY_PATH_TABLES = (
+    "ledger_operator_credits",
+    "ledger_payout_ready",
+    "ledger_quarantine_resolutions",
+    "ledger_request_credits",
+    "payout_attempts",
+    "request_log",
+    "settlement_attempt_outputs",
+    "settlement_receipt_verdicts",
+    "settlement_route_snapshots",
+    "spec022_payable_request_credits",
+)
+# Both BYOM journeys may be executed against the hermetic loopback harness or a
+# physical provider Mac; the run class is recorded in environment.class.
+BYOM_JOURNEY_ENVIRONMENT_CLASSES = ("hermetic-loopback", "physical-provider")
 SIGNED_JOURNEY_RESULT_REQUIRED_KEYS = {
     "schema_version",
     "journey_id",
@@ -2499,6 +2641,180 @@ def _validate_spec016_payout_journey_result(
             _validate_spec016_payout_artifact(root, artifact, f"{location}.signed.artifacts[{index}]", result)
 
 
+def _validate_byom_journey_observations(
+    signed: dict[str, Any],
+    true_fields: set[str],
+    false_fields: set[str],
+    location: str,
+    result: ValidationResult,
+) -> dict[str, Any]:
+    observations = signed.get("observations")
+    if not _expect_object(observations, f"{location}.signed.observations", result):
+        return {}
+    for field_name in sorted(true_fields):
+        if observations.get(field_name) is not True:
+            result.error(f"{location}.signed.observations.{field_name}", "must be true")
+    for field_name in sorted(false_fields):
+        if observations.get(field_name) is not False:
+            result.error(f"{location}.signed.observations.{field_name}", "must be false")
+    return observations
+
+
+def _validate_byom_journey_requirement_ids(
+    signed: dict[str, Any],
+    requirement_id: str,
+    promotable: set[str],
+    label: str,
+    location: str,
+    result: ValidationResult,
+) -> None:
+    signed_requirement_ids = signed.get("requirement_ids")
+    if not isinstance(signed_requirement_ids, list) or requirement_id not in signed_requirement_ids:
+        result.error(f"{location}.signed.requirement_ids", f"must include the requirement being promoted: {requirement_id}")
+    unexpected = [
+        item
+        for item in (signed_requirement_ids or [])
+        if isinstance(item, str) and item not in promotable
+    ]
+    if unexpected:
+        result.error(
+            f"{location}.signed.requirement_ids",
+            f"{label} journey-result cannot promote " + ", ".join(sorted(unexpected)),
+        )
+    if requirement_id not in promotable:
+        result.error(f"{location}.signed.requirement_ids", f"{label} journey-result cannot promote {requirement_id}")
+
+
+def _validate_byom_journey_artifacts(
+    artifacts: list[Any],
+    primary_artifact_id: str,
+    prefix: str,
+    location: str,
+    result: ValidationResult,
+) -> None:
+    observed: set[str] = set()
+    for index, artifact in enumerate(artifacts):
+        if not isinstance(artifact, dict):
+            continue
+        artifact_id = artifact.get("id")
+        if isinstance(artifact_id, str):
+            observed.add(artifact_id)
+        source = artifact.get("source")
+        if not isinstance(source, str) or not source.startswith(prefix) or not source.endswith(".redacted.json"):
+            result.error(
+                f"{location}.signed.artifacts[{index}].source",
+                f"must match {prefix}*.redacted.json",
+            )
+    if primary_artifact_id not in observed:
+        result.error(f"{location}.signed.artifacts", f"must include the reviewed artifact {primary_artifact_id!r}")
+
+
+def _validate_provider_byom_discovery_journey_result(
+    signed: dict[str, Any],
+    requirement_id: str,
+    journeys: list[str],
+    artifacts: list[Any],
+    steps: list[Any],
+    location: str,
+    result: ValidationResult,
+) -> None:
+    if signed.get("journey_id") != PROVIDER_BYOM_DISCOVERY_JOURNEY_ID:
+        result.error(f"{location}.signed.journey_id", f"must equal {PROVIDER_BYOM_DISCOVERY_JOURNEY_ID!r}")
+    if PROVIDER_BYOM_DISCOVERY_JOURNEY_ID not in journeys:
+        result.error(location, f"provider BYOM discovery requirement journeys must include {PROVIDER_BYOM_DISCOVERY_JOURNEY_ID!r}")
+    if signed.get("execution_mode") != PROVIDER_BYOM_DISCOVERY_EXECUTION_MODE:
+        result.error(f"{location}.signed.execution_mode", f"must equal {PROVIDER_BYOM_DISCOVERY_EXECUTION_MODE!r}")
+    environment = signed.get("environment")
+    if isinstance(environment, dict) and environment.get("class") not in BYOM_JOURNEY_ENVIRONMENT_CLASSES:
+        result.error(
+            f"{location}.signed.environment.class",
+            f"must be one of {sorted(BYOM_JOURNEY_ENVIRONMENT_CLASSES)}",
+        )
+    _validate_byom_journey_requirement_ids(
+        signed,
+        requirement_id,
+        set(PROVIDER_BYOM_DISCOVERY_PROMOTABLE_REQUIREMENT_IDS),
+        "provider BYOM discovery",
+        location,
+        result,
+    )
+    _validate_byom_journey_artifacts(
+        artifacts,
+        PROVIDER_BYOM_DISCOVERY_ARTIFACT_ID,
+        PROVIDER_BYOM_DISCOVERY_EVIDENCE_PREFIX,
+        location,
+        result,
+    )
+    _validate_byom_journey_observations(
+        signed,
+        PROVIDER_BYOM_DISCOVERY_TRUE_OBSERVATIONS,
+        PROVIDER_BYOM_DISCOVERY_FALSE_OBSERVATIONS,
+        location,
+        result,
+    )
+    _validate_named_journey_steps(steps, PROVIDER_BYOM_DISCOVERY_STEP_IDS, location, result, "provider BYOM discovery")
+
+
+def _validate_network_model_admission_journey_result(
+    signed: dict[str, Any],
+    requirement_id: str,
+    journeys: list[str],
+    artifacts: list[Any],
+    steps: list[Any],
+    location: str,
+    result: ValidationResult,
+) -> None:
+    if signed.get("journey_id") != NETWORK_MODEL_ADMISSION_JOURNEY_ID:
+        result.error(f"{location}.signed.journey_id", f"must equal {NETWORK_MODEL_ADMISSION_JOURNEY_ID!r}")
+    if NETWORK_MODEL_ADMISSION_JOURNEY_ID not in journeys:
+        result.error(location, f"network model admission requirement journeys must include {NETWORK_MODEL_ADMISSION_JOURNEY_ID!r}")
+    if signed.get("execution_mode") != NETWORK_MODEL_ADMISSION_EXECUTION_MODE:
+        result.error(f"{location}.signed.execution_mode", f"must equal {NETWORK_MODEL_ADMISSION_EXECUTION_MODE!r}")
+    environment = signed.get("environment")
+    if isinstance(environment, dict) and environment.get("class") not in BYOM_JOURNEY_ENVIRONMENT_CLASSES:
+        result.error(
+            f"{location}.signed.environment.class",
+            f"must be one of {sorted(BYOM_JOURNEY_ENVIRONMENT_CLASSES)}",
+        )
+    _validate_byom_journey_requirement_ids(
+        signed,
+        requirement_id,
+        set(NETWORK_MODEL_ADMISSION_PROMOTABLE_REQUIREMENT_IDS),
+        "network model admission",
+        location,
+        result,
+    )
+    _validate_byom_journey_artifacts(
+        artifacts,
+        NETWORK_MODEL_ADMISSION_ARTIFACT_ID,
+        NETWORK_MODEL_ADMISSION_EVIDENCE_PREFIX,
+        location,
+        result,
+    )
+    observations = _validate_byom_journey_observations(
+        signed,
+        NETWORK_MODEL_ADMISSION_TRUE_OBSERVATIONS,
+        NETWORK_MODEL_ADMISSION_FALSE_OBSERVATIONS,
+        location,
+        result,
+    )
+    money_path = observations.get("money_path_zero_rows")
+    money_path_location = f"{location}.signed.observations.money_path_zero_rows"
+    if _expect_object(money_path, money_path_location, result):
+        _expect_keys(
+            money_path,
+            set(NETWORK_MODEL_ADMISSION_MONEY_PATH_TABLES),
+            set(NETWORK_MODEL_ADMISSION_MONEY_PATH_TABLES),
+            money_path_location,
+            result,
+        )
+        for table in NETWORK_MODEL_ADMISSION_MONEY_PATH_TABLES:
+            count = money_path.get(table)
+            if count != 0 or isinstance(count, bool):
+                result.error(f"{money_path_location}.{table}", "must be the integer 0")
+    _validate_named_journey_steps(steps, NETWORK_MODEL_ADMISSION_STEP_IDS, location, result, "network model admission")
+
+
 def _validate_signed_journey_result(
     root: Path,
     source: str,
@@ -2797,6 +3113,27 @@ def _validate_signed_journey_result(
             location,
             result,
             root=root,
+        )
+
+    if journey_id == PROVIDER_BYOM_DISCOVERY_JOURNEY_ID:
+        _validate_provider_byom_discovery_journey_result(
+            signed,
+            requirement_id,
+            [item for item in journeys if isinstance(item, str)],
+            artifact_records,
+            steps,
+            location,
+            result,
+        )
+    if journey_id == NETWORK_MODEL_ADMISSION_JOURNEY_ID:
+        _validate_network_model_admission_journey_result(
+            signed,
+            requirement_id,
+            [item for item in journeys if isinstance(item, str)],
+            artifact_records,
+            steps,
+            location,
+            result,
         )
 
     return len(result.errors) == before

--- a/scripts/check_spec_governance.py
+++ b/scripts/check_spec_governance.py
@@ -2751,6 +2751,18 @@ def _validate_byom_journey_source(
     if path is None:
         return
     module = _byom_evidence_module()
+    # The generic signed-result schema tolerates optional fields that nothing
+    # here binds to the source evidence; a BYOM payload must carry exactly the
+    # builder's closed key set so a hand-signed payload cannot add unbound data.
+    extra_keys = sorted(set(signed) - module.BYOM_JOURNEY_RESULT_PAYLOAD_KEYS)
+    missing_keys = sorted(module.BYOM_JOURNEY_RESULT_PAYLOAD_KEYS - set(signed))
+    if extra_keys or missing_keys:
+        result.error(
+            f"{location}.source.keys",
+            "signed BYOM payload must carry exactly the builder key set"
+            f" (extra={extra_keys}, missing={missing_keys})",
+        )
+        return
     try:
         contract = module.contract_for(journey_id)
         evidence = module.load_json_object(path, "BYOM redacted evidence")

--- a/scripts/tests/fixtures/byom_journeys/admission/captures/admission-status-novel-non-catalog.json
+++ b/scripts/tests/fixtures/byom_journeys/admission/captures/admission-status-novel-non-catalog.json
@@ -1,0 +1,9 @@
+{
+  "admission_state": "network_visible_unpriced",
+  "admission_state_source": "coordinator",
+  "catalog_model_key": null,
+  "provider_guidance": {
+    "earning_path_class": "no_earning_path_in_v0_1"
+  },
+  "schema": "model_admission_status.v1"
+}

--- a/scripts/tests/fixtures/byom_journeys/admission/captures/admission-status-offer-rejected.json
+++ b/scripts/tests/fixtures/byom_journeys/admission/captures/admission-status-offer-rejected.json
@@ -1,0 +1,9 @@
+{
+  "admission_state": "offer_rejected",
+  "admission_state_source": "coordinator",
+  "catalog_model_key": null,
+  "provider_guidance": {
+    "earning_path_class": "no_earning_path_in_v0_1"
+  },
+  "schema": "model_admission_status.v1"
+}

--- a/scripts/tests/fixtures/byom_journeys/admission/captures/admission-status-offer-submitted.json
+++ b/scripts/tests/fixtures/byom_journeys/admission/captures/admission-status-offer-submitted.json
@@ -1,0 +1,9 @@
+{
+  "admission_state": "offer_submitted",
+  "admission_state_source": "coordinator",
+  "catalog_model_key": null,
+  "provider_guidance": {
+    "earning_path_class": "not_earning_yet_catalog_or_receipt_path_exists"
+  },
+  "schema": "model_admission_status.v1"
+}

--- a/scripts/tests/fixtures/byom_journeys/admission/captures/admission-status-reentry.json
+++ b/scripts/tests/fixtures/byom_journeys/admission/captures/admission-status-reentry.json
@@ -1,0 +1,9 @@
+{
+  "admission_state": "withdrawn",
+  "admission_state_source": "coordinator",
+  "catalog_model_key": null,
+  "provider_guidance": {
+    "earning_path_class": "no_earning_path_in_v0_1"
+  },
+  "schema": "model_admission_status.v1"
+}

--- a/scripts/tests/fixtures/byom_journeys/admission/captures/admission-status-revoked.json
+++ b/scripts/tests/fixtures/byom_journeys/admission/captures/admission-status-revoked.json
@@ -1,0 +1,9 @@
+{
+  "admission_state": "revoked",
+  "admission_state_source": "coordinator",
+  "catalog_model_key": null,
+  "provider_guidance": {
+    "earning_path_class": "no_earning_path_in_v0_1"
+  },
+  "schema": "model_admission_status.v1"
+}

--- a/scripts/tests/fixtures/byom_journeys/admission/captures/admission-status-sandbox-probe-only.json
+++ b/scripts/tests/fixtures/byom_journeys/admission/captures/admission-status-sandbox-probe-only.json
@@ -1,0 +1,9 @@
+{
+  "admission_state": "sandbox_probe_only",
+  "admission_state_source": "coordinator",
+  "catalog_model_key": null,
+  "provider_guidance": {
+    "earning_path_class": "not_earning_yet_catalog_or_receipt_path_exists"
+  },
+  "schema": "model_admission_status.v1"
+}

--- a/scripts/tests/fixtures/byom_journeys/admission/captures/admission-status-settlement-capable.json
+++ b/scripts/tests/fixtures/byom_journeys/admission/captures/admission-status-settlement-capable.json
@@ -1,0 +1,9 @@
+{
+  "admission_state": "settlement_capable",
+  "admission_state_source": "coordinator",
+  "catalog_model_key": null,
+  "provider_guidance": {
+    "earning_path_class": "settlement_capable"
+  },
+  "schema": "model_admission_status.v1"
+}

--- a/scripts/tests/fixtures/byom_journeys/admission/captures/admission-withdraw.json
+++ b/scripts/tests/fixtures/byom_journeys/admission/captures/admission-withdraw.json
@@ -1,0 +1,5 @@
+{
+  "reason_code": "provider_requested",
+  "resulting_admission_state": "withdrawn",
+  "schema": "model_admission_withdraw.v1"
+}

--- a/scripts/tests/fixtures/byom_journeys/admission/captures/catalog-economics-catalog-priced.json
+++ b/scripts/tests/fixtures/byom_journeys/admission/captures/catalog-economics-catalog-priced.json
@@ -1,0 +1,13 @@
+{
+  "rows": [
+    {
+      "admission": {
+        "catalog_economics_permitted": true,
+        "settlement_capable": false
+      },
+      "economics_state": "permitted",
+      "rate_source": "live_signed"
+    }
+  ],
+  "schema": "model_catalog_economics.v1"
+}

--- a/scripts/tests/fixtures/byom_journeys/admission/captures/catalog-economics-unpriced.json
+++ b/scripts/tests/fixtures/byom_journeys/admission/captures/catalog-economics-unpriced.json
@@ -1,0 +1,13 @@
+{
+  "rows": [
+    {
+      "admission": {
+        "catalog_economics_permitted": false,
+        "settlement_capable": false
+      },
+      "economics_state": "blocked",
+      "rate_source": "none"
+    }
+  ],
+  "schema": "model_catalog_economics.v1"
+}

--- a/scripts/tests/fixtures/byom_journeys/admission/captures/offer-dry-run.json
+++ b/scripts/tests/fixtures/byom_journeys/admission/captures/offer-dry-run.json
@@ -1,0 +1,6 @@
+{
+  "likely_admission_state": "offerable",
+  "likely_admission_state_source": "local_default",
+  "schema": "model_admission_offer_dry_run.v1",
+  "would_submit": true
+}

--- a/scripts/tests/fixtures/byom_journeys/admission/run-manifest.json
+++ b/scripts/tests/fixtures/byom_journeys/admission/run-manifest.json
@@ -1,0 +1,239 @@
+{
+  "schema_version": "macprovider.byom-journey-run.v1",
+  "journey_id": "JOURNEY-NETWORK-MODEL-ADMISSION",
+  "run_id": "network-model-admission-fixture",
+  "environment_class": "hermetic-loopback",
+  "cli_version": "0.0.0-fixture",
+  "harness": {
+    "name": "test/e2e/byom/run-cli-onboarding-e2e.py",
+    "status": "pass"
+  },
+  "steps": [
+    {
+      "id": "step-01-offer-dry-run",
+      "status": "pass",
+      "assertion": "Dry run produced model_admission_offer_dry_run.v1 and made no coordinator request.",
+      "requirement_ids": [
+        "SPEC-047-R002"
+      ],
+      "documents": [
+        {
+          "id": "offer-dry-run",
+          "schema": "model_admission_offer_dry_run.v1",
+          "path": "captures/offer-dry-run.json"
+        }
+      ]
+    },
+    {
+      "id": "step-02-submit-signed-offer",
+      "status": "pass",
+      "assertion": "Provider-signed offer authenticated, nonce-bound, and accepted as offer_submitted.",
+      "requirement_ids": [
+        "SPEC-047-R002",
+        "SPEC-047-R007"
+      ],
+      "documents": [
+        {
+          "id": "offer-submitted-status",
+          "schema": "model_admission_status.v1",
+          "path": "captures/admission-status-offer-submitted.json"
+        }
+      ]
+    },
+    {
+      "id": "step-03-reject-opaque-endpoint",
+      "status": "pass",
+      "assertion": "Opaque candidate was rejected with no catalog economics and no provider credit.",
+      "requirement_ids": [
+        "SPEC-047-R003",
+        "SPEC-047-R007"
+      ],
+      "documents": [
+        {
+          "id": "opaque-endpoint-rejected-status",
+          "schema": "model_admission_status.v1",
+          "path": "captures/admission-status-offer-rejected.json"
+        }
+      ]
+    },
+    {
+      "id": "step-04-sandbox-probe-only",
+      "status": "pass",
+      "assertion": "sandbox_probe_only stayed out of default paid routing; the probe used the provider channel.",
+      "requirement_ids": [
+        "SPEC-047-R001",
+        "SPEC-047-R003",
+        "SPEC-047-R005",
+        "SPEC-047-R007"
+      ],
+      "documents": [
+        {
+          "id": "sandbox-probe-only-status",
+          "schema": "model_admission_status.v1",
+          "path": "captures/admission-status-sandbox-probe-only.json"
+        }
+      ]
+    },
+    {
+      "id": "step-05-network-visible-unpriced",
+      "status": "pass",
+      "assertion": "network_visible_unpriced disclosed explicitly with every money field null.",
+      "requirement_ids": [
+        "SPEC-047-R004",
+        "SPEC-047-R005"
+      ],
+      "documents": [
+        {
+          "id": "network-visible-unpriced-economics",
+          "schema": "model_catalog_economics.v1",
+          "path": "captures/catalog-economics-unpriced.json"
+        }
+      ]
+    },
+    {
+      "id": "step-06-catalog-matched-not-settlement",
+      "status": "pass",
+      "assertion": "catalog_priced showed signed economics with settlement_capable false and no ledger row.",
+      "requirement_ids": [
+        "SPEC-047-R003",
+        "SPEC-047-R004"
+      ],
+      "documents": [
+        {
+          "id": "catalog-matched-economics",
+          "schema": "model_catalog_economics.v1",
+          "path": "captures/catalog-economics-catalog-priced.json"
+        }
+      ]
+    },
+    {
+      "id": "step-07-revocation-on-drift",
+      "status": "pass",
+      "assertion": "Drifted admitted predicate demoted to revoked and failed closed for routing.",
+      "requirement_ids": [
+        "SPEC-047-R006"
+      ],
+      "documents": [
+        {
+          "id": "revoked-status",
+          "schema": "model_admission_status.v1",
+          "path": "captures/admission-status-revoked.json"
+        }
+      ]
+    },
+    {
+      "id": "step-08-withdrawal",
+      "status": "pass",
+      "assertion": "Provider withdrawal returned withdrawn and deleted no local model artifact.",
+      "requirement_ids": [
+        "SPEC-047-R006"
+      ],
+      "documents": [
+        {
+          "id": "withdrawal-response",
+          "schema": "model_admission_withdraw.v1",
+          "path": "captures/admission-withdraw.json"
+        }
+      ]
+    },
+    {
+      "id": "step-09-settlement-capable-case",
+      "status": "pass",
+      "assertion": "settlement_capable required the route-time snapshot and receipt verification to hold.",
+      "requirement_ids": [
+        "SPEC-047-R003",
+        "SPEC-047-R005"
+      ],
+      "documents": [
+        {
+          "id": "settlement-capable-status",
+          "schema": "model_admission_status.v1",
+          "path": "captures/admission-status-settlement-capable.json"
+        }
+      ]
+    },
+    {
+      "id": "step-10-admission-status-presentation",
+      "status": "pass",
+      "assertion": "Status distinguished catalog/receipt path from no_earning_path_in_v0_1.",
+      "requirement_ids": [
+        "SPEC-047-R002",
+        "SPEC-047-R004"
+      ],
+      "documents": [
+        {
+          "id": "novel-non-catalog-status",
+          "schema": "model_admission_status.v1",
+          "path": "captures/admission-status-novel-non-catalog.json"
+        }
+      ]
+    },
+    {
+      "id": "step-11-transition-validity",
+      "status": "pass",
+      "assertion": "Invalid transition rejected; rejected, withdrawn, and revoked re-entry each demanded fresh evidence.",
+      "requirement_ids": [
+        "SPEC-047-R001",
+        "SPEC-047-R006"
+      ],
+      "documents": [
+        {
+          "id": "re-entry-status",
+          "schema": "model_admission_status.v1",
+          "path": "captures/admission-status-reentry.json"
+        }
+      ]
+    },
+    {
+      "id": "step-12-redaction-review",
+      "status": "pass",
+      "assertion": "Offer packages, coordinator events, and status output carried no secret, prompt, or endpoint material.",
+      "requirement_ids": [
+        "SPEC-047-R007",
+        "SPEC-047-R008"
+      ],
+      "documents": [
+        {
+          "id": "redaction-review-status",
+          "schema": "model_admission_status.v1",
+          "path": "captures/admission-status-offer-submitted.json"
+        }
+      ]
+    }
+  ],
+  "observations": {
+    "catalog_matched_not_settlement_verified": true,
+    "default_buyer_invisibility_verified": true,
+    "dry_run_did_not_submit": true,
+    "earning_path_disclosure_verified": true,
+    "money_path_zero_rows": {
+      "ledger_operator_credits": 0,
+      "ledger_payout_ready": 0,
+      "ledger_quarantine_resolutions": 0,
+      "ledger_request_credits": 0,
+      "payout_attempts": 0,
+      "request_log": 0,
+      "settlement_attempt_outputs": 0,
+      "settlement_receipt_verdicts": 0,
+      "settlement_route_snapshots": 0,
+      "spec022_payable_request_credits": 0
+    },
+    "network_visible_unpriced_disclosed": true,
+    "non_settlement_state_created_provider_credit": false,
+    "provider_price_treated_as_catalog_rate": false,
+    "provider_signature_verified": true,
+    "raw_completion_logged": false,
+    "raw_prompt_logged": false,
+    "rejected_opaque_endpoint_verified": true,
+    "rejected_reoffer_required_fresh_evidence": true,
+    "revocation_on_drift_verified": true,
+    "revoked_reoffer_required_fresh_evidence": true,
+    "sandbox_probe_only_blocked_from_paid_routing": true,
+    "secret_field_persisted": false,
+    "settlement_capable_case_verified": true,
+    "synthetic_probe_used_provider_channel": true,
+    "transition_matrix_enforced": true,
+    "withdrawal_verified": true,
+    "withdrawn_reoffer_required_fresh_evidence": true
+  }
+}

--- a/scripts/tests/fixtures/byom_journeys/discovery/captures/discover-adapter-failure.json
+++ b/scripts/tests/fixtures/byom_journeys/discovery/captures/discover-adapter-failure.json
@@ -1,0 +1,10 @@
+{
+  "candidates": [
+    {
+      "admission_state": "offerable",
+      "admission_state_source": "local_default",
+      "candidate_id": "byom_fixture_candidate"
+    }
+  ],
+  "schema": "provider_byom_discovery.v1"
+}

--- a/scripts/tests/fixtures/byom_journeys/discovery/captures/discover-loopback-runtime.json
+++ b/scripts/tests/fixtures/byom_journeys/discovery/captures/discover-loopback-runtime.json
@@ -1,0 +1,10 @@
+{
+  "candidates": [
+    {
+      "admission_state": "offerable",
+      "admission_state_source": "local_default",
+      "candidate_id": "byom_fixture_candidate"
+    }
+  ],
+  "schema": "provider_byom_discovery.v1"
+}

--- a/scripts/tests/fixtures/byom_journeys/discovery/captures/discover-mlx-cache.json
+++ b/scripts/tests/fixtures/byom_journeys/discovery/captures/discover-mlx-cache.json
@@ -1,0 +1,10 @@
+{
+  "candidates": [
+    {
+      "admission_state": "offerable",
+      "admission_state_source": "local_default",
+      "candidate_id": "byom_fixture_candidate"
+    }
+  ],
+  "schema": "provider_byom_discovery.v1"
+}

--- a/scripts/tests/fixtures/byom_journeys/discovery/captures/discover-non-loopback-rejected.json
+++ b/scripts/tests/fixtures/byom_journeys/discovery/captures/discover-non-loopback-rejected.json
@@ -1,0 +1,10 @@
+{
+  "candidates": [
+    {
+      "admission_state": "offerable",
+      "admission_state_source": "local_default",
+      "candidate_id": "byom_fixture_candidate"
+    }
+  ],
+  "schema": "provider_byom_discovery.v1"
+}

--- a/scripts/tests/fixtures/byom_journeys/discovery/captures/discover-opaque-endpoint.json
+++ b/scripts/tests/fixtures/byom_journeys/discovery/captures/discover-opaque-endpoint.json
@@ -1,0 +1,10 @@
+{
+  "candidates": [
+    {
+      "admission_state": "offerable",
+      "admission_state_source": "local_default",
+      "candidate_id": "byom_fixture_candidate"
+    }
+  ],
+  "schema": "provider_byom_discovery.v1"
+}

--- a/scripts/tests/fixtures/byom_journeys/discovery/captures/discover-state-ladder.json
+++ b/scripts/tests/fixtures/byom_journeys/discovery/captures/discover-state-ladder.json
@@ -1,0 +1,10 @@
+{
+  "candidates": [
+    {
+      "admission_state": "offerable",
+      "admission_state_source": "local_default",
+      "candidate_id": "byom_fixture_candidate"
+    }
+  ],
+  "schema": "provider_byom_discovery.v1"
+}

--- a/scripts/tests/fixtures/byom_journeys/discovery/captures/evaluate-candidate.json
+++ b/scripts/tests/fixtures/byom_journeys/discovery/captures/evaluate-candidate.json
@@ -1,0 +1,8 @@
+{
+  "health_result": "passed",
+  "mutation_summary": {
+    "coordinator_state_mutated": false,
+    "production_config_mutated": false
+  },
+  "schema": "provider_byom_evaluation.v1"
+}

--- a/scripts/tests/fixtures/byom_journeys/discovery/captures/offer-dry-run.json
+++ b/scripts/tests/fixtures/byom_journeys/discovery/captures/offer-dry-run.json
@@ -1,0 +1,6 @@
+{
+  "likely_admission_state": "offerable",
+  "likely_admission_state_source": "local_default",
+  "schema": "model_admission_offer_dry_run.v1",
+  "would_submit": true
+}

--- a/scripts/tests/fixtures/byom_journeys/discovery/run-manifest.json
+++ b/scripts/tests/fixtures/byom_journeys/discovery/run-manifest.json
@@ -1,0 +1,190 @@
+{
+  "schema_version": "macprovider.byom-journey-run.v1",
+  "journey_id": "JOURNEY-PROVIDER-BYOM-DISCOVERY",
+  "run_id": "byom-discovery-fixture",
+  "environment_class": "hermetic-loopback",
+  "cli_version": "0.0.0-fixture",
+  "harness": {
+    "name": "test/e2e/byom/run-cli-onboarding-e2e.py",
+    "status": "pass"
+  },
+  "steps": [
+    {
+      "id": "step-01-discover-mlx-cache",
+      "status": "pass",
+      "assertion": "MLX-cache candidate discovered read-only with a stable namespace-scoped candidate id.",
+      "requirement_ids": [
+        "SPEC-046-R001",
+        "SPEC-046-R002",
+        "SPEC-046-R003"
+      ],
+      "documents": [
+        {
+          "id": "discover-mlx-cache",
+          "schema": "provider_byom_discovery.v1",
+          "path": "captures/discover-mlx-cache.json"
+        }
+      ]
+    },
+    {
+      "id": "step-02-discover-loopback-runtime",
+      "status": "pass",
+      "assertion": "Loopback Ollama adapter enumerated one candidate without leaving the host.",
+      "requirement_ids": [
+        "SPEC-046-R001",
+        "SPEC-046-R002",
+        "SPEC-046-R003"
+      ],
+      "documents": [
+        {
+          "id": "discover-loopback-runtime",
+          "schema": "provider_byom_discovery.v1",
+          "path": "captures/discover-loopback-runtime.json"
+        }
+      ]
+    },
+    {
+      "id": "step-03-discover-opaque-endpoint",
+      "status": "pass",
+      "assertion": "Opaque OpenAI-compatible candidate reported identity_state opaque_endpoint and stayed local_only.",
+      "requirement_ids": [
+        "SPEC-046-R002",
+        "SPEC-046-R003",
+        "SPEC-046-R004"
+      ],
+      "documents": [
+        {
+          "id": "discover-opaque-endpoint",
+          "schema": "provider_byom_discovery.v1",
+          "path": "captures/discover-opaque-endpoint.json"
+        }
+      ]
+    },
+    {
+      "id": "step-04-reject-non-loopback",
+      "status": "pass",
+      "assertion": "Non-loopback adapter origin rejected before any request was issued.",
+      "requirement_ids": [
+        "SPEC-046-R002",
+        "SPEC-046-R007"
+      ],
+      "documents": [
+        {
+          "id": "discover-non-loopback-rejected",
+          "schema": "provider_byom_discovery.v1",
+          "path": "captures/discover-non-loopback-rejected.json"
+        }
+      ]
+    },
+    {
+      "id": "step-05-handle-adapter-failure",
+      "status": "pass",
+      "assertion": "Malformed adapter response surfaced as a warning, not a trust claim.",
+      "requirement_ids": [
+        "SPEC-046-R002",
+        "SPEC-046-R004"
+      ],
+      "documents": [
+        {
+          "id": "discover-adapter-failure",
+          "schema": "provider_byom_discovery.v1",
+          "path": "captures/discover-adapter-failure.json"
+        }
+      ]
+    },
+    {
+      "id": "step-06-evaluate-candidate",
+      "status": "pass",
+      "assertion": "models evaluate ran the bounded local harness and reported health_result passed.",
+      "requirement_ids": [
+        "SPEC-046-R001",
+        "SPEC-046-R005"
+      ],
+      "documents": [
+        {
+          "id": "evaluate-candidate",
+          "schema": "provider_byom_evaluation.v1",
+          "path": "captures/evaluate-candidate.json"
+        }
+      ]
+    },
+    {
+      "id": "step-07-no-production-mutation",
+      "status": "pass",
+      "assertion": "mutation_summary reported no config, cache, weight, or coordinator mutation.",
+      "requirement_ids": [
+        "SPEC-046-R006"
+      ],
+      "documents": [
+        {
+          "id": "evaluate-mutation-summary",
+          "schema": "provider_byom_evaluation.v1",
+          "path": "captures/evaluate-candidate.json"
+        }
+      ]
+    },
+    {
+      "id": "step-08-redaction-review",
+      "status": "pass",
+      "assertion": "JSON and stderr carried no prompt, completion, credential, or local path material.",
+      "requirement_ids": [
+        "SPEC-046-R007"
+      ],
+      "documents": [
+        {
+          "id": "discover-redaction-review",
+          "schema": "provider_byom_discovery.v1",
+          "path": "captures/discover-opaque-endpoint.json"
+        }
+      ]
+    },
+    {
+      "id": "step-09-state-boundary",
+      "status": "pass",
+      "assertion": "Evaluated candidate stayed non-routable and non-earning with no coordinator state.",
+      "requirement_ids": [
+        "SPEC-046-R003"
+      ],
+      "documents": [
+        {
+          "id": "offer-dry-run-state-boundary",
+          "schema": "model_admission_offer_dry_run.v1",
+          "path": "captures/offer-dry-run.json"
+        }
+      ]
+    },
+    {
+      "id": "step-10-local-state-ladder",
+      "status": "pass",
+      "assertion": "local_only, offerable, and local-default not_offered each reported their next action and reason.",
+      "requirement_ids": [
+        "SPEC-046-R003",
+        "SPEC-046-R008"
+      ],
+      "documents": [
+        {
+          "id": "discover-state-ladder",
+          "schema": "provider_byom_discovery.v1",
+          "path": "captures/discover-state-ladder.json"
+        }
+      ]
+    }
+  ],
+  "observations": {
+    "adapter_failure_warned": true,
+    "buyer_traffic_sent": false,
+    "candidate_evaluated": true,
+    "local_state_ladder_verified": true,
+    "loopback_runtime_discovered": true,
+    "mlx_cache_discovered": true,
+    "non_loopback_rejected": true,
+    "opaque_endpoint_candidate_discovered": true,
+    "provider_credit_created": false,
+    "raw_completion_logged": false,
+    "raw_prompt_logged": false,
+    "redacted_artifacts_reviewed": true,
+    "runtime_installed": false,
+    "state_boundary_preserved": true,
+    "weights_downloaded": false
+  }
+}

--- a/scripts/tests/test_byom_journey_evidence.py
+++ b/scripts/tests/test_byom_journey_evidence.py
@@ -267,6 +267,15 @@ class BYOMJourneyCaptureTests(unittest.TestCase):
 
         self.assert_capture_fails("discovery", mutator, "must not contain duplicate JSON keys")
 
+    def test_rejects_captured_document_hiding_a_url_behind_json_escapes(self) -> None:
+        def mutator(_manifest, root):
+            (root / "captures" / "discover-mlx-cache.json").write_text(
+                '{"schema": "provider_byom_discovery.v1", "note": "http:\\u002f\\u002fruntime\\u002einvalid\\u002fapi"}',
+                encoding="utf-8",
+            )
+
+        self.assert_capture_fails("discovery", mutator, ".document")
+
     def test_rejects_captured_document_containing_a_url(self) -> None:
         self.assert_captured_document_rejected(
             {"schema": "provider_byom_discovery.v1", "note": "http://runtime.invalid/api/tags"},
@@ -1069,6 +1078,18 @@ class BYOMJourneyGovernanceSourceTests(unittest.TestCase):
         del signed["observations"]
         errors = self.validate(signed)
         self.assertTrue(any("must carry exactly the builder key set" in error for error in errors), errors)
+
+    def test_rejects_signed_payload_with_an_extra_artifact_record(self) -> None:
+        signed = self.signed()
+        signed["artifacts"] = signed["artifacts"] + [copy.deepcopy(signed["artifacts"][0])]
+        errors = self.validate(signed)
+        self.assertTrue(any("exactly one redacted evidence artifact" in error for error in errors), errors)
+
+    def test_rejects_signed_artifact_record_with_an_extra_field(self) -> None:
+        signed = self.signed()
+        signed["artifacts"][0]["note"] = "unbound"
+        errors = self.validate(signed)
+        self.assertTrue(any("exactly the builder artifact fields" in error for error in errors), errors)
 
     def test_rejects_signed_step_that_disagrees_with_the_source(self) -> None:
         signed = self.signed()

--- a/scripts/tests/test_byom_journey_evidence.py
+++ b/scripts/tests/test_byom_journey_evidence.py
@@ -1,0 +1,609 @@
+"""Tests for the SPEC-046 / SPEC-047 BYOM signed-journey evidence tooling."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.check_spec_governance import (
+    NETWORK_MODEL_ADMISSION_ARTIFACT_ID,
+    NETWORK_MODEL_ADMISSION_EXECUTION_MODE,
+    NETWORK_MODEL_ADMISSION_JOURNEY_ID,
+    NETWORK_MODEL_ADMISSION_MONEY_PATH_TABLES,
+    NETWORK_MODEL_ADMISSION_STEP_ID_ORDER,
+    PROVIDER_BYOM_DISCOVERY_ARTIFACT_ID,
+    PROVIDER_BYOM_DISCOVERY_EXECUTION_MODE,
+    PROVIDER_BYOM_DISCOVERY_JOURNEY_ID,
+    PROVIDER_BYOM_DISCOVERY_STEP_ID_ORDER,
+    ValidationResult,
+    _validate_network_model_admission_journey_result,
+    _validate_provider_byom_discovery_journey_result,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXTURES = REPO_ROOT / "scripts" / "tests" / "fixtures" / "byom_journeys"
+OPERATOR_FINGERPRINT = "a" * 64
+
+
+def load_module(name: str, filename: str):
+    scripts = str(REPO_ROOT / "scripts")
+    inserted = scripts not in sys.path
+    if inserted:
+        sys.path.insert(0, scripts)
+    spec = importlib.util.spec_from_file_location(name, REPO_ROOT / "scripts" / filename)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    try:
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        if inserted:
+            sys.path.remove(scripts)
+
+
+evidence_module = load_module("byom_journey_evidence_under_test", "byom_journey_evidence.py")
+BYOMEvidenceError = evidence_module.BYOMEvidenceError
+
+
+def head_commit(root: Path) -> str:
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=root, capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+class BYOMJourneyCaptureTests(unittest.TestCase):
+    """Capture-side enforcement of the journey step, requirement, and redaction contracts."""
+
+    def setUp(self) -> None:
+        self.temp = Path(tempfile.mkdtemp(prefix="byom-journey-capture-"))
+        self.addCleanup(shutil.rmtree, self.temp, True)
+        self.source_sha = head_commit(REPO_ROOT)
+
+    def staged_manifest(self, selector: str) -> tuple[Path, dict]:
+        staged = self.temp / selector
+        shutil.copytree(FIXTURES / selector, staged)
+        manifest_path = staged / "run-manifest.json"
+        return manifest_path, json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    def capture(self, selector: str, manifest: dict | None = None, manifest_path: Path | None = None) -> dict:
+        if manifest_path is None:
+            manifest_path, default = self.staged_manifest(selector)
+            manifest = default if manifest is None else manifest
+        if manifest is not None:
+            manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+        contract = evidence_module.contract_for(selector)
+        return evidence_module.build_evidence(
+            REPO_ROOT,
+            contract,
+            manifest_path,
+            source_sha=self.source_sha,
+            operator_role="release-operator",
+            operator_identity_fingerprint=OPERATOR_FINGERPRINT,
+            hardware_profile="ci-hermetic-runner",
+            candidate="cli-fixture",
+            captured_at="2026-09-08T00:00:00Z",
+            expires_at=None,
+            summary="fixture journey run",
+        )
+
+    def mutate(self, selector: str, mutator) -> tuple[dict, Path]:
+        manifest_path, manifest = self.staged_manifest(selector)
+        mutator(manifest, manifest_path.parent)
+        return manifest, manifest_path
+
+    def assert_capture_fails(self, selector: str, mutator, fragment: str) -> None:
+        manifest, manifest_path = self.mutate(selector, mutator)
+        with self.assertRaises(BYOMEvidenceError) as caught:
+            self.capture(selector, manifest, manifest_path)
+        self.assertIn(fragment, str(caught.exception))
+
+    def test_discovery_fixture_produces_schema_valid_evidence(self) -> None:
+        evidence = self.capture("discovery")
+        self.assertEqual("macprovider.provider-byom-discovery-evidence.v1", evidence["schema_version"])
+        self.assertEqual(PROVIDER_BYOM_DISCOVERY_JOURNEY_ID, evidence["journey_id"])
+        self.assertEqual(PROVIDER_BYOM_DISCOVERY_EXECUTION_MODE, evidence["execution_mode"])
+        self.assertEqual("hermetic-loopback", evidence["environment"]["class"])
+        self.assertEqual(
+            list(PROVIDER_BYOM_DISCOVERY_STEP_ID_ORDER), [step["id"] for step in evidence["steps"]]
+        )
+        self.assertEqual([f"SPEC-046-R{index:03d}" for index in range(1, 9)], evidence["requirement_ids"])
+        for step in evidence["steps"]:
+            self.assertEqual([PROVIDER_BYOM_DISCOVERY_ARTIFACT_ID], step["artifacts"])
+            for document in step["documents"]:
+                # Digests, never the captured documents themselves.
+                self.assertEqual(64, len(document["sha256"]))
+                self.assertNotIn("path", document)
+
+    def test_admission_fixture_carries_money_path_zero_rows(self) -> None:
+        evidence = self.capture("admission")
+        self.assertEqual("macprovider.network-model-admission-evidence.v1", evidence["schema_version"])
+        self.assertEqual(NETWORK_MODEL_ADMISSION_EXECUTION_MODE, evidence["execution_mode"])
+        self.assertEqual(
+            list(NETWORK_MODEL_ADMISSION_STEP_ID_ORDER), [step["id"] for step in evidence["steps"]]
+        )
+        money_path = evidence["observations"]["money_path_zero_rows"]
+        self.assertEqual(sorted(NETWORK_MODEL_ADMISSION_MONEY_PATH_TABLES), sorted(money_path))
+        self.assertEqual({0}, set(money_path.values()))
+
+    def test_rejects_unknown_step_id(self) -> None:
+        def mutator(manifest, _root):
+            manifest["steps"][0]["id"] = "step-99-invented"
+
+        self.assert_capture_fails("discovery", mutator, "unknown JOURNEY-PROVIDER-BYOM-DISCOVERY step id")
+
+    def test_rejects_missing_required_step(self) -> None:
+        def mutator(manifest, _root):
+            del manifest["steps"][3]
+
+        self.assert_capture_fails("admission", mutator, "missing JOURNEY-NETWORK-MODEL-ADMISSION step(s)")
+
+    def test_rejects_requirement_the_step_does_not_exercise(self) -> None:
+        def mutator(manifest, _root):
+            manifest["steps"][0]["requirement_ids"] = ["SPEC-046-R005"]
+
+        self.assert_capture_fails("discovery", mutator, "is not a requirement this step exercises")
+
+    def test_rejects_requirement_id_from_another_spec(self) -> None:
+        def mutator(manifest, _root):
+            manifest["steps"][0]["requirement_ids"] = ["SPEC-022-R001"]
+
+        self.assert_capture_fails("admission", mutator, "is not a requirement this step exercises")
+
+    def test_rejects_incomplete_requirement_coverage(self) -> None:
+        def mutator(manifest, _root):
+            for step in manifest["steps"]:
+                step["requirement_ids"] = [
+                    item for item in step["requirement_ids"] if item != "SPEC-046-R006"
+                ] or ["SPEC-046-R008"]
+
+        self.assert_capture_fails("discovery", mutator, "SPEC-046-R006")
+
+    def test_rejects_url_in_assertion(self) -> None:
+        def mutator(manifest, _root):
+            manifest["steps"][1]["assertion"] = "adapter answered on http://127.0.0.1:11434/api/tags"
+
+        self.assert_capture_fails("discovery", mutator, "contains a url")
+
+    def test_rejects_absolute_path_in_assertion(self) -> None:
+        def mutator(manifest, _root):
+            manifest["steps"][0]["assertion"] = "scanned /Users/operator/.cache/huggingface for weights"
+
+        self.assert_capture_fails("discovery", mutator, "contains an absolute path")
+
+    def test_rejects_hostname_in_assertion(self) -> None:
+        def mutator(manifest, _root):
+            manifest["steps"][1]["assertion"] = "status readback came from coordinator.malibu.tech"
+
+        self.assert_capture_fails("admission", mutator, "contains a hostname")
+
+    def test_rejects_credential_in_assertion(self) -> None:
+        def mutator(manifest, _root):
+            manifest["steps"][1]["assertion"] = "authorization: Bearer abcdefghijklmnopqrstuvwxyz012345"
+
+        self.assert_capture_fails("admission", mutator, "credential-like value")
+
+    def test_rejects_captured_document_containing_a_credential(self) -> None:
+        def mutator(manifest, root):
+            document = root / "captures" / "discover-mlx-cache.json"
+            document.write_text(
+                json.dumps({"schema": "provider_byom_discovery.v1", "token": "ghp_" + "a" * 24}),
+                encoding="utf-8",
+            )
+
+        self.assert_capture_fails("discovery", mutator, "credential-like value")
+
+    def test_rejects_secret_bearing_observation_key(self) -> None:
+        def mutator(manifest, _root):
+            manifest["observations"]["provider_token_seen"] = False
+
+        self.assert_capture_fails("admission", mutator, "unexpected key(s)")
+
+    def test_rejects_nonzero_money_path_row(self) -> None:
+        def mutator(manifest, _root):
+            manifest["observations"]["money_path_zero_rows"]["ledger_request_credits"] = 1
+
+        self.assert_capture_fails("admission", mutator, "must be the integer 0")
+
+    def test_rejects_missing_money_path_table(self) -> None:
+        def mutator(manifest, _root):
+            del manifest["observations"]["money_path_zero_rows"]["payout_attempts"]
+
+        self.assert_capture_fails("admission", mutator, "payout_attempts")
+
+    def test_rejects_false_required_observation(self) -> None:
+        def mutator(manifest, _root):
+            manifest["observations"]["mlx_cache_discovered"] = False
+
+        self.assert_capture_fails("discovery", mutator, "observations.mlx_cache_discovered must be true")
+
+    def test_rejects_true_forbidden_observation(self) -> None:
+        def mutator(manifest, _root):
+            manifest["observations"]["non_settlement_state_created_provider_credit"] = True
+
+        self.assert_capture_fails(
+            "admission", mutator, "observations.non_settlement_state_created_provider_credit must be false"
+        )
+
+    def test_rejects_unknown_environment_class(self) -> None:
+        def mutator(manifest, _root):
+            manifest["environment_class"] = "production-provider"
+
+        self.assert_capture_fails("discovery", mutator, "environment_class must be one of")
+
+    def test_rejects_failed_step(self) -> None:
+        def mutator(manifest, _root):
+            manifest["steps"][2]["status"] = "fail"
+
+        self.assert_capture_fails("admission", mutator, "status must equal 'pass'")
+
+    def test_rejects_journey_id_mismatch(self) -> None:
+        def mutator(manifest, _root):
+            manifest["journey_id"] = NETWORK_MODEL_ADMISSION_JOURNEY_ID
+
+        self.assert_capture_fails("discovery", mutator, "journey_id must equal")
+
+
+class BYOMJourneyRoundTripTests(unittest.TestCase):
+    """Golden fixture round-trip: run manifest -> redacted evidence -> journey-result payload."""
+
+    def setUp(self) -> None:
+        self.temp = Path(tempfile.mkdtemp(prefix="byom-journey-roundtrip-"))
+        self.addCleanup(shutil.rmtree, self.temp, True)
+
+    def git(self, root: Path, *args: str) -> str:
+        return subprocess.run(
+            ["git", *args],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            check=True,
+            env={
+                "PATH": "/usr/bin:/bin:/usr/local/bin",
+                "HOME": str(root),
+                "GIT_AUTHOR_NAME": "test",
+                "GIT_AUTHOR_EMAIL": "test@example",
+                "GIT_COMMITTER_NAME": "test",
+                "GIT_COMMITTER_EMAIL": "test@example",
+            },
+        ).stdout.strip()
+
+    def make_repo(self) -> Path:
+        root = self.temp / "repo"
+        (root / "specs").mkdir(parents=True)
+        (root / "journeys" / "evidence").mkdir(parents=True)
+        self.git(root, "init", "-q", "-b", "main")
+        shutil.copy(REPO_ROOT / "specs" / "CONFORMANCE.json", root / "specs" / "CONFORMANCE.json")
+        self.git(root, "add", "specs/CONFORMANCE.json")
+        self.git(root, "commit", "-qm", "source")
+        return root
+
+    def round_trip(self, selector: str, evidence_name: str):
+        root = self.make_repo()
+        source_sha = self.git(root, "rev-parse", "HEAD")
+        contract = evidence_module.contract_for(selector)
+        evidence = evidence_module.build_evidence(
+            root,
+            contract,
+            FIXTURES / selector / "run-manifest.json",
+            source_sha=source_sha,
+            operator_role="release-operator",
+            operator_identity_fingerprint=OPERATOR_FINGERPRINT,
+            hardware_profile="ci-hermetic-runner",
+            candidate="cli-fixture",
+            captured_at="2026-09-08T00:00:00Z",
+            expires_at=None,
+            summary="fixture journey run",
+        )
+        source = f"journeys/evidence/{evidence_name}"
+        evidence_module.write_json_atomically(root / source, evidence)
+        self.git(root, "add", source)
+        self.git(root, "commit", "-qm", "evidence")
+        evidence_sha = self.git(root, "rev-parse", "HEAD")
+        payload = evidence_module.build_journey_result_payload(
+            root,
+            contract,
+            source,
+            source_sha=source_sha,
+            evidence_sha=evidence_sha,
+            requirement_ids=None,
+        )
+        return contract, payload, source
+
+    def test_discovery_round_trip_satisfies_the_governance_validator(self) -> None:
+        contract, payload, source = self.round_trip(
+            "discovery", "provider-byom-discovery-20260908T000000Z.redacted.json"
+        )
+        self.assertEqual("macprovider.journey-result.v1", payload["schema_version"])
+        self.assertEqual(PROVIDER_BYOM_DISCOVERY_JOURNEY_ID, payload["journey_id"])
+        self.assertEqual(source, payload["artifacts"][0]["source"])
+        self.assertEqual(PROVIDER_BYOM_DISCOVERY_ARTIFACT_ID, payload["artifacts"][0]["id"])
+        for step in payload["steps"]:
+            self.assertEqual({"id", "status", "assertion", "artifacts"}, set(step))
+        result = ValidationResult()
+        _validate_provider_byom_discovery_journey_result(
+            payload,
+            "SPEC-046-R008",
+            [PROVIDER_BYOM_DISCOVERY_JOURNEY_ID],
+            payload["artifacts"],
+            payload["steps"],
+            "evidence[0]",
+            result,
+        )
+        self.assertEqual([], result.errors)
+
+    def test_admission_round_trip_satisfies_the_governance_validator(self) -> None:
+        contract, payload, source = self.round_trip(
+            "admission", "network-model-admission-20260908T000000Z.redacted.json"
+        )
+        self.assertEqual(NETWORK_MODEL_ADMISSION_JOURNEY_ID, payload["journey_id"])
+        self.assertEqual(NETWORK_MODEL_ADMISSION_ARTIFACT_ID, payload["artifacts"][0]["id"])
+        result = ValidationResult()
+        _validate_network_model_admission_journey_result(
+            payload,
+            "SPEC-047-R003",
+            [NETWORK_MODEL_ADMISSION_JOURNEY_ID],
+            payload["artifacts"],
+            payload["steps"],
+            "evidence[0]",
+            result,
+        )
+        self.assertEqual([], result.errors)
+
+    def test_builder_refuses_a_requirement_from_another_spec(self) -> None:
+        root = self.make_repo()
+        source_sha = self.git(root, "rev-parse", "HEAD")
+        contract = evidence_module.contract_for("discovery")
+        evidence = evidence_module.build_evidence(
+            root,
+            contract,
+            FIXTURES / "discovery" / "run-manifest.json",
+            source_sha=source_sha,
+            operator_role="release-operator",
+            operator_identity_fingerprint=OPERATOR_FINGERPRINT,
+            hardware_profile="ci-hermetic-runner",
+            candidate="cli-fixture",
+            captured_at="2026-09-08T00:00:00Z",
+            expires_at=None,
+            summary="fixture journey run",
+        )
+        source = "journeys/evidence/provider-byom-discovery-20260908T000000Z.redacted.json"
+        evidence_module.write_json_atomically(root / source, evidence)
+        self.git(root, "add", source)
+        self.git(root, "commit", "-qm", "evidence")
+        evidence_sha = self.git(root, "rev-parse", "HEAD")
+        with self.assertRaises(BYOMEvidenceError) as caught:
+            evidence_module.build_journey_result_payload(
+                root,
+                contract,
+                source,
+                source_sha=source_sha,
+                evidence_sha=evidence_sha,
+                requirement_ids="SPEC-047-R001",
+            )
+        self.assertIn("must be covered by evidence.requirement_ids", str(caught.exception))
+
+    def test_builder_rejects_evidence_outside_the_journey_prefix(self) -> None:
+        root = self.make_repo()
+        source_sha = self.git(root, "rev-parse", "HEAD")
+        contract = evidence_module.contract_for("discovery")
+        with self.assertRaises(BYOMEvidenceError) as caught:
+            evidence_module.build_journey_result_payload(
+                root,
+                contract,
+                "journeys/evidence/buyer-enforce-20260818T051838Z.redacted.json",
+                source_sha=source_sha,
+                evidence_sha=source_sha,
+                requirement_ids=None,
+            )
+        self.assertIn("redacted evidence source must be", str(caught.exception))
+
+
+class BYOMJourneyGovernanceValidatorTests(unittest.TestCase):
+    """Governance registration: the two journey ids get their own strict lane."""
+
+    def signed(self, journey: str) -> dict:
+        if journey == "discovery":
+            return {
+                "journey_id": PROVIDER_BYOM_DISCOVERY_JOURNEY_ID,
+                "execution_mode": PROVIDER_BYOM_DISCOVERY_EXECUTION_MODE,
+                "requirement_ids": ["SPEC-046-R008"],
+                "environment": {"class": "physical-provider", "hardware_profile": "m4-16gb", "candidate": "cli"},
+                "observations": {
+                    **{
+                        field: True
+                        for field in (
+                            "adapter_failure_warned",
+                            "candidate_evaluated",
+                            "loopback_runtime_discovered",
+                            "local_state_ladder_verified",
+                            "mlx_cache_discovered",
+                            "non_loopback_rejected",
+                            "opaque_endpoint_candidate_discovered",
+                            "redacted_artifacts_reviewed",
+                            "state_boundary_preserved",
+                        )
+                    },
+                    **{
+                        field: False
+                        for field in (
+                            "buyer_traffic_sent",
+                            "provider_credit_created",
+                            "raw_completion_logged",
+                            "raw_prompt_logged",
+                            "runtime_installed",
+                            "weights_downloaded",
+                        )
+                    },
+                },
+                "steps": [
+                    {"id": step_id, "status": "pass", "artifacts": [PROVIDER_BYOM_DISCOVERY_ARTIFACT_ID]}
+                    for step_id in PROVIDER_BYOM_DISCOVERY_STEP_ID_ORDER
+                ],
+                "artifacts": [
+                    {
+                        "id": PROVIDER_BYOM_DISCOVERY_ARTIFACT_ID,
+                        "sha256": "0" * 64,
+                        "source": "journeys/evidence/provider-byom-discovery-20260908T000000Z.redacted.json",
+                    }
+                ],
+            }
+        return {
+            "journey_id": NETWORK_MODEL_ADMISSION_JOURNEY_ID,
+            "execution_mode": NETWORK_MODEL_ADMISSION_EXECUTION_MODE,
+            "requirement_ids": ["SPEC-047-R003"],
+            "environment": {"class": "hermetic-loopback", "hardware_profile": "ci", "candidate": "cli"},
+            "observations": {
+                **{
+                    field: True
+                    for field in (
+                        "catalog_matched_not_settlement_verified",
+                        "default_buyer_invisibility_verified",
+                        "dry_run_did_not_submit",
+                        "network_visible_unpriced_disclosed",
+                        "earning_path_disclosure_verified",
+                        "provider_signature_verified",
+                        "rejected_opaque_endpoint_verified",
+                        "revocation_on_drift_verified",
+                        "sandbox_probe_only_blocked_from_paid_routing",
+                        "synthetic_probe_used_provider_channel",
+                        "settlement_capable_case_verified",
+                        "transition_matrix_enforced",
+                        "rejected_reoffer_required_fresh_evidence",
+                        "withdrawn_reoffer_required_fresh_evidence",
+                        "revoked_reoffer_required_fresh_evidence",
+                        "withdrawal_verified",
+                    )
+                },
+                **{
+                    field: False
+                    for field in (
+                        "non_settlement_state_created_provider_credit",
+                        "provider_price_treated_as_catalog_rate",
+                        "raw_completion_logged",
+                        "raw_prompt_logged",
+                        "secret_field_persisted",
+                    )
+                },
+                "money_path_zero_rows": {table: 0 for table in NETWORK_MODEL_ADMISSION_MONEY_PATH_TABLES},
+            },
+            "steps": [
+                {"id": step_id, "status": "pass", "artifacts": [NETWORK_MODEL_ADMISSION_ARTIFACT_ID]}
+                for step_id in NETWORK_MODEL_ADMISSION_STEP_ID_ORDER
+            ],
+            "artifacts": [
+                {
+                    "id": NETWORK_MODEL_ADMISSION_ARTIFACT_ID,
+                    "sha256": "0" * 64,
+                    "source": "journeys/evidence/network-model-admission-20260908T000000Z.redacted.json",
+                }
+            ],
+        }
+
+    def validate(self, journey: str, signed: dict, requirement_id: str, journeys: list[str] | None = None):
+        result = ValidationResult()
+        validator = (
+            _validate_provider_byom_discovery_journey_result
+            if journey == "discovery"
+            else _validate_network_model_admission_journey_result
+        )
+        journey_id = (
+            PROVIDER_BYOM_DISCOVERY_JOURNEY_ID if journey == "discovery" else NETWORK_MODEL_ADMISSION_JOURNEY_ID
+        )
+        validator(
+            signed,
+            requirement_id,
+            journeys if journeys is not None else [journey_id],
+            signed.get("artifacts", []),
+            signed.get("steps", []),
+            "evidence[0]",
+            result,
+        )
+        return result.errors
+
+    def test_valid_discovery_payload_passes(self) -> None:
+        self.assertEqual([], self.validate("discovery", self.signed("discovery"), "SPEC-046-R008"))
+
+    def test_valid_admission_payload_passes(self) -> None:
+        self.assertEqual([], self.validate("admission", self.signed("admission"), "SPEC-047-R003"))
+
+    def test_discovery_payload_cannot_promote_a_foreign_requirement(self) -> None:
+        signed = self.signed("discovery")
+        signed["requirement_ids"] = ["SPEC-047-R001"]
+        errors = self.validate("discovery", signed, "SPEC-047-R001")
+        self.assertTrue(any("cannot promote" in error for error in errors), errors)
+
+    def test_admission_payload_rejects_nonzero_money_path_row(self) -> None:
+        signed = copy.deepcopy(self.signed("admission"))
+        signed["observations"]["money_path_zero_rows"]["request_log"] = 3
+        errors = self.validate("admission", signed, "SPEC-047-R003")
+        self.assertTrue(any("money_path_zero_rows.request_log" in error for error in errors), errors)
+
+    def test_admission_payload_rejects_boolean_money_path_row(self) -> None:
+        signed = copy.deepcopy(self.signed("admission"))
+        signed["observations"]["money_path_zero_rows"]["payout_attempts"] = False
+        errors = self.validate("admission", signed, "SPEC-047-R003")
+        self.assertTrue(any("money_path_zero_rows.payout_attempts" in error for error in errors), errors)
+
+    def test_rejects_missing_named_step(self) -> None:
+        signed = copy.deepcopy(self.signed("discovery"))
+        signed["steps"] = signed["steps"][:-1]
+        errors = self.validate("discovery", signed, "SPEC-046-R008")
+        self.assertTrue(any("missing provider BYOM discovery physical steps" in error for error in errors), errors)
+
+    def test_rejects_invented_step(self) -> None:
+        signed = copy.deepcopy(self.signed("admission"))
+        signed["steps"][0]["id"] = "step-00-invented"
+        errors = self.validate("admission", signed, "SPEC-047-R003")
+        self.assertTrue(any("unexpected network model admission physical steps" in error for error in errors), errors)
+
+    def test_rejects_wrong_execution_mode(self) -> None:
+        signed = copy.deepcopy(self.signed("discovery"))
+        signed["execution_mode"] = "isolated-candidate-paid-path"
+        errors = self.validate("discovery", signed, "SPEC-046-R008")
+        self.assertTrue(any("execution_mode" in error for error in errors), errors)
+
+    def test_rejects_unknown_environment_class(self) -> None:
+        signed = copy.deepcopy(self.signed("admission"))
+        signed["environment"]["class"] = "production-provider"
+        errors = self.validate("admission", signed, "SPEC-047-R003")
+        self.assertTrue(any("environment.class" in error for error in errors), errors)
+
+    def test_rejects_artifact_outside_the_journey_evidence_prefix(self) -> None:
+        signed = copy.deepcopy(self.signed("discovery"))
+        signed["artifacts"][0]["source"] = "journeys/evidence/buyer-enforce-20260818T051838Z.redacted.json"
+        errors = self.validate("discovery", signed, "SPEC-046-R008")
+        self.assertTrue(any("provider-byom-discovery-" in error for error in errors), errors)
+
+    def test_rejects_requirement_not_mapped_to_this_journey(self) -> None:
+        signed = copy.deepcopy(self.signed("admission"))
+        errors = self.validate("admission", signed, "SPEC-047-R003", journeys=["JOURNEY-BUYER-PAID-PATH"])
+        self.assertTrue(any("must include" in error for error in errors), errors)
+
+
+class BYOMJourneyConformanceMappingTests(unittest.TestCase):
+    """The journey ids the tooling emits must stay mapped and pending in CONFORMANCE.json."""
+
+    def test_every_promotable_requirement_is_pending_and_mapped(self) -> None:
+        conformance = json.loads((REPO_ROOT / "specs" / "CONFORMANCE.json").read_text(encoding="utf-8"))
+        rows = {row["requirement_id"]: row for row in conformance["requirements"]}
+        for journey_id, prefix in (
+            (PROVIDER_BYOM_DISCOVERY_JOURNEY_ID, "SPEC-046"),
+            (NETWORK_MODEL_ADMISSION_JOURNEY_ID, "SPEC-047"),
+        ):
+            for index in range(1, 9):
+                requirement_id = f"{prefix}-R{index:03d}"
+                row = rows[requirement_id]
+                self.assertIn(journey_id, row["journeys"], requirement_id)
+                self.assertEqual("pending", row["state"], requirement_id)
+                self.assertEqual([], row["evidence"], requirement_id)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_byom_journey_evidence.py
+++ b/scripts/tests/test_byom_journey_evidence.py
@@ -199,6 +199,45 @@ class BYOMJourneyCaptureTests(unittest.TestCase):
 
         self.assert_capture_fails("discovery", mutator, "credential-like value")
 
+    def write_capture(self, root, payload: dict) -> None:
+        (root / "captures" / "discover-mlx-cache.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    def assert_captured_document_rejected(self, payload: dict, fragment: str) -> None:
+        def mutator(_manifest, root):
+            self.write_capture(root, payload)
+
+        self.assert_capture_fails("discovery", mutator, fragment)
+
+    def test_rejects_captured_document_containing_a_url(self) -> None:
+        self.assert_captured_document_rejected(
+            {"schema": "provider_byom_discovery.v1", "note": "http://runtime.invalid/api/tags"},
+            "contains a url",
+        )
+
+    def test_rejects_captured_document_containing_an_absolute_path(self) -> None:
+        self.assert_captured_document_rejected(
+            {"schema": "provider_byom_discovery.v1", "note": "/Users/operator/.cache/huggingface"},
+            "contains an absolute path",
+        )
+
+    def test_rejects_captured_document_containing_a_hostname(self) -> None:
+        self.assert_captured_document_rejected(
+            {"schema": "provider_byom_discovery.v1", "note": "read back from coordinator.malibu.tech"},
+            "contains a hostname",
+        )
+
+    def test_rejects_captured_document_containing_an_ip_literal(self) -> None:
+        self.assert_captured_document_rejected(
+            {"schema": "provider_byom_discovery.v1", "note": "bound 10.11.12.13"},
+            "contains an ipv4 literal",
+        )
+
+    def test_rejects_captured_document_containing_a_localhost_reference(self) -> None:
+        self.assert_captured_document_rejected(
+            {"schema": "provider_byom_discovery.v1", "note": "adapter answered on localhost"},
+            "contains a localhost reference",
+        )
+
     def test_rejects_secret_bearing_observation_key(self) -> None:
         def mutator(manifest, _root):
             manifest["observations"]["provider_token_seen"] = False
@@ -388,6 +427,90 @@ class BYOMJourneyRoundTripTests(unittest.TestCase):
                 requirement_ids="SPEC-047-R001",
             )
         self.assertIn("must be covered by evidence.requirement_ids", str(caught.exception))
+
+    def commit_and_build(self, mutator, selector: str = "discovery"):
+        """Build a payload from committed evidence a mutator was allowed to hand-edit."""
+        root = self.make_repo()
+        source_sha = self.git(root, "rev-parse", "HEAD")
+        contract = evidence_module.contract_for(selector)
+        evidence = evidence_module.build_evidence(
+            root,
+            contract,
+            FIXTURES / selector / "run-manifest.json",
+            source_sha=source_sha,
+            operator_role="release-operator",
+            operator_identity_fingerprint=OPERATOR_FINGERPRINT,
+            hardware_profile="ci-hermetic-runner",
+            candidate="cli-fixture",
+            captured_at="2026-09-08T00:00:00Z",
+            expires_at=None,
+            summary="fixture journey run",
+        )
+        mutator(evidence)
+        source = f"journeys/evidence/{contract.evidence_prefix.split('/')[-1]}20260908T000000Z.redacted.json"
+        evidence_module.write_json_atomically(root / source, evidence)
+        self.git(root, "add", source)
+        self.git(root, "commit", "-qm", "evidence")
+        evidence_sha = self.git(root, "rev-parse", "HEAD")
+        return evidence_module.build_journey_result_payload(
+            root,
+            contract,
+            source,
+            source_sha=source_sha,
+            evidence_sha=evidence_sha,
+            requirement_ids=None,
+        )
+
+    def assert_builder_rejects(self, mutator, fragment: str, selector: str = "discovery") -> None:
+        with self.assertRaises(BYOMEvidenceError) as caught:
+            self.commit_and_build(mutator, selector)
+        self.assertIn(fragment, str(caught.exception))
+
+    def test_builder_rejects_an_extra_evidence_step(self) -> None:
+        def mutator(evidence):
+            extra = copy.deepcopy(evidence["steps"][0])
+            extra["id"] = "step-99-invented"
+            evidence["steps"].append(extra)
+
+        self.assert_builder_rejects(mutator, "unknown JOURNEY-PROVIDER-BYOM-DISCOVERY step id")
+
+    def test_builder_rejects_a_missing_evidence_step(self) -> None:
+        def mutator(evidence):
+            del evidence["steps"][2]
+
+        self.assert_builder_rejects(mutator, "missing JOURNEY-PROVIDER-BYOM-DISCOVERY step(s)")
+
+    def test_builder_rejects_a_step_requirement_outside_the_allowed_set(self) -> None:
+        def mutator(evidence):
+            evidence["steps"][0]["requirement_ids"] = ["SPEC-046-R005"]
+
+        self.assert_builder_rejects(mutator, "is not a requirement this step exercises")
+
+    def test_builder_rejects_top_level_requirement_ids_that_are_not_the_step_union(self) -> None:
+        def mutator(evidence):
+            evidence["requirement_ids"] = [
+                item for item in evidence["requirement_ids"] if item != "SPEC-046-R004"
+            ]
+
+        self.assert_builder_rejects(mutator, "must equal the union of the evidence step requirement ids")
+
+    def test_builder_rejects_padded_top_level_requirement_ids(self) -> None:
+        def mutator(evidence):
+            evidence["requirement_ids"] = sorted(evidence["requirement_ids"] + ["SPEC-047-R001"])
+
+        self.assert_builder_rejects(mutator, "must equal the union of the evidence step requirement ids")
+
+    def test_builder_rejects_evidence_that_stops_covering_every_requirement(self) -> None:
+        def mutator(evidence):
+            for step in evidence["steps"]:
+                step["requirement_ids"] = [
+                    item for item in step["requirement_ids"] if item != "SPEC-046-R006"
+                ] or ["SPEC-046-R008"]
+            evidence["requirement_ids"] = sorted(
+                {item for step in evidence["steps"] for item in step["requirement_ids"]}
+            )
+
+        self.assert_builder_rejects(mutator, "steps do not cover every mapped requirement: SPEC-046-R006")
 
     def test_builder_rejects_evidence_outside_the_journey_prefix(self) -> None:
         root = self.make_repo()

--- a/scripts/tests/test_byom_journey_evidence.py
+++ b/scripts/tests/test_byom_journey_evidence.py
@@ -258,6 +258,15 @@ class BYOMJourneyCaptureTests(unittest.TestCase):
 
         self.assert_capture_fails("discovery", mutator, "must be relative to the run manifest directory")
 
+    def test_rejects_captured_document_with_duplicate_json_keys(self) -> None:
+        def mutator(_manifest, root):
+            (root / "captures" / "discover-mlx-cache.json").write_text(
+                '{"schema": "provider_byom_discovery.v1", "schema": "model_admission_status.v1"}',
+                encoding="utf-8",
+            )
+
+        self.assert_capture_fails("discovery", mutator, "must not contain duplicate JSON keys")
+
     def test_rejects_captured_document_containing_a_url(self) -> None:
         self.assert_captured_document_rejected(
             {"schema": "provider_byom_discovery.v1", "note": "http://runtime.invalid/api/tags"},
@@ -983,6 +992,7 @@ class BYOMJourneyGovernanceSourceTests(unittest.TestCase):
         evidence = self.evidence if evidence is None else evidence
         return copy.deepcopy(
             {
+                "schema_version": evidence_module.JOURNEY_RESULT_PAYLOAD_SCHEMA,
                 "journey_id": evidence["journey_id"],
                 "requirement_ids": evidence["requirement_ids"],
                 "repository": evidence["repository"],
@@ -1043,6 +1053,22 @@ class BYOMJourneyGovernanceSourceTests(unittest.TestCase):
         self.write_evidence(evidence)
         errors = self.validate(self.signed())
         self.assertTrue(any("must equal the union" in error for error in errors), errors)
+
+    def test_rejects_signed_payload_carrying_generic_optional_fields(self) -> None:
+        for extra in ("harness", "config_before", "candidate", "candidate_identity", "eip712", "signer"):
+            with self.subTest(extra=extra):
+                signed = self.signed()
+                signed[extra] = {"unbound": "value"}
+                errors = self.validate(signed)
+                self.assertTrue(
+                    any("must carry exactly the builder key set" in error for error in errors), errors
+                )
+
+    def test_rejects_signed_payload_missing_a_builder_key(self) -> None:
+        signed = self.signed()
+        del signed["observations"]
+        errors = self.validate(signed)
+        self.assertTrue(any("must carry exactly the builder key set" in error for error in errors), errors)
 
     def test_rejects_signed_step_that_disagrees_with_the_source(self) -> None:
         signed = self.signed()

--- a/scripts/tests/test_byom_journey_evidence.py
+++ b/scripts/tests/test_byom_journey_evidence.py
@@ -212,6 +212,52 @@ class BYOMJourneyCaptureTests(unittest.TestCase):
 
         self.assert_capture_fails("discovery", mutator, fragment)
 
+    def test_rejects_captured_document_whose_schema_differs_from_the_manifest(self) -> None:
+        self.assert_captured_document_rejected(
+            {"schema": "model_admission_status.v1", "candidates": []},
+            "does not match the captured document's top-level schema",
+        )
+
+    def test_rejects_captured_document_without_a_top_level_schema(self) -> None:
+        self.assert_captured_document_rejected(
+            {"candidates": []},
+            "does not match the captured document's top-level schema",
+        )
+
+    def test_rejects_captured_document_that_is_not_a_json_object(self) -> None:
+        def mutator(_manifest, root):
+            (root / "captures" / "discover-mlx-cache.json").write_text(
+                json.dumps(["provider_byom_discovery.v1"]), encoding="utf-8"
+            )
+
+        self.assert_capture_fails("discovery", mutator, "must be a JSON object document")
+
+    def test_rejects_captured_document_with_an_absolute_path(self) -> None:
+        def mutator(manifest, root):
+            for step in manifest["steps"]:
+                for document in step.get("documents", []):
+                    document["path"] = str((root / document["path"]).resolve())
+                    break
+                else:
+                    continue
+                break
+
+        self.assert_capture_fails("discovery", mutator, "must be relative to the run manifest directory")
+
+    def test_rejects_captured_document_path_escaping_the_manifest_directory(self) -> None:
+        def mutator(manifest, root):
+            escaped = root.parent / "escaped-capture.json"
+            escaped.write_text(json.dumps({"schema": "provider_byom_discovery.v1"}), encoding="utf-8")
+            for step in manifest["steps"]:
+                for document in step.get("documents", []):
+                    document["path"] = "../escaped-capture.json"
+                    break
+                else:
+                    continue
+                break
+
+        self.assert_capture_fails("discovery", mutator, "must be relative to the run manifest directory")
+
     def test_rejects_captured_document_containing_a_url(self) -> None:
         self.assert_captured_document_rejected(
             {"schema": "provider_byom_discovery.v1", "note": "http://runtime.invalid/api/tags"},

--- a/scripts/tests/test_byom_journey_evidence.py
+++ b/scripts/tests/test_byom_journey_evidence.py
@@ -13,6 +13,8 @@ import unittest
 from pathlib import Path
 
 from scripts.check_spec_governance import (
+    CREDENTIAL_SHAPE_PATTERN_FRAGMENTS,
+    LOCAL_CONSUMER_ENDPOINT_FORBIDDEN_METADATA_RE,
     NETWORK_MODEL_ADMISSION_ARTIFACT_ID,
     NETWORK_MODEL_ADMISSION_EXECUTION_MODE,
     NETWORK_MODEL_ADMISSION_JOURNEY_ID,
@@ -67,7 +69,9 @@ class BYOMJourneyCaptureTests(unittest.TestCase):
         self.source_sha = head_commit(REPO_ROOT)
 
     def staged_manifest(self, selector: str) -> tuple[Path, dict]:
-        staged = self.temp / selector
+        # A fresh staging directory per call, so a subTest loop over rejection
+        # cases never inherits the previous iteration's mutated capture files.
+        staged = Path(tempfile.mkdtemp(prefix=f"{selector}-", dir=self.temp)) / selector
         shutil.copytree(FIXTURES / selector, staged)
         manifest_path = staged / "run-manifest.json"
         return manifest_path, json.loads(manifest_path.read_text(encoding="utf-8"))
@@ -237,6 +241,86 @@ class BYOMJourneyCaptureTests(unittest.TestCase):
             {"schema": "provider_byom_discovery.v1", "note": "adapter answered on localhost"},
             "contains a localhost reference",
         )
+
+    # The hostname rule is shape-based rather than a fixed suffix allowlist, so a
+    # suffix the old list never enumerated must still fail closed -- in a manifest
+    # assertion and in the bytes of a captured document.
+    HOSTNAMES_OUTSIDE_THE_OLD_SUFFIX_LIST = (
+        "provider-mac.xyz",
+        "pool.example.co.uk",
+        "provider-mac.lan",
+        "mac-mini.home",
+        "provider-mac.corp",
+        "runtime.invalid",
+    )
+
+    def test_rejects_hostname_with_a_suffix_outside_the_old_fixed_list(self) -> None:
+        for hostname in self.HOSTNAMES_OUTSIDE_THE_OLD_SUFFIX_LIST:
+            with self.subTest(hostname=hostname):
+
+                def mutator(manifest, _root, hostname=hostname):
+                    manifest["steps"][1]["assertion"] = f"status readback came from {hostname}"
+
+                self.assert_capture_fails("admission", mutator, "contains a hostname")
+
+    def test_rejects_captured_document_hostname_outside_the_old_fixed_list(self) -> None:
+        for hostname in self.HOSTNAMES_OUTSIDE_THE_OLD_SUFFIX_LIST:
+            with self.subTest(hostname=hostname):
+                self.assert_captured_document_rejected(
+                    {"schema": "provider_byom_discovery.v1", "note": f"read back from {hostname}"},
+                    "contains a hostname",
+                )
+
+    def test_rejects_captured_document_containing_an_ipv6_literal(self) -> None:
+        for literal in ("2001:0db8:85a3:0000:0000:8a2e:0370:7334", "fe80::1ff:fe23:4567:890a", "::1"):
+            with self.subTest(literal=literal):
+                self.assert_captured_document_rejected(
+                    {"schema": "provider_byom_discovery.v1", "note": f"bound {literal}"},
+                    "contains an ipv6 literal",
+                )
+
+    # Token shapes the sibling governance scanner already covered while the BYOM
+    # scanner did not: `sk-proj-`, `sk-` carrying `_`/`-`, and a lowercase AKIA.
+    TOKEN_SHAPES_FROM_THE_GOVERNANCE_SIBLING = (
+        "sk-proj-ABCDEFGHIJKLMNOPQRSTUVWX",
+        "sk-ABCDEFGHIJ_KLMNOPQRSTUV-WX",
+        "akiaabcdefghijklmnop",
+        "github_pat_" + "a" * 24,
+        "xoxb-" + "a" * 24,
+        "mp_" + "a" * 20,
+    )
+
+    def test_rejects_token_shapes_covered_by_the_governance_sibling(self) -> None:
+        for token in self.TOKEN_SHAPES_FROM_THE_GOVERNANCE_SIBLING:
+            with self.subTest(token=token):
+
+                def mutator(manifest, _root, token=token):
+                    manifest["steps"][1]["assertion"] = f"offer echoed {token}"
+
+                self.assert_capture_fails("admission", mutator, "credential-like value")
+
+    def test_rejects_captured_document_token_shapes_covered_by_the_sibling(self) -> None:
+        for token in self.TOKEN_SHAPES_FROM_THE_GOVERNANCE_SIBLING:
+            with self.subTest(token=token):
+                self.assert_captured_document_rejected(
+                    {"schema": "provider_byom_discovery.v1", "note": f"echoed {token}"},
+                    "credential-like value",
+                )
+
+    def test_legitimate_dns_shaped_values_still_capture(self) -> None:
+        # The tightened rule must not reject the DNS-shaped value shapes the
+        # contract legitimately emits, so prove them through a real capture.
+        def mutator(manifest, _root):
+            manifest["steps"][0]["assertion"] = (
+                "schema macprovider.provider-byom-discovery-evidence.v1 with document "
+                "provider_byom_discovery.v1, harness run-cli-onboarding-e2e.py, "
+                "SnapshotManifestV1 at 1.8.117 for SPEC-046-R001 in step-01-discover-mlx-cache"
+            )
+
+        manifest, manifest_path = self.mutate("discovery", mutator)
+        evidence = self.capture("discovery", manifest, manifest_path)
+        self.assertIn("SnapshotManifestV1", evidence["steps"][0]["assertion"])
+        self.assertEqual("test/e2e/byom/run-cli-onboarding-e2e.py", evidence["harness"]["name"])
 
     def test_rejects_secret_bearing_observation_key(self) -> None:
         def mutator(manifest, _root):
@@ -708,6 +792,261 @@ class BYOMJourneyGovernanceValidatorTests(unittest.TestCase):
         signed = copy.deepcopy(self.signed("admission"))
         errors = self.validate("admission", signed, "SPEC-047-R003", journeys=["JOURNEY-BUYER-PAID-PATH"])
         self.assertTrue(any("must include" in error for error in errors), errors)
+
+
+class BYOMRedactionScannerTests(unittest.TestCase):
+    """The fail-closed scanner must be as broad as it claims, and no broader."""
+
+    def assert_rejected(self, text: str) -> None:
+        with self.assertRaises(BYOMEvidenceError):
+            evidence_module.reject_unredacted_text(text, "$")
+
+    def assert_accepted(self, text: str) -> None:
+        evidence_module.reject_unredacted_text(text, "$")
+
+    def test_rejects_any_dns_shaped_hostname(self) -> None:
+        for hostname in (
+            "provider-mac.xyz",
+            "pool.example.co.uk",
+            "provider-mac.lan",
+            "mac-mini.home",
+            "provider-mac.corp",
+            "a.b.museum",
+            "coordinator.malibu.tech",
+            "gateway.internal",
+        ):
+            with self.subTest(hostname=hostname):
+                self.assert_rejected(f"read back from {hostname}")
+
+    def test_rejects_urls_paths_and_ip_literals(self) -> None:
+        for text in (
+            "https://gateway.example/v1",
+            "unix:///var/run/thing.sock",
+            "wrote  /Users/operator/.cache/huggingface",
+            "wrote  ~/byom-run/captures",
+            "bound 10.11.12.13",
+            "bound 2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+            "bound fe80::1ff:fe23:4567:890a",
+            "bound ::1",
+            "answered on localhost",
+        ):
+            with self.subTest(text=text):
+                self.assert_rejected(text)
+
+    def test_credential_shapes_are_at_least_the_governance_siblings(self) -> None:
+        # Single source of truth: the BYOM scanner compiles the governance
+        # module's credential-shape fragments, so it can never drift narrower.
+        byom_patterns = {pattern.pattern for pattern in evidence_module.FORBIDDEN_SECRET_VALUE_PATTERNS}
+        self.assertTrue(
+            set(CREDENTIAL_SHAPE_PATTERN_FRAGMENTS).issubset(byom_patterns),
+            sorted(set(CREDENTIAL_SHAPE_PATTERN_FRAGMENTS) - byom_patterns),
+        )
+        for fragment in CREDENTIAL_SHAPE_PATTERN_FRAGMENTS:
+            with self.subTest(fragment=fragment):
+                self.assertIn(fragment, LOCAL_CONSUMER_ENDPOINT_FORBIDDEN_METADATA_RE.pattern)
+
+    def test_rejects_token_shapes(self) -> None:
+        for token in (
+            "sk-proj-ABCDEFGHIJKLMNOPQRSTUVWX",
+            "sk-ABCDEFGHIJ_KLMNOPQRSTUV-WX",
+            "AKIAABCDEFGHIJKLMNOP",
+            "akiaabcdefghijklmnop",
+            "ghp_" + "a" * 24,
+            "github_pat_" + "a" * 24,
+            "xoxb-" + "a" * 24,
+            "mp_" + "a" * 20,
+            "provider-token-abcdefgh",
+            "Bearer " + "a" * 24,
+            # Assembled at runtime so the repository secret preflight does not
+            # read this test fixture as a real PEM header.
+            "-----BEGIN EC PRIVATE " + "KEY-----",
+        ):
+            with self.subTest(token=token):
+                self.assert_rejected(f"value {token} seen")
+
+    def test_accepts_the_allowlisted_and_non_dns_value_shapes(self) -> None:
+        # These are the shapes the evidence contract legitimately emits. The
+        # schema ids, step ids, requirement ids, run ids and versions are not
+        # DNS-shaped at all; the repository source file names are, and are the
+        # only entries the hostname allowlist covers.
+        for value in (
+            "macprovider.provider-byom-discovery-evidence.v1",
+            "macprovider.network-model-admission-evidence.v1",
+            "macprovider.byom-journey-run.v1",
+            "provider_byom_discovery.v1",
+            "model_admission_status.v1",
+            "step-01-discover-mlx-cache",
+            "step-12-redaction-review",
+            "SPEC-046-R008",
+            "SPEC-047-R003",
+            "SnapshotManifestV1",
+            "1.8.117",
+            "v1.2.3",
+            "0.0.0-fixture",
+            "byom-discovery-fixture",
+            "JOURNEY-PROVIDER-BYOM-DISCOVERY",
+            "Augustas11/macprovider",
+            "macprovider-acceptance-p256-v1",
+            "2026-09-08T00:00:00Z",
+            "a" * 64,
+            "test/e2e/byom/run-cli-onboarding-e2e.py",
+            "run-manifest.json",
+            "docs/runbooks/byom-journey-evidence.md",
+            "10/10 steps pass. No money-path rows were written.",
+        ):
+            with self.subTest(value=value):
+                self.assert_accepted(value)
+
+    def test_a_file_name_shape_with_an_unlisted_extension_still_fails_closed(self) -> None:
+        self.assert_rejected("harness at run-cli-onboarding-e2e.zz")
+
+
+class BYOMJourneyGovernanceSourceTests(unittest.TestCase):
+    """Governance re-opens the referenced evidence instead of trusting the signature."""
+
+    def setUp(self) -> None:
+        self.temp = Path(tempfile.mkdtemp(prefix="byom-journey-source-"))
+        self.addCleanup(shutil.rmtree, self.temp, True)
+        self.source = "journeys/evidence/provider-byom-discovery-20260908T000000Z.redacted.json"
+        self.evidence = self.build_evidence()
+        self.write_evidence(self.evidence)
+
+    def build_evidence(self) -> dict:
+        staged = self.temp / "capture"
+        shutil.copytree(FIXTURES / "discovery", staged)
+        return evidence_module.build_evidence(
+            REPO_ROOT,
+            evidence_module.contract_for("discovery"),
+            staged / "run-manifest.json",
+            source_sha=head_commit(REPO_ROOT),
+            operator_role="release-operator",
+            operator_identity_fingerprint=OPERATOR_FINGERPRINT,
+            hardware_profile="ci-hermetic-runner",
+            candidate="cli-fixture",
+            captured_at="2026-09-08T00:00:00Z",
+            expires_at=None,
+            summary="fixture journey run",
+        )
+
+    def write_evidence(self, evidence: dict) -> None:
+        path = self.temp / self.source
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(evidence, indent=2) + "\n", encoding="utf-8")
+
+    def signed(self, evidence: dict | None = None) -> dict:
+        evidence = self.evidence if evidence is None else evidence
+        return copy.deepcopy(
+            {
+                "journey_id": evidence["journey_id"],
+                "requirement_ids": evidence["requirement_ids"],
+                "repository": evidence["repository"],
+                "captured_at": evidence["captured_at"],
+                "expires_at": evidence["expires_at"],
+                "operator": evidence["operator"],
+                "environment": evidence["environment"],
+                "result": evidence["result"],
+                "redaction": evidence["redaction"],
+                "run_id": evidence["run_id"],
+                "execution_mode": evidence["execution_mode"],
+                "observations": evidence["observations"],
+                "steps": [
+                    {
+                        "id": step["id"],
+                        "status": "pass",
+                        "assertion": step["assertion"],
+                        "artifacts": step["artifacts"],
+                    }
+                    for step in evidence["steps"]
+                ],
+                "artifacts": [
+                    {
+                        "id": PROVIDER_BYOM_DISCOVERY_ARTIFACT_ID,
+                        "sha256": "0" * 64,
+                        "source": self.source,
+                    }
+                ],
+            }
+        )
+
+    def validate(self, signed: dict, requirement_id: str = "SPEC-046-R008") -> list[str]:
+        result = ValidationResult()
+        _validate_provider_byom_discovery_journey_result(
+            signed,
+            requirement_id,
+            [PROVIDER_BYOM_DISCOVERY_JOURNEY_ID],
+            signed.get("artifacts", []),
+            signed.get("steps", []),
+            "evidence[0]",
+            result,
+            root=self.temp,
+        )
+        return result.errors
+
+    def test_payload_projected_from_its_source_passes(self) -> None:
+        self.assertEqual([], self.validate(self.signed()))
+
+    def test_rejects_signed_requirement_id_the_source_does_not_cover(self) -> None:
+        signed = self.signed()
+        signed["requirement_ids"] = signed["requirement_ids"] + ["SPEC-047-R001"]
+        errors = self.validate(signed)
+        self.assertTrue(any("must cover every signed requirement ID" in error for error in errors), errors)
+
+    def test_rejects_source_requirement_ids_that_are_not_the_step_union(self) -> None:
+        evidence = copy.deepcopy(self.evidence)
+        evidence["requirement_ids"] = evidence["requirement_ids"] + ["SPEC-046-R002"]
+        self.write_evidence(evidence)
+        errors = self.validate(self.signed())
+        self.assertTrue(any("must equal the union" in error for error in errors), errors)
+
+    def test_rejects_signed_step_that_disagrees_with_the_source(self) -> None:
+        signed = self.signed()
+        signed["steps"][0]["assertion"] = "a claim the source evidence never made"
+        errors = self.validate(signed)
+        self.assertTrue(any("signed steps must match" in error for error in errors), errors)
+
+    def test_rejects_signed_step_dropped_from_the_projection(self) -> None:
+        signed = self.signed()
+        signed["steps"] = signed["steps"][:-1]
+        errors = self.validate(signed)
+        self.assertTrue(any("signed steps must match" in error for error in errors), errors)
+
+    def test_rejects_tampered_signed_observation(self) -> None:
+        signed = self.signed()
+        signed["observations"]["mlx_cache_discovered"] = False
+        errors = self.validate(signed)
+        self.assertTrue(any("signed observations must match" in error for error in errors), errors)
+
+    def test_rejects_tampered_source_observation(self) -> None:
+        evidence = copy.deepcopy(self.evidence)
+        evidence["observations"]["raw_prompt_logged"] = True
+        self.write_evidence(evidence)
+        errors = self.validate(self.signed())
+        self.assertTrue(any("must be false" in error for error in errors), errors)
+
+    def test_rejects_source_evidence_step_outside_the_contract(self) -> None:
+        evidence = copy.deepcopy(self.evidence)
+        evidence["steps"][0]["id"] = "step-00-invented"
+        self.write_evidence(evidence)
+        errors = self.validate(self.signed())
+        self.assertTrue(any("unknown" in error and "step id" in error for error in errors), errors)
+
+    def test_rejects_source_evidence_that_is_not_redacted(self) -> None:
+        evidence = copy.deepcopy(self.evidence)
+        evidence["steps"][0]["assertion"] = "read back from provider-mac.xyz"
+        self.write_evidence(evidence)
+        errors = self.validate(self.signed())
+        self.assertTrue(any("contains a hostname" in error for error in errors), errors)
+
+    def test_rejects_signed_operator_that_disagrees_with_the_source(self) -> None:
+        signed = self.signed()
+        signed["operator"]["role"] = "someone-else"
+        errors = self.validate(signed)
+        self.assertTrue(any("operator" in error and "must match" in error for error in errors), errors)
+
+    def test_rejects_absent_source_artifact(self) -> None:
+        (self.temp / self.source).unlink()
+        errors = self.validate(self.signed())
+        self.assertTrue(any("rejected" in error for error in errors), errors)
 
 
 class BYOMJourneyConformanceMappingTests(unittest.TestCase):

--- a/scripts/tests/test_byom_journey_evidence.py
+++ b/scripts/tests/test_byom_journey_evidence.py
@@ -377,8 +377,8 @@ class BYOMJourneyCaptureTests(unittest.TestCase):
         def mutator(manifest, _root):
             manifest["steps"][0]["assertion"] = (
                 "schema macprovider.provider-byom-discovery-evidence.v1 with document "
-                "provider_byom_discovery.v1, harness run-cli-onboarding-e2e.py, "
-                "SnapshotManifestV1 at 1.8.117 for SPEC-046-R001 in step-01-discover-mlx-cache"
+                "provider_byom_discovery.v1, SnapshotManifestV1 at 1.8.117 "
+                "for SPEC-046-R001 in step-01-discover-mlx-cache"
             )
 
         manifest, manifest_path = self.mutate("discovery", mutator)
@@ -953,16 +953,47 @@ class BYOMRedactionScannerTests(unittest.TestCase):
             "macprovider-acceptance-p256-v1",
             "2026-09-08T00:00:00Z",
             "a" * 64,
-            "test/e2e/byom/run-cli-onboarding-e2e.py",
-            "run-manifest.json",
-            "docs/runbooks/byom-journey-evidence.md",
             "10/10 steps pass. No money-path rows were written.",
         ):
             with self.subTest(value=value):
                 self.assert_accepted(value)
 
-    def test_a_file_name_shape_with_an_unlisted_extension_still_fails_closed(self) -> None:
-        self.assert_rejected("harness at run-cli-onboarding-e2e.zz")
+    def test_file_name_shapes_are_hostnames_everywhere_except_the_harness_name_field(self) -> None:
+        # `.sh`, `.md`, `.py` are file extensions AND look like TLDs. The global
+        # scanner has no allowlist, so those tokens fail closed in assertions and
+        # captured values; only the structurally validated `$.harness.name` field
+        # may carry a repository source file name.
+        for value in (
+            "test/e2e/byom/run-cli-onboarding-e2e.py",
+            "run-manifest.json",
+            "docs/runbooks/byom-journey-evidence.md",
+            "provider-mac.sh",
+            "read back from coordinator.md",
+        ):
+            with self.subTest(value=value):
+                self.assert_rejected(value)
+        for value in (
+            "test/e2e/byom/run-cli-onboarding-e2e.py",
+            "docs/runbooks/byom-journey-evidence.md",
+        ):
+            with self.subTest(harness=value):
+                evidence_module.assert_redacted({"harness": {"name": value, "status": "pass"}})
+
+    def test_harness_name_field_still_requires_a_repository_source_file_name(self) -> None:
+        for value in (
+            "run-cli-onboarding-e2e.zz",
+            "provider-mac.sh/../secrets.sh",
+            "/Users/operator/harness.py",
+            "coordinator.malibu.tech",
+            "http://runtime.invalid/harness.py",
+        ):
+            with self.subTest(harness=value):
+                with self.assertRaises(BYOMEvidenceError):
+                    evidence_module.assert_redacted({"harness": {"name": value, "status": "pass"}})
+
+    def test_a_file_name_shape_in_a_captured_document_value_fails_closed(self) -> None:
+        with self.assertRaises(BYOMEvidenceError):
+            evidence_module.assert_redacted({"note": "see provider-mac.sh"})
 
 
 class BYOMJourneyGovernanceSourceTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

BYOM epic gate #1248 (parent #1240) requires `JOURNEY-PROVIDER-BYOM-DISCOVERY` and `JOURNEY-NETWORK-MODEL-ADMISSION` evidence to land **only through the repo governance path** — signed, no prose-only promotion. The journey contracts existed in `journeys/`, but there was no capture/build tooling and the journey ids were not registered with the governance validator, so the evidence could not be produced or promoted at all. This PR adds that path. It does **not** sign anything and does **not** change any `specs/CONFORMANCE.json` state or evidence entry.

## What is added

- `scripts/byom_journey_evidence.py` — single contract module: journey tables (step ids and execution modes taken verbatim from `journeys/JOURNEY-PROVIDER-BYOM-DISCOVERY.md` and `journeys/JOURNEY-NETWORK-MODEL-ADMISSION.md`), per-step → SPEC-046/047 requirement mapping, fail-closed redaction scanner (URLs, absolute/home paths, any DNS-shaped hostname, IPv4/IPv6 literals, localhost, credential shapes sourced from the governance module's shared fragments), run-manifest → redacted evidence, evidence → journey-result payload. One shared `validate_evidence_steps` is used by capture, both builders, and governance.
- `scripts/capture-byom-journey-evidence.py`, `scripts/build-byom-discovery-journey-result.py`, `scripts/build-network-model-admission-journey-result.py`.
- Governance registration of both journeys in `scripts/check_spec_governance.py`, including `_validate_byom_journey_source`, which re-opens the hash-bound redacted evidence artifact and re-runs the shared step/observation/redaction rules against the signed payload (same pattern as the prebeta and local-consumer journeys).
- Money-path zero-row observations (the ten coordinator tables read in #1381) are required to be integer 0 for the admission journey.
- Golden fixtures + 75 unit tests (`scripts/tests/test_byom_journey_evidence.py`), wired into `make test-dist`.
- `docs/runbooks/byom-journey-evidence.md`: capture → build → sign → preflight → promote → reconcile. Signing is the single step that needs the acceptance signing key (PEM in env, `sign-journey-result.py --input`); the sequence was executed end-to-end against the golden fixtures up to the signature.

## What this does not do

- Does not produce promotable evidence by itself: a manifest missing any normative step is rejected, so a partial hermetic run cannot be signed. The revoked-drift, settlement-capable, and `catalog_priced` steps need the trusted catalog authority that v0.1 lacks — the promotion capstone already tracked on #1248.
- Does not promote SPEC-046/047 conformance.

## Audit

Three codex lanes (code-reviewer, security-reviewer, architect), four rounds, records in `audits/2026-09-08-byom-gates/AUDIT_1248_JOURNEY_EVIDENCE_{PROMPT,R1,R2,R3,R4}.md`.
- R1: 3 MEDIUM (builder trusted hand-authored evidence; captured documents scanned for credentials only; runbook signing command wrong) — fixed.
- R2: 2 MEDIUM (hostname/token scanner narrower than contract; governance did not re-validate the source artifact) — fixed.
- R3: 1 MEDIUM (manifest-declared document schema not checked against parsed JSON) + path confinement LOW — fixed. One LOW carried by design: single-label hostnames are not DNS-shaped and remain an operator redaction-review item.
- R4: final re-run; verdict posted as a PR comment before merge.

## Validation

- `python3 -m unittest scripts.tests.test_byom_journey_evidence` — 75 tests OK.
- `python3 scripts/check_spec_governance.py` — passed.
- Neighbouring `scripts.tests.test_spec_governance`, `test_journey_result_tools`, `test_provider_prebeta_journey_result`, `test_local_consumer_endpoint_journey_result`, `test_byom_contract_lock` — 127 tests OK.
- `python3 scripts/gen_spec_index.py --lint` — ok.
- `make test-byom-e2e` — passed on this branch.
- Stdlib only, noninteractive, no new dependencies.

BYOM epic gates:
- Parent epic: #1240
- Slice issue: #1248 (gate)
- Authority boundary: governance evidence path for SPEC-046-R008 / SPEC-047-R008 release evidence
- SPEC requirements: SPEC-046-R008, SPEC-047-R008
- User-facing state/copy: none
- Machine schema: new evidence schemas `macprovider.provider-byom-discovery-evidence.v1`, `macprovider.network-model-admission-evidence.v1` (governance-only, not provider-visible)
- Security/privacy: fail-closed redaction on emitted evidence and captured documents; signature still required for promotion
- Runtime/liveness: n/a
- Identity/economics/settlement provenance: money-path zero-row observations required for admission journey
- Evidence/tests: see Validation + Audit
- Rollout/rollback/compatibility: scripts only; no runtime change
- Explicitly deferred or not applicable: signing/promotion (operator key), catalog-bound capstone steps

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-046", "SPEC-047"],
  "requirements": ["SPEC-046-R008", "SPEC-047-R008"],
  "authority_domains": ["provider-byom-discovery", "network-model-admission"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "scripts/tests/test_byom_journey_evidence.py#BYOMJourneyEvidenceTests",
    "PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts.tests.test_byom_journey_evidence",
    "python3 scripts/check_spec_governance.py",
    "PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts.tests.test_spec_governance",
    "make test-byom-e2e"
  ],
  "journeys": ["JOURNEY-PROVIDER-BYOM-DISCOVERY", "JOURNEY-NETWORK-MODEL-ADMISSION"]
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
