### PR TITLE
fix: close F12-F13 trusted pricing audit gaps

### DIFF
--- a/phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift
@@ -740,6 +740,11 @@ struct ConsumeUpstreamTimeouts: Sendable {
     )
 }
 
+struct ConsumeReadDeadlinePolicy: Equatable, Sendable {
+    let timeoutNanoseconds: UInt64
+    let refreshOnProgress: Bool
+}
+
 private struct ConsumeUpstreamFailureClassification {
     let status: HTTPResponseStatus
     let forwardedUpstream: Bool
@@ -982,6 +987,8 @@ extension ConsumeUpstreamClient {
 }
 
 final class ConsumePinnedUpstreamClient: ConsumeUpstreamClient, @unchecked Sendable {
+    private static let trustedMetadataMaxReadNanoseconds: UInt64 = 10_000_000_000
+
     private let maxBodyBytes: Int
     private let timeouts: ConsumeUpstreamTimeouts
 
@@ -1121,6 +1128,10 @@ final class ConsumePinnedUpstreamClient: ConsumeUpstreamClient, @unchecked Senda
         guard let host = upstreamTarget(origin: origin).host else {
             throw ConsumeStartupError(code: "local_upstream_url_rejected")
         }
+        return try await resolveGlobalEndpoint(host: host, timeoutNanoseconds: timeoutNanoseconds)
+    }
+
+    static func resolveGlobalEndpoint(host: String, timeoutNanoseconds: UInt64) async throws -> String {
         return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<String, Error>) in
             let gate = ContinuationGate<String>()
             let deadline = DeadlineTimer()
@@ -1156,6 +1167,73 @@ final class ConsumePinnedUpstreamClient: ConsumeUpstreamClient, @unchecked Senda
             return (nil, nil)
         }
         return (components.host, components.port ?? 443)
+    }
+
+    static func fetchTrustedMetadata(
+        url: URL,
+        endpoint: String,
+        timeouts: ConsumeUpstreamTimeouts
+    ) async throws -> Data {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              components.scheme == "https",
+              let host = components.host,
+              !host.isEmpty,
+              components.user == nil,
+              components.password == nil,
+              components.query == nil,
+              components.fragment == nil,
+              components.path == "/v1/rate-card" || components.path == "/v1/rate-card.sig"
+        else {
+            throw ConsumeTrustedPricingError(.fetchFailed)
+        }
+        let portValue = components.port ?? 443
+        guard (1...65_535).contains(portValue),
+              let port = NWEndpoint.Port(rawValue: UInt16(portValue)),
+              ConsumeEndpointConfig.isValidatedGlobalEndpoint(endpoint) else {
+            throw ConsumeTrustedPricingError(.fetchFailed)
+        }
+        let connection = NWConnection(
+            host: NWEndpoint.Host(endpoint),
+            port: port,
+            using: tlsParameters(serverName: host)
+        )
+        let queue = DispatchQueue(label: "macprovider.consume.pricing.\(UUID().uuidString)")
+        connection.start(queue: queue)
+        do {
+            try await waitUntilReady(connection, timeoutNanoseconds: timeouts.connectNanoseconds)
+            try await send(
+                trustedMetadataRequestBytes(host: host, port: portValue, path: components.path),
+                on: connection,
+                timeoutNanoseconds: timeouts.sendNanoseconds
+            )
+            let limit = components.path.hasSuffix(".sig")
+                ? ConsumeTrustedPricingLoader.maxSidecarBytes
+                : ConsumeTrustedPricingLoader.maxRateCardBytes
+            let readDeadline = trustedMetadataReadDeadline(for: timeouts)
+            let response = try await readHTTPResponse(
+                from: connection,
+                maxBodyBytes: limit + 1,
+                timeoutNanoseconds: readDeadline.timeoutNanoseconds,
+                refreshDeadlineOnProgress: readDeadline.refreshOnProgress
+            )
+            guard ConsumeTrustedPricingLoader.responseHeadersAreBounded(response.headers),
+                  (200..<300).contains(response.statusCode) else {
+                throw ConsumeTrustedPricingError(.fetchFailed)
+            }
+            guard response.body.count <= limit else {
+                throw ConsumeTrustedPricingError(
+                    components.path.hasSuffix(".sig") ? .oversizedSidecar : .oversizedRateCard
+                )
+            }
+            connection.cancel()
+            return response.body
+        } catch let error as ConsumeTrustedPricingError {
+            connection.cancel()
+            throw error
+        } catch {
+            connection.cancel()
+            throw ConsumeTrustedPricingError(.fetchFailed)
+        }
     }
 
     private static func fetch(
@@ -1378,10 +1456,22 @@ final class ConsumePinnedUpstreamClient: ConsumeUpstreamClient, @unchecked Senda
         httpRequestBytes(host: host, port: port, bearerToken: bearerToken, body: body, streaming: streaming)
     }
 
