### PR TITLE
Wire SPEC-047 BYOM offers to provider-wire probes

### DIFF
--- a/phase4-coordinator/internal/ws/model_admission.go
+++ b/phase4-coordinator/internal/ws/model_admission.go
@@ -1313,6 +1313,9 @@ func (s *Server) handleProviderModelAdmissionOffer(w http.ResponseWriter, r *htt
 		writeJSON(w, status, modelAdmissionError(code, "model admission offer rejected"))
 		return
 	}
+	probeCtx, cancel := modelAdmissionOfferProbeContext(r.Context())
+	defer cancel()
+	stored = s.maybeRunModelAdmissionSyntheticProbeForOffer(probeCtx, stored, replay)
 	writeJSON(w, http.StatusOK, s.modelAdmissionStatusResponseFromEvent(stored, replay))
 }
 

--- a/phase4-coordinator/internal/ws/model_admission_probe_test.go
+++ b/phase4-coordinator/internal/ws/model_admission_probe_test.go
@@ -1,15 +1,25 @@
 package ws
 
 import (
+	"bytes"
 	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
+	"io"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/augstar/macprovider-coordinator/internal/auth"
+	"github.com/augstar/macprovider-coordinator/internal/billing"
 	"github.com/augstar/macprovider-coordinator/internal/config"
 	"github.com/augstar/macprovider-coordinator/internal/pool"
 	gobwas "github.com/gobwas/ws"
@@ -248,6 +258,234 @@ func TestRunModelAdmissionSyntheticProbeUsesProviderWireSession(t *testing.T) {
 	}
 }
 
