### PR TITLE
feat(byom): v0.2 slice 1a — openai_compatible_loopback adapter + local-default not_offered status (#1453)

### DIFF
--- a/docs/runbooks/byom-disablement-rollback.md
+++ b/docs/runbooks/byom-disablement-rollback.md
@@ -23,7 +23,7 @@ coordinator path mints the trusted catalog binding — so the disablement points
 below are defense-in-depth for individual surfaces, not the thing standing
 between BYOM and provider payouts.
 
-## Disablement matrix (#1248, nine rows)
+## Disablement matrix (#1248, ten rows)
 
 Every row names the switch, its default, and the automated proof — or an
 explicit not-applicable reason. Test references are `file:testName`.
@@ -39,6 +39,7 @@ explicit not-applicable reason. Test references are `file:testName`.
 | 7 | **Settlement** | Billing `verified_model_settlement_mode` read by `Server.settlementEnforceMode()` (`phase4-coordinator/internal/buyer/server.go`): `observe` or a nil billing store ⇒ no settlement side effects. Positive provider credit and final buyer debit additionally require the settlement-capable gate plus SPEC-022 receipt checks (valid receipt key, matching catalog key), each fail-closed. | `observe` (never `enforce` unless configured) | `phase4-coordinator/internal/billing/account_scope_test.go:TestVerifiedModelSettlementModeDefaultsObserve`; `phase4-coordinator/internal/buyer/route_snapshot_test.go:TestBYOMSettlementCapableRequiresValidReceiptKeyBeforeRouting`, `:TestBYOMSettlementCapableBindsAdmissionEventIntoRouteSnapshot`, `:TestBYOMCatalogKeyMismatchFailsClosed` |
 | 8 | **Economics projection** | Rate/payout fields are null unless `rate_card_source: live_signed` + a fresh signed rate card + a coordinator-bound trusted catalog identity all hold. Revoke or expire the signed rate card, or withhold the coordinator admission status, and rows degrade to `economics_state: blocked` with null money fields. | null/unavailable without trusted inputs | `phase3-binary/Tests/macprovider-cliTests/ModelCatalogEconomicsTests.swift:testLocalOnlyCandidateEncodesExplicitNullMoneyFields` (no coordinator status at all), `:testFallbackAndStaleRateCardsKeepMoneyFieldsNull`, `:testSettlementCapableRequiresCoordinatorSettlementState`, `:testFeedIntegrityWarningsBlockEconomicsEvenWithCoordinatorPricing` |
 | 9 | **Malibu app** | Checked-in capability manifest `phase3-binary/app/Sources/Malibu/Resources/MalibuModelCapabilities.json`. Remove/withhold `model_catalog_economics_v1` (and `model_ready_switch_v1`) and the app falls back to its existing static `models list` management. No provider state touched. | on only if the manifest advertises the caps **and** a fresh provider observation agrees | `phase3-binary/app/Tests/MalibuTests/ModelManagementTests.swift:testRefreshFallsBackToLegacyListWhenCatalogEconomicsCapabilityMissing`, `:testLegacyFallbackCancelsPreviousCatalogProjectionExpiry` |
+| 10 | **`openai_compatible_loopback` adapter** (#1453 slice 1) | Off unless the operator names an origin: `models discover/evaluate/offer/admission ...` take **`--openai-compatible-origin`** with **no default**, so omitting it leaves the adapter unattempted: **no `openai_compatible_loopback` row appears in `adapters[]` at all** (same as a skipped Ollama adapter — the projection gains no new wire value), and zero requests are dispatched. **`--skip-openai-compatible`** suppresses it even when an origin is configured. Both are read-only client-side switches: the adapter persists nothing, holds no credential, and its candidates are `identity_state: opaque_endpoint` / `admission_state: local_only`, which `BYOMOfferSubmissionBuilder.canSubmit` refuses, so no coordinator state exists to lose. | off (no default origin) | `phase3-binary/Tests/macprovider-cliTests/BYOMDiscoveryTests.swift:testOpenAICompatibleAdapterIsNotAttemptedWithoutOperatorOrigin`, `:testOpenAICompatibleAdapterEmitsOpaqueEndpointCandidate`, `:testOpenAICompatibleAdapterRejectsNonLoopbackOriginBeforeDispatch`, `:testOpenAICompatibleOfferDryRunClaimsNoCatalogPath`; `phase3-binary/Tests/macprovider-cliTests/BYOMEvaluationTests.swift:testEvaluateOpaqueOpenAICompatibleCandidateStaysNonEarning` |
 
 Supporting client-side notes for rows 1-3: the provider CLI BYOM commands
 (`models discover/evaluate/offer/admission ...`) are client-side and harmless
@@ -107,9 +108,24 @@ directions.
 **Current CLI/app against a pre-BYOM coordinator**
 
 - `phase3-binary/Tests/macprovider-cliTests/BYOMAdmissionTests.swift:testAdmissionStatusAgainstPreBYOMCoordinatorFailsClosedWithoutFabricatingState`
-  - 404/405 (no admission endpoints) and an unknown 200 schema both fail closed;
-    the CLI never fabricates a coordinator admission state and the operator is
-    pointed at `local_default` / `wait_for_coordinator`.
+  - **Transport layer.** The admission client itself still reports 404/405 (no
+    admission endpoints) as an error, and an unknown 200 schema as an error. The
+    CLI never fabricates a coordinator admission state at this layer.
+- `phase3-binary/Tests/macprovider-cliTests/BYOMAdmissionTests.swift:testAdmissionStatusWithoutConfiguredCoordinatorReportsLocalDefaultNotOffered`,
+  `:testAdmissionStatusWithUnreachableCoordinatorReportsLocalDefaultNotOffered`
+  - **Command runtime.** Above that transport, `models admission status` maps
+    exactly two conditions — no coordinator configured, and a coordinator whose
+    admission route is absent or unreachable (404/405, connection failure) — to
+    the local ladder row `admission_state: not_offered` with
+    `admission_state_source: local_default` and the
+    `coordinator_state_unavailable` warning
+    (`phase3-binary/Sources/macprovider-cli/BYOMDiscovery.swift`, `status(providerID:target:)`).
+    That is "coordinator state has not been queried", not a coordinator claim.
+- `phase3-binary/Tests/macprovider-cliTests/BYOMAdmissionTests.swift:testAdmissionStatusKeepsAuthenticationFailuresAsErrors`,
+  `:testAdmissionStatusKeepsUnavailableCoordinatorMappingFor503`
+  - **Still errors.** An unknown successful schema, and 401/403/503, are not
+    mapped to the local ladder: they stay errors, so a policy or authentication
+    fault can never be read as "no offer exists".
 - `phase3-binary/Tests/macprovider-cliTests/ModelCatalogEconomicsTests.swift:testLocalOnlyCandidateEncodesExplicitNullMoneyFields`
   - with no coordinator admission status available (exactly what a pre-BYOM
     coordinator yields, since `readAdmissionStatuses` drops failed lookups), the

--- a/phase3-binary/Sources/macprovider-cli/BYOMDiscovery.swift
+++ b/phase3-binary/Sources/macprovider-cli/BYOMDiscovery.swift
@@ -20,6 +20,10 @@ enum BYOMDiscoveryWarning: String, Codable, Sendable {
     case evaluationFailed = "evaluation_failed"
     case requiresPreparation = "requires_preparation"
     case namespacePermissionInvalid = "namespace_permission_invalid"
+    /// SPEC-046-R003: no coordinator admission state could be read for the
+    /// candidate, so the CLI reports the local ladder's `not_offered` row under
+    /// `admission_state_source: local_default` instead of a coordinator state.
+    case coordinatorStateUnavailable = "coordinator_state_unavailable"
 }
 
 extension BYOMDiscoveryWarning {
@@ -685,6 +689,41 @@ struct BYOMAdmissionStatusWire: Codable, Equatable, Sendable {
         case providerGuidance = "provider_guidance"
         case allowedNextStates = "allowed_next_states"
         case warnings
+    }
+
+    /// SPEC-047-R002 makes this a closed envelope: `catalog_model_key`,
+    /// `coordinator_event_id`, and `state_observed_at` are nullable KEYS, not
+    /// optional ones, and `decodeStrictStatus` requires the exact key set. The
+    /// synthesized encoder would drop a nil key entirely, so encode the nulls
+    /// explicitly, exactly as `Guidance` and `Candidate` already do.
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(schema, forKey: .schema)
+        try container.encode(generatedAt, forKey: .generatedAt)
+        try container.encode(cliVersion, forKey: .cliVersion)
+        try container.encode(providerID, forKey: .providerID)
+        try container.encode(candidateID, forKey: .candidateID)
+        try container.encode(servedModelRef, forKey: .servedModelRef)
+        try encodeNullableString(catalogModelKey, forKey: .catalogModelKey, into: &container)
+        try container.encode(admissionState, forKey: .admissionState)
+        try container.encode(admissionStateSource, forKey: .admissionStateSource)
+        try encodeNullableString(coordinatorEventID, forKey: .coordinatorEventID, into: &container)
+        try encodeNullableString(stateObservedAt, forKey: .stateObservedAt, into: &container)
+        try container.encode(providerGuidance, forKey: .providerGuidance)
+        try container.encode(allowedNextStates, forKey: .allowedNextStates)
+        try container.encode(warnings, forKey: .warnings)
+    }
+
+    private func encodeNullableString(
+        _ value: String?,
+        forKey key: CodingKeys,
+        into container: inout KeyedEncodingContainer<CodingKeys>
+    ) throws {
+        if let value {
+            try container.encode(value, forKey: key)
+        } else {
+            try container.encodeNil(forKey: key)
+        }
     }
 }
 
@@ -1689,14 +1728,17 @@ struct BYOMModelAdmissionRuntime: Sendable {
     let environment: BYOMDiscoveryEnvironment
     let credentialStore: any ProviderCredentialStoring
     let identityStore: any ProviderIdentityKeyStoring
-    let client: BYOMModelAdmissionClient
+    /// Nil when no coordinator URL is configured. Status then stays entirely on
+    /// the SPEC-046-R003 local ladder and opens no connection at all; offers and
+    /// withdrawals still require a coordinator and fail closed without one.
+    let client: BYOMModelAdmissionClient?
     let httpClient: any BYOMDiscoveryHTTPClient
 
     init(
         environment: BYOMDiscoveryEnvironment,
         credentialStore: any ProviderCredentialStoring = KeychainProviderCredentialStore(),
         identityStore: any ProviderIdentityKeyStoring = KeychainReceiptKeyStore(),
-        client: BYOMModelAdmissionClient,
+        client: BYOMModelAdmissionClient?,
         httpClient: any BYOMDiscoveryHTTPClient = BYOMURLSessionHTTPClient()
     ) {
         self.environment = environment
@@ -1712,6 +1754,9 @@ struct BYOMModelAdmissionRuntime: Sendable {
         evaluationDigestSHA256: String?,
         requestedDisclosureClass: String
     ) async throws -> BYOMAdmissionStatusWire {
+        guard let client else {
+            throw BYOMModelAdmissionError.missingCoordinatorURL
+        }
         // Submitting an offer is a deliberate mutating command: the coordinator
         // records the admission event keyed by candidate_id, so the id must be
         // stable. Provision the local identity salt first (idempotent, local CLI
@@ -1743,14 +1788,113 @@ struct BYOMModelAdmissionRuntime: Sendable {
     func status(providerID: String, target: String) async throws -> BYOMAdmissionStatusWire {
         let candidate = await resolveCandidate(target)
         let candidateID = candidate?.candidateID ?? target.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let client else {
+            // No coordinator is configured, so coordinator state "has not been
+            // queried" in the SPEC-046-R003 sense. Report the local ladder
+            // without opening a connection: this path performs no request at all.
+            return try Self.localDefaultStatus(
+                providerID: providerID,
+                candidateID: candidateID,
+                candidate: candidate
+            )
+        }
         guard let bearer = try credentialStore.load(providerID: providerID) else {
             throw BYOMModelAdmissionError.missingBearer(providerID: providerID)
         }
-        let status = try await client.status(candidateID: candidateID, providerID: providerID, bearerToken: bearer)
-        return status.withLocalCandidateIdentityIfCoordinatorHasNoOffer(candidate)
+        do {
+            let status = try await client.status(candidateID: candidateID, providerID: providerID, bearerToken: bearer)
+            return status.withLocalCandidateIdentityIfCoordinatorHasNoOffer(candidate)
+        } catch let error as BYOMModelAdmissionError where Self.isAdmissionRouteAbsent(error) {
+            // A pre-BYOM coordinator serves no SPEC-047 admission route. That is
+            // "coordinator state is unavailable", not an authentication, policy,
+            // or schema fault, so the local ladder answers instead of an error.
+            return try Self.localDefaultStatus(
+                providerID: providerID,
+                candidateID: candidateID,
+                candidate: candidate
+            )
+        } catch let error as URLError where Self.isCoordinatorUnreachable(error) {
+            return try Self.localDefaultStatus(
+                providerID: providerID,
+                candidateID: candidateID,
+                candidate: candidate
+            )
+        }
+    }
+
+    /// 404/405 only: the coordinator answered, but serves no admission route.
+    /// Every other HTTP status stays an error — 401/403 are provider auth faults
+    /// the operator must fix, 503 keeps its #1448 `wait_for_coordinator` mapping,
+    /// and any other 5xx is an unexplained coordinator fault that must not be
+    /// relabelled as "no offer is known for this candidate".
+    private static func isAdmissionRouteAbsent(_ error: BYOMModelAdmissionError) -> Bool {
+        error == .httpStatus(404) || error == .httpStatus(405)
+    }
+
+    /// The request never reached a coordinator that could answer. A decodable
+    /// response, including an unknown or invalid schema, is deliberately absent:
+    /// that is a coordinator contract fault and stays an error.
+    private static func isCoordinatorUnreachable(_ error: URLError) -> Bool {
+        switch error.code {
+        case .cannotConnectToHost,
+             .cannotFindHost,
+             .dnsLookupFailed,
+             .timedOut,
+             .networkConnectionLost,
+             .notConnectedToInternet:
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// The SPEC-046-R003 local ladder as a `model_admission_status.v1` document.
+    ///
+    /// A locally eligible (`offerable`) candidate takes the ladder's `not_offered`
+    /// row: no active coordinator offer is known, because coordinator state is
+    /// unavailable or has not been queried. A `local_only` candidate keeps its own
+    /// state and guidance — its blocker is local, and coordinator reachability
+    /// does not move it. `allowed_next_states` is empty because the candidate has
+    /// not entered coordinator admission (SPEC-047-R002), and the source is never
+    /// `coordinator`, so no coordinator state is fabricated.
+    private static func localDefaultStatus(
+        providerID: String,
+        candidateID: String,
+        candidate: BYOMDiscoveryWire.Candidate?
+    ) throws -> BYOMAdmissionStatusWire {
+        // With no local candidate there is no local state to report: answering
+        // for an unknown candidate would invent inventory rather than report it.
+        guard let candidate, candidate.candidateID == candidateID else {
+            throw BYOMModelAdmissionError.candidateNotFound
+        }
+        let localWarnings = Set(candidate.warningCodes)
+        let isOfferable = candidate.admissionState == "offerable"
+        return BYOMAdmissionStatusWire(
+            schema: "model_admission_status.v1",
+            generatedAt: ModelSwitchingWireCodec.timestamp(),
+            cliVersion: CoordinatorClient.binaryVersion,
+            providerID: providerID,
+            candidateID: candidate.candidateID,
+            servedModelRef: candidate.servedModelRef,
+            catalogModelKey: candidate.catalogModelKey,
+            admissionState: isOfferable ? "not_offered" : candidate.admissionState,
+            admissionStateSource: "local_default",
+            coordinatorEventID: nil,
+            stateObservedAt: nil,
+            providerGuidance: isOfferable
+                ? BYOMDiscoveryGuidance.localNotOfferedGuidance(warnings: localWarnings)
+                : candidate.providerGuidance,
+            allowedNextStates: [],
+            warnings: localWarnings
+                .union([BYOMDiscoveryWarning.coordinatorStateUnavailable.rawValue])
+                .sorted()
+        )
     }
 
     func withdraw(providerID: String, target: String, reasonCode: String) async throws -> BYOMAdmissionWithdrawWire {
+        guard let client else {
+            throw BYOMModelAdmissionError.missingCoordinatorURL
+        }
         let candidate = await resolveCandidate(target)
         let candidateID = candidate?.candidateID ?? target.trimmingCharacters(in: .whitespacesAndNewlines)
         guard candidate != nil || BYOMWithdrawalBuilder.isStableCandidateID(candidateID) else {
@@ -1844,18 +1988,38 @@ struct BYOMDiscoveryEnvironment: Sendable {
     let namespaceURL: URL
     let mlxCacheRoot: URL
     let ollamaOrigin: String?
+    /// Operator-supplied OpenAI-compatible loopback origin. SPEC-046-R002 allows
+    /// an adapter endpoint to be either a well-known loopback default for that
+    /// runtime or an operator-supplied loopback origin; a generic
+    /// OpenAI-compatible server has no well-known port, so this adapter has no
+    /// default and stays unattempted until the operator names an origin.
+    let openAICompatibleOrigin: String?
+
+    init(
+        namespaceURL: URL,
+        mlxCacheRoot: URL,
+        ollamaOrigin: String?,
+        openAICompatibleOrigin: String? = nil
+    ) {
+        self.namespaceURL = namespaceURL
+        self.mlxCacheRoot = mlxCacheRoot
+        self.ollamaOrigin = ollamaOrigin
+        self.openAICompatibleOrigin = openAICompatibleOrigin
+    }
 
     static func production(
         namespacePath: String?,
         mlxCacheDir: String?,
         ollamaOrigin: String?,
+        openAICompatibleOrigin: String? = nil,
         environment: [String: String] = ProcessInfo.processInfo.environment,
         homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
     ) -> BYOMDiscoveryEnvironment {
         BYOMDiscoveryEnvironment(
             namespaceURL: namespacePath.map(URL.init(fileURLWithPath:)) ?? defaultNamespaceURL(homeDirectory: homeDirectory),
             mlxCacheRoot: mlxCacheDir.map(URL.init(fileURLWithPath:)) ?? defaultMLXCacheRoot(environment: environment, homeDirectory: homeDirectory),
-            ollamaOrigin: ollamaOrigin
+            ollamaOrigin: ollamaOrigin,
+            openAICompatibleOrigin: openAICompatibleOrigin
         )
     }
 
@@ -2046,6 +2210,28 @@ struct BYOMDiscoveryRunner {
             }
         }
 
+        // SPEC-046-R002: no well-known default, so the adapter is attempted only
+        // when the operator supplies an origin. An adapter that was never
+        // attempted contributes no row at all, exactly as the Ollama adapter
+        // does when it is skipped. An absent row already means "not attempted",
+        // so inventing a status value for it would put an undefined string on
+        // the wire and change the no-flag projection for existing consumers.
+        let openAIOrigin = environment.openAICompatibleOrigin?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let openAIOrigin, !openAIOrigin.isEmpty {
+            let openAICompatible = await BYOMOpenAICompatibleDiscovery(
+                origin: openAIOrigin,
+                namespace: namespace.bytes,
+                namespaceWarnings: namespace.warnings,
+                httpClient: httpClient
+            ).discover()
+            adapters.append(openAICompatible.adapter)
+            candidates.append(contentsOf: openAICompatible.candidates)
+            warnings.formUnion(openAICompatible.adapter.warningCodes)
+            for candidate in openAICompatible.candidates {
+                warnings.formUnion(candidate.warningCodes)
+            }
+        }
+
         candidates.sort {
             if $0.runtimeSource == $1.runtimeSource {
                 return $0.servedModelRef < $1.servedModelRef
@@ -2148,9 +2334,7 @@ struct BYOMEvaluationRunner: Sendable {
             )
         }
 
-        guard candidate.runtimeSource == "ollama_loopback",
-              let baseURL = BYOMLoopbackOriginValidator.validatedHTTPOrigin(environment.ollamaOrigin ?? ""),
-              let runtimeModel = ollamaModelName(from: candidate.servedModelRef) else {
+        guard let resolved = resolveLoopbackRuntime(for: candidate) else {
             let warnings = mergedWarnings(candidate, adding: [.requiresPreparation])
             return failureDocument(
                 for: candidate,
@@ -2161,7 +2345,37 @@ struct BYOMEvaluationRunner: Sendable {
             )
         }
 
-        return await evaluateOpenAICompatible(candidate: candidate, runtimeModel: runtimeModel, baseURL: baseURL)
+        return await evaluateOpenAICompatible(
+            candidate: candidate,
+            runtimeModel: resolved.runtimeModel,
+            baseURL: resolved.baseURL
+        )
+    }
+
+    /// Both loopback runtime adapters are probed through the same bounded
+    /// OpenAI chat-completions harness; only the configured origin and the
+    /// `served_model_ref` prefix differ. Local artifact candidates (`mlx_cache`)
+    /// have no local endpoint to probe and stay `requires_preparation`.
+    private func resolveLoopbackRuntime(
+        for candidate: BYOMDiscoveryWire.Candidate
+    ) -> (runtimeModel: String, baseURL: URL)? {
+        let origin: String?
+        let prefix: String
+        switch candidate.runtimeSource {
+        case "ollama_loopback":
+            origin = environment.ollamaOrigin
+            prefix = "ollama:"
+        case BYOMOpenAICompatibleDiscovery.runtimeSource:
+            origin = environment.openAICompatibleOrigin
+            prefix = BYOMOpenAICompatibleDiscovery.servedModelRefPrefix
+        default:
+            return nil
+        }
+        guard let baseURL = BYOMLoopbackOriginValidator.validatedHTTPOrigin(origin ?? ""),
+              let runtimeModel = runtimeModelName(from: candidate.servedModelRef, prefix: prefix) else {
+            return nil
+        }
+        return (runtimeModel, baseURL)
     }
 
     private func evaluateOpenAICompatible(
@@ -2355,9 +2569,9 @@ struct BYOMEvaluationRunner: Sendable {
         }
     }
 
-    private func ollamaModelName(from servedModelRef: String) -> String? {
-        guard servedModelRef.hasPrefix("ollama:") else { return nil }
-        let name = String(servedModelRef.dropFirst("ollama:".count))
+    private func runtimeModelName(from servedModelRef: String, prefix: String) -> String? {
+        guard servedModelRef.hasPrefix(prefix) else { return nil }
+        let name = String(servedModelRef.dropFirst(prefix.count))
         guard BYOMDiscoveryPrivacy.isSafeRuntimeModelReference(name) else { return nil }
         return name
     }
@@ -2435,7 +2649,7 @@ struct BYOMEvaluationRunner: Sendable {
 
     private func adapterIdentity(for candidate: BYOMDiscoveryWire.Candidate) -> String {
         switch candidate.runtimeSource {
-        case "ollama_loopback":
+        case "ollama_loopback", BYOMOpenAICompatibleDiscovery.runtimeSource:
             return "openai_compatible_loopback"
         case "mlx_cache":
             return "mlx_cache_local_artifact"
@@ -3329,6 +3543,151 @@ struct BYOMOllamaDiscovery: Sendable {
     }
 }
 
+/// SPEC-046-R002 `openai_compatible_loopback` adapter.
+///
+/// Deliberately a thin wrapper over the same shared safety layer the Ollama
+/// adapter uses (#1246): `BYOMLoopbackOriginValidator` for URL admission,
+/// `BYOMDiscoveryHTTPBounds` + the injected client for redirect/proxy/byte
+/// bounds, `StrictJSONParser` via `BYOMDiscoveryJSON` for parser limits, and
+/// `BYOMDiscoveryPrivacy` for redaction. It reimplements none of them.
+///
+/// A generic OpenAI-compatible server exposes only `GET /v1/models`, which
+/// carries no artifact hash and no catalog identity, so every candidate it
+/// produces is an opaque endpoint: `identity_state: "opaque_endpoint"`,
+/// `locality: "opaque_local_endpoint"`, null `catalog_model_key`, and local
+/// inventory state only.
+struct BYOMOpenAICompatibleDiscovery: Sendable {
+    static let runtimeSource = "openai_compatible_loopback"
+    static let servedModelRefPrefix = "openai_compatible:"
+
+    private let origin: String
+    private let namespace: Data?
+    private let namespaceWarnings: [BYOMDiscoveryWarning]
+    private let httpClient: any BYOMDiscoveryHTTPClient
+
+    init(
+        origin: String,
+        namespace: Data?,
+        namespaceWarnings: [BYOMDiscoveryWarning] = [],
+        httpClient: any BYOMDiscoveryHTTPClient
+    ) {
+        self.origin = origin
+        self.namespace = namespace
+        self.namespaceWarnings = namespaceWarnings
+        self.httpClient = httpClient
+    }
+
+    func discover() async -> (adapter: BYOMDiscoveryWire.Adapter, candidates: [BYOMDiscoveryWire.Candidate]) {
+        guard let baseURL = BYOMLoopbackOriginValidator.validatedHTTPOrigin(origin) else {
+            // The rejected origin is never echoed back: R007 forbids surfacing a
+            // full local endpoint, and the closed warning code is the diagnostic.
+            return (
+                BYOMDiscoveryWire.Adapter(
+                    runtimeSource: Self.runtimeSource,
+                    status: "rejected",
+                    originClass: "rejected",
+                    warningCodes: [BYOMDiscoveryWarning.adapterRejectedNonLoopback.rawValue]
+                ),
+                []
+            )
+        }
+
+        do {
+            let response = try await httpClient.get(
+                baseURL.appendingPathComponent("v1/models"),
+                maxHeaderBytes: BYOMDiscoveryHTTPBounds.maxHeaderBytes,
+                maxBodyBytes: BYOMDiscoveryHTTPBounds.maxBodyBytes
+            )
+            guard response.statusCode == 200 else {
+                return adapterFailure(.adapterUnavailable, status: "unavailable")
+            }
+            guard BYOMDiscoveryHTTPBounds.headerBytes(response.headers) <= BYOMDiscoveryHTTPBounds.maxHeaderBytes else {
+                return adapterFailure(.adapterResponseTruncated, status: "truncated")
+            }
+            guard response.body.count <= BYOMDiscoveryHTTPBounds.maxBodyBytes else {
+                return adapterFailure(.adapterResponseTruncated, status: "truncated")
+            }
+            let inventory = try BYOMDiscoveryJSON.parseOpenAIModels(response.body)
+            return (
+                BYOMDiscoveryWire.Adapter(
+                    runtimeSource: Self.runtimeSource,
+                    status: "ok",
+                    originClass: "loopback_http",
+                    warningCodes: inventory.warningCodes.map(\.rawValue).sorted()
+                ),
+                inventory.modelIDs.map(buildCandidate)
+            )
+        } catch is CancellationError {
+            return adapterFailure(.adapterTimeout, status: "timeout")
+        } catch let error as URLError where error.code == .timedOut {
+            return adapterFailure(.adapterTimeout, status: "timeout")
+        } catch let error as BYOMDiscoveryAdapterError {
+            switch error {
+            case .malformed:
+                return adapterFailure(.adapterMalformedResponse, status: "malformed")
+            case .truncated:
+                return adapterFailure(.adapterResponseTruncated, status: "truncated")
+            case .rejectedNonLoopback:
+                return adapterFailure(.adapterRejectedNonLoopback, status: "rejected")
+            }
+        } catch {
+            return adapterFailure(.adapterUnavailable, status: "unavailable")
+        }
+    }
+
+    private func adapterFailure(
+        _ warning: BYOMDiscoveryWarning,
+        status: String
+    ) -> (adapter: BYOMDiscoveryWire.Adapter, candidates: [BYOMDiscoveryWire.Candidate]) {
+        (
+            BYOMDiscoveryWire.Adapter(
+                runtimeSource: Self.runtimeSource,
+                status: status,
+                originClass: "loopback_http",
+                warningCodes: [warning.rawValue]
+            ),
+            []
+        )
+    }
+
+    private func buildCandidate(_ modelID: String) -> BYOMDiscoveryWire.Candidate {
+        let servedModelRef = Self.servedModelRefPrefix + modelID
+        let (candidateID, idWarnings) = BYOMCandidateIdentity.candidateID(
+            namespace: namespace,
+            runtimeSource: Self.runtimeSource,
+            servedModelRef: servedModelRef
+        )
+        let warnings = Set((namespaceWarnings + idWarnings + [.capabilityUnevaluated, .evaluationRequired]).map(\.rawValue))
+        // SPEC-046-R003 local-state ladder: an opaque endpoint's identity is
+        // insufficient for offering — there is no artifact hash and no catalog
+        // key to bind — so it stays local inventory and never reports
+        // `offerable`. SPEC-047 rejects opaque endpoints for network admission,
+        // so a locally optimistic label here would over-promise.
+        let admission = "local_only"
+        return BYOMDiscoveryWire.Candidate(
+            candidateID: candidateID,
+            runtimeSource: Self.runtimeSource,
+            displayName: BYOMDiscoveryPrivacy.displayName(from: modelID),
+            servedModelRef: servedModelRef,
+            catalogModelKey: nil,
+            identityState: "opaque_endpoint",
+            locality: "opaque_local_endpoint",
+            estimatedGB: nil,
+            contextWindowTokens: nil,
+            // `GET /v1/models` reports no capability, size, or runtime version,
+            // so every advisory field stays null rather than false (R004).
+            capabilities: .unknown,
+            readinessState: "ready",
+            fitState: "unknown",
+            evaluationState: "not_evaluated",
+            admissionState: admission,
+            admissionStateSource: "local_default",
+            providerGuidance: BYOMDiscoveryGuidance.opaqueEndpointGuidance(warnings: warnings),
+            warningCodes: Array(warnings).sorted()
+        )
+    }
+}
+
 enum BYOMLoopbackOriginValidator {
     static func validatedHTTPOrigin(_ raw: String) -> URL? {
         guard var components = URLComponents(string: raw.trimmingCharacters(in: .whitespacesAndNewlines)),
@@ -3377,11 +3736,20 @@ enum BYOMLoopbackOriginValidator {
 enum BYOMDiscoveryHTTPBounds {
     static let maxHeaderBytes = 64 * 1024
     static let maxBodyBytes = 256 * 1024
+    /// Records an adapter will read from one runtime inventory response. One
+    /// bound shared by every adapter parser (#1246: the adapters reimplement no
+    /// parser-bound logic), so the cap cannot drift apart per runtime source.
+    static let maxInventoryRecords = 100
 
     static func headerBytes(_ headers: [(String, String)]) -> Int {
         headers.reduce(0) { total, header in
             total + header.0.utf8.count + header.1.utf8.count
         }
+    }
+
+    /// The records an adapter parser is allowed to look at, in wire order.
+    static func boundedInventoryRecords(_ records: [JSONValue]) -> ArraySlice<JSONValue> {
+        records.prefix(maxInventoryRecords)
     }
 }
 
@@ -3406,7 +3774,7 @@ enum BYOMDiscoveryJSON {
         }
         var models: [OllamaModel] = []
         var withheldReference = false
-        for value in rawModels.prefix(100) {
+        for value in BYOMDiscoveryHTTPBounds.boundedInventoryRecords(rawModels) {
             guard case .object(let object) = value,
                   case .string(let name)? = object["name"] else {
                 throw BYOMDiscoveryAdapterError.malformed
@@ -3436,6 +3804,41 @@ enum BYOMDiscoveryJSON {
             ))
         }
         return OllamaInventory(models: models, warningCodes: withheldReference ? [.modelReferenceRedacted] : [])
+    }
+
+    struct OpenAIModelInventory {
+        let modelIDs: [String]
+        let warningCodes: [BYOMDiscoveryWarning]
+    }
+
+    /// Parse `GET /v1/models` through the same bounded strict parser and
+    /// record-count cap the Ollama adapter uses. An id that is not a safe
+    /// runtime model reference is withheld entirely (R007: no placeholder
+    /// candidate, no synthesized identity) and reported as
+    /// `model_reference_redacted` on the adapter.
+    static func parseOpenAIModels(_ data: Data) throws -> OpenAIModelInventory {
+        guard let text = String(data: data, encoding: .utf8),
+              case .object(let root) = try? StrictJSONParser.parse(text),
+              case .array(let rawModels)? = root["data"] else {
+            throw BYOMDiscoveryAdapterError.malformed
+        }
+        var modelIDs: [String] = []
+        var withheldReference = false
+        for value in BYOMDiscoveryHTTPBounds.boundedInventoryRecords(rawModels) {
+            guard case .object(let object) = value,
+                  case .string(let id)? = object["id"] else {
+                throw BYOMDiscoveryAdapterError.malformed
+            }
+            guard BYOMDiscoveryPrivacy.isSafeRuntimeModelReference(id) else {
+                withheldReference = true
+                continue
+            }
+            modelIDs.append(id)
+        }
+        return OpenAIModelInventory(
+            modelIDs: modelIDs,
+            warningCodes: withheldReference ? [.modelReferenceRedacted] : []
+        )
     }
 
     static func contextWindowTokens(from data: Data) -> Int? {
@@ -3762,6 +4165,40 @@ enum BYOMDiscoveryPrivacy {
 }
 
 enum BYOMDiscoveryGuidance {
+    /// Guidance for an `opaque_endpoint` candidate. The state is always
+    /// `local_only`, so the ladder's own next actions apply: fix the blocking
+    /// local condition, or — when nothing is blocking — run `models evaluate`,
+    /// which is the only thing an opaque endpoint can usefully do locally.
+    static func opaqueEndpointGuidance(warnings: Set<String>) -> BYOMDiscoveryWire.Guidance {
+        let blocked = !warnings.isDisjoint(with: BYOMDiscoveryWarning.submitBlockingWarningCodes)
+        return BYOMDiscoveryWire.Guidance(
+            stateLabelKey: "byom.local.local_only",
+            stateMeaningKey: "byom.local.opaque_endpoint_not_earning",
+            nextAction: blocked ? "fix_local_blocker" : "evaluate",
+            transitionReasonCode: warnings.sorted().first,
+            earningPathClass: "local_inventory_only"
+        )
+    }
+
+    /// Guidance for the SPEC-046-R003 local ladder's `not_offered` row under
+    /// `admission_state_source: local_default`, which the ladder defines as
+    /// "coordinator state is unavailable or has not been queried". The candidate
+    /// is locally eligible, so the next action is the ladder's own — status
+    /// readback, offer dry-run, or a refreshed offer — which is exactly the
+    /// `offerable` row's action, including its evaluate-first preference for an
+    /// unevaluated candidate. The label change between `offerable` and
+    /// `not_offered` is action-neutral, so the two rows MUST NOT disagree here.
+    static func localNotOfferedGuidance(warnings: Set<String>) -> BYOMDiscoveryWire.Guidance {
+        let offerable = guidance(forAdmissionState: "offerable", warnings: warnings)
+        return BYOMDiscoveryWire.Guidance(
+            stateLabelKey: "byom.local.not_offered",
+            stateMeaningKey: "byom.local.not_offered_coordinator_state_unavailable",
+            nextAction: offerable.nextAction,
+            transitionReasonCode: BYOMDiscoveryWarning.coordinatorStateUnavailable.rawValue,
+            earningPathClass: offerable.earningPathClass
+        )
+    }
+
     static func guidance(forAdmissionState state: String, warnings: Set<String>) -> BYOMDiscoveryWire.Guidance {
         switch state {
         case "offerable":

--- a/phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift
@@ -43,6 +43,12 @@ struct ModelsDiscoverCommand: AsyncParsableCommand {
     @Flag(help: "Skip the Ollama-compatible loopback adapter.")
     var skipOllama = false
 
+    @Option(help: "Operator-supplied OpenAI-compatible loopback origin to query. Must be http://127.0.0.0/8:<port> or http://[::1]:<port>. There is no default: the adapter is not attempted unless this is set.")
+    var openaiCompatibleOrigin: String?
+
+    @Flag(help: "Skip the OpenAI-compatible loopback adapter.")
+    var skipOpenaiCompatible = false
+
     func run() async throws {
         guard emitJSON else {
             writeStderr("models discover is JSON-only in this release; pass --json")
@@ -51,7 +57,8 @@ struct ModelsDiscoverCommand: AsyncParsableCommand {
         let environment = BYOMDiscoveryEnvironment.production(
             namespacePath: localDiscoveryNamespacePath,
             mlxCacheDir: mlxCacheDir,
-            ollamaOrigin: skipOllama ? nil : ollamaOrigin
+            ollamaOrigin: skipOllama ? nil : ollamaOrigin,
+            openAICompatibleOrigin: skipOpenaiCompatible ? nil : openaiCompatibleOrigin
         )
         let document = await BYOMDiscoveryRunner(environment: environment).discover()
         for warning in document.warnings.sorted() {
@@ -85,6 +92,12 @@ struct ModelsEvaluateCommand: AsyncParsableCommand {
     @Flag(help: "Skip the Ollama-compatible loopback adapter during candidate lookup.")
     var skipOllama = false
 
+    @Option(help: "Operator-supplied OpenAI-compatible loopback origin to query. Must be http://127.0.0.0/8:<port> or http://[::1]:<port>. There is no default: the adapter is not attempted unless this is set.")
+    var openaiCompatibleOrigin: String?
+
+    @Flag(help: "Skip the OpenAI-compatible loopback adapter during candidate lookup.")
+    var skipOpenaiCompatible = false
+
     func run() async throws {
         guard emitJSON else {
             writeStderr("models evaluate is JSON-only in this release; pass --json")
@@ -93,7 +106,8 @@ struct ModelsEvaluateCommand: AsyncParsableCommand {
         let environment = BYOMDiscoveryEnvironment.production(
             namespacePath: localDiscoveryNamespacePath,
             mlxCacheDir: mlxCacheDir,
-            ollamaOrigin: skipOllama ? nil : ollamaOrigin
+            ollamaOrigin: skipOllama ? nil : ollamaOrigin,
+            openAICompatibleOrigin: skipOpenaiCompatible ? nil : openaiCompatibleOrigin
         )
         let document = await BYOMEvaluationRunner(target: candidate, environment: environment).evaluate()
         for warning in document.warnings.sorted() {
@@ -148,6 +162,12 @@ struct ModelsOfferCommand: AsyncParsableCommand {
     @Flag(help: "Skip the Ollama-compatible loopback adapter during candidate lookup.")
     var skipOllama = false
 
+    @Option(help: "Operator-supplied OpenAI-compatible loopback origin to query. Must be http://127.0.0.0/8:<port> or http://[::1]:<port>. There is no default: the adapter is not attempted unless this is set.")
+    var openaiCompatibleOrigin: String?
+
+    @Flag(help: "Skip the OpenAI-compatible loopback adapter during candidate lookup.")
+    var skipOpenaiCompatible = false
+
     func run() async throws {
         guard emitJSON else {
             if dryRun {
@@ -160,7 +180,8 @@ struct ModelsOfferCommand: AsyncParsableCommand {
         let environment = BYOMDiscoveryEnvironment.production(
             namespacePath: localDiscoveryNamespacePath,
             mlxCacheDir: mlxCacheDir,
-            ollamaOrigin: skipOllama ? nil : ollamaOrigin
+            ollamaOrigin: skipOllama ? nil : ollamaOrigin,
+            openAICompatibleOrigin: skipOpenaiCompatible ? nil : openaiCompatibleOrigin
         )
         if dryRun {
             let document = await BYOMOfferDryRunRunner(target: candidate, environment: environment).dryRun()
@@ -215,7 +236,12 @@ struct ModelsAdmissionCommand: AsyncParsableCommand {
 struct ModelsAdmissionStatusCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "status",
-        abstract: "Read coordinator-backed BYOM admission status."
+        // SPEC-046-R003: the command reads coordinator admission state when a
+        // coordinator is configured and reachable, and otherwise reports the
+        // local ladder under admission_state_source local_default rather than
+        // failing. "Coordinator-backed" alone contradicted that fallback.
+        abstract: "Read BYOM admission status: coordinator readback when a coordinator "
+            + "is configured and reachable, otherwise the local default state."
     )
 
     @Argument(help: "Candidate id, served model reference, or display name from models discover --json.")
@@ -245,13 +271,19 @@ struct ModelsAdmissionStatusCommand: AsyncParsableCommand {
     @Flag(help: "Skip the Ollama-compatible loopback adapter during candidate lookup.")
     var skipOllama = false
 
+    @Option(help: "Operator-supplied OpenAI-compatible loopback origin to query. Must be http://127.0.0.0/8:<port> or http://[::1]:<port>. There is no default: the adapter is not attempted unless this is set.")
+    var openaiCompatibleOrigin: String?
+
+    @Flag(help: "Skip the OpenAI-compatible loopback adapter during candidate lookup.")
+    var skipOpenaiCompatible = false
+
     func run() async throws {
         guard emitJSON else {
             writeStderr("models admission status is JSON-only in this release; pass --json")
             throw ExitCode(2)
         }
         do {
-            let resolved = try loadModelAdmissionConfig(
+            let resolved = try loadModelAdmissionStatusConfig(
                 config: config,
                 coordinatorURL: coordinatorURL,
                 providerID: providerID
@@ -259,9 +291,10 @@ struct ModelsAdmissionStatusCommand: AsyncParsableCommand {
             let environment = BYOMDiscoveryEnvironment.production(
                 namespacePath: localDiscoveryNamespacePath,
                 mlxCacheDir: mlxCacheDir,
-                ollamaOrigin: skipOllama ? nil : ollamaOrigin
+                ollamaOrigin: skipOllama ? nil : ollamaOrigin,
+                openAICompatibleOrigin: skipOpenaiCompatible ? nil : openaiCompatibleOrigin
             )
-            let client = try BYOMModelAdmissionClient(coordinatorURL: resolved.coordinatorURL)
+            let client = try resolved.coordinatorURL.map { try BYOMModelAdmissionClient(coordinatorURL: $0) }
             let runtime = BYOMModelAdmissionRuntime(
                 environment: environment,
                 credentialStore: ProviderCredentialStoreFactory.providerStore(for: resolved.config),
@@ -316,6 +349,12 @@ struct ModelsAdmissionWithdrawCommand: AsyncParsableCommand {
     @Flag(help: "Skip the Ollama-compatible loopback adapter during candidate lookup.")
     var skipOllama = false
 
+    @Option(help: "Operator-supplied OpenAI-compatible loopback origin to query. Must be http://127.0.0.0/8:<port> or http://[::1]:<port>. There is no default: the adapter is not attempted unless this is set.")
+    var openaiCompatibleOrigin: String?
+
+    @Flag(help: "Skip the OpenAI-compatible loopback adapter during candidate lookup.")
+    var skipOpenaiCompatible = false
+
     func run() async throws {
         guard emitJSON else {
             writeStderr("models admission withdraw is JSON-only in this release; pass --json")
@@ -334,7 +373,8 @@ struct ModelsAdmissionWithdrawCommand: AsyncParsableCommand {
             let environment = BYOMDiscoveryEnvironment.production(
                 namespacePath: localDiscoveryNamespacePath,
                 mlxCacheDir: mlxCacheDir,
-                ollamaOrigin: skipOllama ? nil : ollamaOrigin
+                ollamaOrigin: skipOllama ? nil : ollamaOrigin,
+                openAICompatibleOrigin: skipOpenaiCompatible ? nil : openaiCompatibleOrigin
             )
             let client = try BYOMModelAdmissionClient(coordinatorURL: resolved.coordinatorURL)
             let runtime = BYOMModelAdmissionRuntime(
@@ -398,6 +438,12 @@ struct ModelsCatalogEconomicsCommand: AsyncParsableCommand {
     @Flag(help: "Skip the Ollama-compatible loopback adapter during candidate lookup.")
     var skipOllama = false
 
+    @Option(help: "Operator-supplied OpenAI-compatible loopback origin to query. Must be http://127.0.0.0/8:<port> or http://[::1]:<port>. There is no default: the adapter is not attempted unless this is set.")
+    var openaiCompatibleOrigin: String?
+
+    @Flag(help: "Skip the OpenAI-compatible loopback adapter during candidate lookup.")
+    var skipOpenaiCompatible = false
+
     func run() async throws {
         guard emitJSON else {
             writeStderr("models catalog-economics is JSON-only in this release; pass --json")
@@ -414,7 +460,8 @@ struct ModelsCatalogEconomicsCommand: AsyncParsableCommand {
         let environment = BYOMDiscoveryEnvironment.production(
             namespacePath: localDiscoveryNamespacePath,
             mlxCacheDir: mlxCacheDir,
-            ollamaOrigin: skipOllama ? nil : ollamaOrigin
+            ollamaOrigin: skipOllama ? nil : ollamaOrigin,
+            openAICompatibleOrigin: skipOpenaiCompatible ? nil : openaiCompatibleOrigin
         )
         let discovery = await BYOMDiscoveryRunner(environment: environment).discover()
         let inputs = await AutotuneStaticInputs().loadRecommendationInputs()
@@ -495,6 +542,37 @@ struct ModelsCatalogEconomicsCommand: AsyncParsableCommand {
         resolved.coordinatorURL = coordinatorURL
         return (resolved, coordinatorURL, providerID)
     }
+}
+
+/// Status is the one admission command that is meaningful without a coordinator:
+/// SPEC-046-R003's local ladder reports `not_offered` under
+/// `admission_state_source: local_default` when coordinator state "is unavailable
+/// or has not been queried". Offer submission and withdrawal mutate coordinator
+/// state and keep requiring a coordinator URL through `loadModelAdmissionConfig`.
+private func loadModelAdmissionStatusConfig(
+    config: String?,
+    coordinatorURL: String?,
+    providerID: String?
+) throws -> (config: AppConfig, coordinatorURL: String?, providerID: String) {
+    var resolved = try ConfigLoader.load(cli: CLIOverrides(
+        coordinatorURL: coordinatorURL,
+        providerID: providerID,
+        configPath: config
+    ))
+    guard let providerID = resolved.providerID?.trimmingCharacters(in: .whitespacesAndNewlines),
+          !providerID.isEmpty else {
+        throw BYOMModelAdmissionError.missingProviderID
+    }
+    let trimmedCoordinatorURL = resolved.coordinatorURL?
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+        .nonEmpty
+    resolved.providerID = providerID
+    resolved.coordinatorURL = trimmedCoordinatorURL
+    return (resolved, trimmedCoordinatorURL, providerID)
+}
+
+private extension String {
+    var nonEmpty: String? { isEmpty ? nil : self }
 }
 
 private func loadModelAdmissionConfig(

--- a/phase3-binary/Tests/macprovider-cliTests/BYOMAdmissionTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/BYOMAdmissionTests.swift
@@ -662,8 +662,10 @@ final class BYOMAdmissionTests: XCTestCase {
 
     // #1248 old-client compatibility: a current CLI pointed at a pre-BYOM
     // coordinator (no SPEC-047 admission endpoints -> 404/405, or an unknown
-    // response schema) must fail closed and never fabricate a coordinator
-    // admission state. The provider stays on local_default inventory state.
+    // response schema) must never fabricate a COORDINATOR admission state. The
+    // transport still refuses to produce one; the provider is answered from the
+    // SPEC-046-R003 local ladder instead (local_default `not_offered`), which is
+    // what that ladder means by "coordinator state is unavailable".
     func testAdmissionStatusAgainstPreBYOMCoordinatorFailsClosedWithoutFabricatingState() async throws {
         for status in [404, 405] {
             let session = makeBYOMAdmissionSession { _ in
@@ -678,6 +680,33 @@ final class BYOMAdmissionTests: XCTestCase {
                 XCTAssertTrue(error.description.contains("local_default"))
                 XCTAssertTrue(error.description.contains("wait_for_coordinator"))
             }
+
+            let runtime = try makeLocalLadderRuntime(
+                name: "byom-admission-prebyom-\(status)",
+                client: BYOMModelAdmissionClient(
+                    baseURL: URL(string: "https://coordinator.test")!,
+                    session: makeBYOMAdmissionSession { _ in
+                        BYOMAdmissionMockHTTPResponse(statusCode: status, body: "not found")
+                    }
+                )
+            )
+            let document = try await runtime.status(
+                providerID: "provider-byom-a",
+                target: "mlx-community/Tiny-1B-4bit"
+            )
+            XCTAssertEqual(document.schema, "model_admission_status.v1")
+            XCTAssertEqual(document.admissionStateSource, "local_default")
+            XCTAssertNotEqual(document.admissionStateSource, "coordinator")
+            XCTAssertEqual(document.admissionState, "not_offered")
+            XCTAssertNil(document.coordinatorEventID)
+            XCTAssertNil(document.stateObservedAt)
+            XCTAssertEqual(document.allowedNextStates, [])
+            XCTAssertTrue(document.warnings.contains("coordinator_state_unavailable"))
+            XCTAssertEqual(document.providerGuidance.transitionReasonCode, "coordinator_state_unavailable")
+            // Action-neutral with the `offerable` row it came from: this fixture
+            // candidate is unevaluated, so both rows say evaluate first.
+            XCTAssertEqual(document.providerGuidance.nextAction, "evaluate")
+            XCTAssertEqual(document.providerGuidance.earningPathClass, "local_inventory_only")
         }
 
         // An older coordinator that answers 200 with a schema this release does
@@ -695,6 +724,242 @@ final class BYOMAdmissionTests: XCTestCase {
         } catch let error as BYOMModelAdmissionError {
             XCTAssertEqual(error, .invalidStatusSchema)
         }
+
+        // A coordinator that answered with a decodable-but-wrong document is a
+        // contract fault, not an unavailable coordinator: it must NOT be
+        // relabelled as the local ladder's `not_offered`.
+        let schemaFaultRuntime = try makeLocalLadderRuntime(
+            name: "byom-admission-schema-fault",
+            client: BYOMModelAdmissionClient(
+                baseURL: URL(string: "https://coordinator.test")!,
+                session: makeBYOMAdmissionSession { _ in
+                    BYOMAdmissionMockHTTPResponse(
+                        statusCode: 200,
+                        body: #"{"schema":"models_browse.v1","rows":[]}"#
+                    )
+                }
+            )
+        )
+        do {
+            _ = try await schemaFaultRuntime.status(
+                providerID: "provider-byom-a",
+                target: "mlx-community/Tiny-1B-4bit"
+            )
+            XCTFail("an unknown coordinator schema became a local ladder state")
+        } catch let error as BYOMModelAdmissionError {
+            XCTAssertEqual(error, .invalidStatusSchema)
+        }
+    }
+
+    // SPEC-046-R003 local ladder, trigger (a): no coordinator is configured at
+    // all. The CLI must answer from local inventory and must not open a
+    // connection to anything while doing it.
+    func testAdmissionStatusWithoutConfiguredCoordinatorReportsLocalDefaultNotOffered() async throws {
+        let probes = BYOMAdmissionRequestRecorder()
+        let runtime = try makeLocalLadderRuntime(
+            name: "byom-admission-no-coordinator",
+            client: nil,
+            httpClient: BYOMAdmissionRecordingDiscoveryHTTPClient(recorder: probes)
+        )
+
+        let document = try await runtime.status(
+            providerID: "provider-byom-a",
+            target: "mlx-community/Tiny-1B-4bit"
+        )
+
+        XCTAssertEqual(document.schema, "model_admission_status.v1")
+        XCTAssertEqual(document.admissionStateSource, "local_default")
+        XCTAssertEqual(document.admissionState, "not_offered")
+        XCTAssertEqual(document.providerID, "provider-byom-a")
+        XCTAssertEqual(document.servedModelRef, "mlx-community/Tiny-1B-4bit")
+        XCTAssertNil(document.coordinatorEventID)
+        XCTAssertNil(document.stateObservedAt)
+        XCTAssertEqual(document.allowedNextStates, [])
+        XCTAssertEqual(document.providerGuidance.stateLabelKey, "byom.local.not_offered")
+        XCTAssertEqual(document.providerGuidance.transitionReasonCode, "coordinator_state_unavailable")
+        XCTAssertEqual(document.providerGuidance.earningPathClass, "local_inventory_only")
+        XCTAssertTrue(document.warnings.contains("coordinator_state_unavailable"))
+        XCTAssertEqual(probes.count, 0, "the unconfigured-coordinator path made a request")
+
+        // The ladder's `not_offered` row is action-neutral with the `offerable`
+        // row it came from: the unevaluated fixture candidate is sent to
+        // evaluation first, and a candidate with nothing outstanding is sent to
+        // the offer dry run. Both are the offerable row's own choice.
+        XCTAssertEqual(document.providerGuidance.nextAction, "evaluate")
+        XCTAssertEqual(
+            BYOMDiscoveryGuidance.localNotOfferedGuidance(warnings: []).nextAction,
+            "offer_dry_run"
+        )
+        XCTAssertEqual(
+            BYOMDiscoveryGuidance.localNotOfferedGuidance(warnings: ["evaluation_required"]).nextAction,
+            BYOMDiscoveryGuidance.guidance(
+                forAdmissionState: "offerable",
+                warnings: ["evaluation_required"]
+            ).nextAction
+        )
+    }
+
+    // Trigger (b), transport half: the coordinator is configured but refuses the
+    // connection. Same ladder row, and exactly the one attempted request.
+    func testAdmissionStatusWithUnreachableCoordinatorReportsLocalDefaultNotOffered() async throws {
+        let attempts = BYOMAdmissionRequestRecorder()
+        let session = makeBYOMAdmissionSession { request in
+            _ = attempts.record(request)
+            throw URLError(.cannotConnectToHost)
+        }
+        let runtime = try makeLocalLadderRuntime(
+            name: "byom-admission-unreachable",
+            client: BYOMModelAdmissionClient(
+                baseURL: URL(string: "https://coordinator.test")!,
+                session: session
+            )
+        )
+
+        let document = try await runtime.status(
+            providerID: "provider-byom-a",
+            target: "mlx-community/Tiny-1B-4bit"
+        )
+
+        XCTAssertEqual(document.admissionStateSource, "local_default")
+        XCTAssertEqual(document.admissionState, "not_offered")
+        XCTAssertTrue(document.warnings.contains("coordinator_state_unavailable"))
+        XCTAssertEqual(document.providerGuidance.transitionReasonCode, "coordinator_state_unavailable")
+        XCTAssertEqual(attempts.count, 1, "the unreachable-coordinator path did not make exactly one request")
+    }
+
+    // Auth faults are the provider's to fix and must stay errors: a 401/403 must
+    // never be laundered into "no offer is known for this candidate".
+    func testAdmissionStatusKeepsAuthenticationFailuresAsErrors() async throws {
+        for status in [401, 403] {
+            let runtime = try makeLocalLadderRuntime(
+                name: "byom-admission-auth-\(status)",
+                client: BYOMModelAdmissionClient(
+                    baseURL: URL(string: "https://coordinator.test")!,
+                    session: makeBYOMAdmissionSession { _ in
+                        BYOMAdmissionMockHTTPResponse(statusCode: status, body: "denied")
+                    }
+                )
+            )
+            do {
+                _ = try await runtime.status(
+                    providerID: "provider-byom-a",
+                    target: "mlx-community/Tiny-1B-4bit"
+                )
+                XCTFail("HTTP \(status) became a local ladder state")
+            } catch let error as BYOMModelAdmissionError {
+                XCTAssertEqual(error, .httpStatus(status))
+            }
+        }
+    }
+
+    // #1448 disablement mapping is unchanged: 503 stays an error whose guidance
+    // is wait_for_coordinator, not a relabelled local state.
+    func testAdmissionStatusKeepsUnavailableCoordinatorMappingFor503() async throws {
+        let runtime = try makeLocalLadderRuntime(
+            name: "byom-admission-503",
+            client: BYOMModelAdmissionClient(
+                baseURL: URL(string: "https://coordinator.test")!,
+                session: makeBYOMAdmissionSession { _ in
+                    BYOMAdmissionMockHTTPResponse(
+                        statusCode: 503,
+                        body: #"{"error":{"code":"submissions_disabled"}}"#
+                    )
+                }
+            )
+        )
+        do {
+            _ = try await runtime.status(
+                providerID: "provider-byom-a",
+                target: "mlx-community/Tiny-1B-4bit"
+            )
+            XCTFail("HTTP 503 became a local ladder state")
+        } catch let error as BYOMModelAdmissionError {
+            XCTAssertEqual(error, .httpStatus(503))
+            XCTAssertTrue(error.description.contains("wait_for_coordinator"))
+            XCTAssertTrue(error.description.contains("unchanged"))
+        }
+    }
+
+    // A `local_only` candidate's blocker is local, so coordinator reachability
+    // does not move it: it keeps its own state and its own guidance.
+    func testAdmissionStatusKeepsLocalOnlyCandidateOnItsOwnLadderRow() async throws {
+        let root = try temporaryBYOMAdmissionDirectory("byom-admission-local-only")
+        let cache = root.appendingPathComponent("hf", isDirectory: true)
+        try createBYOMAdmissionMLXSnapshot(cacheRoot: cache, modelID: "mlx-community/Tiny-1B-4bit")
+        // No namespace file: the candidate id is unstable, which is a blocking
+        // local warning, so the ladder holds the candidate at local_only.
+        let runtime = BYOMModelAdmissionRuntime(
+            environment: BYOMDiscoveryEnvironment(
+                namespaceURL: root.appendingPathComponent("absent.namespace"),
+                mlxCacheRoot: cache,
+                ollamaOrigin: nil
+            ),
+            credentialStore: BYOMAdmissionCredentialStore(token: "provider-token-test"),
+            identityStore: BYOMAdmissionIdentityStore(identity: Curve25519.Signing.PrivateKey()),
+            client: nil,
+            httpClient: BYOMAdmissionDiscoveryHTTPClient()
+        )
+
+        let document = try await runtime.status(
+            providerID: "provider-byom-a",
+            target: "mlx-community/Tiny-1B-4bit"
+        )
+
+        XCTAssertEqual(document.admissionStateSource, "local_default")
+        XCTAssertEqual(document.admissionState, "local_only")
+        XCTAssertEqual(document.providerGuidance.stateLabelKey, "byom.local.local_only")
+        XCTAssertEqual(document.providerGuidance.nextAction, "fix_local_blocker")
+        XCTAssertEqual(document.providerGuidance.transitionReasonCode, "candidate_id_unstable")
+        XCTAssertTrue(document.warnings.contains("candidate_id_unstable"))
+        XCTAssertTrue(document.warnings.contains("coordinator_state_unavailable"))
+    }
+
+    // The local-default document is the same closed envelope as a coordinator
+    // one: it must survive the strict decoder, which requires the exact key set
+    // (nullable keys present as null) and rejects any unknown field.
+    func testLocalDefaultAdmissionStatusRoundTripsThroughTheStrictDecoder() async throws {
+        let runtime = try makeLocalLadderRuntime(name: "byom-admission-roundtrip", client: nil)
+        let document = try await runtime.status(
+            providerID: "provider-byom-a",
+            target: "mlx-community/Tiny-1B-4bit"
+        )
+
+        let encoded = try ModelSwitchingWireCodec.encode(document)
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(encoded.utf8)) as? [String: Any]
+        )
+        XCTAssertTrue(object["coordinator_event_id"] is NSNull)
+        XCTAssertTrue(object["state_observed_at"] is NSNull)
+
+        let decoded = try BYOMAdmissionStatusWire.decodeStrictStatus(
+            from: Data(encoded.utf8),
+            expectedProviderID: "provider-byom-a",
+            expectedCandidateID: document.candidateID
+        )
+        XCTAssertEqual(decoded, document)
+    }
+
+    private func makeLocalLadderRuntime(
+        name: String,
+        client: BYOMModelAdmissionClient?,
+        httpClient: any BYOMDiscoveryHTTPClient = BYOMAdmissionDiscoveryHTTPClient()
+    ) throws -> BYOMModelAdmissionRuntime {
+        let root = try temporaryBYOMAdmissionDirectory(name)
+        let namespace = root.appendingPathComponent("ns")
+        let cache = root.appendingPathComponent("hf", isDirectory: true)
+        try writeBYOMAdmissionNamespace(at: namespace)
+        try createBYOMAdmissionMLXSnapshot(cacheRoot: cache, modelID: "mlx-community/Tiny-1B-4bit")
+        return BYOMModelAdmissionRuntime(
+            environment: BYOMDiscoveryEnvironment(
+                namespaceURL: namespace,
+                mlxCacheRoot: cache,
+                ollamaOrigin: nil
+            ),
+            credentialStore: BYOMAdmissionCredentialStore(token: "provider-token-test"),
+            identityStore: BYOMAdmissionIdentityStore(identity: Curve25519.Signing.PrivateKey()),
+            client: client,
+            httpClient: httpClient
+        )
     }
 
     // #1248 disablement matrix, "Offer submit" row, provider side: the
@@ -847,6 +1112,15 @@ private struct BYOMAdmissionIdentityStore: ProviderIdentityKeyStoring {
     func commitAdmissionIdentityRotation(providerId: String, expectedPublicKey: Data, previousValidUntil: Date?) throws -> Curve25519.Signing.PrivateKey { identity ?? Curve25519.Signing.PrivateKey() }
     func commitAdmissionIdentityRecovery(providerId: String, expectedPublicKey: Data) throws -> Curve25519.Signing.PrivateKey { identity ?? Curve25519.Signing.PrivateKey() }
     func cancelAdmissionIdentityRotation(providerId: String) throws {}
+}
+
+private struct BYOMAdmissionRecordingDiscoveryHTTPClient: BYOMDiscoveryHTTPClient {
+    let recorder: BYOMAdmissionRequestRecorder
+
+    func get(_ url: URL, maxHeaderBytes: Int, maxBodyBytes: Int) async throws -> BYOMHTTPResponse {
+        _ = recorder.record(URLRequest(url: url))
+        return BYOMHTTPResponse(statusCode: 200, headers: [], body: Data(#"{"models":[]}"#.utf8))
+    }
 }
 
 private struct BYOMAdmissionDiscoveryHTTPClient: BYOMDiscoveryHTTPClient {

--- a/phase3-binary/Tests/macprovider-cliTests/BYOMDiscoveryTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/BYOMDiscoveryTests.swift
@@ -1000,6 +1000,351 @@ final class BYOMDiscoveryTests: XCTestCase {
         XCTAssertEqual(before, after)
     }
 
+    // MARK: - openai_compatible_loopback adapter (SPEC-046-R002/R003/R004)
+
+    // SPEC-046-R003: an OpenAI-compatible endpoint reports only a model id, so
+    // every candidate it yields is an opaque endpoint — no catalog key, no size,
+    // no capability claim, and local inventory state only.
+    func testOpenAICompatibleAdapterEmitsOpaqueEndpointCandidate() async throws {
+        let root = try temporaryDirectory("byom-openai-opaque")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let namespace = try seededNamespace(in: root)
+
+        let client = RecordingBYOMHTTPClient(response: BYOMHTTPResponse(
+            statusCode: 200,
+            headers: [("content-type", "application/json")],
+            body: Data(#"{"object":"list","data":[{"id":"opaque-mini-1b","object":"model"}]}"#.utf8)
+        ))
+        let document = await BYOMDiscoveryRunner(
+            environment: BYOMDiscoveryEnvironment(
+                namespaceURL: namespace,
+                mlxCacheRoot: root.appendingPathComponent("hf", isDirectory: true),
+                ollamaOrigin: nil,
+                openAICompatibleOrigin: "http://127.0.0.1:39311"
+            ),
+            httpClient: client
+        ).discover()
+
+        XCTAssertEqual(client.requestLog, ["GET http://127.0.0.1:39311/v1/models"])
+        let adapter = try XCTUnwrap(document.adapters.first { $0.runtimeSource == "openai_compatible_loopback" })
+        XCTAssertEqual(adapter.status, "ok")
+        XCTAssertEqual(adapter.originClass, "loopback_http")
+        XCTAssertEqual(adapter.warningCodes, [])
+
+        let candidate = try XCTUnwrap(document.candidates.first { $0.runtimeSource == "openai_compatible_loopback" })
+        XCTAssertTrue(candidate.candidateID.hasPrefix("byom_"))
+        XCTAssertFalse(candidate.candidateID.hasPrefix("byom_unstable_"))
+        XCTAssertEqual(candidate.servedModelRef, "openai_compatible:opaque-mini-1b")
+        XCTAssertEqual(candidate.displayName, "opaque-mini-1b")
+        XCTAssertNil(candidate.catalogModelKey)
+        XCTAssertEqual(candidate.identityState, "opaque_endpoint")
+        XCTAssertEqual(candidate.locality, "opaque_local_endpoint")
+        XCTAssertNil(candidate.estimatedGB)
+        XCTAssertNil(candidate.contextWindowTokens)
+        XCTAssertEqual(candidate.capabilities, .unknown)
+        XCTAssertEqual(candidate.readinessState, "ready")
+        XCTAssertEqual(candidate.fitState, "unknown")
+        XCTAssertEqual(candidate.evaluationState, "not_evaluated")
+        XCTAssertEqual(candidate.admissionState, "local_only")
+        XCTAssertEqual(candidate.admissionStateSource, "local_default")
+        XCTAssertEqual(candidate.providerGuidance.earningPathClass, "local_inventory_only")
+        XCTAssertEqual(candidate.providerGuidance.nextAction, "evaluate")
+        XCTAssertEqual(candidate.warningCodes, ["capability_unevaluated", "evaluation_required"])
+
+        // Every advisory capability stays null, never false (R004).
+        let encoded = try ModelSwitchingWireCodec.encode(document)
+        for field in ["chat_completions", "streaming", "tool_call_passthrough", "quantization", "family", "runtime_version"] {
+            XCTAssertTrue(encoded.contains("\"\(field)\":null"), "\(field) must be null, not false")
+        }
+    }
+
+    // #1246: both adapter parsers read the SAME shared inventory record bound,
+    // so neither can drift. This mirrors
+    // `testOllamaRedactionDoesNotInspectPastExistingRecordBound` exactly: a
+    // record that would be withheld sits beyond the cap and is therefore never
+    // inspected, so no `model_reference_redacted` warning is raised for it.
+    func testOpenAICompatibleRedactionDoesNotInspectPastSharedRecordBound() async throws {
+        let bound = BYOMDiscoveryHTTPBounds.maxInventoryRecords
+        for withheldFirst in [false, true] {
+            let root = try temporaryDirectory("byom-openai-bound")
+            defer { try? FileManager.default.removeItem(at: root) }
+            let namespace = try seededNamespace(in: root)
+
+            let first = withheldFirst ? "/Users/private/model" : "opaque-mini-1b"
+            let last = withheldFirst ? "opaque-mini-1b" : "/Users/private/model"
+            let records = Array(repeating: ["id": first, "object": "model"], count: bound)
+                + [["id": last, "object": "model"]]
+            let body = try JSONSerialization.data(withJSONObject: ["object": "list", "data": records])
+
+            let document = await BYOMDiscoveryRunner(
+                environment: BYOMDiscoveryEnvironment(
+                    namespaceURL: namespace,
+                    mlxCacheRoot: root.appendingPathComponent("hf", isDirectory: true),
+                    ollamaOrigin: nil,
+                    openAICompatibleOrigin: "http://127.0.0.1:39311"
+                ),
+                httpClient: StubBYOMHTTPClient(response: BYOMHTTPResponse(
+                    statusCode: 200,
+                    headers: [("content-type", "application/json")],
+                    body: body
+                ))
+            ).discover()
+
+            let adapter = try XCTUnwrap(document.adapters.first { $0.runtimeSource == "openai_compatible_loopback" })
+            let candidates = document.candidates.filter { $0.runtimeSource == "openai_compatible_loopback" }
+            XCTAssertEqual(adapter.status, "ok")
+            XCTAssertEqual(candidates.count, withheldFirst ? 0 : bound)
+            XCTAssertEqual(adapter.warningCodes, withheldFirst ? ["model_reference_redacted"] : [])
+            XCTAssertFalse(try ModelSwitchingWireCodec.encode(document).contains("private"))
+        }
+    }
+
+    // SPEC-046-R002: this adapter has no well-known default. Without an
+    // operator-supplied origin nothing is dispatched and the adapter
+    // contributes no row at all, matching the Ollama adapter's skip behaviour.
+    // An absent row already means "not attempted", so the no-flag projection is
+    // unchanged for existing consumers and no new status value reaches the wire.
+    func testOpenAICompatibleAdapterIsNotAttemptedWithoutOperatorOrigin() async throws {
+        let root = try temporaryDirectory("byom-openai-absent")
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        // No `--openai-compatible-origin` default is shipped.
+        XCTAssertNil(try ModelsDiscoverCommand.parse(["--json"]).openaiCompatibleOrigin)
+        // The legacy catalog commands stay outside this taxonomy (SPEC-046-R001).
+        XCTAssertThrowsError(try ModelsListCommand.parse(["--json", "--openai-compatible-origin", "http://127.0.0.1:1"]))
+
+        let client = RecordingBYOMHTTPClient()
+        let document = await BYOMDiscoveryRunner(
+            environment: BYOMDiscoveryEnvironment(
+                namespaceURL: root.appendingPathComponent("ns"),
+                mlxCacheRoot: root.appendingPathComponent("hf", isDirectory: true),
+                ollamaOrigin: nil
+            ),
+            httpClient: client
+        ).discover()
+
+        XCTAssertEqual(client.requestLog, [])
+        XCTAssertNil(document.adapters.first { $0.runtimeSource == "openai_compatible_loopback" })
+        XCTAssertTrue(document.candidates.allSatisfy { $0.runtimeSource != "openai_compatible_loopback" })
+        // Same shape the Ollama adapter already had when it is not attempted.
+        XCTAssertNil(document.adapters.first { $0.runtimeSource == "ollama_loopback" })
+        // Every emitted adapter status stays inside the existing vocabulary.
+        for adapter in document.adapters {
+            XCTAssertTrue(
+                ["ok", "unavailable", "timeout", "malformed", "truncated", "rejected"].contains(adapter.status),
+                "unexpected adapter status \(adapter.status)"
+            )
+        }
+    }
+
+    // SPEC-046-R002/R007: a non-loopback origin is rejected by the shared
+    // validator before any request is dispatched, and the rejected endpoint is
+    // never echoed into stdout JSON or stderr diagnostics.
+    func testOpenAICompatibleAdapterRejectsNonLoopbackOriginBeforeDispatch() async throws {
+        let root = try temporaryDirectory("byom-openai-reject")
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        for origin in ["http://0.0.0.0:39311", "http://192.168.1.10:39311", "http://localhost:39311", "https://127.0.0.1:39311"] {
+            let client = RecordingBYOMHTTPClient()
+            let document = await BYOMDiscoveryRunner(
+                environment: BYOMDiscoveryEnvironment(
+                    namespaceURL: root.appendingPathComponent("ns"),
+                    mlxCacheRoot: root.appendingPathComponent("hf", isDirectory: true),
+                    ollamaOrigin: nil,
+                    openAICompatibleOrigin: origin
+                ),
+                httpClient: client
+            ).discover()
+
+            XCTAssertEqual(client.requestLog, [], "dispatched a request for \(origin)")
+            let adapter = try XCTUnwrap(document.adapters.first { $0.runtimeSource == "openai_compatible_loopback" })
+            XCTAssertEqual(adapter.status, "rejected")
+            XCTAssertEqual(adapter.originClass, "rejected")
+            XCTAssertEqual(adapter.warningCodes, ["adapter_rejected_non_loopback"])
+            XCTAssertTrue(document.candidates.isEmpty)
+            let encoded = try ModelSwitchingWireCodec.encode(document)
+            XCTAssertFalse(encoded.contains(origin), "rejection leaked \(origin)")
+        }
+    }
+
+    // SPEC-046-R002: every adapter failure class maps to a closed warning code
+    // and produces no candidate and no partial trust claim.
+    func testOpenAICompatibleAdapterFailureClassesMapToClosedWarningCodes() async throws {
+        let root = try temporaryDirectory("byom-openai-failures")
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let oversized = Data(repeating: 0x20, count: BYOMDiscoveryHTTPBounds.maxBodyBytes + 1)
+        let cases: [(client: StubBYOMHTTPClient, status: String, warning: String)] = [
+            (StubBYOMHTTPClient(response: BYOMHTTPResponse(statusCode: 503, headers: [], body: Data())), "unavailable", "adapter_unavailable"),
+            (StubBYOMHTTPClient(error: URLError(.timedOut)), "timeout", "adapter_timeout"),
+            (StubBYOMHTTPClient(response: BYOMHTTPResponse(
+                statusCode: 200,
+                headers: [("content-type", "application/json")],
+                body: Data(#"{"data":"not-an-array"}"#.utf8)
+            )), "malformed", "adapter_malformed_response"),
+            (StubBYOMHTTPClient(response: BYOMHTTPResponse(statusCode: 200, headers: [], body: oversized)), "truncated", "adapter_response_truncated"),
+        ]
+
+        for testCase in cases {
+            let document = await BYOMDiscoveryRunner(
+                environment: BYOMDiscoveryEnvironment(
+                    namespaceURL: root.appendingPathComponent("ns"),
+                    mlxCacheRoot: root.appendingPathComponent("hf", isDirectory: true),
+                    ollamaOrigin: nil,
+                    openAICompatibleOrigin: "http://127.0.0.1:39311"
+                ),
+                httpClient: testCase.client
+            ).discover()
+
+            let adapter = try XCTUnwrap(document.adapters.first { $0.runtimeSource == "openai_compatible_loopback" })
+            XCTAssertEqual(adapter.status, testCase.status)
+            XCTAssertEqual(adapter.warningCodes, [testCase.warning])
+            XCTAssertTrue(document.candidates.isEmpty, "\(testCase.warning) fabricated a candidate")
+            XCTAssertTrue(document.warnings.contains(testCase.warning))
+        }
+    }
+
+    // SPEC-046-R007: an unsafe model id is withheld entirely — no placeholder
+    // candidate, no synthesized identity — and only the fixed provenance code is
+    // retained. A safe sibling in the same inventory stays visible.
+    func testOpenAICompatibleUnsafeModelIDsAreWithheldWithoutPlaceholder() async throws {
+        let root = try temporaryDirectory("byom-openai-redaction")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let namespace = try seededNamespace(in: root)
+
+        let unsafeIDs = [
+            "coordinator.malibu.tech:443",
+            "hf.co/library/x",
+            "sk-live-abcdefghijklmnopqrstuvwxyz",
+            "http://127.0.0.1:9/models",
+            "127.0.0.1:11434",
+        ]
+        let body = #"{"data":["# + (unsafeIDs + ["safe-mini-1b"])
+            .map { #"{"id":"\#($0)"}"# }
+            .joined(separator: ",") + "]}"
+
+        let document = await BYOMDiscoveryRunner(
+            environment: BYOMDiscoveryEnvironment(
+                namespaceURL: namespace,
+                mlxCacheRoot: root.appendingPathComponent("hf", isDirectory: true),
+                ollamaOrigin: nil,
+                openAICompatibleOrigin: "http://127.0.0.1:39311"
+            ),
+            httpClient: StubBYOMHTTPClient(response: BYOMHTTPResponse(
+                statusCode: 200,
+                headers: [("content-type", "application/json")],
+                body: Data(body.utf8)
+            ))
+        ).discover()
+
+        let adapter = try XCTUnwrap(document.adapters.first { $0.runtimeSource == "openai_compatible_loopback" })
+        XCTAssertEqual(adapter.status, "ok")
+        XCTAssertEqual(adapter.warningCodes, ["model_reference_redacted"])
+        XCTAssertTrue(document.warnings.contains("model_reference_redacted"))
+        let candidates = document.candidates.filter { $0.runtimeSource == "openai_compatible_loopback" }
+        XCTAssertEqual(candidates.map(\.servedModelRef), ["openai_compatible:safe-mini-1b"])
+        let encoded = try ModelSwitchingWireCodec.encode(document)
+        for unsafeID in unsafeIDs {
+            XCTAssertFalse(encoded.contains(unsafeID), "withheld id leaked: \(unsafeID)")
+        }
+    }
+
+    // SPEC-046-R002 "bounded JSON nesting/parser work": the shared strict parser
+    // turns a pathologically nested but under-cap body into the closed
+    // malformed code rather than a stack overflow.
+    func testOpenAICompatibleParserBoundsRejectPathologicalNesting() throws {
+        let depth = 20_000
+        let nested = Data((
+            #"{"data":["# + String(repeating: "[", count: depth)
+                + String(repeating: "]", count: depth) + "]}"
+        ).utf8)
+        XCTAssertLessThan(nested.count, BYOMDiscoveryHTTPBounds.maxBodyBytes)
+        for hostile in [nested, Data(String(repeating: "{", count: 50_000).utf8)] {
+            XCTAssertThrowsError(try BYOMDiscoveryJSON.parseOpenAIModels(hostile)) { error in
+                guard case BYOMDiscoveryAdapterError.malformed = error else {
+                    return XCTFail("expected malformed, got \(error)")
+                }
+            }
+        }
+        // A wrong-typed id is a malformed response, not a privacy redaction.
+        XCTAssertThrowsError(try BYOMDiscoveryJSON.parseOpenAIModels(Data(#"{"data":[{"id":7}]}"#.utf8)))
+    }
+
+    // SPEC-046-R003: the candidate id is the namespace-scoped HMAC over
+    // `runtime_source || 0x00 || normalized served_model_ref`, so it is stable
+    // across runs and never collides with another adapter's id for the same
+    // model name.
+    func testOpenAICompatibleCandidateIDIsStableAndScopedByRuntimeSource() throws {
+        let namespace = Data(repeating: 0x5b, count: 32)
+        let (first, firstWarnings) = BYOMCandidateIdentity.candidateID(
+            namespace: namespace,
+            runtimeSource: "openai_compatible_loopback",
+            servedModelRef: "openai_compatible:opaque-mini-1b"
+        )
+        let (second, _) = BYOMCandidateIdentity.candidateID(
+            namespace: namespace,
+            runtimeSource: "openai_compatible_loopback",
+            servedModelRef: "openai_compatible:Opaque-Mini-1B"
+        )
+        let (ollama, _) = BYOMCandidateIdentity.candidateID(
+            namespace: namespace,
+            runtimeSource: "ollama_loopback",
+            servedModelRef: "openai_compatible:opaque-mini-1b"
+        )
+        XCTAssertEqual(firstWarnings, [])
+        XCTAssertEqual(first, second)
+        XCTAssertNotEqual(first, ollama)
+        XCTAssertNotNil(first.range(of: #"^byom_[a-z2-7]{52}$"#, options: .regularExpression))
+    }
+
+    // SPEC-046-R003 / SPEC-047: an opaque endpoint has no artifact hash and no
+    // catalog key, so the dry-run must not claim a catalog earning path and must
+    // not predict a submittable offer.
+    func testOpenAICompatibleOfferDryRunClaimsNoCatalogPath() async throws {
+        let root = try temporaryDirectory("byom-openai-dryrun")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let namespace = try seededNamespace(in: root)
+
+        let document = await BYOMOfferDryRunRunner(
+            target: "openai_compatible:opaque-mini-1b",
+            environment: BYOMDiscoveryEnvironment(
+                namespaceURL: namespace,
+                mlxCacheRoot: root.appendingPathComponent("hf", isDirectory: true),
+                ollamaOrigin: nil,
+                openAICompatibleOrigin: "http://127.0.0.1:39311"
+            ),
+            httpClient: StubBYOMHTTPClient(response: BYOMHTTPResponse(
+                statusCode: 200,
+                headers: [("content-type", "application/json")],
+                body: Data(#"{"data":[{"id":"opaque-mini-1b"}]}"#.utf8)
+            ))
+        ).dryRun()
+
+        XCTAssertEqual(document.servedModelRef, "openai_compatible:opaque-mini-1b")
+        XCTAssertNil(document.catalogModelKey)
+        XCTAssertFalse(document.wouldSubmit)
+        XCTAssertEqual(document.likelyAdmissionState, "local_only")
+        XCTAssertEqual(document.likelyAdmissionStateSource, "local_default")
+        XCTAssertEqual(document.reasonCode, "no_trusted_catalog_match")
+        XCTAssertEqual(document.providerGuidance.earningPathClass, "local_inventory_only")
+        XCTAssertNotEqual(
+            document.providerGuidance.stateMeaningKey,
+            "byom.offer_dry_run.catalog_path_missing_trusted_binding"
+        )
+    }
+
+    /// 0700 directory holding an 0600 32-byte salt, so discovery reports stable
+    /// `byom_` ids instead of `byom_unstable_` ones.
+    private func seededNamespace(in root: URL) throws -> URL {
+        let directory = root.appendingPathComponent("nsdir", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: directory.path)
+        let namespace = directory.appendingPathComponent("ns")
+        try Data(repeating: 0x5b, count: 32).write(to: namespace)
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: namespace.path)
+        return namespace
+    }
+
     private func createMLXSnapshot(
         cacheRoot: URL,
         modelID: String,

--- a/phase3-binary/Tests/macprovider-cliTests/BYOMEvaluationTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/BYOMEvaluationTests.swift
@@ -67,6 +67,62 @@ final class BYOMEvaluationTests: XCTestCase {
         XCTAssertEqual(runtime.requestPaths, ["/api/tags", "/v1/chat/completions"])
     }
 
+    // SPEC-046-R005/R006: an opaque `openai_compatible_loopback` candidate runs
+    // through the same bounded chat-completions harness as the Ollama adapter.
+    // The probe proves liveness only: the candidate stays local inventory, the
+    // mutation summary stays all-false, and no prompt/completion text or origin
+    // reaches stdout or stderr.
+    func testEvaluateOpaqueOpenAICompatibleCandidateStaysNonEarning() async throws {
+        let root = try temporaryBYOMEvaluationDirectory("byom-eval-opaque")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let namespace = root.appendingPathComponent("ns")
+        let cache = root.appendingPathComponent("hf", isDirectory: true)
+        let runtime = try BYOMEvaluationLoopbackRuntime(
+            tagsBody: #"{"models":[]}"#,
+            modelsBody: #"{"object":"list","data":[{"id":"opaque-mini-1b","object":"model"}]}"#,
+            chatStatusCode: 200,
+            chatBody: """
+            {"id":"chatcmpl-local","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":2,"total_tokens":12}}
+            """
+        )
+
+        let command = try ModelsEvaluateCommand.parse([
+            "openai_compatible:opaque-mini-1b",
+            "--json",
+            "--local-discovery-namespace-path", namespace.path,
+            "--mlx-cache-dir", cache.path,
+            "--skip-ollama",
+            "--openai-compatible-origin", runtime.origin,
+        ])
+        let capture = await captureBYOMEvaluationOutput {
+            try await command.run()
+        }
+
+        XCTAssertNil(capture.error)
+        let object = try jsonObject(capture.stdout)
+        XCTAssertEqual(object["runtime_source"] as? String, "openai_compatible_loopback")
+        XCTAssertEqual(object["served_model_ref"] as? String, "openai_compatible:opaque-mini-1b")
+        XCTAssertEqual(object["adapter_identity"] as? String, "openai_compatible_loopback")
+        XCTAssertEqual(object["health_result"] as? String, "passed")
+        XCTAssertEqual(object["completion_tokens"] as? Int, 2)
+        XCTAssertTrue(object["catalog_model_key"] is NSNull)
+        // Liveness is not offerability: an opaque endpoint never satisfies the
+        // offer preconditions, however healthy the probe was.
+        XCTAssertEqual(object["offer_preconditions_appear_satisfied"] as? Bool, false)
+        let mutations = try XCTUnwrap(object["mutation_summary"] as? [String: Any])
+        for field in ["production_config_mutated", "coordinator_state_mutated", "production_model_switched", "runtime_started", "downloads_started"] {
+            XCTAssertEqual(mutations[field] as? Bool, false, "\(field) must stay false")
+        }
+        let guidance = try XCTUnwrap(object["provider_guidance"] as? [String: Any])
+        XCTAssertEqual(guidance["earning_path_class"] as? String, "local_inventory_only")
+
+        let emitted = capture.stdout + capture.stderr
+        XCTAssertFalse(emitted.contains("MacProvider BYOM local evaluation health probe"))
+        XCTAssertFalse(emitted.contains("\"content\":\"ok\""))
+        XCTAssertFalse(emitted.contains(runtime.origin))
+        XCTAssertEqual(runtime.requestPaths, ["/v1/models", "/v1/chat/completions"])
+    }
+
     func testEvaluateMLXCandidateBlocksWithoutCacheMutation() async throws {
         let root = try temporaryBYOMEvaluationDirectory("byom-eval-mlx")
         let cache = root.appendingPathComponent("hf", isDirectory: true)
@@ -645,6 +701,7 @@ private final class BYOMEvaluationLoopbackRuntime {
     let origin: String
     private let socketFD: Int32
     private let tagsBody: Data
+    private let modelsBody: Data?
     private let chatStatusCode: Int
     private let chatHeaders: [(String, String)]
     private let chatBody: Data
@@ -657,11 +714,13 @@ private final class BYOMEvaluationLoopbackRuntime {
 
     init(
         tagsBody: String,
+        modelsBody: String? = nil,
         chatStatusCode: Int,
         chatHeaders: [(String, String)] = [],
         chatBody: String
     ) throws {
         self.tagsBody = Data(tagsBody.utf8)
+        self.modelsBody = modelsBody.map { Data($0.utf8) }
         self.chatStatusCode = chatStatusCode
         self.chatHeaders = chatHeaders
         self.chatBody = Data(chatBody.utf8)
@@ -724,6 +783,8 @@ private final class BYOMEvaluationLoopbackRuntime {
         record(path)
         if path == "/api/tags" {
             write(statusCode: 200, headers: [], body: tagsBody, to: client)
+        } else if path == "/v1/models", let modelsBody {
+            write(statusCode: 200, headers: [], body: modelsBody, to: client)
         } else {
             write(statusCode: chatStatusCode, headers: chatHeaders, body: chatBody, to: client)
         }


### PR DESCRIPTION
## Summary

BYOM v0.2 **slice 1a** (epic #1453) — the CLI half of slice 1, split from #1456 so each PR fits one authority boundary and the independent reviewer's size cap. Slice 1b (discovery-journey driver + evidence validation) stacks on this branch.

### `openai_compatible_loopback` discovery adapter (SPEC-046-R002/R003/R004/R007)
- `--openai-compatible-origin <loopback origin>` (and `--skip-openai-compatible`) on every `models` subcommand. No default origin: absent flag = adapter not attempted, no adapter row emitted, zero requests.
- `GET /v1/models` through the shared safety layer only: `BYOMLoopbackOriginValidator`, `BYOMDiscoveryHTTPBounds` (headers/body/shared `maxInventoryRecords`), bounded no-redirect no-proxy client, strict parser, `isSafeRuntimeModelReference`. The adapter adds no URL admission, redirect, redaction, or parser-bound logic (#1246 rule); the #1446 rejection matrix holds for the new flag.
- Opaque candidates: `identity_state: opaque_endpoint`, `locality: opaque_local_endpoint`, `catalog_model_key: null`, capabilities null (not false), `admission_state: local_only` / `local_default`, `earning_path_class: local_inventory_only`; unsafe model ids omitted via the shared guard; failures map to the closed warning codes. Opaque candidates cannot reach catalog match, offer submission, or any earning path by construction. Evaluation reuses the existing bounded chat-completions path.

### Local-default `not_offered` admission status (SPEC-046-R003 ladder; SPEC-047-R002 status schema)
`models admission status <candidate> --json` now emits `admission_state_source: local_default`, `admission_state: not_offered`, `allowed_next_states: []`, guidance with `transition_reason_code: coordinator_state_unavailable` (the R003 warning code that had no emitter), when the coordinator is unconfigured (zero requests) or unreachable / 404 / 405 (exactly one request). 401/403 and other statuses stay errors; the #1448 503 mapping is unchanged; `local_only` candidates unchanged; the source is never `coordinator`, so no coordinator state is fabricated. Nullable status keys are encoded as explicit `null` so the document round-trips the strict decoder. This is the state the discovery journey's step 10 requires and v0.1 could not produce.

### Rollback
Adapter row in `docs/runbooks/byom-disablement-rollback.md`: omit the flag or pass `--skip-openai-compatible`; no state. No wire change for existing adapters; `models list`/browse unchanged.

## Audit
Reviewed as part of the combined slice-1 diff: four codex rounds (records `audits/2026-09-09-byom-v02-slice1/`, landing with slice 1b), R4 0 CRITICAL / 0 HIGH with all MEDIUMs fixed; the adapter and status paths were marked clean by all three lanes from R2 onward. Independent review: `/code-review ultra` on this PR.

## Validation
`swift build`; `swift test --filter BYOM` (99), `--filter ModelsSubcommandTests` (44), `--filter ModelCatalogEconomicsTests` (8), all 0 failures; `make test-byom-e2e` passed on this branch alone. Full unfiltered `swift test` not run locally (documented MLX metallib local-env failure); CI runs it.

BYOM epic gates:
- Parent epic: #1453 (slice 1a)
- Slice issue: #1453
- Authority boundary: SPEC-046 provider-local discovery CLI
- SPEC requirements: SPEC-046-R002, SPEC-046-R003, SPEC-046-R004, SPEC-046-R007
- User-facing state/copy: local-default `not_offered` status document with existing closed guidance keys; opaque candidates labelled `local_inventory_only`; `models admission status` help text updated
- Machine schema: none new (all enums pre-existing in SPEC-046-R003 / SPEC-047-R002)
- Security/privacy: shared loopback/bounds/redaction layer only; origin never leaks
- Runtime/liveness: adapter absent = not attempted; unconfigured coordinator = zero requests
- Identity/economics/settlement provenance: opaque candidates null-catalog, local_only, non-submittable
- Evidence/tests: see Validation
- Rollout/rollback/compatibility: disablement row added; no wire change for existing adapters
- Explicitly deferred or not applicable: journey driver/evidence (slice 1b); LM Studio / llama.cpp adapters (v0.3)

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "issue": "https://github.com/Augustas11/macprovider/issues/1453",
  "specs": ["SPEC-046"],
  "requirements": ["SPEC-046-R002", "SPEC-046-R003", "SPEC-046-R004", "SPEC-046-R007"],
  "authority_domains": ["provider-byom-discovery"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "phase3-binary/Tests/macprovider-cliTests/BYOMDiscoveryTests.swift",
    "phase3-binary/Tests/macprovider-cliTests/BYOMAdmissionTests.swift",
    "phase3-binary/Tests/macprovider-cliTests/BYOMEvaluationTests.swift",
    "swift test --filter BYOM",
    "make test-byom-e2e"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