+    static func trustedMetadataRequestBytesForTesting(host: String, port: Int, path: String) -> Data {
+        trustedMetadataRequestBytes(host: host, port: port, path: path)
+    }
+
+    static func trustedMetadataReadDeadline(for timeouts: ConsumeUpstreamTimeouts) -> ConsumeReadDeadlinePolicy {
+        ConsumeReadDeadlinePolicy(
+            timeoutNanoseconds: min(timeouts.readNanoseconds, trustedMetadataMaxReadNanoseconds),
+            refreshOnProgress: false
+        )
+    }
+
     private static func readHTTPResponse(
         from connection: NWConnection,
         maxBodyBytes: Int,
-        timeoutNanoseconds: UInt64
+        timeoutNanoseconds: UInt64,
+        refreshDeadlineOnProgress: Bool = true
     ) async throws -> ConsumeUpstreamResponse {
         try await withCheckedThrowingContinuation { continuation in
             let state = ReceiveState()
@@ -1404,9 +1494,11 @@ final class ConsumePinnedUpstreamClient: ConsumeUpstreamClient, @unchecked Senda
                     }
                     if let data, !data.isEmpty {
                         state.received.append(data)
-                        deadline.schedule(nanoseconds: timeoutNanoseconds) {
-                            connection.cancel()
-                            finish(.failure(ConsumeUpstreamForwardError.dispatchedUnavailable))
+                        if refreshDeadlineOnProgress {
+                            deadline.schedule(nanoseconds: timeoutNanoseconds) {
+                                connection.cancel()
+                                finish(.failure(ConsumeUpstreamForwardError.dispatchedUnavailable))
+                            }
                         }
                     }
                     if let headerRange = state.received.range(of: headerTerminator) {
@@ -2057,6 +2149,20 @@ final class ConsumePinnedUpstreamClient: ConsumeUpstreamClient, @unchecked Senda
         request.append(Data("Content-Length: \(body.count)\r\n\r\n".utf8))
         request.append(body)
         return request
+    }
+
+    private static func trustedMetadataRequestBytes(host: String, port: Int, path: String) -> Data {
+        let hostHeader = host.contains(":") && !host.hasPrefix("[") ? "[\(host)]" : host
+        let authority = port == 443 ? hostHeader : "\(hostHeader):\(port)"
+        return Data(([
+            "GET \(path) HTTP/1.1",
+            "Host: \(authority)",
+            "Accept: application/json",
+            "Accept-Encoding: identity",
+            "Connection: close",
+            "",
+            "",
+        ].joined(separator: "\r\n")).utf8)
     }
 }
 

--- a/phase3-binary/Sources/macprovider-cli/ConsumeTrustedPricing.swift
+++ b/phase3-binary/Sources/macprovider-cli/ConsumeTrustedPricing.swift
@@ -145,21 +145,33 @@ struct ConsumeTrustedPricingLoader: Sendable {
     static let staleAge: TimeInterval = 14 * 24 * 3600
     static let maxAge: TimeInterval = 30 * 24 * 3600
 
-    var fetch: @Sendable (URL) async throws -> Data
+    var resolveEndpoint: @Sendable (String) async throws -> String
+    var fetch: @Sendable (URL, String) async throws -> Data
     var trustedPublicKeys: [String: String]
     var expectedPolicyVersion: String
     var minimumGeneratedAt: Date
     var now: @Sendable () -> Date
 
     init(
-        fetch: @escaping @Sendable (URL) async throws -> Data = { url in
-            try await ConsumeTrustedPricingLoader.defaultFetch(url)
+        resolveEndpoint: @escaping @Sendable (String) async throws -> String = { host in
+            try await ConsumePinnedUpstreamClient.resolveGlobalEndpoint(
+                host: host,
+                timeoutNanoseconds: ConsumeUpstreamTimeouts.default.connectNanoseconds
+            )
+        },
+        fetch: @escaping @Sendable (URL, String) async throws -> Data = { url, endpoint in
+            try await ConsumePinnedUpstreamClient.fetchTrustedMetadata(
+                url: url,
+                endpoint: endpoint,
+                timeouts: .default
+            )
         },
         trustedPublicKeys: [String: String] = AutotuneStaticInputs.defaultTrustedPublicKeys,
         expectedPolicyVersion: String = Self.defaultExpectedPolicyVersion(),
         minimumGeneratedAt: Date = Self.defaultMinimumGeneratedAt(),
         now: @escaping @Sendable () -> Date = { Date() }
     ) {
+        self.resolveEndpoint = resolveEndpoint
         self.fetch = fetch
         self.trustedPublicKeys = trustedPublicKeys
         self.expectedPolicyVersion = expectedPolicyVersion
@@ -174,11 +186,11 @@ struct ConsumeTrustedPricingLoader: Sendable {
             return .unavailable(reason: .fetchFailed)
         }
         do {
-            let body = try await fetch(bodyURL)
+            let body = try await fetchValidated(bodyURL)
             guard body.count <= Self.maxRateCardBytes else {
                 return .unavailable(reason: .oversizedRateCard)
             }
-            let sidecar = try await fetch(sidecarURL)
+            let sidecar = try await fetchValidated(sidecarURL)
             guard sidecar.count <= Self.maxSidecarBytes else {
                 return .unavailable(reason: .oversizedSidecar)
             }
@@ -230,54 +242,15 @@ struct ConsumeTrustedPricingLoader: Sendable {
         )
     }
 
-    private static func defaultFetch(_ url: URL) async throws -> Data {
-        try await fetch(url, session: defaultURLSession())
-    }
-
-    static func defaultURLSession(protocolClasses: [AnyClass]? = nil) -> URLSession {
-        let configuration = URLSessionConfiguration.ephemeral
-        configuration.timeoutIntervalForRequest = 5
-        configuration.timeoutIntervalForResource = 10
-        configuration.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
-        configuration.urlCache = nil
-        configuration.httpCookieStorage = nil
-        configuration.httpCookieAcceptPolicy = .never
-        configuration.httpAdditionalHeaders = nil
-        configuration.connectionProxyDictionary = [:]
-        configuration.waitsForConnectivity = false
-        configuration.protocolClasses = protocolClasses
-        return URLSession(configuration: configuration, delegate: NoRedirectURLSessionDelegate(), delegateQueue: nil)
-    }
-
-    static func fetch(_ url: URL, session: URLSession) async throws -> Data {
-        defer { session.invalidateAndCancel() }
-        let limit = url.path.hasSuffix(".sig") ? Self.maxSidecarBytes : Self.maxRateCardBytes
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
-        request.setValue("identity", forHTTPHeaderField: "Accept-Encoding")
-        let (bytes, response) = try await session.bytes(for: request)
-        guard let http = response as? HTTPURLResponse else {
+    private func fetchValidated(_ url: URL) async throws -> Data {
+        guard let host = url.host, !host.isEmpty else {
             throw ConsumeTrustedPricingError(.fetchFailed)
         }
-        guard Self.responseHeadersAreBounded(http) else {
+        let endpoint = try await resolveEndpoint(host)
+        guard ConsumeEndpointConfig.isValidatedGlobalEndpoint(endpoint) else {
             throw ConsumeTrustedPricingError(.fetchFailed)
         }
-        guard (200 ..< 300).contains(http.statusCode) else {
-            throw ConsumeTrustedPricingError(.fetchFailed)
-        }
-        if response.expectedContentLength > Int64(limit) {
-            throw ConsumeTrustedPricingError(url.path.hasSuffix(".sig") ? .oversizedSidecar : .oversizedRateCard)
-        }
-        var data = Data()
-        data.reserveCapacity(min(limit, max(0, Int(response.expectedContentLength))))
-        for try await byte in bytes {
-            data.append(byte)
-            if data.count > limit {
-                throw ConsumeTrustedPricingError(url.path.hasSuffix(".sig") ? .oversizedSidecar : .oversizedRateCard)
-            }
-        }
-        return data
+        return try await fetch(url, endpoint)
     }
 
     private static func defaultExpectedPolicyVersion() -> String {
@@ -312,14 +285,14 @@ struct ConsumeTrustedPricingLoader: Sendable {
         return SignatureSidecar(keyID: keyID, signature: signature)
     }
 
-    private static func responseHeadersAreBounded(_ response: HTTPURLResponse) -> Bool {
-        guard response.allHeaderFields.count <= maxResponseHeaderCount else {
+    static func responseHeadersAreBounded(_ headers: [(String, String)]) -> Bool {
+        guard headers.count <= maxResponseHeaderCount else {
             return false
         }
         var total = 0
-        for (rawName, rawValue) in response.allHeaderFields {
-            total += String(describing: rawName).utf8.count
-            total += String(describing: rawValue).utf8.count
+        for (name, value) in headers {
+            total += name.utf8.count
+            total += value.utf8.count
             if total > maxResponseHeaderBytes {
                 return false
             }

--- a/phase3-binary/Tests/macprovider-cliTests/ConsumeTrustedPricingTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ConsumeTrustedPricingTests.swift
@@ -88,7 +88,9 @@ final class ConsumeTrustedPricingTests: XCTestCase {
     func testLoaderFetchesCanonicalEndpointsAndFailsClosedWithoutFallback() async throws {
         let fixture = try SignedRateCardFixture(generatedAt: "2026-09-02T12:00:00Z")
         let loader = ConsumeTrustedPricingLoader(
-            fetch: { url in
+            resolveEndpoint: { _ in "8.8.8.8" },
+            fetch: { url, endpoint in
+                XCTAssertEqual(endpoint, "8.8.8.8")
                 switch url.path {
                 case "/v1/rate-card":
                     return fixture.body
@@ -107,7 +109,8 @@ final class ConsumeTrustedPricingTests: XCTestCase {
         XCTAssertEqual(loaded, .available(try loader.verify(rateCardBytes: fixture.body, sidecarBytes: fixture.sidecar)))
 
         let failingLoader = ConsumeTrustedPricingLoader(
-            fetch: { _ in throw ConsumeTrustedPricingError(.fetchFailed) },
+            resolveEndpoint: { _ in "8.8.8.8" },
+            fetch: { _, _ in throw ConsumeTrustedPricingError(.fetchFailed) },
             trustedPublicKeys: fixture.trustedPublicKeys,
             expectedPolicyVersion: fixture.policyVersion,
             now: { SignedRateCardFixture.date("2026-08-29T00:00:00Z") }
@@ -116,37 +119,82 @@ final class ConsumeTrustedPricingTests: XCTestCase {
         XCTAssertEqual(failed, .unavailable(reason: .fetchFailed))
     }
 
-    func testDefaultFetchRejectsUnboundedHeadersStatusAndOversizedMetadata() async throws {
-        defer { ConsumeTrustedPricingMockURLProtocol.requestHandler = nil }
-        let url = URL(string: "https://api.example.test/v1/rate-card.sig")!
+    func testPinnedMetadataRequestIsCredentialFreeAndHeadersRemainBounded() throws {
+        let request = String(decoding: ConsumePinnedUpstreamClient.trustedMetadataRequestBytesForTesting(
+            host: "api.example.test",
+            port: 443,
+            path: "/v1/rate-card.sig"
+        ), as: UTF8.self)
+        XCTAssertEqual(request, [
+            "GET /v1/rate-card.sig HTTP/1.1",
+            "Host: api.example.test",
+            "Accept: application/json",
+            "Accept-Encoding: identity",
+            "Connection: close",
+            "",
+            "",
+        ].joined(separator: "\r\n"))
+        XCTAssertFalse(request.localizedCaseInsensitiveContains("Authorization:"))
+        XCTAssertFalse(request.localizedCaseInsensitiveContains("Cookie:"))
+        XCTAssertFalse(request.localizedCaseInsensitiveContains("Proxy-Authorization:"))
 
-        ConsumeTrustedPricingMockURLProtocol.requestHandler = { request in
-            XCTAssertEqual(request.value(forHTTPHeaderField: "Accept-Encoding"), "identity")
-            var headers: [String: String] = [:]
-            for index in 0 ... ConsumeTrustedPricingLoader.maxResponseHeaderCount {
-                headers["X-Test-\(index)"] = "v"
-            }
-            return Self.response(for: request, status: 200, headers: headers, data: Data())
-        }
-        let headerFailure = try await fetchFailure(url)
-        XCTAssertEqual(headerFailure, .fetchFailed)
+        let tooManyHeaders = (0...ConsumeTrustedPricingLoader.maxResponseHeaderCount).map { ("X-Test-\($0)", "v") }
+        XCTAssertFalse(ConsumeTrustedPricingLoader.responseHeadersAreBounded(tooManyHeaders))
+        XCTAssertFalse(ConsumeTrustedPricingLoader.responseHeadersAreBounded([
+            ("X-Test", String(repeating: "x", count: ConsumeTrustedPricingLoader.maxResponseHeaderBytes + 1)),
+        ]))
+    }
 
-        ConsumeTrustedPricingMockURLProtocol.requestHandler = { request in
-            Self.response(
-                for: request,
-                status: 200,
-                headers: ["Content-Length": "\(ConsumeTrustedPricingLoader.maxSidecarBytes + 1)"],
-                data: Data()
+    func testPinnedMetadataTransportRejectsNonGlobalEndpointBeforeConnecting() async throws {
+        do {
+            _ = try await ConsumePinnedUpstreamClient.fetchTrustedMetadata(
+                url: URL(string: "https://api.example.test/v1/rate-card")!,
+                endpoint: "127.0.0.1",
+                timeouts: .default
             )
+            XCTFail("private endpoint unexpectedly reached the transport")
+        } catch let error as ConsumeTrustedPricingError {
+            XCTAssertEqual(error.reason, .fetchFailed)
         }
-        let sizeFailure = try await fetchFailure(url)
-        XCTAssertEqual(sizeFailure, .oversizedSidecar)
+    }
 
-        ConsumeTrustedPricingMockURLProtocol.requestHandler = { request in
-            Self.response(for: request, status: 500, headers: [:], data: Data("nope".utf8))
+    func testPinnedMetadataReadDeadlineIsAbsoluteUnderSlowDripProgress() {
+        let policy = ConsumePinnedUpstreamClient.trustedMetadataReadDeadline(for: .default)
+        XCTAssertEqual(policy.timeoutNanoseconds, 10_000_000_000)
+        XCTAssertFalse(policy.refreshOnProgress)
+
+        var expiryNanoseconds = policy.timeoutNanoseconds
+        let slowDripProgress: [UInt64] = [1_000_000_000, 9_000_000_000, 9_999_999_999]
+        for progressNanoseconds in slowDripProgress where policy.refreshOnProgress {
+            expiryNanoseconds = progressNanoseconds + policy.timeoutNanoseconds
         }
-        let statusFailure = try await fetchFailure(url)
-        XCTAssertEqual(statusFailure, .fetchFailed)
+        XCTAssertEqual(expiryNanoseconds, 10_000_000_000)
+    }
+
+    func testPricingFetchRejectsPrivateResolutionBeforeRateCardRequest() async throws {
+        let fixture = try SignedRateCardFixture(generatedAt: "2026-09-02T12:00:00Z")
+        let recorder = PricingTransportRecorder(endpoints: ["127.0.0.1"], fixture: fixture)
+        let loader = fixture.loader(now: "2026-09-03T00:00:00Z", recorder: recorder)
+
+        let result = await loader.load(from: "https://api.example.test")
+        let resolvedHosts = await recorder.resolvedHosts()
+        let fetchedPaths = await recorder.fetchedPaths()
+        XCTAssertEqual(result, .unavailable(reason: .fetchFailed))
+        XCTAssertEqual(resolvedHosts, ["api.example.test"])
+        XCTAssertEqual(fetchedPaths, [])
+    }
+
+    func testPricingFetchRepeatsResolutionAndRejectsPrivateSidecarRebinding() async throws {
+        let fixture = try SignedRateCardFixture(generatedAt: "2026-09-02T12:00:00Z")
+        let recorder = PricingTransportRecorder(endpoints: ["8.8.8.8", "127.0.0.1"], fixture: fixture)
+        let loader = fixture.loader(now: "2026-09-03T00:00:00Z", recorder: recorder)
+
+        let result = await loader.load(from: "https://api.example.test")
+        let resolvedHosts = await recorder.resolvedHosts()
+        let fetchedPaths = await recorder.fetchedPaths()
+        XCTAssertEqual(result, .unavailable(reason: .fetchFailed))
+        XCTAssertEqual(resolvedHosts, ["api.example.test", "api.example.test"])
+        XCTAssertEqual(fetchedPaths, ["/v1/rate-card@8.8.8.8"])
     }
 
     private func verifyFailure(
@@ -163,53 +211,6 @@ final class ConsumeTrustedPricingTests: XCTestCase {
         }
     }
 
-    private func fetchFailure(_ url: URL) async throws -> ConsumeTrustedPricingUnavailableReason {
-        do {
-            let session = ConsumeTrustedPricingLoader.defaultURLSession(protocolClasses: [ConsumeTrustedPricingMockURLProtocol.self])
-            _ = try await ConsumeTrustedPricingLoader.fetch(url, session: session)
-            XCTFail("fetch unexpectedly succeeded")
-            return .notLoaded
-        } catch let error as ConsumeTrustedPricingError {
-            return error.reason
-        }
-    }
-
-    private static func response(
-        for request: URLRequest,
-        status: Int,
-        headers: [String: String],
-        data: Data
-    ) -> (HTTPURLResponse, Data) {
-        (
-            HTTPURLResponse(url: request.url!, statusCode: status, httpVersion: "HTTP/1.1", headerFields: headers)!,
-            data
-        )
-    }
-}
-
-private final class ConsumeTrustedPricingMockURLProtocol: URLProtocol {
-    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
-
-    override class func canInit(with request: URLRequest) -> Bool { true }
-
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
-
-    override func startLoading() {
-        guard let requestHandler = Self.requestHandler else {
-            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
-            return
-        }
-        do {
-            let (response, data) = try requestHandler(request)
-            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-            client?.urlProtocol(self, didLoad: data)
-            client?.urlProtocolDidFinishLoading(self)
-        } catch {
-            client?.urlProtocol(self, didFailWithError: error)
-        }
-    }
-
-    override func stopLoading() {}
 }
 
 private struct SignedRateCardFixture {
@@ -232,9 +233,22 @@ private struct SignedRateCardFixture {
     func loader(
         now rawNow: String,
         expectedPolicyVersion: String? = nil,
-        minimumGeneratedAt: Date = .distantPast
+        minimumGeneratedAt: Date = .distantPast,
+        recorder: PricingTransportRecorder? = nil
     ) -> ConsumeTrustedPricingLoader {
         ConsumeTrustedPricingLoader(
+            resolveEndpoint: { host in
+                if let recorder {
+                    return await recorder.resolve(host)
+                }
+                return "8.8.8.8"
+            },
+            fetch: { url, endpoint in
+                guard let recorder else {
+                    throw ConsumeTrustedPricingError(.fetchFailed)
+                }
+                return await recorder.fetch(url, endpoint: endpoint)
+            },
             trustedPublicKeys: trustedPublicKeys,
             expectedPolicyVersion: expectedPolicyVersion ?? policyVersion,
             minimumGeneratedAt: minimumGeneratedAt,
@@ -291,4 +305,29 @@ private struct SignedRateCardFixture {
         {"version":"\(projection.projectionHash)","policy_version":"\(policyVersion)","generated_at":"\(generatedAt)","usd_per_million_credits":1.0,"rows":{\(rowsJSON)}}
         """.utf8)
     }
+}
+
+private actor PricingTransportRecorder {
+    private var endpoints: [String]
+    private let fixture: SignedRateCardFixture
+    private var hosts: [String] = []
+    private var paths: [String] = []
+
+    init(endpoints: [String], fixture: SignedRateCardFixture) {
+        self.endpoints = endpoints
+        self.fixture = fixture
+    }
+
+    func resolve(_ host: String) -> String {
+        hosts.append(host)
+        return endpoints.removeFirst()
+    }
+
+    func fetch(_ url: URL, endpoint: String) -> Data {
+        paths.append("\(url.path)@\(endpoint)")
+        return url.path.hasSuffix(".sig") ? fixture.sidecar : fixture.body
+    }
+
+    func resolvedHosts() -> [String] { hosts }
+    func fetchedPaths() -> [String] { paths }
 }

--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -6995,19 +6995,24 @@
     {
       "requirement_id": "SPEC-045-R003",
       "spec_id": "SPEC-045",
-      "state": "conformant",
+      "state": "pending",
       "implementation": [
         "phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift:struct ConsumeLocalTokenVerifier",
         "phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift:struct ConsumeCredentialLoader",
         "phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift:static func httpRequestBytesForTesting",
-        "phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift:private static func httpRequestBytes"
+        "phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift:private static func httpRequestBytes",
+        "phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift:static func resolveGlobalEndpoint",
+        "phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift:static func fetchTrustedMetadata",
+        "phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift:private static func trustedMetadataRequestBytes"
       ],
       "tests": [
         "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testLocalTokenVerifierAcceptsOnlyOneAcceptedHeader",
         "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testCredentialSourceOrderPrefersExplicitThenEnvFileThenDefaultThenEnvironment",
         "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testCredentialFileRejectsGroupReadableFileAndSymlink",
         "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testCredentialFileRejectsExtendedACLAndRevalidatesDeletion",
-        "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase4PinnedUpstreamGeneratedHeadersAreClosedAndSanitized"
+        "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase4PinnedUpstreamGeneratedHeadersAreClosedAndSanitized",
+        "phase3-binary/Tests/macprovider-cliTests/ConsumeTrustedPricingTests.swift:testPinnedMetadataRequestIsCredentialFreeAndHeadersRemainBounded",
+        "phase3-binary/Tests/macprovider-cliTests/ConsumeTrustedPricingTests.swift:testPinnedMetadataTransportRejectsNonGlobalEndpointBeforeConnecting"
       ],
       "journeys": [
         "JOURNEY-LOCAL-CONSUMER-ENDPOINT"
@@ -7026,12 +7031,17 @@
           "expires_at": "2027-08-24"
         }
       ],
-      "gap": null
+      "gap": {
+        "verdict": "UNKNOWN",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/1433",
+        "rationale": "The pinned upstream transport has changed beyond the historical dc63ecec candidate, and that signed journey does not prove the required negative TLS, repeated-DNS, connected-peer, proxy, redirect, or zero-credential-byte boundary matrix. Existing evidence is retained as historical provenance; refreshed matching implementation evidence and separately authorized signed journey evidence remain required."
+      }
     },
     {
       "requirement_id": "SPEC-045-R004",
       "spec_id": "SPEC-045",
-      "state": "conformant",
+      "state": "pending",
       "implementation": [
         "phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift:struct ConsumeBudgetConfig",
         "phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift:struct ConsumePricedExposureEstimate",
@@ -7042,7 +7052,11 @@
         "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase3BudgetFlagsParseAndRejectInvalidCombinations",
         "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase3CPricedEstimateUsesGrossRatesAndRoundsUp",
         "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase3CPricedEstimateCapRejectsBeforeLedgerAppend",
-        "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase3PerRequestCapRejectsBeforeLedgerAppend"
+        "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase3PerRequestCapRejectsBeforeLedgerAppend",
+        "phase3-binary/Tests/macprovider-cliTests/ConsumeTrustedPricingTests.swift:testPinnedMetadataTransportRejectsNonGlobalEndpointBeforeConnecting",
+        "phase3-binary/Tests/macprovider-cliTests/ConsumeTrustedPricingTests.swift:testPinnedMetadataReadDeadlineIsAbsoluteUnderSlowDripProgress",
+        "phase3-binary/Tests/macprovider-cliTests/ConsumeTrustedPricingTests.swift:testPricingFetchRejectsPrivateResolutionBeforeRateCardRequest",
+        "phase3-binary/Tests/macprovider-cliTests/ConsumeTrustedPricingTests.swift:testPricingFetchRepeatsResolutionAndRejectsPrivateSidecarRebinding"
       ],
       "journeys": [
         "JOURNEY-LOCAL-CONSUMER-ENDPOINT"
@@ -7061,7 +7075,12 @@
           "expires_at": "2027-08-24"
         }
       ],
-      "gap": null
+      "gap": {
+        "verdict": "UNKNOWN",
+        "owner": "@Augustas11",
+        "issue": "https://github.com/Augustas11/macprovider/issues/1433",
+        "rationale": "Trusted pricing metadata now repeats global-address validation and pins each body and sidecar connection, changing the mapped pricing loader beyond the historical dc63ecec candidate. Local rebinding regression tests do not replace refreshed matching commit and signed journey evidence."
+      }
     },
     {
       "requirement_id": "SPEC-045-R005",
@@ -7201,6 +7220,11 @@
         "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase4FakeGatewayStreamingSDKPayloadEmitsOpenAICompatibleSSE",
         "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase4FakeGatewayRedirectStatusIsPreservedWithoutLocationOrSecondDispatch",
         "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase4PinnedUpstreamGeneratedHeadersAreClosedAndSanitized",
+        "phase3-binary/Tests/macprovider-cliTests/ConsumeTrustedPricingTests.swift:testPinnedMetadataRequestIsCredentialFreeAndHeadersRemainBounded",
+        "phase3-binary/Tests/macprovider-cliTests/ConsumeTrustedPricingTests.swift:testPinnedMetadataTransportRejectsNonGlobalEndpointBeforeConnecting",
+        "phase3-binary/Tests/macprovider-cliTests/ConsumeTrustedPricingTests.swift:testPinnedMetadataReadDeadlineIsAbsoluteUnderSlowDripProgress",
+        "phase3-binary/Tests/macprovider-cliTests/ConsumeTrustedPricingTests.swift:testPricingFetchRejectsPrivateResolutionBeforeRateCardRequest",
+        "phase3-binary/Tests/macprovider-cliTests/ConsumeTrustedPricingTests.swift:testPricingFetchRepeatsResolutionAndRejectsPrivateSidecarRebinding",
         "scripts/test-signed-local-consumer-endpoint-journey-workflow.sh:required_workflow = [",
         "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase3DSendFailuresAreAmbiguous",
         "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase3DAmbiguousSendFailureHoldsReservationAcrossRestart",
@@ -7226,8 +7250,8 @@
       "gap": {
         "verdict": "UNKNOWN",
         "owner": "@Augustas11",
-        "issue": "https://github.com/Augustas11/macprovider/issues/927",
-        "rationale": "The mapped pinned upstream client and local handler changed for ambiguous-send budget safety after the historical dc63ecec candidate. New local negative tests cover exposure retention, denial, and ledger reopen, but the unchanged signed journey does not attest this implementation; refreshed matching commit and signed journey evidence remain required."
+        "issue": "https://github.com/Augustas11/macprovider/issues/1433",
+        "rationale": "The mapped pinned transports and local handler changed after the historical dc63ecec candidate. Local tests now cover pricing rebinding denial and credential-free metadata requests, plus ambiguous-send exposure retention and ledger reopen; however, the required production-transport negative TLS, connected-peer, proxy, redirect, and zero-credential-byte matrix remains incomplete, and the unchanged signed journey does not attest the current implementation. Existing evidence is historical provenance only; refreshed matching implementation evidence and separately authorized signed journey evidence remain required."
       }
     },
     {

--- a/specs/README.md
+++ b/specs/README.md
@@ -53,7 +53,7 @@ it can no longer drift. Do not hand-edit the table; edit each spec's
 | SPEC-042 | Pool Control Plane and Trusted-Pool Manifest | 0.0.30 | draft | complete | pending: 12 | [SPEC-042-pool-control-plane.md](SPEC-042-pool-control-plane.md) |
 | SPEC-043 | Trusted Pool Creator Onboarding MVP | 0.1.0 | normative | complete | pending: 12 | [SPEC-043-trusted-pool-creator-onboarding.md](SPEC-043-trusted-pool-creator-onboarding.md) |
 | SPEC-044 | Malibu Model Catalog Economics | 0.1.1 | draft | complete | pending: 12 | [SPEC-044-malibu-model-catalog-economics.md](SPEC-044-malibu-model-catalog-economics.md) |
-| SPEC-045 | Local Consumer Endpoint Mode | 0.1.0 | draft | complete | conformant: 3, pending: 5 | [SPEC-045-local-consumer-endpoint-mode.md](SPEC-045-local-consumer-endpoint-mode.md) |
+| SPEC-045 | Local Consumer Endpoint Mode | 0.1.0 | draft | complete | conformant: 1, pending: 7 | [SPEC-045-local-consumer-endpoint-mode.md](SPEC-045-local-consumer-endpoint-mode.md) |
 | SPEC-046 | Provider BYOM Discovery | 0.1.2 | draft | complete | pending: 8 | [SPEC-046-provider-byom-discovery.md](SPEC-046-provider-byom-discovery.md) |
 | SPEC-047 | Network Model Admission | 0.1.3 | draft | complete | pending: 8 | [SPEC-047-network-model-admission.md](SPEC-047-network-model-admission.md) |
 <!-- AUTOGEN:spec-index END -->


### PR DESCRIPTION
## Summary

Implements Astra audit corrections F12 and F13 after adversarial code, security, and architecture verification.

- Replace ambient `URLSession` trusted-pricing downloads with a credential-free direct TLS transport pinned to a freshly resolved global address.
- Repeat DNS/global-address validation independently for the rate card and signature sidecar, retaining hostname certificate verification through TLS SNI.
- Reject redirects and proxy routing by construction, bound headers/body bytes, and apply a non-refreshing 10-second metadata read deadline.
- Correct SPEC-045 conformance claims: R003, R004, and R008 remain pending until matching real-wire negative transport and separately authorized signed journey evidence exists.
- Regenerate the SPEC index to reflect the corrected conformance counts.

## Validation

- `cd phase3-binary && swift test --filter ConsumeTrustedPricingTests` — 11 tests, 0 failures.
- `cd phase3-binary && swift test --filter ConsumeCommandTests` — 132 tests, 0 failures.
- `make test-dist` — passed.
- `python3 scripts/check_spec_governance.py --base-ref origin/main` — passed.
- `python3 scripts/gen_spec_index.py --check` — passed.
- `git diff --check` — passed.

No signed journey was created: issue #1433 continues to track the production-transport evidence matrix and matching signed evidence.

## Audit gate

Final exact-diff reviews against `origin/main`:

- Code: 0 critical / 0 high / 0 medium / 0 low.
- Security: 0 critical / 0 high / 0 medium / 1 low.
- Architecture: 0 critical / 0 high / 0 medium.

Carried LOW: the required real-wire negative TLS, connected-peer, proxy, redirect, and zero-credential-byte fixture remains incomplete. The conformance registry now explicitly records this as pending under #1433.

## Governance

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": ["SPEC-045"],
  "requirements": ["SPEC-045-R003", "SPEC-045-R004", "SPEC-045-R008"],
  "authority_domains": ["local-consumer-endpoint"],
  "arbitration": ["UNKNOWN"],
  "tests": [
    "cd phase3-binary && swift test --filter ConsumeTrustedPricingTests",
    "cd phase3-binary && swift test --filter ConsumeCommandTests",
    "make test-dist",
    "python3 scripts/check_spec_governance.py --base-ref origin/main",
    "python3 scripts/gen_spec_index.py --check"
  ],
  "journeys": ["JOURNEY-LOCAL-CONSUMER-ENDPOINT"]
}
SPEC-GOVERNANCE-DECLARATION-END