+func TestModelAdmissionOfferHandlerTriggersProviderWireProbe(t *testing.T) {
+	endpointHits := make(chan struct{}, 1)
+	endpoint := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		endpointHits <- struct{}{}
+		http.Error(w, "must not be called", http.StatusTeapot)
+	}))
+	defer endpoint.Close()
+
+	serverConn, providerConn := net.Pipe()
+	defer serverConn.Close()
+	defer providerConn.Close()
+
+	registry := pool.NewRegistry(nil)
+	provider := &pool.Provider{
+		ProviderID:      "provider-byom-trigger",
+		AssignedID:      "session-trigger",
+		ModelID:         "catalog-default",
+		EndpointURL:     endpoint.URL,
+		Tier:            pool.TierProvisional,
+		InferencePath:   pool.InferencePathWSTunneled,
+		State:           pool.StateReady,
+		SlotsFree:       1,
+		SlotsTotal:      1,
+		MaxConcurrency:  1,
+		LastActivityAt:  time.Now().UTC(),
+		LastHeartbeatAt: time.Now().UTC(),
+	}
+	registry.Register(provider, serverConn)
+	admissions := NewMemoryModelAdmissionStore()
+	tokens, bearer, priv := bindModelAdmissionProbeIdentity(t, provider.ProviderID)
+	server := NewServer(modelAdmissionProbeAuthConfig(), registry, zerolog.Nop(),
+		WithTokenValidator(tokens),
+		WithTokenIssuer(tokens),
+		WithBootstrapTokenStore(tokens),
+		WithModelAdmissionStore(admissions),
+	)
+	server.newUUID = func() string { return "offer-trigger" }
+	session := newProviderSession(provider.ProviderID, provider.AssignedID, serverConn, provider.MaxConcurrency)
+	server.sessions.Store(sessionKey(provider.ProviderID, provider.AssignedID), session)
+	go session.runWriter()
+
+	probeDone := make(chan struct{})
+	go func() {
+		defer close(probeDone)
+		probed := readModelAdmissionProbeRequestFrame(t, providerConn)
+		if probed.RequestID != "req-model-admission-probe-offer-trigger" {
+			t.Errorf("probe request id = %q", probed.RequestID)
+		}
+		if !strings.Contains(probed.Body, `"model":"ollama:qwen3-8b"`) {
+			t.Errorf("probe body = %s", probed.Body)
+		}
+		server.handleInferenceChunk(provider.ProviderID, provider.AssignedID, mustJSON(InferenceResponseChunk{
+			Type:      "inference_response_chunk",
+			RequestID: probed.RequestID,
+			Seq:       0,
+			Data:      `{"choices":[{"message":{"content":"ok"}}]}`,
+		}))
+		server.handleInferenceEnd(provider.ProviderID, provider.AssignedID, mustJSON(InferenceResponseEnd{
+			Type:       "inference_response_end",
+			RequestID:  probed.RequestID,
+			Status:     "complete",
+			ChunksSent: 1,
+		}))
+	}()
+
+	candidateID := "byom_" + strings.Repeat("t", 52)
+	payload := signedModelAdmissionProbeOffer(t, provider.ProviderID, candidateID, "ollama:qwen3-8b", priv, nil)
+	status, body := postModelAdmissionProbeOffer(t, server, bearer, payload)
+	if status != http.StatusOK {
+		t.Fatalf("offer status=%d body=%s", status, body)
+	}
+	<-probeDone
+	response := decodeModelAdmissionProbeMap(t, body)
+	if response["admission_state"] != "network_admitted_unsettled" ||
+		response["admission_state_source"] != "coordinator" ||
+		response["coordinator_event_id"] == "" {
+		t.Fatalf("unexpected probe-triggered response: %#v", response)
+	}
+	latest, found, err := admissions.LatestModelAdmissionStatus(context.Background(), provider.ProviderID, candidateID)
+	if err != nil || !found {
+		t.Fatalf("latest status found=%v err=%v", found, err)
+	}
+	if latest.State != "network_admitted_unsettled" || ModelAdmissionSettlementStateCandidate(latest) {
+		t.Fatalf("unexpected latest admission: %+v", latest)
+	}
+	settlement, err := admissions.SettlementCapableModelAdmissionStatusesForServedModel(context.Background(), provider.ProviderID, "ollama:qwen3-8b")
+	if err != nil {
+		t.Fatalf("settlement route statuses: %v", err)
+	}
+	if len(settlement) != 0 {
+		t.Fatalf("probe-triggered admission leaked settlement route status: %+v", settlement)
+	}
+	select {
+	case <-endpointHits:
+		t.Fatal("WS model admission trigger dereferenced provider EndpointURL")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestModelAdmissionOfferHandlerProbeSurvivesSubmitterCancellation(t *testing.T) {
+	serverConn, providerConn := net.Pipe()
+	defer serverConn.Close()
+	defer providerConn.Close()
+
+	registry := pool.NewRegistry(nil)
+	provider := &pool.Provider{
+		ProviderID:      "provider-byom-cancel",
+		AssignedID:      "session-cancel",
+		ModelID:         "catalog-default",
+		EndpointURL:     "http://127.0.0.1:11434/forbidden",
+		Tier:            pool.TierProvisional,
+		InferencePath:   pool.InferencePathWSTunneled,
+		State:           pool.StateReady,
+		SlotsFree:       1,
+		SlotsTotal:      1,
+		MaxConcurrency:  1,
+		LastActivityAt:  time.Now().UTC(),
+		LastHeartbeatAt: time.Now().UTC(),
+	}
+	registry.Register(provider, serverConn)
+	authStore, bearer, priv := bindModelAdmissionProbeIdentity(t, provider.ProviderID)
+	sqliteAdmissions, err := NewSQLiteModelAdmissionStore(authStore.DB())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancelRequest := context.WithCancel(context.Background())
+	admissions := cancelAfterModelAdmissionOfferStore{
+		ModelAdmissionStore: sqliteAdmissions,
+		cancel:              cancelRequest,
+	}
+	server := NewServer(modelAdmissionProbeAuthConfig(), registry, zerolog.Nop(),
+		WithTokenValidator(authStore),
+		WithTokenIssuer(authStore),
+		WithBootstrapTokenStore(authStore),
+		WithModelAdmissionStore(admissions),
+	)
+	server.newUUID = func() string { return "offer-cancel" }
+	session := newProviderSession(provider.ProviderID, provider.AssignedID, serverConn, provider.MaxConcurrency)
+	server.sessions.Store(sessionKey(provider.ProviderID, provider.AssignedID), session)
+	go session.runWriter()
+
+	probeDone := make(chan struct{})
+	go func() {
+		defer close(probeDone)
+		probed := readModelAdmissionProbeRequestFrame(t, providerConn)
+		server.handleInferenceChunk(provider.ProviderID, provider.AssignedID, mustJSON(InferenceResponseChunk{
+			Type:      "inference_response_chunk",
+			RequestID: probed.RequestID,
+			Seq:       0,
+			Data:      `{"choices":[{"message":{"content":"ok"}}]}`,
+		}))
+		server.handleInferenceEnd(provider.ProviderID, provider.AssignedID, mustJSON(InferenceResponseEnd{
+			Type:       "inference_response_end",
+			RequestID:  probed.RequestID,
+			Status:     "complete",
+			ChunksSent: 1,
+		}))
+	}()
+
+	candidateID := "byom_" + strings.Repeat("v", 52)
+	payload := signedModelAdmissionProbeOffer(t, provider.ProviderID, candidateID, "ollama:qwen3-8b", priv, nil)
+	status, body := postModelAdmissionProbeOfferWithContext(t, ctx, server, bearer, payload)
+	if status != http.StatusOK {
+		t.Fatalf("offer status=%d body=%s", status, body)
+	}
+	<-probeDone
+	response := decodeModelAdmissionProbeMap(t, body)
+	if response["admission_state"] != "network_admitted_unsettled" {
+		t.Fatalf("request cancellation prevented probe result response: %#v", response)
+	}
+	latest, found, err := sqliteAdmissions.LatestModelAdmissionStatus(context.Background(), provider.ProviderID, candidateID)
+	if err != nil || !found {
+		t.Fatalf("latest status found=%v err=%v", found, err)
+	}
+	if latest.State != "network_admitted_unsettled" {
+		t.Fatalf("request cancellation stranded admission state: %+v", latest)
+	}
+}
+
+func TestModelAdmissionOfferHandlerDoesNotDereferenceProviderEndpointWithoutWSSession(t *testing.T) {
+	endpointHits := make(chan struct{}, 1)
+	endpoint := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		endpointHits <- struct{}{}
+		http.Error(w, "must not be called", http.StatusTeapot)
+	}))
+	defer endpoint.Close()
+
+	registry := pool.NewRegistry(nil)
+	registry.Register(&pool.Provider{
+		ProviderID:      "provider-byom-http",
+		AssignedID:      "session-http",
+		ModelID:         "catalog-default",
+		EndpointURL:     endpoint.URL,
+		Tier:            pool.TierProvisional,
+		InferencePath:   pool.InferencePathHTTPForwarding,
+		State:           pool.StateReady,
+		SlotsFree:       1,
+		SlotsTotal:      1,
+		MaxConcurrency:  1,
+		LastActivityAt:  time.Now().UTC(),
+		LastHeartbeatAt: time.Now().UTC(),
+	}, nil)
+	admissions := NewMemoryModelAdmissionStore()
+	tokens, bearer, priv := bindModelAdmissionProbeIdentity(t, "provider-byom-http")
+	server := NewServer(modelAdmissionProbeAuthConfig(), registry, zerolog.Nop(),
+		WithTokenValidator(tokens),
+		WithTokenIssuer(tokens),
+		WithBootstrapTokenStore(tokens),
+		WithModelAdmissionStore(admissions),
+	)
+
+	candidateID := "byom_" + strings.Repeat("u", 52)
+	payload := signedModelAdmissionProbeOffer(t, "provider-byom-http", candidateID, "ollama:qwen3-8b", priv, nil)
+	status, body := postModelAdmissionProbeOffer(t, server, bearer, payload)
+	if status != http.StatusOK {
+		t.Fatalf("offer status=%d body=%s", status, body)
+	}
+	response := decodeModelAdmissionProbeMap(t, body)
+	if response["admission_state"] != modelAdmissionOfferSubmitted {
+		t.Fatalf("unexpected offer response without WS session: %#v", response)
+	}
+	select {
+	case <-endpointHits:
+		t.Fatal("model admission trigger dereferenced provider EndpointURL")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
 func modelAdmissionProbeOffer(tag, candidateRune string) ModelAdmissionEvent {
 	return ModelAdmissionEvent{
 		ProviderID:               "provider-byom-a",
@@ -300,4 +538,123 @@ func openProbeAdmissionStore(t *testing.T) *auth.Store {
 
 func modelAdmissionProbeStringsOf(value string, count int) string {
 	return strings.Repeat(value, count)
+}
+
+func modelAdmissionProbeAuthConfig() config.Config {
+	cfg := config.Default()
+	cfg.Auth.RequireProviderTokens = true
+	return cfg
+}
+
+func bindModelAdmissionProbeIdentity(t *testing.T, providerID string) (*auth.Store, string, ed25519.PrivateKey) {
+	t.Helper()
+	store := openProbeAdmissionStore(t)
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, bearer, err := store.IssueToken(context.Background(), providerID, providerID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.BindAdmissionIdentity(context.Background(), providerID, bearer, pub, time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+	return store, bearer, priv
+}
+
+func signedModelAdmissionProbeOffer(t *testing.T, providerID, candidateID, servedModelRef string, priv ed25519.PrivateKey, overrides map[string]any) map[string]any {
+	t.Helper()
+	pubkey := priv.Public().(ed25519.PublicKey)
+	pubkeyDigest := sha256.Sum256(pubkey)
+	signedFields := map[string]any{
+		"signature_domain":         "macprovider.model_admission.offer.v1",
+		"provider_id":              providerID,
+		"candidate_id":             candidateID,
+		"runtime_source":           "ollama_loopback",
+		"served_model_ref":         servedModelRef,
+		"catalog_model_key":        "",
+		"discovery_digest_sha256":  modelAdmissionProbeStringsOf("a", 64),
+		"evaluation_digest_sha256": modelAdmissionProbeStringsOf("b", 64),
+		"artifact_hashes":          map[string]any{},
+		"advisory_capabilities": map[string]any{
+			"chat_completions":              true,
+			"streaming":                     nil,
+			"tool_call_passthrough":         nil,
+			"structured_output_passthrough": nil,
+			"json_mode":                     nil,
+			"usage_reporting":               nil,
+			"max_context_tokens":            2048,
+			"quantization":                  nil,
+			"family":                        nil,
+			"runtime_version":               nil,
+		},
+		"fit_evidence_source":        "local_discovery",
+		"local_readiness":            "ready",
+		"requested_disclosure_class": "non_earning_provider_asserted",
+		"timestamp":                  time.Now().UTC().Format(time.RFC3339Nano),
+		"nonce":                      "nonce_" + candidateID,
+		"idempotency_key":            "request_" + candidateID,
+		"signing_key_digest":         hex.EncodeToString(pubkeyDigest[:]),
+		"cli_version":                "1.8.111",
+	}
+	for key, value := range overrides {
+		signedFields[key] = value
+	}
+	canonical, err := billing.CanonicalJSON(signedFields)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signature := ed25519.Sign(priv, canonical)
+	request := map[string]any{"schema": "model_admission_offer_submit.v1"}
+	for key, value := range signedFields {
+		request[key] = value
+	}
+	request["signature_algorithm"] = "ed25519"
+	request["provider_signature"] = base64.StdEncoding.EncodeToString(signature)
+	return request
+}
+
+func postModelAdmissionProbeOffer(t *testing.T, server *Server, bearer string, payload map[string]any) (int, string) {
+	t.Helper()
+	return postModelAdmissionProbeOfferWithContext(t, context.Background(), server, bearer, payload)
+}
+
+func postModelAdmissionProbeOfferWithContext(t *testing.T, ctx context.Context, server *Server, bearer string, payload map[string]any) (int, string) {
+	t.Helper()
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/v1/provider/model-admission/offers", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	server.handleProviderModelAdmissionOffer(rr, req)
+	resp := rr.Result()
+	defer resp.Body.Close()
+	out, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, string(out)
+}
+
+type cancelAfterModelAdmissionOfferStore struct {
+	ModelAdmissionStore
+	cancel context.CancelFunc
+}
+
+func (s cancelAfterModelAdmissionOfferStore) AppendModelAdmissionOffer(ctx context.Context, event ModelAdmissionEvent) (ModelAdmissionEvent, bool, error) {
+	stored, replay, err := s.ModelAdmissionStore.AppendModelAdmissionOffer(ctx, event)
+	if err == nil {
+		s.cancel()
+	}
+	return stored, replay, err
+}
+
+func decodeModelAdmissionProbeMap(t *testing.T, body string) map[string]any {
+	t.Helper()
+	var out map[string]any
+	if err := json.Unmarshal([]byte(body), &out); err != nil {
+		t.Fatalf("decode json: %v body=%s", err, body)
+	}
+	return out
 }

--- a/phase4-coordinator/internal/ws/server.go
+++ b/phase4-coordinator/internal/ws/server.go
@@ -4191,6 +4191,47 @@ func providerProbeModelID(provider pool.Provider) string {
 	return provider.ModelID
 }
 
+func modelAdmissionOfferProbeContext(parent context.Context) (context.Context, context.CancelFunc) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	return context.WithTimeout(context.WithoutCancel(parent), modelAdmissionSyntheticProbeTimeout+modelAdmissionRuntimeRevocationTimeout)
+}
+
+func (s *Server) maybeRunModelAdmissionSyntheticProbeForOffer(ctx context.Context, current ModelAdmissionEvent, replay bool) ModelAdmissionEvent {
+	if replay {
+		return current
+	}
+	provider, ok := s.modelAdmissionSyntheticProbeProvider(current.ProviderID)
+	if !ok {
+		return current
+	}
+	probed, err := s.runModelAdmissionSyntheticProbe(ctx, current, provider, "network_admitted_unsettled", false)
+	if err != nil {
+		s.log.Warn().
+			Err(err).
+			Str("provider_id", current.ProviderID).
+			Str("candidate_id", current.CandidateID).
+			Msg("model admission synthetic probe did not complete")
+		if probed.CoordinatorEventID != "" {
+			return probed
+		}
+		return current
+	}
+	return probed
+}
+
+func (s *Server) modelAdmissionSyntheticProbeProvider(providerID string) (pool.Provider, bool) {
+	provider, ok := s.pool.Resolve(providerID, "")
+	if !ok || !provider.IsWSTunneled() {
+		return pool.Provider{}, false
+	}
+	if _, ok := s.sessionFor(provider.ProviderID, provider.AssignedID); !ok {
+		return pool.Provider{}, false
+	}
+	return provider, true
+}
+
 func (s *Server) runModelAdmissionSyntheticProbe(ctx context.Context, current ModelAdmissionEvent, provider pool.Provider, targetState string, experimentalVisibilityAuthorized bool) (ModelAdmissionEvent, error) {
 	if s.modelAdmissions == nil {
 		return ModelAdmissionEvent{}, errors.New("model admission store is required")


### PR DESCRIPTION
## Summary

This PR makes the SPEC-047 provider-wire synthetic probe reachable from live authenticated BYOM model admission offers.

After a signed offer is durably accepted, the coordinator now opportunistically runs the bounded synthetic probe only when it already has a matching WS-tunneled provider session. A passing probe advances the candidate to `network_admitted_unsettled`; providers without a live WS session, or HTTP-forwarding providers, remain at `offer_submitted`.

## Behavior change

- Authenticated offer submission can now trigger the provider-wire synthetic probe immediately after offer persistence.
- Probe work is detached from submitter transport cancellation with a bounded coordinator context, so a client disconnect after offer append cannot strand the candidate before probe/result persistence.
- Successful probe results remain non-settlement: `network_admitted_unsettled` only.
- The trigger does not dereference provider-local `EndpointURL` values and does not use HTTP warmup for BYOM admission offers.
- The trigger does not mint `catalog_priced`, `settlement_capable`, signed journey evidence, catalog exposure, paid routing, billing, settlement, or production readiness.

## Tests

Passed locally from `phase4-coordinator`:

- `go test ./internal/ws -run 'TestModelAdmissionOfferHandlerTriggersProviderWireProbe|TestModelAdmissionOfferHandlerDoesNotDereferenceProviderEndpointWithoutWSSession|TestModelAdmissionOfferHandlerProbeSurvivesSubmitterCancellation|TestRunModelAdmissionSyntheticProbeUsesProviderWireSession|TestModelAdmissionSyntheticProbe' -count=1`
- `go test ./internal/ws ./internal/buyer ./internal/routing -run 'ModelAdmission|BYOM|PoolCheckReadinessAppliesBYOM|Route' -count=1`
- `go test ./internal/ws -count=1`
- `go vet ./internal/ws`
- `git diff --check`

Review lanes over the final diff:

- Code review: 0 Critical, 0 High, 0 Medium, 0 Low findings.
- Security review: 0 Critical, 0 High, 0 Medium, 0 Low findings.
- Architecture/spec-boundary review: 0 Critical, 0 High, 0 Medium findings; 1 Low operational watch for synchronous bounded probe latency.

## Conformance and evidence

This PR advances local implementation and tests for SPEC-047, but does not change `specs/CONFORMANCE.json`, does not promote conformance, and does not add or refresh signed journey evidence. SPEC-047 remains draft/partial/not-deployed until the full admission lifecycle and `JOURNEY-NETWORK-MODEL-ADMISSION` evidence exist.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-047"],
  "requirements": [
    "SPEC-047-R001",
    "SPEC-047-R002",
    "SPEC-047-R003",
    "SPEC-047-R005",
    "SPEC-047-R008"
  ],
  "authority_domains": ["network-model-admission"],
  "arbitration": ["DECISION_REQUIRED"],
  "tests": [
    "go test ./internal/ws -run 'TestModelAdmissionOfferHandlerTriggersProviderWireProbe|TestModelAdmissionOfferHandlerDoesNotDereferenceProviderEndpointWithoutWSSession|TestModelAdmissionOfferHandlerProbeSurvivesSubmitterCancellation|TestRunModelAdmissionSyntheticProbeUsesProviderWireSession|TestModelAdmissionSyntheticProbe' -count=1",
    "go test ./internal/ws ./internal/buyer ./internal/routing -run 'ModelAdmission|BYOM|PoolCheckReadinessAppliesBYOM|Route' -count=1",
    "go test ./internal/ws -count=1",
    "go vet ./internal/ws",
    "git diff --check"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END

## Known gaps

- Live production provider scheduling and retry loops are not implemented here.
- Refreshed signed SPEC-047 journey evidence is not captured here.
- Default buyer exposure for BYOM models remains intentionally blocked until catalog and settlement prerequisites are implemented and evidenced.
- The offer handler runs the bounded probe synchronously; if offer volume or UX requires it, a later queue-backed trigger can decouple response latency without changing state semantics.
