### PR TITLE
feat(byom): v0.2 slice 1b — hermetic discovery-journey driver + typed capture validation (#1453)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -432,6 +432,14 @@ jobs:
         # check. Reuses the SwiftPM build warmed by the swift test step above.
         run: make test-byom-e2e
 
+      - name: Run BYOM discovery-journey driver and evidence pipeline (hermetic)
+        # #1453 slice 1: the ten-step JOURNEY-PROVIDER-BYOM-DISCOVERY driver plus
+        # capture -> build -> preflight. Gated here so a drift between the driver's
+        # manifest and the governance step/requirement/observation tables (or the
+        # fail-closed redaction scan) fails a required check instead of surfacing
+        # during an operator signing session. Reuses the SwiftPM build above.
+        run: make test-byom-discovery-journey
+
       - name: Install reviewed XcodeGen artifact
         shell: bash
         run: |

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 # targets below to preserve parallel jobs and failure isolation.
 
 .PHONY: test test-coordinator test-coordinator-integration test-gateway test-integration test-dist \
-        test-byom-e2e \
+        test-byom-e2e test-byom-discovery-journey \
         vet vet-coordinator vet-gateway \
         lint-coordinator \
         build-linux check check-exceptions fmt verify-autotune-catalog
@@ -20,6 +20,14 @@ test: test-coordinator test-gateway test-integration test-dist
 # BYOM-affecting provider CLI/app release. See test/e2e/byom/README.md.
 test-byom-e2e:
 	test/e2e/byom/run-cli-onboarding-e2e.py
+
+# Hermetic JOURNEY-PROVIDER-BYOM-DISCOVERY gate (#1453 slice 1). Runs the
+# ten-step discovery-journey driver, then feeds its run manifest through the
+# real evidence pipeline (capture -> build -> preflight): the pipeline is the
+# acceptance test for the driver. Signing stays an operator step and is not run
+# here. See docs/runbooks/byom-journey-evidence.md.
+test-byom-discovery-journey:
+	bash scripts/test-byom-discovery-journey.sh
 
 verify-autotune-catalog:
 	python3 scripts/catalog-release.py verify
@@ -65,6 +73,7 @@ test-dist:
 	PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v scripts.tests.test_upstream_watch
 	PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v scripts.tests.test_byom_contract_lock
 	PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v scripts.tests.test_byom_journey_evidence
+	PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v scripts.tests.test_discovery_journey_driver
 	node --test phase3-binary/app/Tests/MalibuTests/payout-signer-chain.test.mjs
 	bash scripts/test-production-exceptions.sh
 	bash scripts/test-coordinator-advertised-version-test.sh

--- a/audits/2026-09-09-byom-v02-slice1/AUDIT_BYOM_V02_SLICE1_PROMPT.md
+++ b/audits/2026-09-09-byom-v02-slice1/AUDIT_BYOM_V02_SLICE1_PROMPT.md
@@ -1,0 +1,27 @@
+# Audit — BYOM v0.2 slice 1: `openai_compatible_loopback` discovery adapter + hermetic discovery-journey driver (#1453)
+
+METHOD CONSTRAINT: first-party software-correctness review. Do NOT author adversarial payloads. Evaluate by reading source and running the EXISTING tests (`cd phase3-binary && swift test --filter BYOM`, `make test-byom-discovery-journey`, `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts.tests.test_discovery_journey_driver scripts.tests.test_byom_journey_evidence`). Describe gaps abstractly (field + condition).
+
+Review the COMPLETE diff `git diff origin/main...HEAD` on branch `feat/byom-v02-slice1-openai-compat-adapter`. Every file.
+
+## What the change does
+1. Adds the SPEC-046-R002 `openai_compatible_loopback` discovery adapter to the Swift CLI: operator-supplied loopback origin only (`--openai-compatible-origin`, no default), `GET /v1/models` through the SHARED safety layer (`BYOMLoopbackOriginValidator`, `BYOMDiscoveryHTTPBounds`, `BYOMURLSessionHTTPClient`, strict parser, `isSafeRuntimeModelReference`), producing candidates with `identity_state: opaque_endpoint`, `locality: opaque_local_endpoint`, `catalog_model_key: null`, null capabilities, a local non-earning admission state, and the closed warning codes. Evaluation reuses the existing chat-completions path.
+2. Adds `test/e2e/byom/run-discovery-journey.py`: a hermetic driver that executes all ten `JOURNEY-PROVIDER-BYOM-DISCOVERY` steps against loopback stubs and emits `run-manifest.json` (`macprovider.byom-journey-run.v1`) + captured CLI documents, wired as `make test-byom-discovery-journey` which also runs capture → build → preflight from `scripts/`.
+
+## Invariants to verify (challenge them)
+- Gate #1246: the adapter reimplements NO URL admission, redirect policy, redaction, parser bound, or timeout logic; every rejection/bound in the #1446 matrix holds for the new origin flag; the origin never appears in JSON, stderr, warnings, or captured documents.
+- SPEC-046-R003 closed schema: no new fields; every enum value used exists in the spec; `candidate_id` construction unchanged; opaque candidates cannot reach `catalog_model_key`, `catalog_matched`, or any earning path; provider_guidance is truthful and localization-safe.
+- Model ids from `/v1/models` are untrusted: host/IP/path/credential-shaped ids are redacted through the shared guard, never emitted raw; nesting/size bounds apply.
+- The absent flag means the adapter is not attempted (no default origin, no probing, no port scan).
+- Driver truthfulness: every manifest observation is set from the driver's OWN checks, not hardcoded; step assertions and captured documents contain no URL/absolute path/hostname/IP/localhost/credential (capture's scanner must pass on real output); mutation checks actually hash the fixture dirs; step-04 asserts the stub received zero requests; step-10 reaches `local_only`/`offerable`/`not_offered` through the CLI's real ladder.
+- The driver cannot be used to fabricate evidence: it does not accept overrides for observations or step statuses; failed steps fail the run.
+- CI wiring: the new target runs where `test-byom-e2e` runs; no path-detection gap.
+- Old-client compatibility: no wire/schema change for existing adapters; `models list`/browse unchanged.
+
+## Lanes to report (this pass is: {{LANE}})
+Report CRITICAL / HIGH / MEDIUM / LOW / INFO; merge bar 0 C / 0 H / 0 M.
+- code-reviewer: adapter correctness vs the Ollama adapter; envelope exactness; test adequacy (do tests assert the pre-conditions, not just happy paths?); driver correctness and manifest shape vs the golden fixture and `byom_journey_evidence.py` contract.
+- security-reviewer: SSRF/loopback escape via the new flag; redaction of endpoint/model ids; evidence-fabrication paths in the driver; secrets in stubs/fixtures.
+- architect: harness reuse vs duplication; whether the driver is the right seam for physical runs later; CI/Makefile placement; runbook accuracy.
+
+End with `VERDICT: <N> CRITICAL / <N> HIGH / <N> MEDIUM / <N> LOW / <N> INFO`. Cite file:line. Do not invent issues to fill a lane.

--- a/audits/2026-09-09-byom-v02-slice1/AUDIT_BYOM_V02_SLICE1_R1.md
+++ b/audits/2026-09-09-byom-v02-slice1/AUDIT_BYOM_V02_SLICE1_R1.md
@@ -1,0 +1,310 @@
+# AUDIT — BYOM v0.2 slice 1, round 1
+
+Branch: `feat/byom-v02-slice1-openai-compat-adapter`
+Diff under review: `git diff origin/main...HEAD` — commits `f0acf885`
+(`openai_compatible_loopback` discovery adapter) and `7cdc0b5b` (hermetic
+discovery-journey driver, wrapper, Makefile/CI wiring, tests, runbooks).
+Prompt: `audits/2026-09-09-byom-v02-slice1/AUDIT_BYOM_V02_SLICE1_PROMPT.md`
+Date: 2026-09-09
+
+## Verdicts (three lanes, R1)
+
+| Lane | Verdict | C | H | M | L | INFO |
+| --- | --- | --- | --- | --- | --- | --- |
+| code-reviewer | REQUEST CHANGES | 0 | 0 | 6 | 0 | 2 |
+| security-reviewer | BLOCK | 0 | 0 | 3 | 1 | — |
+| architect | BLOCK | 0 | 0 | 5 | 0 | 2 |
+
+All three lanes agreed on the same root shape: the Swift adapter composes the
+existing shared safety layer correctly and no SSRF/loopback escape or earning-path
+leak was found (all three lanes confirmed this explicitly), but the new evidence
+layer asserted several things it had not established.
+
+## Findings (deduplicated across lanes)
+
+The fourteen MEDIUM/LOW findings deduplicate to eight distinct defects. "Lanes"
+names every lane that raised it.
+
+### F1 — Captured documents deleted required schema fields before hashing
+
+Lanes: code-reviewer, security-reviewer (OWASP A08), architect.
+`redact_for_capture()` recursively removed `provider_guidance.state_label_key`
+and `state_meaning_key` from every captured document, then hashed the altered
+object under the original schema name. SPEC-046-R003 requires both fields in
+every `provider_guidance` object, so the digest the signed evidence binds to
+could not prove the CLI emitted them, nor that they were localization-safe. The
+runbook endorsed the lossy transform.
+
+**Resolution.** Captures are archived whole; the stripping is gone.
+
+- `scripts/byom_journey_evidence.py:119-135` — `GUIDANCE_OBJECT_KEY`,
+  `GUIDANCE_LOCALIZATION_KEY_FIELDS`, and the closed grammar
+  `LOCALIZATION_KEY_RE = ^byom\.[a-z0-9_]+(?:\.[a-z0-9_]+)+$`.
+- `scripts/byom_journey_evidence.py:359-364` —
+  `reject_unredacted_text_except_hostname()`: every rule (credential shapes,
+  URL, absolute path, home-relative path, IPv4, IPv6, localhost) minus the
+  shape-based DNS rule.
+- `scripts/byom_journey_evidence.py:378-387` —
+  `reject_unredacted_localization_key()`: the above, then the value must
+  `fullmatch` the grammar. Anything else fails closed.
+- `scripts/byom_journey_evidence.py:416-448` —
+  `assert_captured_document_redacted()` and `_walk_captured_document()`: the
+  field-scoped structural walk. The exemption applies only to those two field
+  names, only when the enclosing object is a `provider_guidance` dict, at any
+  depth (candidate rows, and top-level evaluation/dry-run/status/withdraw
+  documents). Every key, every other string value, and every other field of the
+  same guidance object keeps the full rule set.
+- `scripts/byom_journey_evidence.py:597-615` — `_digest_document()`
+  restructured: the DECODED structural walk is the authority for the hostname
+  rule (it is the only scan that can tell a localization key from a hostname,
+  and JSON escapes are already decoded when it runs); the raw-text scan over the
+  archived bytes then runs every rule EXCEPT the hostname rule.
+- `test/e2e/byom/run-discovery-journey.py:415-437` — the driver captures the
+  whole document and runs the same imported functions.
+- `assert_redacted()` / `_walk_redaction()` are unchanged: emitted evidence has
+  no exemption at all, and never carries a `provider_guidance` object.
+- Golden fixtures under `scripts/tests/fixtures/byom_journeys/` pass unchanged.
+
+Tests: `scripts/tests/test_byom_journey_evidence.py:215-266` (keys accepted at
+those paths; `coordinator.malibu.tech` at those paths rejected; the same
+localization-key shape rejected in `next_action` and in `display_name`; an
+escaped hostname in a captured document still rejected) and
+`scripts/tests/test_discovery_journey_driver.py:236-278, 331-368`.
+
+### F2 — Step 08 did not run the real scanner over actual CLI output
+
+Lanes: code-reviewer, security-reviewer.
+Raw stdout/stderr were checked only against a finite list of run-specific
+strings. A forbidden-shaped value that was not in that list could pass while the
+manifest claimed all JSON and stderr were clean.
+
+**Resolution.** `test/e2e/byom/run-discovery-journey.py:346-384` — every command
+the driver runs now has its parsed stdout put through the same field-aware
+structured scan (the evidence module's own functions, imported, not
+reimplemented), its raw stdout through the non-hostname rules, and its stderr
+through the full generic scanner. Any failure fails the run and therefore step
+08. The run-specific forbidden-string check is retained as an additional
+assertion at `:979-1000`, now including the coordinator sink's origin and port.
+
+### F3 — Step 10 asserts `not_offered` guidance it never observes — resolved
+
+Lanes: code-reviewer, security-reviewer, architect. **Carried as BLOCKING.**
+
+The journey contract (`journeys/JOURNEY-PROVIDER-BYOM-DISCOVERY.md:58-60`)
+requires `local_only`, `offerable`, and local-default `not_offered` each to
+report the provider-facing next action and local transition reason. The driver
+verifies guidance for `local_only` and `offerable` from discovery, and takes
+`not_offered` from `models catalog-economics`, whose admission object carries no
+guidance fields — yet the step assertion claims all three reported both.
+
+**No CLI surface can produce local-default `not_offered` with a
+`provider_guidance` object.** Verified by exhaustive reading of every
+`provider_guidance` emitter and every `local_default` producer:
+
+- `localAdmissionState()`
+  (`phase3-binary/Sources/macprovider-cli/BYOMDiscovery.swift:4053-4070`) returns
+  only `local_only` or `offerable`. It is the sole admission-state source for the
+  MLX-cache and Ollama candidate builders (`:3224`, `:3379`); the opaque-endpoint
+  builder hardcodes `local_only` (`:3526`). Discovery therefore never emits a
+  `not_offered` candidate.
+- `models offer --dry-run` echoes the candidate's state through
+  `localDefaultAdmissionState()` (`:2702-2708`), so its `likely_admission_state`
+  can only be `not_offered` if a candidate already carried it — unreachable.
+- `model_admission_status.v1` does define `local_default` + `not_offered` +
+  guidance (`:824-826`, `:894-899`), but the CLI never constructs that wire
+  locally. `decodeStrictStatus()` only decodes a **coordinator** response, and
+  the single non-decoder construction
+  (`withLocalCandidateIdentityIfCoordinatorHasNoOffer`, `:1810-1824`) is guarded
+  on `admissionStateSource == "coordinator"`. `models admission status` requires
+  a coordinator URL and a bearer token, and a pre-BYOM coordinator (404/405)
+  produces an error exit, not a document.
+- `model_catalog_economics.v1` does emit local-default `not_offered` rows
+  (`ModelCatalogEconomics.swift:436-445`) but its `Admission` struct
+  (`ModelCatalogEconomics.swift:49-56`) has no guidance fields at all.
+
+Driving this through a coordinator stub was rejected: the resulting document
+would carry `admission_state_source: "coordinator"`, would be the stub's
+assertion rather than the CLI's, and would contradict F4's requirement that the
+coordinator ledger finish empty.
+
+This is a CLI gap, not a harness gap. SPEC-046 explicitly contemplates the state
+(`specs/SPEC-046-provider-byom-discovery.md:92` — local_default `not_offered`
+means "coordinator state is unavailable or has not been queried"; `:96` — a
+locally eligible candidate may move between `offerable` and `not_offered` as
+coordinator reachability changes), but the implementation always chooses
+`offerable` and never emits the local-default `not_offered` label. Closing it
+means adding a CLI code path that produces that label with guidance — a
+governed wire-behaviour change under SPEC-046-R003/R008 that belongs in its own
+change with its own SPEC confirmation.
+
+**Resolution.** The CLI now produces the ladder row. `models admission status
+<candidate> --json` emits a `model_admission_status.v1` document with
+`admission_state_source: "local_default"`, `admission_state: "not_offered"`,
+`coordinator_event_id` and `state_observed_at` null, `allowed_next_states` empty
+(SPEC-047-R002 for a candidate that has not entered coordinator admission),
+`provider_guidance.transition_reason_code: "coordinator_state_unavailable"`, and
+the same warning code in `warnings`, in exactly two situations: no coordinator is
+configured, or a configured coordinator is unreachable or serves no admission
+route (404/405). 401/403, 503 (which keeps its #1448 `wait_for_coordinator`
+mapping), any other status, and any decodable response all stay errors.
+
+- `phase3-binary/Sources/macprovider-cli/BYOMDiscovery.swift:23-26` —
+  `BYOMDiscoveryWarning.coordinatorStateUnavailable`, the R003 warning code
+  nothing emitted before.
+- `phase3-binary/Sources/macprovider-cli/BYOMDiscovery.swift:4181-4200` —
+  `BYOMDiscoveryGuidance.localNotOfferedGuidance(warnings:)`. The reason code is
+  the R003 warning code; the next action is taken from the `offerable` row so the
+  two rows stay action-neutral as the ladder requires (`evaluate` while the
+  candidate is unevaluated, `offer_dry_run` otherwise); the earning path class is
+  the existing local `local_inventory_only`.
+- `phase3-binary/Sources/macprovider-cli/BYOMDiscovery.swift:1788-1824` —
+  `BYOMModelAdmissionRuntime.status` falls through to the local ladder for an
+  absent route or an unreachable host, and only for those.
+- `phase3-binary/Sources/macprovider-cli/BYOMDiscovery.swift:1826-1850` —
+  `isAdmissionRouteAbsent` / `isCoordinatorUnreachable`, the closed trigger set.
+- `phase3-binary/Sources/macprovider-cli/BYOMDiscovery.swift:1852-1893` —
+  `localDefaultStatus`: an `offerable` candidate takes the `not_offered` row, a
+  `local_only` candidate keeps its own state and guidance, an unresolvable target
+  is `candidateNotFound` rather than invented inventory, and the source is never
+  `coordinator`.
+- `phase3-binary/Sources/macprovider-cli/BYOMDiscovery.swift:694-729` —
+  `BYOMAdmissionStatusWire.encode(to:)` writes the nullable keys explicitly, so
+  the emitted document satisfies the closed SPEC-047-R002 envelope and round-trips
+  through `decodeStrictStatus`.
+- `phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift:281-300,
+  541-572` — `models admission status` accepts a missing `coordinator_url` and
+  builds no client; offer and withdrawal still require one.
+- `test/e2e/byom/run-discovery-journey.py:922-988` — step 10 reaches the row
+  through `models admission status` with no coordinator configured at all, and
+  asserts the coordinator sink ledger and connection count are unchanged across
+  it. The step-10 assertion now states exactly what is checked: all three states
+  report a closed next action; `local_only` and `not_offered` each report a
+  non-null local transition reason; `offerable` reports the nullable field with
+  no blocker to name (SPEC-046-R003 makes it nullable, and inventing a code for
+  an unblocked candidate was rejected).
+
+Tests: `phase3-binary/Tests/macprovider-cliTests/BYOMAdmissionTests.swift:669-727`
+(pre-BYOM 404/405 — transport still refuses to fabricate a coordinator state, and
+the runtime now answers with the local-default document), `:728-755` (a decodable
+unknown schema stays an error), `:757-802` (no coordinator configured: the
+document, plus zero probe requests), `:804-830` (unreachable coordinator: the
+document, plus exactly one attempted request), `:832-855` (401/403 stay errors),
+`:857-883` (503 keeps the `wait_for_coordinator` mapping), `:885-918`
+(`local_only` candidate keeps its own row), `:920-940` (the document round-trips
+through the strict decoder with its nullable keys present as null).
+
+### F4 — Two negative observations were literals, not measurements
+
+Lanes: code-reviewer, architect.
+`buyer_traffic_sent` and `provider_credit_created` were assigned `False`
+directly, with no preceding independent check, contradicting the driver's and
+runbook's claim that every observation comes from the driver's own assertions.
+
+**Resolution.** Both now derive from harness-owned ledgers, checked at the end of
+the run.
+
+- `test/e2e/byom/run-discovery-journey.py:164-175` —
+  `ConnectionRecordingHTTPServer` counts accepted connections, not only parsed
+  requests, so a TLS handshake or half-open probe against the port still
+  registers.
+- `test/e2e/byom/run-discovery-journey.py:285-309` — `CoordinatorSinkHandler`
+  records every request and serves nothing (503), so a leaked request is recorded
+  and then fails rather than being satisfied by a fabricated document.
+- `test/e2e/byom/run-discovery-journey.py:580-591` — the sink is configured as
+  the CLI's coordinator (`MACPROVIDER_COORDINATOR_URL`) for every command in the
+  run.
+- `test/e2e/byom/run-discovery-journey.py:1005-1048` — before assignment:
+  the harness started no buyer gateway (checked against the harness's own
+  complete server list); the only chat request anywhere in the run is the
+  evaluation's single local probe to the adapter stub, and no chat request
+  reached any other stub; the coordinator sink finished with an empty request
+  ledger and zero accepted connections. Any violation fails the run before the
+  observation is set.
+- Runbook provenance sentence rewritten at
+  `docs/runbooks/byom-journey-evidence.md:102-112`.
+
+### F5 — Executed binary was not bound to `source_sha`
+
+Lanes: code-reviewer (MEDIUM), architect (MEDIUM), security-reviewer (LOW).
+`MACPROVIDER_CLI_BINARY` could point at any executable while the wrapper
+unconditionally recorded the repository `HEAD` as `source_sha`, so evidence could
+be attributed to a commit it never executed.
+
+**Resolution.** A new `--evidence` mode, used by the CI wrapper.
+
+- `test/e2e/byom/run-discovery-journey.py:99-103` — `EVIDENCE_SOURCE_PATHS`
+  (`phase3-binary`, `scripts`, `test/e2e/byom`).
+- `test/e2e/byom/run-discovery-journey.py:115-160` —
+  `require_clean_evidence_source()` (tracked-only `git status --porcelain
+  --untracked-files=no` over those paths, empty or fail closed) and
+  `build_cli(..., evidence_mode)`, which refuses `MACPROVIDER_CLI_BINARY` in
+  evidence mode and builds from the current source. Non-evidence local runs keep
+  the override.
+- `scripts/test-byom-discovery-journey.sh:44-48` — the gate passes `--evidence`.
+- The manifest schema is unchanged.
+
+### F6 — The new parser duplicated the shared record-count bound
+
+Lane: code-reviewer.
+`parseOpenAIModels` hardcoded `rawModels.prefix(100)` separately from
+`parseOllamaTags`, contradicting the #1246 invariant that the adapter
+reimplements no parser-bound logic, and the boundary test covered Ollama only.
+
+**Resolution.** `phase3-binary/Sources/macprovider-cli/BYOMDiscovery.swift:3592-3610`
+— `BYOMDiscoveryHTTPBounds.maxInventoryRecords` and
+`boundedInventoryRecords(_:)`; both parsers call it (`:3633`, `:3683`).
+Test: `phase3-binary/Tests/macprovider-cliTests/BYOMDiscoveryTests.swift:1061-1104`
+— `testOpenAICompatibleRedactionDoesNotInspectPastSharedRecordBound`, mirroring
+the Ollama test including the withheld-record-beyond-the-cap condition.
+
+### F7 — A failed rerun could leave a stale passing manifest
+
+Lane: security-reviewer (OWASP A08).
+The driver accepted an existing output directory and wrote `run-manifest.json`
+only on success, so a failed rerun into a previously successful directory left
+that pass manifest consumable.
+
+**Resolution.**
+- `test/e2e/byom/run-discovery-journey.py:492-508` — `prepare_out_dir()` requires
+  a new or empty directory and creates it mode 0700. Operator data is refused,
+  never deleted.
+- `test/e2e/byom/run-discovery-journey.py:482-490` — the manifest is written to
+  a temp file and `os.replace`d into place, only after every step and observation
+  check has passed.
+- Regression tests: `scripts/tests/test_discovery_journey_driver.py:386-405`
+  (`test_a_failed_rerun_cannot_reuse_a_stale_manifest_directory`,
+  `test_a_failed_run_publishes_no_manifest`).
+
+### F8 — `not_configured` was a new, undocumented wire status
+
+Lane: architect.
+With no origin supplied the runner appended an adapter row with
+`status: "not_configured"`, a value SPEC-046 does not define, and added a row to
+the no-flag projection that existing consumers had not seen.
+
+**Resolution.** The row is omitted entirely, matching the existing Ollama
+skip behaviour.
+`phase3-binary/Sources/macprovider-cli/BYOMDiscovery.swift:2069-2089` — the
+`else` branch and the `unconfiguredAdapter` constant are gone. No new wire value
+is introduced.
+Test: `phase3-binary/Tests/macprovider-cliTests/BYOMDiscoveryTests.swift:1102-1136`
+— the frozen `not_configured` assertion is replaced by absence of the row, parity
+with the skipped Ollama adapter, and a check that every emitted adapter status
+stays inside the existing vocabulary.
+
+## Carried items
+
+- **F3 (MEDIUM × 3 lanes) — resolved.** The CLI change described under F3 above
+  landed in this branch; no item is carried.
+- INFO (code-reviewer, architect): the adapter's reuse of the shared origin
+  validator, bounded no-proxy/no-redirect transport, and runtime-reference guard
+  was confirmed correct by all three lanes; no SSRF or loopback escape was found;
+  opaque candidates remain null-catalog, null-capability, `local_only`, and
+  non-submittable. CI placement beside `test-byom-e2e` and the changed-path
+  classifier were confirmed correct. No action.
+
+## Merge bar
+
+0 CRITICAL / 0 HIGH / 0 MEDIUM required. F1 through F8 are resolved. The fixes
+have not yet been re-audited as a combined diff; re-run the three lanes over the
+full fix before merging.

--- a/audits/2026-09-09-byom-v02-slice1/AUDIT_BYOM_V02_SLICE1_R2.md
+++ b/audits/2026-09-09-byom-v02-slice1/AUDIT_BYOM_V02_SLICE1_R2.md
@@ -1,0 +1,227 @@
+# AUDIT — BYOM v0.2 slice 1, round 2
+
+Branch: `feat/byom-v02-slice1-openai-compat-adapter`
+Diff under review: `git diff origin/main...HEAD` — the full combined fix as it
+will land (`openai_compatible_loopback` adapter, hermetic discovery-journey
+driver and CI gate, the R1 fixes, and the local-default `not_offered` admission
+status), not a follow-up slice.
+Prompt: `audits/2026-09-09-byom-v02-slice1/AUDIT_BYOM_V02_SLICE1_PROMPT.md`
+Round 1 record: `audits/2026-09-09-byom-v02-slice1/AUDIT_BYOM_V02_SLICE1_R1.md`
+Date: 2026-09-09
+
+## Verdicts (three lanes, R2)
+
+| Lane | Verdict | C | H | M | L | INFO |
+| --- | --- | --- | --- | --- | --- | --- |
+| code-reviewer | REQUEST CHANGES | 0 | 1 | 2 | 3 | 0 |
+| security-reviewer | BLOCK | 0 | 0 | 1 | 0 | — |
+| architect | BLOCK | 0 | 0 | 2 | 1 | 2 |
+
+All three lanes again confirmed the adapter itself: the shared loopback origin
+validator, the bounded no-proxy/no-redirect transport, the shared parser bounds,
+and the model-reference privacy guard are reused rather than reimplemented; no
+SSRF or loopback escape was found; the absent-origin path probes nothing; opaque
+candidates stay null-catalog, null-capability, `local_only`, non-earning, and
+non-submittable; and the new local-default `not_offered` path preserves the
+401/403/503 error mapping. Every R2 finding is in the evidence layer, not the
+adapter.
+
+## Findings (deduplicated across lanes)
+
+The nine lane findings deduplicate to five distinct defects.
+
+### F9 (HIGH) — Evidence-source binding was CI-order-dependent and raced its own build
+
+Lanes: code-reviewer (HIGH), security-reviewer (MEDIUM, OWASP A08), architect
+(MEDIUM ×2). R1 F5 was not actually closed.
+
+Three separate holes, one root cause — the driver checked its inputs once, before
+doing the thing that changes them:
+
+1. **CI order.** The `swift test` step runs before `make test-byom-discovery-journey`
+   in the same job (`.github/workflows/ci.yml:423`, `:436`) and rewrites tracked
+   `phase3-binary/Package.resolved` under the runner's default toolchain. The
+   evidence-mode cleanliness check then refused to run at all. The required check
+   was red for a reason that says nothing about the run.
+2. **The build raced the check.** After a manual restore the gate passed — and
+   its own plain `swift build` mutated the lockfile again, *after* the sole
+   cleanliness check, then published and preflighted evidence against the
+   `SOURCE_SHA` the wrapper had already recorded.
+3. **Untracked inputs were exempt by design.** The check used
+   `--untracked-files=no` and a unit test explicitly endorsed that. SwiftPM's
+   executable target selects the whole `Sources/macprovider-cli` directory with
+   no closed source list (`phase3-binary/Package.swift:59`), so an untracked
+   `.swift` file there is a build input while the evidence names `HEAD`.
+
+A fourth, related hole (architect MEDIUM, security MEDIUM): the operator runbook
+documented the driver **without** `--evidence`, and that mode accepts a
+`MACPROVIDER_CLI_BINARY` override and checks nothing — yet still wrote a
+`run-manifest.json` that capture accepts. Following the runbook produced a
+promotable manifest bound to nothing.
+
+**Resolution.** Evidence mode is now order-independent, locked, re-checked, and
+the only mode that can publish.
+
+- `test/e2e/byom/run-discovery-journey.py:286` — `EVIDENCE_RESTORED_LOCKFILE`,
+  and `:306` `restore_locked_package_resolved()`: the committed
+  `Package.resolved` is restored from `HEAD` before the cleanliness check. The
+  comment states why this is honest rather than lenient — the drift is an
+  artifact of CI step ordering, and `HEAD`'s lockfile is separately proven
+  consistent by the `phase3-binary (locked SwiftPM resolve)` job
+  (`.github/workflows/ci.yml:467-490`, `scripts/verify-swift-package-lock.sh`).
+  The wrapper does the same first (`scripts/test-byom-discovery-journey.sh:51`).
+- `test/e2e/byom/run-discovery-journey.py:268` — `EVIDENCE_SOURCE_PATHS` is now
+  `phase3-binary/Sources`, `phase3-binary/Tests`, `phase3-binary/Package.swift`,
+  `phase3-binary/Package.resolved`, `scripts`, `test/e2e/byom`.
+- `test/e2e/byom/run-discovery-journey.py:325` — `require_clean_evidence_source()`
+  uses `git status --porcelain --untracked-files=all` and fails closed on
+  anything reported. It takes a `phase` label so the message names when the
+  tree drifted.
+- `test/e2e/byom/run-discovery-journey.py:294`, `:370` —
+  `SWIFT_LOCKED_RESOLUTION_FLAG = "--only-use-versions-from-resolved-file"`,
+  appended to the evidence-mode build. This is the same lock the locked-resolve
+  CI job applies through xcodebuild's `-onlyUsePackageVersionsFromResolvedFile`:
+  resolution may only use the versions in `Package.resolved` and fails if that
+  file is out of date, so the build cannot rewrite it.
+- `test/e2e/byom/run-discovery-journey.py:377` — the cleanliness check runs
+  **again after the build**, before anything is captured or published.
+- `scripts/test-byom-discovery-journey.sh:64` — `SOURCE_SHA` is read only after
+  the driver (and therefore the post-build check) has succeeded. Reading it
+  earlier named a commit before knowing whether the run stayed bound to it.
+- `test/e2e/byom/run-discovery-journey.py:736` — only an `--evidence` run writes
+  `run-manifest.json`; a run without it writes the same content as
+  `run-summary.json`, a name `scripts/capture-byom-journey-evidence.py` does not
+  consume. An unbound run is non-promotable by construction, not by operator
+  discipline.
+- `docs/runbooks/byom-journey-evidence.md:93` — step 1 uses `--evidence` and
+  states that a non-evidence run cannot be captured; `:152` documents the full
+  binding (restore, tracked+untracked check, locked build, post-build re-check,
+  late `source_sha`).
+
+Tests, `scripts/tests/test_discovery_journey_driver.py`:
+- `:518` `test_evidence_mode_refuses_an_untracked_swift_source_file` — reverses
+  the R1 test that endorsed untracked files; an untracked `.swift` under
+  `Sources/macprovider-cli` is refused.
+- `:534` `test_lockfile_drift_after_the_build_fails_closed`.
+- `:545` `test_the_committed_lockfile_is_restored_before_the_check`.
+- `:557` `test_evidence_builds_with_locked_resolution` — asserts the flag, and
+  that the locked-resolve script applies the xcodebuild equivalent.
+- `:583` `test_the_ci_wrapper_runs_the_driver_in_evidence_mode` — asserts the
+  wrapper's ordering: restore, then run, then record `SOURCE_SHA`.
+- `:596` `ManifestPublicationModeTests` — evidence publishes `run-manifest.json`;
+  a non-evidence run publishes `run-summary.json` and no manifest; the runbook
+  passes `--evidence`.
+
+**CI-order simulation (the exact sequence that failed in R2), run locally:**
+`swift test --filter BYOMDiscoveryTests` (which dirties the lockfile), then
+`make test-byom-discovery-journey` — passes, and leaves `Package.resolved`
+unmodified afterwards.
+
+### F10 (MEDIUM) — Captured documents were not validated against complete closed schemas
+
+Lane: code-reviewer.
+Capture checked JSON-ness, the top-level schema id, and redaction — never the
+exact field set. Step 03 read `capabilities` through an `or {}` fallback, so
+"every capability value is null" was vacuously true for an absent or partial
+object; step 07 accepted any nonempty subset of `mutation_summary` whose present
+values were false. A redaction-clean but schema-incomplete document would have
+been digested into signed evidence as if the CLI had emitted the full envelope.
+
+**Resolution.** Every capture is validated against its complete closed schema;
+a missing field and an unknown field both fail the step.
+
+- `test/e2e/byom/run-discovery-journey.py:196` — `assert_exact_object()`.
+- `test/e2e/byom/run-discovery-journey.py:206` — `validate_captured_document()`,
+  called from `ManifestBuilder.capture()` at `:677` (after the redaction scan,
+  so a leaky document still fails as a leak).
+- Field sets: SPEC-046-R003 discovery envelope, candidate, and
+  `provider_guidance`; the exact SPEC-046-R004 capability list; the
+  SPEC-046-R005 evaluation envelope and `mutation_summary`; the SPEC-047-R002
+  `model_admission_offer_dry_run.v1` and `model_admission_status.v1` envelopes.
+  The two shapes the specs describe without enumerating field names —
+  `adapters[]` rows and the `model_catalog_economics.v1` row — are frozen at
+  the shape the CLI actually emits, so a silent projection change fails the
+  gate. An unrecognized schema id is refused outright.
+- `test/e2e/byom/run-discovery-journey.py:943` — step 03 asserts the exact
+  capability field set with every value `null` (no `or {}` fallback).
+- `test/e2e/byom/run-discovery-journey.py:1068` — step 07 asserts the exact
+  mutation-summary field set with every value `false`.
+
+Tests: `scripts/tests/test_discovery_journey_driver.py:638`
+(`ClosedCaptureSchemaTests`) covers a missing and an unknown field at the
+envelope (`:668`, `:673`), candidate, capability (`:683`, `:690`), guidance, and
+mutation-summary (`:700`, `:706`) levels, plus an unvalidated schema id and the
+SPEC-046-R004 capability list itself. The suite's document fixtures were
+rewritten as complete closed documents.
+
+### F11 (LOW) — `--version` bypassed the all-command redaction scan
+
+Lane: code-reviewer.
+Version collection called `subprocess.run` directly, so neither stream entered
+`Runner.transcript` or the shared scanner, contradicting the documented claim
+that the scan covers every command's real stdout and stderr.
+
+**Resolution.** `test/e2e/byom/run-discovery-journey.py:564` — `Runner.run_text()`
+runs the command, records both streams in the transcript, and applies the shared
+scanners; `Runner.run()` is now a JSON wrapper around it, and `:852` collects the
+version through it. Runbook claim updated to say `--version` included.
+
+### F12 (LOW) — Rollback runbook described superseded wire behaviour
+
+Lanes: code-reviewer, architect.
+Row 10 still promised `adapters[].status: not_configured` for an absent origin,
+a value R1 removed, and the old-coordinator section did not separate the three
+distinct behaviours.
+
+**Resolution.** `docs/runbooks/byom-disablement-rollback.md` row 10 — an absent
+origin emits **no** `openai_compatible_loopback` adapter row at all (parity with
+a skipped Ollama adapter; no new wire value) and dispatches zero requests. The
+old-coordinator section (`:111`) now separates: the **transport** still reports
+404/405 and an unknown 200 schema as errors; the **command runtime** maps only
+"no coordinator configured" and "admission route absent or unreachable" to the
+local ladder row `not_offered` / `local_default` with
+`coordinator_state_unavailable`; and 401/403/503 plus unknown successful schemas
+**stay errors**. Each is cited to its existing test.
+
+### F13 (LOW) — Misaligned arguments in two production call sites
+
+Lane: code-reviewer. Style only.
+
+**Resolution.** `phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift:290`
+and `:372` — `openAICompatibleOrigin:` aligned with `ollamaOrigin:`; all six call
+sites now match.
+
+## Carried items
+
+- **Binding an executable digest into the run manifest — carried, not done.**
+  Both the security and architect lanes suggested recording a SHA-256 of the
+  built CLI in the manifest and cross-checking it during capture. The run
+  manifest is a closed schema (`macprovider.byom-journey-run.v1`) shared with the
+  admission journey, validated on both the capture side and the governance side
+  (`scripts/byom_journey_evidence.py`, `scripts/check_spec_governance.py`), and
+  mirrored by committed golden fixtures. Adding a field is a journey-contract and
+  schema change affecting both journeys, so it belongs to a later slice rather
+  than to an audit-fix commit. What this slice does instead is make the *source*
+  binding sound: locked build, tracked+untracked cleanliness before and after the
+  build, and `source_sha` recorded only once the post-build check passed.
+- **Isolated-checkout builds — not adopted.** The architect's strongest option
+  (build evidence from a fresh `git worktree` of `source_sha` with a private
+  scratch path) was weighed against the chosen option in that lane's own
+  trade-off table. The current-worktree path with a locked build and a post-build
+  re-check closes the same holes at a fraction of the CI cost; the isolated
+  checkout stays available if a later slice needs provenance stronger than
+  "this tree, verified unchanged across the build".
+- **`~` config-path expansion — pre-existing.** `models admission status`
+  resolves `~` from the account rather than from `HOME`, which is why the driver
+  hands it an explicit harness-owned `--config`. Not introduced by this branch;
+  no change made here.
+- **INFO (all three lanes) — no action.** Adapter composition, shared safety
+  layer reuse, absent-origin no-probe behaviour, opaque-candidate non-earning
+  states, the closed local-default status envelope, the driver's position as the
+  CI seam, and the changed-path classifier were each confirmed correct again.
+
+## Merge bar
+
+0 CRITICAL / 0 HIGH / 0 MEDIUM. F9 through F13 are resolved in this branch. The
+executable-digest binding is carried with a stated reason; the `~` expansion is
+pre-existing. Re-run the three lanes over the full combined diff before merging.

--- a/audits/2026-09-09-byom-v02-slice1/AUDIT_BYOM_V02_SLICE1_R3.md
+++ b/audits/2026-09-09-byom-v02-slice1/AUDIT_BYOM_V02_SLICE1_R3.md
@@ -1,0 +1,212 @@
+# AUDIT — BYOM v0.2 slice 1, round 3
+
+Branch: `feat/byom-v02-slice1-openai-compat-adapter`
+Diff under review: `git diff origin/main...HEAD` — the full combined fix as it
+will land (`openai_compatible_loopback` adapter, hermetic discovery-journey
+driver and CI gate, the R1 fixes, the local-default `not_offered` admission
+status, and the R2 fixes), not a follow-up slice.
+Prompt: `audits/2026-09-09-byom-v02-slice1/AUDIT_BYOM_V02_SLICE1_PROMPT.md`
+Round 1 record: `audits/2026-09-09-byom-v02-slice1/AUDIT_BYOM_V02_SLICE1_R1.md`
+Round 2 record: `audits/2026-09-09-byom-v02-slice1/AUDIT_BYOM_V02_SLICE1_R2.md`
+Date: 2026-09-09
+
+## Verdicts (three lanes, R3)
+
+| Lane | Verdict | C | H | M | L | INFO |
+| --- | --- | --- | --- | --- | --- | --- |
+| code-reviewer | REQUEST CHANGES | 0 | 0 | 3 | 1 | 0 |
+| security-reviewer | PASS (one LOW) | 0 | 0 | 0 | 1 | — |
+| architect | APPROVE | 0 | 0 | 0 | 0 | — |
+
+The architect lane is clean. The security lane confirmed every R2 resolution and
+found no new CRITICAL/HIGH/MEDIUM: strict literal-loopback origin admission,
+disabled redirects and proxies, bounded responses, the shared model-reference
+guard, opaque candidates that cannot reach a catalog key or the earning path,
+non-overridable observations, failed steps blocking manifest publication, the R2
+source binding, and correct CI placement. All three R3 MEDIUMs are in the
+evidence layer, and all three are the same shape as R1/R2: a control that was
+right for the driver but not for the boundary it actually has to hold.
+
+## Findings (deduplicated across lanes)
+
+Four lane findings deduplicate to four distinct defects (the two LOWs are the
+same defect seen from the code and security lanes).
+
+### F14 (MEDIUM) — Evidence mode silently discarded local lockfile changes
+
+Lanes: code-reviewer.
+`test/e2e/byom/run-discovery-journey.py:306` and
+`scripts/test-byom-discovery-journey.sh:51` each ran an unconditional
+`git checkout HEAD -- phase3-binary/Package.resolved` before the cleanliness
+check. R2 introduced that restore to make the gate order-independent in CI, and
+it does — but it cannot tell CI resolution drift from an operator's uncommitted
+work, and `git checkout HEAD --` leaves no copy of what it overwrote. The
+reviewer hit this during the review itself: their checkout began with an
+unstaged lockfile modification and the gate destroyed it.
+
+**Resolution.** The rule is now conditional, and it lives in exactly one place.
+`test/e2e/byom/run-discovery-journey.py:204` `restore_locked_package_resolved()`
+compares the working-tree lockfile to `HEAD` and takes one of three branches:
+
+- equal — return, writing nothing;
+- differs, `GITHUB_ACTIONS` or `CI` is `true`/`1`, and nothing is staged for the
+  file — restore `HEAD`'s bytes and print a notice saying why (an ephemeral CI
+  checkout is discarded with the job, so nothing uncommitted there is work
+  anyone wanted; and `HEAD`'s lockfile is separately proven by the
+  `phase3-binary (locked SwiftPM resolve)` job);
+- anything else — a local run, or a CI run with the lockfile **staged** — raise,
+  naming the file and telling the operator to commit it or restore it
+  themselves. Nothing is written.
+
+`scripts/test-byom-discovery-journey.sh:53` no longer touches the lockfile at
+all; the comment there says why, and points at the driver.
+`docs/runbooks/byom-journey-evidence.md:163` documents the three branches.
+
+Regression coverage, `scripts/tests/test_discovery_journey_driver.py`: a clean
+lockfile passes untouched; a differing lockfile is restored under
+`GITHUB_ACTIONS=true` and under `CI=true`; a differing lockfile on a local run is
+refused **and its bytes asserted unchanged**; a *staged* lockfile is refused even
+with the CI flag set; `CI=false` and an empty environment are not CI. A wrapper
+test asserts the shipped script contains no lockfile checkout.
+
+Verified end to end: after `swift test` rewrote the lockfile,
+`make test-byom-discovery-journey` on this machine refused with the new message
+and the file's md5 was identical before and after.
+
+### F15 (MEDIUM) — Cleanup deleted the pre-existing evidence file it had refused to overwrite
+
+Lane: code-reviewer.
+`scripts/test-byom-discovery-journey.sh:27` installed the EXIT trap **before**
+the `[ -e "$EVIDENCE" ]` existence check. On a collision the script printed
+"refusing to overwrite", exited 1, and the trap then `rm -f`-ed the very file it
+had refused to touch. Two runs in the same second share the timestamped name, so
+one run could delete another's artifact.
+
+**Resolution.** `scripts/test-byom-discovery-journey.sh:22` — the artifact
+lifecycle is now ownership-based rather than name-based. `EVIDENCE_DIR` and
+`OUT_DIR` are declared empty, the trap is armed while both are empty (so a
+failure before creation removes nothing), and each is then assigned from its own
+`mktemp -d`. The evidence directory is `mktemp -d
+journeys/evidence/provider-byom-discovery-ci-XXXXXX` — inside the tree because
+the capture contract only accepts
+`journeys/evidence/provider-byom-discovery-*.redacted.json`
+(`scripts/check_spec_governance.py:321`) and the builder verifies the bytes
+against a commit containing them. `cleanup()` removes a directory only when its
+variable is non-empty, i.e. only when this invocation created it. Collisions are
+now structurally impossible, so the "refuse to overwrite" check is gone with the
+race it guarded.
+
+Regression coverage,
+`scripts/tests/test_discovery_journey_driver.py::WrapperEvidenceArtifactTests`:
+the wrapper's real artifact prologue is extracted verbatim from the shipped
+script and run in a scratch tree containing a pre-existing
+`provider-byom-discovery-ci-*.redacted.json`. A failed run that had already
+written its own evidence leaves the pre-existing file **byte-identical** while
+removing its own directory; a failure before `mktemp` deletes nothing; four runs
+produce four distinct directories.
+
+### F16 (MEDIUM) — Closed-schema validation stopped at the driver, not the evidence trust boundary
+
+Lanes: code-reviewer.
+R2 added complete closed-schema validation, but put it in the driver
+(`test/e2e/byom/run-discovery-journey.py:206`). `_digest_document()`
+(`scripts/byom_journey_evidence.py:550`) — the boundary every capture crosses,
+including the hand-authored physical-provider and admission runs the runbook
+describes — checked only the claimed top-level schema and redaction, then hashed
+whatever it was given. A redaction-clean but schema-incomplete document was
+digested into evidence, and the evidence tests demonstrated exactly that by
+accepting an incomplete discovery document. R2's "every capture" claim was true
+only of the driver's captures.
+
+**Resolution.** The closed key sets and the validator moved to the shared
+contract. `scripts/byom_journey_evidence.py:550` now defines the field sets and
+`validate_captured_cli_document(schema, parsed, location)` (`:669`), invoked from
+`_digest_document()` at `:782` — after the redaction scans, before the digest, so
+a document that is both leaky and incomplete still reports the leak first. The
+driver keeps a four-line wrapper
+(`test/e2e/byom/run-discovery-journey.py:131`) that calls the shared function and
+converts `BYOMEvidenceError` to `HarnessFailure`, so a bad capture still fails
+the step that produced it instead of the pipeline three commands later; its
+duplicate constants and `assert_exact_object` are deleted.
+
+Coverage is every schema a discovery **or** admission journey document can be —
+`provider_byom_discovery.v1` (envelope, `adapters[]` rows, candidates,
+capabilities, `provider_guidance`), `provider_byom_evaluation.v1` including the
+exact `mutation_summary`, `model_admission_offer_dry_run.v1`,
+`model_admission_status.v1`, `model_admission_withdraw.v1` (new in R3; the
+admission journey's step-08 document was previously unvalidated at any layer),
+and `model_catalog_economics.v1` rows and their `admission` object. An
+unenumerated schema fails closed. The withdraw field set mirrors the CLI's own
+strict decoder (`BYOMAdmissionWithdrawWire.topLevelKeys`,
+`phase3-binary/Sources/macprovider-cli/BYOMDiscovery.swift:768`). As in R2,
+`adapters[]` rows and catalog-economics rows — the two shapes the specs describe
+without enumerating field names — are frozen at the emitted shape with a comment
+saying so.
+
+The golden fixtures under
+`scripts/tests/fixtures/byom_journeys/{discovery,admission}/captures/` were
+minimal stubs (three to five fields each); all nineteen are now **complete**
+closed documents. `scripts/tests/test_byom_journey_evidence.py`'s
+`guidance_document()` helper, which hand-built a two-field discovery document and
+asserted it was accepted, now starts from the golden fixture and overrides only
+the guidance fields under test.
+
+Regression coverage through the **real capture path**
+(`build_evidence` → `_digest_document`), not the driver:
+missing and unknown envelope fields; a missing nested candidate field; missing
+and unknown nested capability fields; missing and unknown nested
+`provider_guidance` fields; a missing nested `adapters[]` field; a missing
+`mutation_summary` field; a missing withdraw envelope field; an unknown
+catalog-economics row field; and an unenumerated schema.
+
+### F17 (LOW) — `--version` stdout skipped the hostname rule
+
+Lanes: code-reviewer (LOW), security-reviewer (LOW, OWASP A08). One defect.
+`Runner.run_text()` applied `reject_unredacted_text_except_hostname()` to all
+stdout, because JSON documents legitimately carry the SPEC-046-R003 localization
+keys. JSON commands then got the structural scan in `run()`, but `--version`
+returns straight out of `run_text()` and never received the hostname rule — so
+the driver docstring's and the runbook's "every command, `--version` included"
+was not exact. Non-blocking: the downstream capture scan would still reject such
+a manifest.
+
+**Resolution.** `test/e2e/byom/run-discovery-journey.py:499` — `run_text()` now
+applies the FULL plaintext scan by default, hostname rule included. The
+exemption is a `defer_hostname_scan` argument set only by `run()`
+(`:554`), whose very next act is
+`assert_captured_document_redacted()`, the structured walk that decides those
+keys field by field. `--version` and any other plain-text command get the whole
+rule set.
+
+Regression coverage,
+`scripts/tests/test_discovery_journey_driver.py::RunnerStdoutScanTests`: a clean
+version string passes; a DNS-shaped version string is refused through the real
+`run_text()`; the JSON path still accepts a localization key.
+`docs/runbooks/byom-journey-evidence.md:142` restated accordingly.
+
+## Carried items (unchanged from R2, not re-reported by any lane)
+
+- **Binding an executable digest into the run manifest — carried, not done.**
+  The run manifest is a closed schema (`macprovider.byom-journey-run.v1`) shared
+  with the admission journey and mirrored by committed golden fixtures; adding a
+  field is a journey-contract change for a later slice. This slice keeps the
+  *source* binding sound instead: locked build, tracked+untracked cleanliness
+  before and after the build, `source_sha` recorded only after the post-build
+  check.
+- **Isolated-checkout builds — not adopted.** The current-worktree path with a
+  locked build and a post-build re-check closes the same holes at a fraction of
+  the CI cost. Still available if a later slice needs stronger provenance.
+- **`~` config-path expansion — pre-existing.** Not introduced by this branch;
+  the driver hands `models admission status` an explicit harness-owned
+  `--config`.
+- **INFO — no action.** All three lanes re-confirmed the adapter: shared safety
+  layer reuse, absent-origin no-probe, opaque candidates null-catalog and
+  non-earning, step-04's zero-dispatch ledger check, step-10's real CLI ladder,
+  CI path classification, and unchanged `models list`/browse contracts.
+
+## Merge bar
+
+0 CRITICAL / 0 HIGH / 0 MEDIUM. F14, F15, F16, and F17 are resolved in this
+branch. The three R2 carried items are unchanged and still carried with their
+stated reasons. Re-run the three lanes over the full combined diff before
+merging.

--- a/audits/2026-09-09-byom-v02-slice1/AUDIT_BYOM_V02_SLICE1_R4.md
+++ b/audits/2026-09-09-byom-v02-slice1/AUDIT_BYOM_V02_SLICE1_R4.md
@@ -1,0 +1,241 @@
+# AUDIT — BYOM v0.2 slice 1, round 4
+
+Branch: `feat/byom-v02-slice1-openai-compat-adapter`
+Diff under review: `git diff origin/main...HEAD` — the full combined fix as it
+will land (`openai_compatible_loopback` adapter, hermetic discovery-journey
+driver and CI gate, the local-default `not_offered` admission status, and the
+R1/R2/R3 fixes), not a follow-up slice.
+Prompt: `audits/2026-09-09-byom-v02-slice1/AUDIT_BYOM_V02_SLICE1_PROMPT.md`
+Round 1 record: `audits/2026-09-09-byom-v02-slice1/AUDIT_BYOM_V02_SLICE1_R1.md`
+Round 2 record: `audits/2026-09-09-byom-v02-slice1/AUDIT_BYOM_V02_SLICE1_R2.md`
+Round 3 record: `audits/2026-09-09-byom-v02-slice1/AUDIT_BYOM_V02_SLICE1_R3.md`
+Date: 2026-09-09
+
+## Verdicts (three lanes, R4)
+
+| Lane | Verdict | C | H | M | L | INFO |
+| --- | --- | --- | --- | --- | --- | --- |
+| code-reviewer | REQUEST CHANGES | 0 | 0 | 2 | 1 | 0 |
+| security-reviewer | PASS (one MEDIUM) | 0 | 0 | 1 | 0 | — |
+| architect | REQUEST CHANGES | 0 | 0 | 1 | 1 | 1 |
+
+No lane found a CRITICAL or a HIGH, and no lane found a runtime defect in the
+adapter: all three re-confirmed strict loopback admission, the shared bounded
+HTTP client and parser, the model-reference privacy guard, opaque candidates
+that cannot reach a catalog key or the earning path, zero dispatch on the
+non-loopback path, the real local-state ladder in step 10, and the R3 lockfile
+and owned-cleanup fixes. Every R4 finding is in the evidence layer.
+
+The four lane findings deduplicate to three distinct defects plus one INFO.
+
+## Findings
+
+### F18 (MEDIUM, all three lanes) — Closed-schema validation checked key sets, not values
+
+Lanes: code-reviewer, security-reviewer (OWASP A08), architect.
+
+`scripts/byom_journey_evidence.py:validate_captured_cli_document` enforced exact
+key sets and nothing else: no wire types, no nullability, no closed enums, no
+nested object shapes, no cross-field rules. R3 had treated "closed schema" and
+"exact key set" as the same thing, and the committed golden fixtures proved they
+are not — every one of these passed validation and could have backed signed
+evidence:
+
+- `identity_state: "declared_local"`, `locality: "local_weights"` — neither in
+  the SPEC-046-R003 enums; the CLI emits `runtime_reported` and `local_artifact`.
+- `evaluation_state: "evaluated"`, `next_action: "configure_coordinator"`,
+  `next_action: "serve_traffic"`, `next_action: "await_coordinator_decision"`,
+  `next_action: "await_catalog_admission"` — none in the R003 enums.
+- `adapter_response_malformed` and `opaque_endpoint_identity` in `warning_codes`
+  — the wire code is `adapter_malformed_response`, and the second is not a
+  warning code at all.
+- adapter `status: "failed"` / `"rejected_non_loopback"` — the adapter emits
+  `malformed` and `rejected`.
+- evaluation `capability_results` as bare strings — the CLI emits
+  `{result, source, reason_code}` objects.
+- `completion_sha256` for the wire key `response_body_sha256`.
+- catalog-economics `prepare`/`evaluate`/`switch`/`adopt_recommendation`/
+  `cleanup_staging` as booleans and `source` as a string — all five actions and
+  the source are objects on the wire.
+
+Because validation runs immediately before digesting, a schema-invalid document
+could back signed evidence. The security lane rated the blast radius as invalid
+CLI output hashed into signed conformance evidence and used at promotion
+preflight.
+
+**Resolution — validator.** `scripts/byom_journey_evidence.py:676-818` adds the
+closed value enums, transcribed from the spec text where the spec closes the
+vocabulary and frozen from the CLI encoder (with a comment saying so) where it
+does not: `RUNTIME_SOURCES`, `IDENTITY_STATES`, `LOCALITIES`,
+`READINESS_STATES`, `FIT_STATES`, `EVALUATION_STATES`, `ADMISSION_STATES`,
+`ADMISSION_STATE_SOURCES`, `LOCAL_DEFAULT_ADMISSION_STATES`,
+`COORDINATOR_ADMISSION_STATES`, `ADMISSION_ALLOWED_NEXT_STATES`,
+`NEXT_ACTIONS`, `EARNING_PATH_CLASSES`, `WARNING_CODES`,
+`WITHDRAW_REASON_CODES`, `ADAPTER_STATUSES`, `ORIGIN_CLASSES`, and the
+evaluation scalar sets.
+`scripts/byom_journey_evidence.py:820-911` adds the typed helpers
+(`require_bool`, `require_int`, `require_number`, `require_text`,
+`require_nullable`, `require_enum`, `require_enum_list`) and
+`_require_admission_pair` (`:873`), which implements the cross-field rule:
+`admission_state_source == local_default` admits only
+`{local_only, not_offered, offerable}`, and `coordinator` only the ten
+SPEC-047-R001 states.
+`scripts/byom_journey_evidence.py:914-1220` replaces the key-set-only body with
+one validator per schema —
+`_validate_discovery`, `_validate_evaluation`, `_validate_offer_dry_run`,
+`_validate_admission_status`, `_validate_admission_withdraw`,
+`_validate_catalog_economics` — covering field types, nullability, every closed
+enum above, the SPEC-046-R004 capability object (nullable booleans, nullable
+number, nullable strings — "unknown is null, never false"), evaluation
+capability results as `{result, source, reason_code}` objects, the
+`{prompt_sha256, response_body_sha256}` diagnostic-hash keys, the SPEC-047-R002
+dry-run / status / withdraw enums, `allowed_next_states` as a subset of the
+SPEC-047-R001 row for the reported state (and empty for a `local_default`
+state), and the catalog-economics `source` and action objects.
+
+Enum sources used: SPEC-046-R003 (identity/locality/readiness/fit/evaluation/
+admission states, admission-state source, `next_action`, `earning_path_class`,
+warning codes), SPEC-046-R004 (capability nullability), SPEC-046-R002 (adapter
+enum), SPEC-047-R001 (coordinator states and the transition table),
+SPEC-047-R002 (dry-run/status/withdraw envelopes and the withdrawal
+`reason_code`). Implementation-defined sets frozen from
+`phase3-binary/Sources/macprovider-cli/BYOMDiscovery.swift`
+(adapter `status`, `origin_class`, `health_result`, `adapter_identity`,
+`usage_reporting_source`, `fit_estimate_source`, capability result/source) and
+`phase3-binary/Sources/macprovider-cli/ModelCatalogEconomics.swift`
+(`Source` and `Action` shapes).
+
+**Resolution — fixtures.** Every golden capture was regenerated from real CLI
+output rather than corrected by hand. `scripts/tests/fixtures/byom_journeys/README.md`
+records the provenance of each one; the short version:
+
+- `discovery/captures/*.json` (all eight): real, unedited output of
+  `test/e2e/byom/run-discovery-journey.py --out <tmp>`, copied verbatim.
+- `admission/captures/offer-dry-run.json`,
+  `admission-status-offer-submitted.json`, `admission-withdraw.json`,
+  `admission-status-reentry.json`, `catalog-economics-unpriced.json`: real,
+  unedited output of the CLI driven against the hermetic coordinator stub in
+  `test/e2e/byom/run-cli-onboarding-e2e.py` (dry-run, offer submit, status
+  readback, withdraw, post-withdrawal status, catalog-economics).
+- `admission-status-offer-rejected.json`, `-sandbox-probe-only.json`,
+  `-revoked.json`, `-settlement-capable.json`, `-novel-non-catalog.json`: the
+  real `offer_submitted` readback with ONLY `admission_state`,
+  `allowed_next_states`, and the dependent `provider_guidance` fields changed to
+  values from the closed enums; plus `state_meaning_key` on the
+  settlement-capable one (keeping the real `not_earning` key would assert
+  something false) and `catalog_model_key: null` on the novel-non-catalog one
+  (step 10 is the non-catalog presentation case). Provider id, candidate id,
+  served model reference, timestamps, `cli_version`, and
+  `admission_state_source` are the real CLI's.
+- `catalog-economics-catalog-priced.json`: the real unpriced document with edits
+  confined to the single BYOM row; the other nine catalog rows are untouched.
+
+Nothing was scrubbed. No real document tripped the redaction scanner.
+
+**Resolution — rejection tests.** `scripts/tests/test_byom_journey_evidence.py:353-509`
+adds sixteen tests through the real capture path covering a wrong type
+(`chat_completions: "yes"`, `projection_sequence: "1"`, `prepare: false`,
+capability results as strings), an out-of-enum value (`identity_state`,
+`locality`, `evaluation_state`, `next_action`, `warning_codes[0]`, adapter
+`status`, withdrawal `reason_code`, an illegal `allowed_next_states` edge), a
+null in a non-nullable field (`display_name`, `admission_state`), the renamed
+diagnostic hash, and the `local_default` / coordinator-state mismatch on both a
+discovery candidate and an admission status document.
+`scripts/tests/test_byom_journey_evidence.py:111` — the fixture-accepting test
+— is now true of documents the CLI actually emits.
+
+The two sample documents in `scripts/tests/test_discovery_journey_driver.py:66-137`
+carried the same class of invention (`origin_class: "loopback"`,
+`fit_estimate_source: "runtime_reported"`, empty `capability_results` and
+`diagnostic_hashes`) and were corrected to real wire values.
+
+### F19 (MEDIUM, code-reviewer) — Discovery evidence was not bound to the discovery driver
+
+The real driver reports `test/e2e/byom/run-discovery-journey.py`, but the
+discovery golden manifest still named `run-cli-onboarding-e2e.py`, and
+`build_evidence()` accepted any existing repository-relative source file — the
+test at `test_byom_journey_evidence.py:556` explicitly preserved the stale
+identity. A hand-built or stale manifest could therefore claim discovery
+evidence under the wrong harness provenance.
+
+**Resolution.** `scripts/byom_journey_evidence.py:187` and `:206` add
+`expected_harness_name` to `JourneyContract`;
+`scripts/byom_journey_evidence.py:229` and `:244` bind discovery to
+`test/e2e/byom/run-discovery-journey.py` and admission to
+`test/e2e/byom/run-cli-onboarding-e2e.py` (the harness the admission runbook
+names and the one that actually produces admission runs);
+`scripts/byom_journey_evidence.py:1525-1529` enforces exact equality in
+`build_evidence()`.
+`scripts/tests/fixtures/byom_journeys/discovery/run-manifest.json:8` now names
+the driver. `scripts/tests/test_byom_journey_evidence.py:700-725` adds three
+rejection tests (each journey naming the other's harness, and a manifest naming
+an unrelated repository file), and `:743` replaces the assertion that preserved
+the stale name.
+
+### F20 (LOW, code-reviewer + architect) — Redaction-failure diagnostics re-emitted the forbidden value
+
+`test/e2e/byom/run-discovery-journey.py:721/732` embedded the first 24
+characters of the leaked value in the `HarnessFailure`, and the top-level
+handler writes that exception to stderr — so the detector for the
+no-origin/no-path stderr invariant could itself violate it. The forbidden set is
+exactly origins, absolute paths, the probe prompt, and the completion marker.
+
+**Resolution.** `test/e2e/byom/run-discovery-journey.py:738-766` takes
+`forbidden` as `(category, value)` pairs and reports only the category and the
+entry's index; `:1317-1336` supplies the categories (`adapter_origin`,
+`coordinator_origin`, `loopback_host_port`, `local_path`, `probe_prompt`,
+`completion_marker`).
+`scripts/tests/test_discovery_journey_driver.py:372-383` asserts the exception
+text contains neither the value, nor its first 24 bytes, nor `127.0.0.1`.
+
+### F21 (LOW, architect) — Existing output directories were not made user-private
+
+`prepare_out_dir()` accepted an existing empty directory and then called
+`mkdir(mode=0o700, exist_ok=True)`; POSIX applies that mode only when mkdir
+actually creates the directory, so a pre-existing permissive `--out` stayed
+permissive, and captures were written with default permissions. On a multi-user
+host that publishes otherwise redaction-clean operator-local inventory.
+
+**Resolution.** `test/e2e/byom/run-discovery-journey.py:712-736` chmods an
+existing (empty, so nothing is destroyed) directory to `0700`;
+`:604-609` creates `captures/` `0700`, `:640-646` creates each capture file
+`0600`, and `:707` writes the manifest `0600`.
+`scripts/tests/test_discovery_journey_driver.py:389-395` and `:511-520` assert
+both.
+
+### F22 (INFO, architect) — Admission-status help contradicted its new local behavior
+
+`ModelsSubcommand.swift:236` still read "Read coordinator-backed BYOM admission
+status" although the command deliberately supports a coordinator-free
+`local_default` result.
+
+**Resolution.** `phase3-binary/Sources/macprovider-cli/ModelsSubcommand.swift:237-245`
+now describes coordinator readback with the local-default fallback. The
+withdrawal command's "coordinator-backed" wording is left alone: withdrawal
+always reaches the coordinator.
+
+## Verification
+
+- `cd phase3-binary && swift build` — PASS.
+- `swift test --filter BYOM` — PASS, 99 tests, 0 failures.
+- `swift test --filter ModelsSubcommandTests` — PASS, 44 tests, 0 failures.
+- `make test-byom-e2e` — PASS.
+- `CI=true make test-byom-discovery-journey` — PASS (driver, capture, build,
+  preflight).
+- `make test-byom-discovery-journey` — PASS.
+- `python3 -m unittest scripts.tests.test_discovery_journey_driver
+  scripts.tests.test_byom_journey_evidence scripts.tests.test_spec_governance` —
+  PASS, 230 tests, 0 failures.
+- `python3 scripts/check_spec_governance.py` — PASS.
+- `python3 scripts/gen_spec_index.py --lint` — PASS.
+- `git diff --check` — clean.
+
+## Carried items
+
+None. Every R4 finding — the three defects and the INFO — is resolved above; no
+LOW or INFO is carried into the PR.
+
+## Closing note
+
+R5 codex re-run deliberately NOT run — four anchored rounds; closure delegated to
+an independent review on the PR.

--- a/audits/2026-09-09-byom-v02-slice1/AUDIT_BYOM_V02_SLICE1_R5_INDEPENDENT.md
+++ b/audits/2026-09-09-byom-v02-slice1/AUDIT_BYOM_V02_SLICE1_R5_INDEPENDENT.md
@@ -1,0 +1,10 @@
+# Audit record R5 — independent review (`/code-review ultra`), 2026-09-09
+
+After four anchored codex rounds, slice 1 was split for the reviewer's size cap into #1457 (1a: adapter + local-default `not_offered`) and #1458 (1b: discovery-journey driver + typed capture validation).
+
+| PR | Result | Resolution |
+|---|---|---|
+| #1457 (1a) | 0 findings | merged `82a42b3e` |
+| #1458 (1b) | 1 normal: `EVALUATION_HEALTH_RESULTS` frozen without `timed_out`, which the CLI emits on `CancellationError` / `URLError.timedOut`; a real timed-out physical evaluation would fail closed at capture. The hermetic stubs never time out, so CI could not see it. | `timed_out` added to the frozen set; `test_accepts_a_timed_out_evaluation_capture` proves capture accepts it. Every other frozen set re-checked against the Swift encoder literals (`health_result`, adapter `status`, usage/fit sources): no other omission. |
+
+Gate met for both PRs.

--- a/docs/runbooks/byom-journey-evidence.md
+++ b/docs/runbooks/byom-journey-evidence.md
@@ -34,7 +34,9 @@ to the journey, or capture fails.
 
 `environment.class` records how the run was executed:
 
-- `hermetic-loopback` — the harness at `test/e2e/byom/run-cli-onboarding-e2e.py`
+- `hermetic-loopback` — a loopback harness: the discovery-journey driver at
+  `test/e2e/byom/run-discovery-journey.py` (`make test-byom-discovery-journey`)
+  or the onboarding harness at `test/e2e/byom/run-cli-onboarding-e2e.py`
   (`make test-byom-e2e`).
 - `physical-provider` — a real Mac run per
   `test/e2e/byom/CANDIDATE-E2E-RUNBOOK.md`.
@@ -82,23 +84,143 @@ result to them.
 
 ## Step 1 — run the journey and collect CLI documents
 
-Hermetic:
+### Discovery journey, hermetic: one command
+
+```bash
+test/e2e/byom/run-discovery-journey.py --evidence --out ~/byom-run
+```
+
+`--evidence` is not optional here. It is what makes the run capturable at all:
+only an `--evidence` run writes `run-manifest.json`. A run without it writes
+`run-summary.json` — the same content under a name step 3 does not consume — so
+a local debugging run cannot be promoted no matter what the operator does next.
+That is deliberate: without `--evidence` the driver accepts a
+`MACPROVIDER_CLI_BINARY` override and never checks the source tree, so the run
+proves nothing about any commit.
+
+The driver runs all ten `JOURNEY-PROVIDER-BYOM-DISCOVERY` steps against
+loopback stubs and an on-disk MLX-cache fixture, writes every captured CLI
+document to `~/byom-run/captures/`, and writes `~/byom-run/run-manifest.json`
+itself — so **steps 1 and 2 are already done** and you can go straight to step 3.
+`--out` must be a new or empty directory: reusing one is refused rather than
+cleaned, so a failing rerun can never leave an earlier run's passing manifest
+sitting there as if it were current. The manifest is published atomically and
+only after every step and observation check has passed.
+
+Every observation in that manifest is set from the driver's own assertions. The
+two negative observations are read off harness-owned ledgers rather than
+declared: a recording coordinator sink is configured as the CLI's coordinator
+for the whole run and must finish with zero requests and zero accepted
+connections (`provider_credit_created`), and the harness starts no buyer gateway
+at all while the only chat request anywhere in the run is the evaluation's
+single local probe (`buyer_traffic_sent`). A failed assertion aborts the run, so
+a manifest exists only for a run where all ten steps passed.
+`make test-byom-discovery-journey` runs the driver and then step 3 and step 4
+against its output, which is how CI proves the driver and the governance tables
+have not drifted apart.
+
+Step 10 reaches the ladder's local-default `not_offered` row by running `models
+admission status <offerable candidate> --json` with no coordinator configured at
+all — a harness-owned config with a provider id and no `coordinator_url`, and
+`MACPROVIDER_COORDINATOR_URL` removed from that one command's environment — so
+the CLI answers from local inventory, the document carries
+`admission_state_source: local_default` with the `coordinator_state_unavailable`
+warning, and the coordinator sink ledger stays empty.
+
+Captured CLI documents are stored **whole**. Nothing is stripped before hashing,
+so the digest binds the CLI's complete closed envelope, including the
+SPEC-046-R003 `provider_guidance` localization keys. Those two fields —
+`state_label_key` and `state_meaning_key` — are dotted label paths
+(`byom.local.offerable`) and therefore DNS-shaped by coincidence, so the shared
+scanner validates them against a closed `byom.<segment>.<segment>…` grammar at
+exactly those two paths inside a `provider_guidance` object, while still
+applying every credential, URL, path, IP, and localhost check to the value.
+Anything else at those paths fails closed, and the same string in any other
+field is still just a hostname. The driver runs that same scan — the capture
+tool's own functions, imported not reimplemented — over every command's real
+stdout and stderr, and over every document before writing it, so it cannot emit
+a manifest that step 3 would reject. The localization-key exemption applies only
+to stdout that is about to receive the structured document scan: plain-text
+output such as `--version` gets the full plaintext scan, hostname rule included.
+
+Every captured document is also validated against its **complete** closed
+schema, and that validation lives in the shared capture contract
+(`scripts/byom_journey_evidence.py`), invoked from the document-digest step. It
+therefore covers every discovery capture that reaches evidence — the hermetic
+driver's and a hand-authored physical discovery run's alike — not only the
+documents this driver produced. The field sets are the SPEC-046-R003 discovery
+envelope and candidate fields, the exact SPEC-046-R004 capability object, the
+SPEC-046-R005 evaluation envelope and mutation summary, and the SPEC-047-R002
+dry-run and status envelopes; `adapters[]` rows and `model_catalog_economics.v1`
+rows, which the specs describe without enumerating field names, are frozen at
+the shape the CLI emits. A missing field, an unknown field, and an unenumerated
+schema all fail closed. Redaction-clean is not the same as complete, and the
+signed evidence binds a digest of these documents.
+
+**Scope of typed validation (epic #1453 slice 1b).** Typed closed-enum
+validation currently applies to the **discovery** journey's documents only,
+because the hermetic driver above is what produces real CLI captures to type the
+validators against. The **admission** journey
+(`JOURNEY-NETWORK-MODEL-ADMISSION`) keeps the earlier capture boundary — the
+full redaction scans plus the check that a document's own top-level `schema`
+equals the schema its manifest claims — since that journey cannot be captured
+end to end before catalog binding exists. Typed validation of admission captures
+lands with the admission-journey slice (epic #1453 slice 7). Both journeys keep
+the harness-name binding: a run manifest may only name its own journey's
+harness.
+
+`--evidence` binds the run to the commit the evidence names:
+
+- the `MACPROVIDER_CLI_BINARY` override is refused;
+- `phase3-binary/Package.resolved` is reconciled with `HEAD` first, and only
+  ever in one direction. If the working-tree lockfile already matches `HEAD`,
+  nothing happens. If it differs **in an ephemeral CI checkout** (`GITHUB_ACTIONS`
+  or `CI` set, and nothing staged for the file), `HEAD`'s bytes are restored with
+  a logged notice: that drift is the earlier `swift test` step resolving the
+  graph under the runner's default toolchain, and `HEAD`'s lockfile is separately
+  proven consistent by the `phase3-binary (locked SwiftPM resolve)` job.
+  Anywhere else — a developer machine, or a CI run with the lockfile staged — a
+  differing lockfile is uncommitted work, so the run **refuses** rather than
+  discarding it; commit the file or restore it yourself and re-run. The CI
+  wrapper does no lockfile surgery of its own;
+- the tree must then be clean — **tracked and untracked** — across
+  `phase3-binary/Sources`, `phase3-binary/Tests`, `phase3-binary/Package.swift`,
+  `phase3-binary/Package.resolved`, `scripts/`, and `test/e2e/byom/`. Untracked
+  counts: SwiftPM builds every `.swift` file under the executable's source
+  directory;
+- the CLI is built from that source with locked resolution
+  (`--only-use-versions-from-resolved-file`, the same lock the locked-resolve CI
+  job applies through xcodebuild), so the build cannot rewrite the lockfile;
+- the cleanliness check runs **again after the build**, and the CI wrapper
+  records `source_sha` only once that post-build check has passed.
+
+Local exploratory runs may omit `--evidence` and keep the override; they produce
+no manifest.
+
+### Everything else: hand-authored
+
+For the admission journey, and for a physical-provider discovery run
+(`test/e2e/byom/CANDIDATE-E2E-RUNBOOK.md`), collect the documents and write the
+manifest by hand as described below.
 
 ```bash
 make test-byom-e2e
 ```
 
-Physical provider Mac: follow `test/e2e/byom/CANDIDATE-E2E-RUNBOOK.md`.
-
 Save each `--json` document the run produced (discovery, evaluation, offer
 dry-run, admission status, withdrawal, catalog economics) into one local
-directory, e.g. `~/byom-run/captures/`. For the admission journey, also read the
-money-path row counts directly from the coordinator's own tables (ledger,
-settlement, payout, request log) — not from a quiet API.
+directory, e.g. `~/byom-run/captures/`. Redact each document first: a captured
+value that carries an endpoint, a local path, a hostname, an IP literal or a
+credential makes step 3 refuse the whole run. For the admission journey, also
+read the money-path row counts directly from the coordinator's own tables
+(ledger, settlement, payout, request log) — not from a quiet API.
 
 ## Step 2 — write the run manifest
 
-Create `~/byom-run/run-manifest.json` using schema
+Skip this step for a hermetic discovery run: the driver already wrote the
+manifest.
+
+Otherwise create `~/byom-run/run-manifest.json` using schema
 `macprovider.byom-journey-run.v1`. Copy the shape from the committed golden
 fixtures:
 
@@ -226,8 +348,10 @@ conformance change, and let `spec-index / check` run.
 
 ```bash
 PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v scripts.tests.test_byom_journey_evidence
+PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v scripts.tests.test_discovery_journey_driver
 python3 scripts/check_spec_governance.py
 make test-byom-e2e
+make test-byom-discovery-journey
 ```
 
 The unit suite also runs inside `make test-dist`.

--- a/scripts/byom_journey_evidence.py
+++ b/scripts/byom_journey_evidence.py
@@ -117,6 +117,22 @@ REPO_SOURCE_FILE_NAME_RE = re.compile(
     r"\.(?:go|json|jsonl|md|mjs|py|sh|swift|toml|ts|txt|yaml|yml)$"
 )
 REPO_SOURCE_FILE_FIELDS = frozenset({"$.harness.name"})
+# SPEC-046-R003 requires every `provider_guidance` object to carry
+# `state_label_key` and `state_meaning_key`. Those two values are dotted
+# localization label paths (`byom.local.offerable`) and are therefore DNS-shaped
+# by coincidence, exactly like the repository source-file names above. Captured
+# CLI documents are archived whole -- deleting the fields would leave the digest
+# proving nothing about them -- so they get the same treatment: a closed grammar
+# checked at exactly those two field names inside a `provider_guidance` object,
+# at any depth, with every other rule (credential, URL, absolute/home path,
+# IPv4, IPv6, localhost) still applied to the value. Anything that is not a
+# whole localization key fails closed, and a localization-key-shaped string in
+# any other field is still just a hostname. The exemption is scoped to captured
+# CLI documents: the emitted-evidence scan (`assert_redacted`) has no exemption
+# at all, and evidence never carries a `provider_guidance` object.
+GUIDANCE_OBJECT_KEY = "provider_guidance"
+GUIDANCE_LOCALIZATION_KEY_FIELDS = frozenset({"state_label_key", "state_meaning_key"})
+LOCALIZATION_KEY_RE = re.compile(r"^byom\.[a-z0-9_]+(?:\.[a-z0-9_]+)+$")
 FORBIDDEN_VALUE_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     ("a url", re.compile(r"(?i)[a-z][a-z0-9+.-]*://")),
     ("an absolute path", re.compile(r"(?:^|[\s\"'=,;(\[])(?:/[A-Za-z0-9._~-]+){2,}")),
@@ -168,12 +184,14 @@ class JourneyContract:
         evidence_schema: str,
         evidence_prefix: str,
         artifact_id: str,
+        expected_harness_name: str,
         step_id_order: tuple[str, ...],
         step_requirement_ids: dict[str, set[str]],
         promotable_requirement_ids: set[str],
         true_observations: set[str],
         false_observations: set[str],
         release_evidence_requirement_id: str,
+        typed_capture_validation: bool,
         money_path_tables: tuple[str, ...] = (),
     ) -> None:
         self.selector = selector
@@ -182,12 +200,26 @@ class JourneyContract:
         self.evidence_schema = evidence_schema
         self.evidence_prefix = evidence_prefix
         self.artifact_id = artifact_id
+        # The one harness whose run manifest may back this journey's evidence.
+        # Without it the contract accepted any existing repository-relative
+        # source file, so a discovery manifest could claim the admission
+        # harness's provenance (R4 MEDIUM).
+        self.expected_harness_name = expected_harness_name
         self.step_id_order = step_id_order
         self.step_requirement_ids = step_requirement_ids
         self.promotable_requirement_ids = promotable_requirement_ids
         self.true_observations = true_observations
         self.false_observations = false_observations
         self.release_evidence_requirement_id = release_evidence_requirement_id
+        # Whether `_digest_document` runs the typed closed-enum capture
+        # validators over this journey's documents. See the SCOPE note above
+        # `validate_captured_cli_document`: the discovery journey has a
+        # hermetic driver producing real CLI captures, so its documents are
+        # validated in full. The admission journey's captures cannot be
+        # produced end to end until catalog binding exists, so it keeps the
+        # earlier boundary (redaction scans plus top-level `schema` equality)
+        # until the admission-journey slice (epic #1453 slice 7) captures it.
+        self.typed_capture_validation = typed_capture_validation
         self.money_path_tables = money_path_tables
 
     def allowed_step_requirement_ids(self, step_id: str) -> set[str]:
@@ -204,12 +236,14 @@ DISCOVERY_CONTRACT = JourneyContract(
     evidence_schema=PROVIDER_BYOM_DISCOVERY_EVIDENCE_SCHEMA,
     evidence_prefix=PROVIDER_BYOM_DISCOVERY_EVIDENCE_PREFIX,
     artifact_id=PROVIDER_BYOM_DISCOVERY_ARTIFACT_ID,
+    expected_harness_name="test/e2e/byom/run-discovery-journey.py",
     step_id_order=PROVIDER_BYOM_DISCOVERY_STEP_ID_ORDER,
     step_requirement_ids=PROVIDER_BYOM_DISCOVERY_STEP_REQUIREMENT_IDS,
     promotable_requirement_ids=set(PROVIDER_BYOM_DISCOVERY_PROMOTABLE_REQUIREMENT_IDS),
     true_observations=PROVIDER_BYOM_DISCOVERY_TRUE_OBSERVATIONS,
     false_observations=PROVIDER_BYOM_DISCOVERY_FALSE_OBSERVATIONS,
     release_evidence_requirement_id="SPEC-046-R008",
+    typed_capture_validation=True,
 )
 ADMISSION_CONTRACT = JourneyContract(
     selector="admission",
@@ -218,12 +252,15 @@ ADMISSION_CONTRACT = JourneyContract(
     evidence_schema=NETWORK_MODEL_ADMISSION_EVIDENCE_SCHEMA,
     evidence_prefix=NETWORK_MODEL_ADMISSION_EVIDENCE_PREFIX,
     artifact_id=NETWORK_MODEL_ADMISSION_ARTIFACT_ID,
+    expected_harness_name="test/e2e/byom/run-cli-onboarding-e2e.py",
     step_id_order=NETWORK_MODEL_ADMISSION_STEP_ID_ORDER,
     step_requirement_ids=NETWORK_MODEL_ADMISSION_STEP_REQUIREMENT_IDS,
     promotable_requirement_ids=set(NETWORK_MODEL_ADMISSION_PROMOTABLE_REQUIREMENT_IDS),
     true_observations=NETWORK_MODEL_ADMISSION_TRUE_OBSERVATIONS,
     false_observations=NETWORK_MODEL_ADMISSION_FALSE_OBSERVATIONS,
     release_evidence_requirement_id="SPEC-047-R008",
+    # Scoped off in this slice; see `typed_capture_validation` above.
+    typed_capture_validation=False,
     money_path_tables=NETWORK_MODEL_ADMISSION_MONEY_PATH_TABLES,
 )
 CONTRACTS: dict[str, JourneyContract] = {
@@ -340,25 +377,39 @@ def reject_hostname_like_text(text: str, location: str) -> None:
         fail(f"{location} contains a hostname; evidence must stay redacted")
 
 
+def reject_unredacted_text_except_hostname(text: str, location: str) -> None:
+    """Every redaction rule except the shape-based DNS hostname rule."""
+    reject_secret_like_text(text, location)
+    for label, pattern in FORBIDDEN_VALUE_PATTERNS:
+        if pattern.search(text):
+            fail(f"{location} contains {label}; evidence must stay redacted")
+
+
 def reject_unredacted_repo_source_file(value: str, location: str) -> None:
     """Scoped rule for the repository source file-name fields.
 
     Runs every scan except the hostname rule, then requires the whole value to be
     a repository-relative source file name with a known extension.
     """
-    reject_secret_like_text(value, location)
-    for label, pattern in FORBIDDEN_VALUE_PATTERNS:
-        if pattern.search(value):
-            fail(f"{location} contains {label}; evidence must stay redacted")
+    reject_unredacted_text_except_hostname(value, location)
     if ".." in Path(value).parts or not REPO_SOURCE_FILE_NAME_RE.fullmatch(value):
         fail(f"{location} must be a repository-relative source file name")
 
 
+def reject_unredacted_localization_key(value: str, location: str) -> None:
+    """Scoped rule for `provider_guidance.state_label_key` / `state_meaning_key`.
+
+    Runs every scan except the hostname rule, then requires the WHOLE value to
+    match the closed localization-key grammar. A value that is a hostname, a
+    partial key, or anything else fails closed.
+    """
+    reject_unredacted_text_except_hostname(value, location)
+    if not LOCALIZATION_KEY_RE.fullmatch(value):
+        fail(f"{location} must be a closed byom localization key")
+
+
 def reject_unredacted_text(text: str, location: str) -> None:
-    reject_secret_like_text(text, location)
-    for label, pattern in FORBIDDEN_VALUE_PATTERNS:
-        if pattern.search(text):
-            fail(f"{location} contains {label}; evidence must stay redacted")
+    reject_unredacted_text_except_hostname(text, location)
     reject_hostname_like_text(text, location)
 
 
@@ -381,6 +432,40 @@ def _walk_redaction(value: Any, location: str) -> None:
             reject_unredacted_repo_source_file(value, location)
         else:
             reject_unredacted_text(value, location)
+
+
+def assert_captured_document_redacted(value: Any, location: str = "$") -> None:
+    """Fail-closed scan for a whole captured CLI document.
+
+    Identical to `assert_redacted` except that inside a `provider_guidance`
+    object -- at any depth, so candidate rows and top-level evaluation, dry-run,
+    and status documents are all covered -- the two SPEC-046-R003
+    localization-key fields are validated against the closed localization-key
+    grammar instead of the shape-based hostname rule. Every other key and every
+    other string value, including any other field of the same guidance object,
+    keeps the full rule set.
+    """
+    reject_forbidden_keys(value, location)
+    _walk_captured_document(value, location, in_guidance=False)
+
+
+def _walk_captured_document(value: Any, location: str, *, in_guidance: bool) -> None:
+    if isinstance(value, dict):
+        for key, item in value.items():
+            reject_unredacted_text(key, f"{location} key {key!r}")
+            if in_guidance and key in GUIDANCE_LOCALIZATION_KEY_FIELDS and isinstance(item, str):
+                reject_unredacted_localization_key(item, f"{location}.{key}")
+                continue
+            _walk_captured_document(
+                item,
+                f"{location}.{key}",
+                in_guidance=(key == GUIDANCE_OBJECT_KEY and isinstance(item, dict)),
+            )
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            _walk_captured_document(item, f"{location}[{index}]", in_guidance=False)
+    elif isinstance(value, str):
+        reject_unredacted_text(value, location)
 
 
 def repository_relative(root: Path, value: str, label: str) -> str:
@@ -483,7 +568,642 @@ def load_mapped_pending_requirements(root: Path, contract: JourneyContract) -> s
     return mapped
 
 
-def _digest_document(manifest_dir: Path, entry: Any, step_id: str, index: int) -> dict[str, Any]:
+# --- Closed CLI-document schemas -------------------------------------------
+#
+# A captured CLI document is the thing the signed evidence digests, so the
+# digest is only a conformance claim if the document is COMPLETE. Redaction
+# alone is not enough: a discovery envelope that stopped emitting `capabilities`,
+# or an evaluation whose `mutation_summary` carried one field, is redaction-clean
+# and still a false claim. These key sets are therefore enforced here, at the
+# capture trust boundary (`_digest_document`), not in whichever harness produced
+# the document, so a hand-authored physical discovery run goes through the same
+# gate as the hermetic discovery driver.
+#
+# SCOPE (epic #1453 slice 1b): these schemas cover the DISCOVERY journey's
+# documents only -- `provider_byom_discovery.v1`, `provider_byom_evaluation.v1`,
+# `model_admission_offer_dry_run.v1`, `model_admission_status.v1`, and
+# `model_catalog_economics.v1` as the discovery driver emits them. The admission
+# journey (`JOURNEY-NETWORK-MODEL-ADMISSION`) is NOT typed-validated here: see
+# `JourneyContract.typed_capture_validation` and the note in `_digest_document`.
+#
+# Every set is exact: a missing key and an unknown key both fail closed. The
+# field lists are the normative ones -- SPEC-046-R003 (discovery envelope,
+# candidate, provider_guidance), SPEC-046-R004 (capability object), SPEC-046-R005
+# (evaluation envelope), SPEC-047-R002 (dry-run and status envelopes) -- except
+# the two the specs describe without enumerating field names, `adapters[]` rows
+# and the `model_catalog_economics.v1` row, which are frozen here at the shape
+# the CLI actually emits so a silent projection change fails closed rather than
+# passing unnoticed.
+
+DISCOVERY_ENVELOPE_KEYS = frozenset({
+    "schema", "generated_at", "cli_version", "projection_sequence",
+    "adapters", "candidates", "warnings",
+})
+DISCOVERY_ADAPTER_KEYS = frozenset({
+    "runtime_source", "origin_class", "status", "warning_codes",
+})
+DISCOVERY_CANDIDATE_KEYS = frozenset({
+    "candidate_id", "runtime_source", "display_name", "served_model_ref",
+    "catalog_model_key", "identity_state", "locality", "estimated_gb",
+    "context_window_tokens", "capabilities", "readiness_state", "fit_state",
+    "evaluation_state", "admission_state", "admission_state_source",
+    "provider_guidance", "warning_codes",
+})
+# SPEC-046-R004, exactly.
+CAPABILITY_KEYS = frozenset({
+    "chat_completions", "streaming", "tool_call_passthrough",
+    "structured_output_passthrough", "json_mode", "usage_reporting",
+    "max_context_tokens", "quantization", "family", "runtime_version",
+})
+# SPEC-046-R003; SPEC-047-R002 requires the dry-run and status envelopes to
+# reuse this same object.
+PROVIDER_GUIDANCE_KEYS = frozenset({
+    "state_label_key", "state_meaning_key", "next_action",
+    "transition_reason_code", "earning_path_class",
+})
+EVALUATION_ENVELOPE_KEYS = frozenset({
+    "schema", "generated_at", "cli_version", "candidate_id", "runtime_source",
+    "served_model_ref", "catalog_model_key", "adapter_identity",
+    "health_result", "latency_ms", "tokens_per_second", "completion_tokens",
+    "output_bytes", "request_count", "usage_reporting_source",
+    "capability_results", "fit_estimate_source", "mutation_summary",
+    "diagnostic_hashes", "provider_guidance",
+    "offer_preconditions_appear_satisfied", "warnings",
+})
+EVALUATION_MUTATION_SUMMARY_KEYS = frozenset({
+    "production_config_mutated", "production_model_switched", "runtime_started",
+    "downloads_started", "temporary_files_created", "coordinator_state_mutated",
+})
+# SPEC-047-R002, exactly.
+OFFER_DRY_RUN_ENVELOPE_KEYS = frozenset({
+    "schema", "generated_at", "cli_version", "candidate_id", "served_model_ref",
+    "catalog_model_key", "would_submit", "likely_admission_state",
+    "likely_admission_state_source", "provider_guidance", "reason_code",
+    "warnings",
+})
+ADMISSION_STATUS_ENVELOPE_KEYS = frozenset({
+    "schema", "generated_at", "cli_version", "provider_id", "candidate_id",
+    "served_model_ref", "catalog_model_key", "admission_state",
+    "admission_state_source", "coordinator_event_id", "state_observed_at",
+    "provider_guidance", "allowed_next_states", "warnings",
+})
+CATALOG_ECONOMICS_ENVELOPE_KEYS = frozenset({
+    "schema", "generated_at", "projection_sequence", "source", "rows", "warnings",
+})
+CATALOG_ECONOMICS_ROW_KEYS = frozenset({
+    "model_key", "display_model_id", "served_model_id", "action_model_id",
+    "is_current", "runtime_state", "economics_state", "admission", "fit",
+    "estimated_gb", "weights_present_locally", "ready_provider_count",
+    "demand_rank", "demand_weight", "supply_deficit_score",
+    "prompt_rate_usd_per_million_tokens", "completion_rate_usd_per_million_tokens",
+    "provider_prompt_payout_usd_per_million_tokens",
+    "provider_completion_payout_usd_per_million_tokens", "provider_share_bps",
+    "rate_source", "rate_card_key", "rate_card_version", "rate_card_generated_at",
+    "adopt_recommendation", "prepare", "evaluate", "switch", "cleanup_staging",
+    "disabled_reason", "warning_codes",
+})
+CATALOG_ECONOMICS_ADMISSION_KEYS = frozenset({
+    "state", "source", "settlement_capable", "catalog_economics_permitted",
+    "coordinator_event_id", "state_observed_at",
+})
+# `model_catalog_economics.v1` nested objects. The spec does not enumerate these
+# either, so -- like the row itself -- they are frozen at the shape
+# `ModelCatalogEconomicsWire.Source` / `.Action` actually encodes. The R4 audit
+# found hand-authored fixtures carrying `prepare: false` and a string `source`
+# where the CLI emits objects; only a shape check catches that.
+CATALOG_ECONOMICS_SOURCE_KEYS = frozenset({
+    "cli_version", "cli_build_commit", "process_launch_id", "process_started_at",
+    "projection_protocol_version", "rate_card_source", "rate_card_digest",
+    "rate_card_signature_digest", "demand_feed_digest", "candidate_feed_digest",
+    "rate_card_max_age_seconds",
+})
+CATALOG_ECONOMICS_ACTION_KEYS = frozenset({
+    "available", "requires_confirmation", "transaction_kind", "transaction_id",
+    "action_timeout_seconds", "estimated_bytes", "unavailable_reason",
+})
+CATALOG_ECONOMICS_ACTION_FIELDS = (
+    "switch", "prepare", "evaluate", "adopt_recommendation", "cleanup_staging",
+)
+
+# --- Closed value enums ----------------------------------------------------
+#
+# Exact key sets prove a document is COMPLETE; they do not prove its values are
+# ones the CLI can emit. The R4 audit showed that gap concretely: fixtures
+# carrying `identity_state: declared_local`, `locality: local_weights`,
+# `evaluation_state: evaluated`, and `next_action: serve_traffic` passed
+# validation and could have backed signed evidence. Every enum below is
+# transcribed from the normative spec text; where a spec deliberately leaves a
+# field's vocabulary to the implementation, the set is frozen from the CLI
+# encoder instead and says so.
+
+# SPEC-046-R002 v0.1 adapter enum, exactly.
+RUNTIME_SOURCES = frozenset({
+    "mlx_cache", "ollama_loopback", "lmstudio_loopback", "llamacpp_loopback",
+    "openai_compatible_loopback",
+})
+# SPEC-046-R003 candidate enums, exactly.
+IDENTITY_STATES = frozenset({
+    "catalog_matched", "artifact_hash_available", "runtime_reported",
+    "opaque_endpoint", "unknown",
+})
+LOCALITIES = frozenset({
+    "local_artifact", "loopback_runtime", "opaque_local_endpoint", "unknown",
+})
+READINESS_STATES = frozenset({
+    "ready", "needs_runtime", "needs_weights", "requires_preparation",
+    "unreachable", "unknown",
+})
+FIT_STATES = frozenset({"fits", "does_not_fit", "unknown"})
+EVALUATION_STATES = frozenset({
+    "not_evaluated", "running", "passed", "failed", "timed_out", "blocked",
+})
+ADMISSION_STATE_SOURCES = frozenset({"local_default", "coordinator"})
+# SPEC-046-R003 `admission_state`, all twelve values.
+ADMISSION_STATES = frozenset({
+    "local_only", "not_offered", "offerable", "offer_submitted", "offer_rejected",
+    "sandbox_probe_only", "network_visible_unpriced", "network_admitted_unsettled",
+    "catalog_priced", "settlement_capable", "withdrawn", "revoked",
+})
+# SPEC-046-R003: under `admission_state_source: local_default` the CLI may only
+# report its own local ladder. A network state carried on a local default would
+# be the CLI promoting a candidate no coordinator ever admitted.
+LOCAL_DEFAULT_ADMISSION_STATES = frozenset({"local_only", "not_offered", "offerable"})
+# SPEC-047-R001 v0.1 coordinator states, exactly. `local_only` and `offerable`
+# are CLI-only inventory states and are deliberately absent.
+COORDINATOR_ADMISSION_STATES = frozenset({
+    "not_offered", "offer_submitted", "offer_rejected", "sandbox_probe_only",
+    "network_visible_unpriced", "network_admitted_unsettled", "catalog_priced",
+    "settlement_capable", "withdrawn", "revoked",
+})
+# SPEC-047-R001 transition table. `allowed_next_states` must be a subset of the
+# row for the state the document reports: a document offering an edge the state
+# machine has no row for is not readback of any legal coordinator state.
+ADMISSION_ALLOWED_NEXT_STATES = {
+    "not_offered": frozenset({"offer_submitted"}),
+    "offer_submitted": frozenset({
+        "offer_rejected", "sandbox_probe_only", "network_visible_unpriced",
+        "network_admitted_unsettled", "catalog_priced", "withdrawn", "revoked",
+    }),
+    "offer_rejected": frozenset({"offer_submitted", "revoked"}),
+    "sandbox_probe_only": frozenset({
+        "network_visible_unpriced", "network_admitted_unsettled", "catalog_priced",
+        "withdrawn", "revoked",
+    }),
+    "network_visible_unpriced": frozenset({
+        "network_admitted_unsettled", "catalog_priced", "withdrawn", "revoked",
+    }),
+    "network_admitted_unsettled": frozenset({
+        "catalog_priced", "settlement_capable", "withdrawn", "revoked",
+    }),
+    "catalog_priced": frozenset({
+        "network_admitted_unsettled", "settlement_capable", "withdrawn", "revoked",
+    }),
+    "settlement_capable": frozenset({
+        "network_admitted_unsettled", "catalog_priced", "withdrawn", "revoked",
+    }),
+    "withdrawn": frozenset({"offer_submitted"}),
+    "revoked": frozenset({"offer_submitted"}),
+}
+# SPEC-046-R003 `provider_guidance` enums, exactly.
+NEXT_ACTIONS = frozenset({
+    "fix_local_blocker", "evaluate", "offer_dry_run", "submit_offer",
+    "revise_and_reoffer", "check_status", "withdraw", "wait_for_coordinator",
+    "maintain_runtime", "none",
+})
+EARNING_PATH_CLASSES = frozenset({
+    "local_inventory_only", "not_earning_yet_catalog_or_receipt_path_exists",
+    "no_earning_path_in_v0_1", "settlement_capable",
+})
+# SPEC-046-R003 warning-code enum plus the four R007 redaction-provenance codes,
+# which that section adds to the same enum. Mirrors `BYOMDiscoveryWarning`.
+WARNING_CODES = frozenset({
+    "candidate_id_unstable", "adapter_unavailable", "adapter_timeout",
+    "adapter_rejected_non_loopback", "adapter_malformed_response",
+    "adapter_response_truncated", "catalog_match_unverified",
+    "capability_unevaluated", "evaluation_required", "evaluation_failed",
+    "requires_preparation", "namespace_permission_invalid",
+    "coordinator_state_unavailable", "capability_family_redacted",
+    "capability_quantization_redacted", "capability_runtime_version_redacted",
+    "model_reference_redacted",
+})
+# The vocabularies below are left to the implementation by their specs, so each
+# set is frozen from the CLI encoder rather than from spec text. A CLI that
+# starts emitting a value outside one of them fails capture, which is the
+# intended outcome: an unreviewed projection change must not silently back
+# signed evidence.
+#
+# `adapters[].status`: BYOMDiscovery.swift emits exactly these six.
+ADAPTER_STATUSES = frozenset({
+    "ok", "unavailable", "timeout", "malformed", "truncated", "rejected",
+})
+# `adapters[].origin_class`: null for a non-HTTP adapter such as `mlx_cache`.
+ORIGIN_CLASSES = frozenset({"loopback_http", "rejected"})
+# `provider_byom_evaluation.v1` scalars, from the evaluation encoder.
+EVALUATION_HEALTH_RESULTS = frozenset({"passed", "failed", "blocked"})
+EVALUATION_ADAPTER_IDENTITIES = frozenset({
+    "openai_compatible_loopback", "mlx_cache_local_artifact", "unknown",
+})
+EVALUATION_USAGE_REPORTING_SOURCES = frozenset({
+    "runtime_reported", "absent", "not_evaluated",
+})
+EVALUATION_FIT_ESTIMATE_SOURCES = frozenset({"discovery_fit_state"})
+# A blocked evaluation reports `runtime_source: "unknown"` for a candidate it
+# never resolved, so the evaluation envelope admits one value discovery does not.
+EVALUATION_RUNTIME_SOURCES = RUNTIME_SOURCES | {"unknown"}
+# SPEC-046-R005 capability test results; the CLI models each as an object, not a
+# bare string. The R4 audit found a fixture using strings here.
+EVALUATION_CAPABILITY_RESULT_KEYS = frozenset({"result", "source", "reason_code"})
+EVALUATION_CAPABILITY_RESULTS = frozenset({"passed", "failed", "not_tested"})
+EVALUATION_CAPABILITY_SOURCES = frozenset({
+    "evaluation", "not_evaluated", "runtime_reported", "absent",
+})
+# SPEC-046-R005 requires transcripts to be content-hashed, never retained; these
+# are the hash fields the evaluation encoder emits. The R4 audit found a fixture
+# using `completion_sha256`, a key the CLI has never emitted.
+EVALUATION_DIAGNOSTIC_HASH_KEYS = frozenset({"prompt_sha256", "response_body_sha256"})
+
+
+def require_bool(value: Any, where: str) -> bool:
+    if not isinstance(value, bool):
+        fail(f"{where} must be a JSON boolean")
+    return value
+
+
+def require_int(value: Any, where: str) -> int:
+    # `isinstance(True, int)` is True in Python; a boolean is not an integer here.
+    if isinstance(value, bool) or not isinstance(value, int):
+        fail(f"{where} must be a JSON integer")
+    return value
+
+
+def require_number(value: Any, where: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        fail(f"{where} must be a JSON number")
+    return value
+
+
+def require_text(value: Any, where: str) -> str:
+    """A non-empty string. A free-text field may still not be null or a number."""
+    if not isinstance(value, str) or not value:
+        fail(f"{where} must be a non-empty JSON string")
+    return value
+
+
+def require_nullable(value: Any, where: str, check) -> Any:
+    """A nullable field is either JSON null or whatever `check` accepts.
+
+    SPEC-046-R004 is explicit that an unknown value is null -- never `false`,
+    never a sentinel string -- so for those fields the nullable wrapper is the
+    whole rule rather than a convenience.
+    """
+    if value is None:
+        return None
+    return check(value, where)
+
+
+def require_enum(value: Any, allowed: frozenset[str], where: str) -> str:
+    if not isinstance(value, str):
+        fail(f"{where} must be a JSON string")
+    if value not in allowed:
+        fail(f"{where} is not a permitted value: {value!r}")
+    return value
+
+
+def require_enum_list(value: Any, allowed: frozenset[str], where: str) -> list[str]:
+    items = require_list(value, where)
+    for index, item in enumerate(items):
+        require_enum(item, allowed, f"{where}[{index}]")
+    return items
+
+
+def _require_admission_pair(
+    document: dict[str, Any], state_field: str, source_field: str, where: str
+) -> tuple[str, str]:
+    """SPEC-046-R003 / SPEC-047-R002 cross-field rule on a state and its source.
+
+    Reading the state without its source is the mistake both specs single out:
+    `not_offered` means local advisory inventory under `local_default` and
+    authoritative coordinator readback under `coordinator`. A document claiming
+    a network state under `local_default` is the CLI promoting a candidate no
+    coordinator admitted, so it must never reach a digest.
+    """
+    source = require_enum(
+        document[source_field], ADMISSION_STATE_SOURCES, f"{where}.{source_field}"
+    )
+    state = require_enum(document[state_field], ADMISSION_STATES, f"{where}.{state_field}")
+    allowed = (
+        LOCAL_DEFAULT_ADMISSION_STATES if source == "local_default"
+        else COORDINATOR_ADMISSION_STATES
+    )
+    if state not in allowed:
+        fail(
+            f"{where}.{state_field} {state!r} is not a permitted state for "
+            f"{source_field} {source!r}"
+        )
+    return state, source
+
+
+def assert_exact_object(value: Any, expected_keys: frozenset[str], where: str) -> dict[str, Any]:
+    """The captured document must carry exactly these fields -- no more, no less."""
+    if not isinstance(value, dict):
+        fail(f"{where} must be a JSON object")
+    present = set(value)
+    missing = sorted(expected_keys - present)
+    if missing:
+        fail(f"{where} is missing required fields: " + ", ".join(missing))
+    unknown = sorted(present - expected_keys)
+    if unknown:
+        fail(f"{where} carries unknown fields: " + ", ".join(unknown))
+    return value
+
+
+def _validate_guidance(document: dict[str, Any], where: str) -> None:
+    """SPEC-046-R003 `provider_guidance`, reused verbatim by every SPEC-047-R002
+    envelope. The two `*_key` fields are localization keys, so they are checked
+    as non-empty strings; the rest are closed enums."""
+    location = where + ".provider_guidance"
+    guidance = assert_exact_object(document["provider_guidance"], PROVIDER_GUIDANCE_KEYS, location)
+    require_text(guidance["state_label_key"], location + ".state_label_key")
+    require_text(guidance["state_meaning_key"], location + ".state_meaning_key")
+    require_enum(guidance["next_action"], NEXT_ACTIONS, location + ".next_action")
+    require_nullable(
+        guidance["transition_reason_code"], location + ".transition_reason_code", require_text
+    )
+    require_enum(
+        guidance["earning_path_class"], EARNING_PATH_CLASSES, location + ".earning_path_class"
+    )
+
+
+def _validate_envelope_header(document: dict[str, Any], where: str) -> None:
+    """Fields every CLI envelope carries. `schema` itself is cross-checked
+    against the manifest's claim in `_digest_document`."""
+    require_text(document["schema"], where + ".schema")
+    require_text(document["generated_at"], where + ".generated_at")
+    require_text(document["cli_version"], where + ".cli_version")
+
+
+def _validate_capabilities(candidate: dict[str, Any], where: str) -> None:
+    """SPEC-046-R004: six nullable booleans, one nullable number, three nullable
+    strings. `false` is a claim that the capability is absent, so a `false`
+    standing in for an unknown value is exactly what this rejects."""
+    location = where + ".capabilities"
+    capabilities = assert_exact_object(candidate["capabilities"], CAPABILITY_KEYS, location)
+    for field in (
+        "chat_completions", "streaming", "tool_call_passthrough",
+        "structured_output_passthrough", "json_mode", "usage_reporting",
+    ):
+        require_nullable(capabilities[field], f"{location}.{field}", require_bool)
+    require_nullable(capabilities["max_context_tokens"], location + ".max_context_tokens", require_number)
+    for field in ("quantization", "family", "runtime_version"):
+        require_nullable(capabilities[field], f"{location}.{field}", require_text)
+
+
+def _validate_discovery(parsed: dict[str, Any], location: str) -> None:
+    assert_exact_object(parsed, DISCOVERY_ENVELOPE_KEYS, location)
+    _validate_envelope_header(parsed, location)
+    require_int(parsed["projection_sequence"], location + ".projection_sequence")
+    require_enum_list(parsed["warnings"], WARNING_CODES, location + ".warnings")
+    for index, adapter in enumerate(require_list(parsed["adapters"], location + ".adapters")):
+        where = f"{location} adapters[{index}]"
+        assert_exact_object(adapter, DISCOVERY_ADAPTER_KEYS, where)
+        require_enum(adapter["runtime_source"], RUNTIME_SOURCES, where + ".runtime_source")
+        require_enum(adapter["status"], ADAPTER_STATUSES, where + ".status")
+        require_nullable(
+            adapter["origin_class"], where + ".origin_class",
+            lambda value, at: require_enum(value, ORIGIN_CLASSES, at),
+        )
+        require_enum_list(adapter["warning_codes"], WARNING_CODES, where + ".warning_codes")
+    for index, candidate in enumerate(require_list(parsed["candidates"], location + ".candidates")):
+        where = f"{location} candidates[{index}]"
+        assert_exact_object(candidate, DISCOVERY_CANDIDATE_KEYS, where)
+        require_text(candidate["candidate_id"], where + ".candidate_id")
+        require_enum(candidate["runtime_source"], RUNTIME_SOURCES, where + ".runtime_source")
+        require_text(candidate["display_name"], where + ".display_name")
+        require_text(candidate["served_model_ref"], where + ".served_model_ref")
+        require_nullable(candidate["catalog_model_key"], where + ".catalog_model_key", require_text)
+        require_enum(candidate["identity_state"], IDENTITY_STATES, where + ".identity_state")
+        require_enum(candidate["locality"], LOCALITIES, where + ".locality")
+        require_nullable(candidate["estimated_gb"], where + ".estimated_gb", require_number)
+        require_nullable(
+            candidate["context_window_tokens"], where + ".context_window_tokens", require_int
+        )
+        _validate_capabilities(candidate, where)
+        require_enum(candidate["readiness_state"], READINESS_STATES, where + ".readiness_state")
+        require_enum(candidate["fit_state"], FIT_STATES, where + ".fit_state")
+        require_enum(candidate["evaluation_state"], EVALUATION_STATES, where + ".evaluation_state")
+        _require_admission_pair(candidate, "admission_state", "admission_state_source", where)
+        _validate_guidance(candidate, where)
+        require_enum_list(candidate["warning_codes"], WARNING_CODES, where + ".warning_codes")
+
+
+def _validate_evaluation(parsed: dict[str, Any], location: str) -> None:
+    assert_exact_object(parsed, EVALUATION_ENVELOPE_KEYS, location)
+    _validate_envelope_header(parsed, location)
+    require_text(parsed["candidate_id"], location + ".candidate_id")
+    require_enum(parsed["runtime_source"], EVALUATION_RUNTIME_SOURCES, location + ".runtime_source")
+    require_text(parsed["served_model_ref"], location + ".served_model_ref")
+    require_nullable(parsed["catalog_model_key"], location + ".catalog_model_key", require_text)
+    require_enum(
+        parsed["adapter_identity"], EVALUATION_ADAPTER_IDENTITIES, location + ".adapter_identity"
+    )
+    require_enum(parsed["health_result"], EVALUATION_HEALTH_RESULTS, location + ".health_result")
+    require_nullable(parsed["latency_ms"], location + ".latency_ms", require_int)
+    require_nullable(parsed["tokens_per_second"], location + ".tokens_per_second", require_number)
+    require_nullable(parsed["completion_tokens"], location + ".completion_tokens", require_int)
+    require_int(parsed["output_bytes"], location + ".output_bytes")
+    require_int(parsed["request_count"], location + ".request_count")
+    require_enum(
+        parsed["usage_reporting_source"], EVALUATION_USAGE_REPORTING_SOURCES,
+        location + ".usage_reporting_source",
+    )
+    results = require_object(parsed["capability_results"], location + ".capability_results")
+    for name, result in results.items():
+        where = f"{location}.capability_results[{name!r}]"
+        entry = assert_exact_object(result, EVALUATION_CAPABILITY_RESULT_KEYS, where)
+        require_enum(entry["result"], EVALUATION_CAPABILITY_RESULTS, where + ".result")
+        require_enum(entry["source"], EVALUATION_CAPABILITY_SOURCES, where + ".source")
+        require_nullable(entry["reason_code"], where + ".reason_code", require_text)
+    require_enum(
+        parsed["fit_estimate_source"], EVALUATION_FIT_ESTIMATE_SOURCES,
+        location + ".fit_estimate_source",
+    )
+    mutations = assert_exact_object(
+        parsed["mutation_summary"], EVALUATION_MUTATION_SUMMARY_KEYS,
+        location + ".mutation_summary",
+    )
+    # Every mutation flag is a hard SPEC-046-R006 claim; a missing or non-boolean
+    # value must not read as "no mutation".
+    for field in sorted(EVALUATION_MUTATION_SUMMARY_KEYS):
+        require_bool(mutations[field], f"{location}.mutation_summary.{field}")
+    hashes = assert_exact_object(
+        parsed["diagnostic_hashes"], EVALUATION_DIAGNOSTIC_HASH_KEYS,
+        location + ".diagnostic_hashes",
+    )
+    require_string(
+        hashes["prompt_sha256"], SHA256_RE, location + ".diagnostic_hashes.prompt_sha256"
+    )
+    require_nullable(
+        hashes["response_body_sha256"], location + ".diagnostic_hashes.response_body_sha256",
+        lambda value, at: require_string(value, SHA256_RE, at),
+    )
+    _validate_guidance(parsed, location)
+    require_bool(
+        parsed["offer_preconditions_appear_satisfied"],
+        location + ".offer_preconditions_appear_satisfied",
+    )
+    require_enum_list(parsed["warnings"], WARNING_CODES, location + ".warnings")
+
+
+def _validate_offer_dry_run(parsed: dict[str, Any], location: str) -> None:
+    assert_exact_object(parsed, OFFER_DRY_RUN_ENVELOPE_KEYS, location)
+    _validate_envelope_header(parsed, location)
+    require_text(parsed["candidate_id"], location + ".candidate_id")
+    require_text(parsed["served_model_ref"], location + ".served_model_ref")
+    require_nullable(parsed["catalog_model_key"], location + ".catalog_model_key", require_text)
+    require_bool(parsed["would_submit"], location + ".would_submit")
+    _require_admission_pair(
+        parsed, "likely_admission_state", "likely_admission_state_source", location
+    )
+    _validate_guidance(parsed, location)
+    require_nullable(parsed["reason_code"], location + ".reason_code", require_text)
+    require_enum_list(parsed["warnings"], WARNING_CODES, location + ".warnings")
+
+
+def _validate_admission_status(parsed: dict[str, Any], location: str) -> None:
+    assert_exact_object(parsed, ADMISSION_STATUS_ENVELOPE_KEYS, location)
+    _validate_envelope_header(parsed, location)
+    require_text(parsed["provider_id"], location + ".provider_id")
+    require_text(parsed["candidate_id"], location + ".candidate_id")
+    require_text(parsed["served_model_ref"], location + ".served_model_ref")
+    require_nullable(parsed["catalog_model_key"], location + ".catalog_model_key", require_text)
+    state, source = _require_admission_pair(
+        parsed, "admission_state", "admission_state_source", location
+    )
+    require_nullable(parsed["coordinator_event_id"], location + ".coordinator_event_id", require_text)
+    require_nullable(parsed["state_observed_at"], location + ".state_observed_at", require_text)
+    _validate_guidance(parsed, location)
+    next_states = require_enum_list(
+        parsed["allowed_next_states"], ADMISSION_STATES, location + ".allowed_next_states"
+    )
+    # SPEC-047-R002: empty for a local default that has not entered coordinator
+    # admission, and otherwise only edges SPEC-047-R001 actually allows.
+    if source == "local_default":
+        if next_states:
+            fail(
+                f"{location}.allowed_next_states must be empty for a local_default state"
+            )
+    else:
+        allowed = ADMISSION_ALLOWED_NEXT_STATES[state]
+        for index, next_state in enumerate(next_states):
+            if next_state not in allowed:
+                fail(
+                    f"{location}.allowed_next_states[{index}] {next_state!r} is not an "
+                    f"allowed transition from {state!r}"
+                )
+    require_enum_list(parsed["warnings"], WARNING_CODES, location + ".warnings")
+
+
+def _validate_catalog_economics(parsed: dict[str, Any], location: str) -> None:
+    assert_exact_object(parsed, CATALOG_ECONOMICS_ENVELOPE_KEYS, location)
+    require_text(parsed["schema"], location + ".schema")
+    require_text(parsed["generated_at"], location + ".generated_at")
+    require_int(parsed["projection_sequence"], location + ".projection_sequence")
+    assert_exact_object(parsed["source"], CATALOG_ECONOMICS_SOURCE_KEYS, location + ".source")
+    require_list(parsed["warnings"], location + ".warnings")
+    for index, row in enumerate(require_list(parsed["rows"], location + ".rows")):
+        where = f"{location} rows[{index}]"
+        assert_exact_object(row, CATALOG_ECONOMICS_ROW_KEYS, where)
+        require_text(row["model_key"], where + ".model_key")
+        require_text(row["served_model_id"], where + ".served_model_id")
+        require_text(row["display_model_id"], where + ".display_model_id")
+        require_nullable(row["action_model_id"], where + ".action_model_id", require_text)
+        require_bool(row["is_current"], where + ".is_current")
+        require_bool(row["weights_present_locally"], where + ".weights_present_locally")
+        require_text(row["runtime_state"], where + ".runtime_state")
+        require_nullable(row["estimated_gb"], where + ".estimated_gb", require_number)
+        require_enum(row["fit"], FIT_STATES, where + ".fit")
+        require_nullable(row["disabled_reason"], where + ".disabled_reason", require_text)
+        require_list(row["warning_codes"], where + ".warning_codes")
+        admission = assert_exact_object(
+            row["admission"], CATALOG_ECONOMICS_ADMISSION_KEYS, where + ".admission"
+        )
+        _require_admission_pair(admission, "state", "source", where + ".admission")
+        require_bool(
+            admission["catalog_economics_permitted"],
+            where + ".admission.catalog_economics_permitted",
+        )
+        require_bool(admission["settlement_capable"], where + ".admission.settlement_capable")
+        require_nullable(
+            admission["coordinator_event_id"], where + ".admission.coordinator_event_id", require_text
+        )
+        require_nullable(
+            admission["state_observed_at"], where + ".admission.state_observed_at", require_text
+        )
+        # Money fields. A string or boolean here would read as a rate.
+        for field in (
+            "prompt_rate_usd_per_million_tokens", "completion_rate_usd_per_million_tokens",
+            "provider_prompt_payout_usd_per_million_tokens",
+            "provider_completion_payout_usd_per_million_tokens", "demand_weight",
+            "supply_deficit_score",
+        ):
+            require_nullable(row[field], f"{where}.{field}", require_number)
+        for field in ("provider_share_bps", "demand_rank", "ready_provider_count"):
+            require_nullable(row[field], f"{where}.{field}", require_int)
+        for field in ("rate_card_version", "rate_card_generated_at", "rate_card_key"):
+            require_nullable(row[field], f"{where}.{field}", require_text)
+        require_text(row["rate_source"], where + ".rate_source")
+        require_text(row["economics_state"], where + ".economics_state")
+        for field in CATALOG_ECONOMICS_ACTION_FIELDS:
+            action = assert_exact_object(
+                row[field], CATALOG_ECONOMICS_ACTION_KEYS, f"{where}.{field}"
+            )
+            require_bool(action["available"], f"{where}.{field}.available")
+            require_bool(action["requires_confirmation"], f"{where}.{field}.requires_confirmation")
+            for nullable_text in ("transaction_kind", "transaction_id", "unavailable_reason"):
+                require_nullable(
+                    action[nullable_text], f"{where}.{field}.{nullable_text}", require_text
+                )
+            for nullable_int in ("action_timeout_seconds", "estimated_bytes"):
+                require_nullable(
+                    action[nullable_int], f"{where}.{field}.{nullable_int}", require_int
+                )
+
+
+def validate_captured_cli_document(schema: Any, parsed: Any, location: str = "$") -> None:
+    """Validate one captured CLI document against its complete closed schema.
+
+    Invoked from `_digest_document` for the DISCOVERY journey only in this slice
+    (epic #1453 slice 1b), so every discovery document that reaches evidence --
+    driver-produced or hand-authored -- is complete before its bytes are hashed.
+    An unrecognised schema fails closed: a document nobody enumerated cannot be
+    known to be complete, so it may not back a signed step. Consequently only
+    the five schemas the discovery driver emits are enumerated below;
+    `model_admission_withdraw.v1` appears in the admission journey alone and is
+    typed with that journey (slice 7).
+
+    "Complete" means the exact key set AND the values: R4 showed that key-set
+    validation alone accepts `identity_state: declared_local`, capability results
+    as strings, and `next_action: serve_traffic` -- none of which the CLI can
+    emit -- so each schema below also checks wire types, nullability, the closed
+    enums its spec defines, and the state/source cross-field rules.
+    """
+    if schema == "provider_byom_discovery.v1":
+        _validate_discovery(parsed, location)
+    elif schema == "provider_byom_evaluation.v1":
+        _validate_evaluation(parsed, location)
+    elif schema == "model_admission_offer_dry_run.v1":
+        _validate_offer_dry_run(parsed, location)
+    elif schema == "model_admission_status.v1":
+        _validate_admission_status(parsed, location)
+    elif schema == "model_catalog_economics.v1":
+        _validate_catalog_economics(parsed, location)
+    else:
+        fail(f"captured document {location} has an unvalidated schema: {schema!r}")
+
+
+def _digest_document(
+    manifest_dir: Path, contract: JourneyContract, entry: Any, step_id: str, index: int
+) -> dict[str, Any]:
     location = f"{step_id}.documents[{index}]"
     document = require_object(entry, location)
     require_exact_keys(document, {"id", "schema", "path"}, {"id", "schema", "path"}, location)
@@ -534,13 +1254,37 @@ def _digest_document(manifest_dir: Path, entry: Any, step_id: str, index: int) -
     # journey-result binds to, so the redaction claim has to hold for the bytes we
     # digest: a captured document that still carries a URL, an absolute or
     # home-relative path, a hostname, an IP literal, a localhost reference, or a
-    # credential must not be archived at all. There is deliberately no allowlist
-    # for raw-document fields -- a CLI document that legitimately needs an
-    # endpoint or a path in it is a document the operator redacts before capture.
-    reject_unredacted_text(decoded, f"{location}.path")
-    # JSON string escapes (\u002f, \u002e, ...) can hide a URL, path, or hostname
-    # from the serialized-text scan, so the decoded values are scanned as well.
-    _walk_redaction(parsed, f"{location}.document")
+    # credential must not be archived at all. A CLI document that legitimately
+    # needs an endpoint or a path in it is a document the operator redacts before
+    # capture; the one exemption is the field-scoped localization-key rule.
+    #
+    # The DECODED structural walk is the authority here. It is the only scan that
+    # can tell a `provider_guidance` localization key from a hostname, it covers
+    # every key and every string value field by field, and JSON string escapes
+    # (\u002f, \u002e, ...) that would hide a URL, path, or hostname from a
+    # serialized-text scan are already decoded by the time it runs.
+    assert_captured_document_redacted(parsed, f"{location}.document")
+    # The raw-text scan over the archived bytes runs every rule EXCEPT the
+    # hostname rule -- the structural walk owns that one -- so material sitting
+    # outside any decoded string still fails closed.
+    reject_unredacted_text_except_hostname(decoded, f"{location}.path")
+    # Completeness is the other half of the trust claim. A redaction-clean but
+    # schema-incomplete document would let a signed step assert conformance the
+    # bytes under the digest do not carry, so the closed key sets are checked
+    # here -- the one boundary every capture crosses -- rather than in whichever
+    # harness produced the document.
+    #
+    # SCOPE (epic #1453 slice 1b): typed validation is enabled for the DISCOVERY
+    # journey, whose hermetic driver produces every capture from a real CLI run,
+    # so the enums and cross-field rules are checked against documents the CLI
+    # actually emitted. The ADMISSION journey keeps the earlier boundary --
+    # redaction scans plus top-level `schema` equality, both already applied
+    # above -- because that journey cannot be captured end to end before catalog
+    # binding exists, so there is no real admission run to type the validators
+    # against. Typed validation of admission captures lands with the
+    # admission-journey slice (epic #1453 slice 7).
+    if contract.typed_capture_validation:
+        validate_captured_cli_document(schema, parsed, f"{location}.document")
     return {
         "id": document_id,
         "schema": schema,
@@ -673,7 +1417,7 @@ def _require_manifest_steps(
                 "artifacts": [contract.artifact_id],
                 "requirement_ids": step.get("requirement_ids"),
                 "documents": [
-                    _digest_document(manifest_dir, document, step_id, document_index)
+                    _digest_document(manifest_dir, contract, document, step_id, document_index)
                     for document_index, document in enumerate(documents)
                 ],
             }
@@ -771,6 +1515,14 @@ def build_evidence(
     require_exact_keys(harness, {"name", "status"}, {"name", "status"}, "harness")
     harness_name = require_string(harness.get("name"), REPO_RELATIVE_FILE_RE, "harness.name")
     repository_relative(root, harness_name, "harness.name")
+    # Each journey has exactly one harness that can produce its run manifest.
+    # "Some existing repository file" was not provenance: it let a discovery
+    # manifest be signed under the admission harness's identity, and vice versa.
+    if harness_name != contract.expected_harness_name:
+        fail(
+            f"harness.name must equal {contract.expected_harness_name!r} for "
+            f"{contract.journey_id}, not {harness_name!r}"
+        )
     if harness.get("status") != "pass":
         fail("harness.status must equal 'pass'")
 

--- a/scripts/byom_journey_evidence.py
+++ b/scripts/byom_journey_evidence.py
@@ -799,7 +799,9 @@ ADAPTER_STATUSES = frozenset({
 # `adapters[].origin_class`: null for a non-HTTP adapter such as `mlx_cache`.
 ORIGIN_CLASSES = frozenset({"loopback_http", "rejected"})
 # `provider_byom_evaluation.v1` scalars, from the evaluation encoder.
-EVALUATION_HEALTH_RESULTS = frozenset({"passed", "failed", "blocked"})
+# BYOMDiscovery.swift emits `timed_out` for CancellationError / URLError.timedOut
+# (the hermetic stubs never time out, so only a physical run reaches it).
+EVALUATION_HEALTH_RESULTS = frozenset({"passed", "failed", "blocked", "timed_out"})
 EVALUATION_ADAPTER_IDENTITIES = frozenset({
     "openai_compatible_loopback", "mlx_cache_local_artifact", "unknown",
 })

--- a/scripts/test-byom-discovery-journey.sh
+++ b/scripts/test-byom-discovery-journey.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Hermetic JOURNEY-PROVIDER-BYOM-DISCOVERY gate (#1453 slice 1).
+#
+# Runs the ten-step driver, then feeds its run manifest through the real
+# evidence pipeline: capture -> build -> preflight. The pipeline IS the
+# acceptance test for the driver -- a manifest that capture's step tables,
+# requirement tables, observation tables, or fail-closed redaction scan reject
+# fails this gate.
+#
+# Nothing here signs or promotes anything: signing needs the operator
+# acceptance key and stays out of CI (docs/runbooks/byom-journey-evidence.md
+# step 6). Nothing is left in the working tree either -- the redacted evidence
+# is written under journeys/evidence/ only long enough for the builder to read
+# it, and the commit that carries it for the builder's byte check is a dangling
+# `git commit-tree` object that moves no ref, index, or branch.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+# Every artifact this gate writes lives under a directory `mktemp -d` created
+# for this invocation, so two runs -- even in the same second -- can never name
+# the same path, and cleanup can never delete another run's artifact. A
+# timestamped filename plus a "refuse to overwrite" check could not promise
+# either: the trap that ran on the refusal deleted the file it had just refused
+# to touch (R3 MEDIUM). The evidence directory has to stay inside
+# `journeys/evidence/` and keep the journey's prefix, because the capture
+# contract only accepts `journeys/evidence/provider-byom-discovery-*.redacted.json`
+# and the builder verifies the bytes against a commit that contains them.
+EVIDENCE_DIR=""
+OUT_DIR=""
+
+cleanup() {
+  # Only ever remove what this invocation created. Both variables are set from
+  # a successful `mktemp -d`, so an empty one means the directory is not ours.
+  [ -n "$EVIDENCE_DIR" ] && rm -rf "$EVIDENCE_DIR"
+  [ -n "$OUT_DIR" ] && rm -rf "$OUT_DIR"
+  return 0
+}
+trap cleanup EXIT
+
+EVIDENCE_DIR="$(mktemp -d "journeys/evidence/provider-byom-discovery-ci-XXXXXX")"
+OUT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/byom-discovery-journey-XXXXXX")"
+EVIDENCE="${EVIDENCE_DIR}/run.redacted.json"
+UNSIGNED="${OUT_DIR}/journey-result.unsigned.json"
+INDEX="${OUT_DIR}/git-index"
+
+REQUIREMENT_IDS="SPEC-046-R001,SPEC-046-R002,SPEC-046-R003,SPEC-046-R004,SPEC-046-R005,SPEC-046-R006,SPEC-046-R007,SPEC-046-R008"
+# The evidence artifact records an operator identity as a SHA-256 fingerprint.
+# This gate is not an operator run, so it uses a fixed, non-identifying label.
+OPERATOR_FINGERPRINT="$(printf 'ci-hermetic-discovery-journey' | shasum -a 256 | cut -d' ' -f1)"
+
+# The lockfile rule is the driver's, and only the driver's: unconditionally
+# restoring phase3-binary/Package.resolved from HEAD here destroyed local
+# uncommitted lockfile work with no way to get it back (R3 MEDIUM). In
+# `--evidence` mode the driver restores HEAD's lockfile only in an ephemeral CI
+# checkout, where the drift is the earlier `swift test` step's resolution and
+# HEAD's lockfile is separately proven by the `phase3-binary (locked SwiftPM
+# resolve)` job; on a developer machine it refuses to run instead, and says to
+# commit or restore the file.
+
+# `--evidence` binds the run to the commit: the driver refuses a
+# MACPROVIDER_CLI_BINARY override, requires a clean tree -- tracked AND
+# untracked -- across the CLI source, the scripts, and the harness, builds the
+# CLI with locked resolution so the build cannot rewrite the lockfile, and
+# re-checks cleanliness after the build before publishing the manifest. Without
+# --evidence the driver publishes no manifest at all.
+test/e2e/byom/run-discovery-journey.py --evidence --out "$OUT_DIR"
+
+# Recorded only now: the driver's post-build cleanliness check has passed, so
+# this commit is what produced the manifest above. Reading it earlier would
+# name a commit before knowing whether the run stayed bound to it.
+SOURCE_SHA="$(git rev-parse HEAD)"
+
+python3 scripts/capture-byom-journey-evidence.py \
+  --journey discovery \
+  --run-manifest "${OUT_DIR}/run-manifest.json" \
+  --output "$EVIDENCE" \
+  --source-sha "$SOURCE_SHA" \
+  --operator-role release-operator \
+  --operator-identity-fingerprint "$OPERATOR_FINGERPRINT" \
+  --hardware-profile ci-hermetic-runner \
+  --candidate "$(git rev-parse --short HEAD)" \
+  --summary "hermetic discovery journey"
+
+# The builder verifies the evidence bytes against a commit that contains them,
+# so give it one without touching the branch: a temporary index produces the
+# tree, and commit-tree produces an unreferenced commit whose parent is HEAD.
+GIT_INDEX_FILE="$INDEX" git read-tree HEAD
+GIT_INDEX_FILE="$INDEX" git update-index --add "$EVIDENCE"
+EVIDENCE_TREE="$(GIT_INDEX_FILE="$INDEX" git write-tree)"
+EVIDENCE_SHA="$(git commit-tree "$EVIDENCE_TREE" -p "$SOURCE_SHA" -m "ephemeral discovery-journey evidence")"
+
+python3 scripts/build-byom-discovery-journey-result.py \
+  "$EVIDENCE" \
+  --output "$UNSIGNED" \
+  --source-sha "$SOURCE_SHA" \
+  --evidence-sha "$EVIDENCE_SHA" \
+  --requirement-ids "$REQUIREMENT_IDS"
+
+python3 scripts/preflight-signed-journey-promotion.py \
+  --source-sha "$SOURCE_SHA" \
+  --requirement-ids "$REQUIREMENT_IDS" \
+  --journey-id JOURNEY-PROVIDER-BYOM-DISCOVERY
+
+echo "test-byom-discovery-journey: driver, capture, build, and preflight passed"

--- a/scripts/tests/fixtures/byom_journeys/README.md
+++ b/scripts/tests/fixtures/byom_journeys/README.md
@@ -1,0 +1,67 @@
+# BYOM journey golden fixtures
+
+These run manifests and captures are the golden inputs for
+`scripts/tests/test_byom_journey_evidence.py`. Capture validates every one of
+them through the real path in `scripts/byom_journey_evidence.py`, so they have
+to be documents the CLI can actually emit — not plausible-looking JSON.
+
+The R4 audit of #1453 slice 1 found the opposite: the captures had been
+hand-synthesized, and carried values no CLI ever produced (`identity_state:
+declared_local`, `locality: local_weights`, capability results as strings,
+`completion_sha256` for `response_body_sha256`, `next_action: serve_traffic`).
+Key-set-only validation accepted all of them. The validator now checks wire
+types, nullability, the closed SPEC enums, and the state/source cross-field
+rules, and the `discovery/` fixtures were regenerated from real CLI output. That
+validator runs for the discovery journey only in this slice; `admission/` is
+covered below.
+
+## Provenance
+
+### `discovery/` — all captures are real, unedited CLI output
+
+Produced by running the hermetic driver and copying its captures verbatim:
+
+```bash
+test/e2e/byom/run-discovery-journey.py --out /tmp/byom-discovery
+cp /tmp/byom-discovery/captures/*.json \
+   scripts/tests/fixtures/byom_journeys/discovery/captures/
+```
+
+`run-manifest.json` is hand-written (it is the contract fixture, not a captured
+document), but its `harness.name` is now the driver that actually produces these
+captures — the evidence contract binds each journey to exactly one harness.
+
+The driver emits three further captures (`admission-status-state-ladder`,
+`discover-state-ladder-unstable`, `catalog-economics-state-ladder`) that this
+manifest does not reference; they are omitted rather than committed unused.
+
+### `admission/` — unchanged in this slice, still hand-authored
+
+The admission captures are exactly as they were before this slice: they are
+hand-authored, not real CLI output, and this slice deliberately does not touch
+them. Typed closed-enum validation is scoped to the discovery journey here (see
+`JourneyContract.typed_capture_validation` in
+`scripts/byom_journey_evidence.py`), so these fixtures are still validated only
+by the redaction scans and the check that each document's own top-level `schema`
+equals the schema its manifest claims — the boundary that applied before this
+slice.
+
+The reason is provenance, not appetite: the `JOURNEY-NETWORK-MODEL-ADMISSION`
+journey cannot be captured end to end until catalog binding exists, so there is
+no real admission run to regenerate these fixtures from or to type the
+validators against. Regenerating them and turning typed validation on for the
+admission contract lands together with the admission-journey slice (epic #1453
+slice 7).
+
+`admission/run-manifest.json` still names `test/e2e/byom/run-cli-onboarding-e2e.py`,
+and the harness-name binding introduced in this slice applies to both journeys:
+an admission manifest may not claim the discovery driver's provenance, or any
+other repository file's.
+
+## Regenerating
+
+Re-running the discovery driver and copying its captures is the whole procedure
+for `discovery/`. `admission/` has no regeneration procedure yet — that arrives
+with the admission-journey slice. If a real document ever trips capture's
+redaction scanner, that is a CLI bug to report — never a value to edit out of
+the fixture.

--- a/scripts/tests/fixtures/byom_journeys/discovery/captures/discover-adapter-failure.json
+++ b/scripts/tests/fixtures/byom_journeys/discovery/captures/discover-adapter-failure.json
@@ -1,10 +1,68 @@
 {
+  "adapters": [
+    {
+      "origin_class": null,
+      "runtime_source": "mlx_cache",
+      "status": "ok",
+      "warning_codes": []
+    },
+    {
+      "origin_class": "loopback_http",
+      "runtime_source": "openai_compatible_loopback",
+      "status": "malformed",
+      "warning_codes": [
+        "adapter_malformed_response"
+      ]
+    }
+  ],
   "candidates": [
     {
       "admission_state": "offerable",
       "admission_state_source": "local_default",
-      "candidate_id": "byom_fixture_candidate"
+      "candidate_id": "byom_4xgiy2qjoayzyeepb7np7xdel37m2avdmu6hwfhe2jlwzu2b77kq",
+      "capabilities": {
+        "chat_completions": null,
+        "family": null,
+        "json_mode": null,
+        "max_context_tokens": 4096,
+        "quantization": "q4",
+        "runtime_version": null,
+        "streaming": null,
+        "structured_output_passthrough": null,
+        "tool_call_passthrough": null,
+        "usage_reporting": null
+      },
+      "catalog_model_key": null,
+      "context_window_tokens": 4096,
+      "display_name": "mlx-community/Tiny-1B-4bit",
+      "estimated_gb": 1,
+      "evaluation_state": "not_evaluated",
+      "fit_state": "fits",
+      "identity_state": "runtime_reported",
+      "locality": "local_artifact",
+      "provider_guidance": {
+        "earning_path_class": "local_inventory_only",
+        "next_action": "evaluate",
+        "state_label_key": "byom.local.offerable",
+        "state_meaning_key": "byom.local.offerable_not_earning",
+        "transition_reason_code": null
+      },
+      "readiness_state": "ready",
+      "runtime_source": "mlx_cache",
+      "served_model_ref": "mlx-community/Tiny-1B-4bit",
+      "warning_codes": [
+        "capability_unevaluated",
+        "evaluation_required"
+      ]
     }
   ],
-  "schema": "provider_byom_discovery.v1"
+  "cli_version": "1.8.123",
+  "generated_at": "2026-09-09T03:46:10.841Z",
+  "projection_sequence": 1,
+  "schema": "provider_byom_discovery.v1",
+  "warnings": [
+    "adapter_malformed_response",
+    "capability_unevaluated",
+    "evaluation_required"
+  ]
 }

--- a/scripts/tests/fixtures/byom_journeys/discovery/captures/discover-loopback-runtime.json
+++ b/scripts/tests/fixtures/byom_journeys/discovery/captures/discover-loopback-runtime.json
@@ -1,10 +1,104 @@
 {
+  "adapters": [
+    {
+      "origin_class": null,
+      "runtime_source": "mlx_cache",
+      "status": "ok",
+      "warning_codes": []
+    },
+    {
+      "origin_class": "loopback_http",
+      "runtime_source": "ollama_loopback",
+      "status": "ok",
+      "warning_codes": []
+    }
+  ],
   "candidates": [
     {
       "admission_state": "offerable",
       "admission_state_source": "local_default",
-      "candidate_id": "byom_fixture_candidate"
+      "candidate_id": "byom_4xgiy2qjoayzyeepb7np7xdel37m2avdmu6hwfhe2jlwzu2b77kq",
+      "capabilities": {
+        "chat_completions": null,
+        "family": null,
+        "json_mode": null,
+        "max_context_tokens": 4096,
+        "quantization": "q4",
+        "runtime_version": null,
+        "streaming": null,
+        "structured_output_passthrough": null,
+        "tool_call_passthrough": null,
+        "usage_reporting": null
+      },
+      "catalog_model_key": null,
+      "context_window_tokens": 4096,
+      "display_name": "mlx-community/Tiny-1B-4bit",
+      "estimated_gb": 1,
+      "evaluation_state": "not_evaluated",
+      "fit_state": "fits",
+      "identity_state": "runtime_reported",
+      "locality": "local_artifact",
+      "provider_guidance": {
+        "earning_path_class": "local_inventory_only",
+        "next_action": "evaluate",
+        "state_label_key": "byom.local.offerable",
+        "state_meaning_key": "byom.local.offerable_not_earning",
+        "transition_reason_code": null
+      },
+      "readiness_state": "ready",
+      "runtime_source": "mlx_cache",
+      "served_model_ref": "mlx-community/Tiny-1B-4bit",
+      "warning_codes": [
+        "capability_unevaluated",
+        "evaluation_required"
+      ]
+    },
+    {
+      "admission_state": "offerable",
+      "admission_state_source": "local_default",
+      "candidate_id": "byom_ma54n3hvotbe2c7dkqf6or7s3i5kxlyb7xndgst3qk5cxh7kurda",
+      "capabilities": {
+        "chat_completions": true,
+        "family": "llama",
+        "json_mode": null,
+        "max_context_tokens": null,
+        "quantization": "Q4_0",
+        "runtime_version": null,
+        "streaming": null,
+        "structured_output_passthrough": null,
+        "tool_call_passthrough": null,
+        "usage_reporting": null
+      },
+      "catalog_model_key": null,
+      "context_window_tokens": null,
+      "display_name": "tiny-ollama-1b-q4",
+      "estimated_gb": 1,
+      "evaluation_state": "not_evaluated",
+      "fit_state": "fits",
+      "identity_state": "runtime_reported",
+      "locality": "loopback_runtime",
+      "provider_guidance": {
+        "earning_path_class": "local_inventory_only",
+        "next_action": "evaluate",
+        "state_label_key": "byom.local.offerable",
+        "state_meaning_key": "byom.local.offerable_not_earning",
+        "transition_reason_code": null
+      },
+      "readiness_state": "ready",
+      "runtime_source": "ollama_loopback",
+      "served_model_ref": "ollama:tiny-ollama-1b-q4",
+      "warning_codes": [
+        "capability_unevaluated",
+        "evaluation_required"
+      ]
     }
   ],
-  "schema": "provider_byom_discovery.v1"
+  "cli_version": "1.8.123",
+  "generated_at": "2026-09-09T03:46:10.512Z",
+  "projection_sequence": 1,
+  "schema": "provider_byom_discovery.v1",
+  "warnings": [
+    "capability_unevaluated",
+    "evaluation_required"
+  ]
 }

--- a/scripts/tests/fixtures/byom_journeys/discovery/captures/discover-mlx-cache.json
+++ b/scripts/tests/fixtures/byom_journeys/discovery/captures/discover-mlx-cache.json
@@ -1,10 +1,59 @@
 {
+  "adapters": [
+    {
+      "origin_class": null,
+      "runtime_source": "mlx_cache",
+      "status": "ok",
+      "warning_codes": []
+    }
+  ],
   "candidates": [
     {
       "admission_state": "offerable",
       "admission_state_source": "local_default",
-      "candidate_id": "byom_fixture_candidate"
+      "candidate_id": "byom_4xgiy2qjoayzyeepb7np7xdel37m2avdmu6hwfhe2jlwzu2b77kq",
+      "capabilities": {
+        "chat_completions": null,
+        "family": null,
+        "json_mode": null,
+        "max_context_tokens": 4096,
+        "quantization": "q4",
+        "runtime_version": null,
+        "streaming": null,
+        "structured_output_passthrough": null,
+        "tool_call_passthrough": null,
+        "usage_reporting": null
+      },
+      "catalog_model_key": null,
+      "context_window_tokens": 4096,
+      "display_name": "mlx-community/Tiny-1B-4bit",
+      "estimated_gb": 1,
+      "evaluation_state": "not_evaluated",
+      "fit_state": "fits",
+      "identity_state": "runtime_reported",
+      "locality": "local_artifact",
+      "provider_guidance": {
+        "earning_path_class": "local_inventory_only",
+        "next_action": "evaluate",
+        "state_label_key": "byom.local.offerable",
+        "state_meaning_key": "byom.local.offerable_not_earning",
+        "transition_reason_code": null
+      },
+      "readiness_state": "ready",
+      "runtime_source": "mlx_cache",
+      "served_model_ref": "mlx-community/Tiny-1B-4bit",
+      "warning_codes": [
+        "capability_unevaluated",
+        "evaluation_required"
+      ]
     }
   ],
-  "schema": "provider_byom_discovery.v1"
+  "cli_version": "1.8.123",
+  "generated_at": "2026-09-09T03:46:10.400Z",
+  "projection_sequence": 1,
+  "schema": "provider_byom_discovery.v1",
+  "warnings": [
+    "capability_unevaluated",
+    "evaluation_required"
+  ]
 }

--- a/scripts/tests/fixtures/byom_journeys/discovery/captures/discover-non-loopback-rejected.json
+++ b/scripts/tests/fixtures/byom_journeys/discovery/captures/discover-non-loopback-rejected.json
@@ -1,10 +1,68 @@
 {
+  "adapters": [
+    {
+      "origin_class": null,
+      "runtime_source": "mlx_cache",
+      "status": "ok",
+      "warning_codes": []
+    },
+    {
+      "origin_class": "rejected",
+      "runtime_source": "openai_compatible_loopback",
+      "status": "rejected",
+      "warning_codes": [
+        "adapter_rejected_non_loopback"
+      ]
+    }
+  ],
   "candidates": [
     {
       "admission_state": "offerable",
       "admission_state_source": "local_default",
-      "candidate_id": "byom_fixture_candidate"
+      "candidate_id": "byom_4xgiy2qjoayzyeepb7np7xdel37m2avdmu6hwfhe2jlwzu2b77kq",
+      "capabilities": {
+        "chat_completions": null,
+        "family": null,
+        "json_mode": null,
+        "max_context_tokens": 4096,
+        "quantization": "q4",
+        "runtime_version": null,
+        "streaming": null,
+        "structured_output_passthrough": null,
+        "tool_call_passthrough": null,
+        "usage_reporting": null
+      },
+      "catalog_model_key": null,
+      "context_window_tokens": 4096,
+      "display_name": "mlx-community/Tiny-1B-4bit",
+      "estimated_gb": 1,
+      "evaluation_state": "not_evaluated",
+      "fit_state": "fits",
+      "identity_state": "runtime_reported",
+      "locality": "local_artifact",
+      "provider_guidance": {
+        "earning_path_class": "local_inventory_only",
+        "next_action": "evaluate",
+        "state_label_key": "byom.local.offerable",
+        "state_meaning_key": "byom.local.offerable_not_earning",
+        "transition_reason_code": null
+      },
+      "readiness_state": "ready",
+      "runtime_source": "mlx_cache",
+      "served_model_ref": "mlx-community/Tiny-1B-4bit",
+      "warning_codes": [
+        "capability_unevaluated",
+        "evaluation_required"
+      ]
     }
   ],
-  "schema": "provider_byom_discovery.v1"
+  "cli_version": "1.8.123",
+  "generated_at": "2026-09-09T03:46:10.730Z",
+  "projection_sequence": 1,
+  "schema": "provider_byom_discovery.v1",
+  "warnings": [
+    "adapter_rejected_non_loopback",
+    "capability_unevaluated",
+    "evaluation_required"
+  ]
 }

--- a/scripts/tests/fixtures/byom_journeys/discovery/captures/discover-opaque-endpoint.json
+++ b/scripts/tests/fixtures/byom_journeys/discovery/captures/discover-opaque-endpoint.json
@@ -1,10 +1,104 @@
 {
+  "adapters": [
+    {
+      "origin_class": null,
+      "runtime_source": "mlx_cache",
+      "status": "ok",
+      "warning_codes": []
+    },
+    {
+      "origin_class": "loopback_http",
+      "runtime_source": "openai_compatible_loopback",
+      "status": "ok",
+      "warning_codes": []
+    }
+  ],
   "candidates": [
     {
       "admission_state": "offerable",
       "admission_state_source": "local_default",
-      "candidate_id": "byom_fixture_candidate"
+      "candidate_id": "byom_4xgiy2qjoayzyeepb7np7xdel37m2avdmu6hwfhe2jlwzu2b77kq",
+      "capabilities": {
+        "chat_completions": null,
+        "family": null,
+        "json_mode": null,
+        "max_context_tokens": 4096,
+        "quantization": "q4",
+        "runtime_version": null,
+        "streaming": null,
+        "structured_output_passthrough": null,
+        "tool_call_passthrough": null,
+        "usage_reporting": null
+      },
+      "catalog_model_key": null,
+      "context_window_tokens": 4096,
+      "display_name": "mlx-community/Tiny-1B-4bit",
+      "estimated_gb": 1,
+      "evaluation_state": "not_evaluated",
+      "fit_state": "fits",
+      "identity_state": "runtime_reported",
+      "locality": "local_artifact",
+      "provider_guidance": {
+        "earning_path_class": "local_inventory_only",
+        "next_action": "evaluate",
+        "state_label_key": "byom.local.offerable",
+        "state_meaning_key": "byom.local.offerable_not_earning",
+        "transition_reason_code": null
+      },
+      "readiness_state": "ready",
+      "runtime_source": "mlx_cache",
+      "served_model_ref": "mlx-community/Tiny-1B-4bit",
+      "warning_codes": [
+        "capability_unevaluated",
+        "evaluation_required"
+      ]
+    },
+    {
+      "admission_state": "local_only",
+      "admission_state_source": "local_default",
+      "candidate_id": "byom_c6bidtyyoqnlutdfwflcoaq22bbnw6udi343rl64c4wooqumoshq",
+      "capabilities": {
+        "chat_completions": null,
+        "family": null,
+        "json_mode": null,
+        "max_context_tokens": null,
+        "quantization": null,
+        "runtime_version": null,
+        "streaming": null,
+        "structured_output_passthrough": null,
+        "tool_call_passthrough": null,
+        "usage_reporting": null
+      },
+      "catalog_model_key": null,
+      "context_window_tokens": null,
+      "display_name": "opaque-mini-1b",
+      "estimated_gb": null,
+      "evaluation_state": "not_evaluated",
+      "fit_state": "unknown",
+      "identity_state": "opaque_endpoint",
+      "locality": "opaque_local_endpoint",
+      "provider_guidance": {
+        "earning_path_class": "local_inventory_only",
+        "next_action": "evaluate",
+        "state_label_key": "byom.local.local_only",
+        "state_meaning_key": "byom.local.opaque_endpoint_not_earning",
+        "transition_reason_code": "capability_unevaluated"
+      },
+      "readiness_state": "ready",
+      "runtime_source": "openai_compatible_loopback",
+      "served_model_ref": "openai_compatible:opaque-mini-1b",
+      "warning_codes": [
+        "capability_unevaluated",
+        "evaluation_required"
+      ]
     }
   ],
-  "schema": "provider_byom_discovery.v1"
+  "cli_version": "1.8.123",
+  "generated_at": "2026-09-09T03:46:10.624Z",
+  "projection_sequence": 1,
+  "schema": "provider_byom_discovery.v1",
+  "warnings": [
+    "capability_unevaluated",
+    "evaluation_required"
+  ]
 }

--- a/scripts/tests/fixtures/byom_journeys/discovery/captures/discover-state-ladder.json
+++ b/scripts/tests/fixtures/byom_journeys/discovery/captures/discover-state-ladder.json
@@ -1,10 +1,149 @@
 {
+  "adapters": [
+    {
+      "origin_class": null,
+      "runtime_source": "mlx_cache",
+      "status": "ok",
+      "warning_codes": []
+    },
+    {
+      "origin_class": "loopback_http",
+      "runtime_source": "ollama_loopback",
+      "status": "ok",
+      "warning_codes": []
+    },
+    {
+      "origin_class": "loopback_http",
+      "runtime_source": "openai_compatible_loopback",
+      "status": "ok",
+      "warning_codes": []
+    }
+  ],
   "candidates": [
     {
       "admission_state": "offerable",
       "admission_state_source": "local_default",
-      "candidate_id": "byom_fixture_candidate"
+      "candidate_id": "byom_4xgiy2qjoayzyeepb7np7xdel37m2avdmu6hwfhe2jlwzu2b77kq",
+      "capabilities": {
+        "chat_completions": null,
+        "family": null,
+        "json_mode": null,
+        "max_context_tokens": 4096,
+        "quantization": "q4",
+        "runtime_version": null,
+        "streaming": null,
+        "structured_output_passthrough": null,
+        "tool_call_passthrough": null,
+        "usage_reporting": null
+      },
+      "catalog_model_key": null,
+      "context_window_tokens": 4096,
+      "display_name": "mlx-community/Tiny-1B-4bit",
+      "estimated_gb": 1,
+      "evaluation_state": "not_evaluated",
+      "fit_state": "fits",
+      "identity_state": "runtime_reported",
+      "locality": "local_artifact",
+      "provider_guidance": {
+        "earning_path_class": "local_inventory_only",
+        "next_action": "evaluate",
+        "state_label_key": "byom.local.offerable",
+        "state_meaning_key": "byom.local.offerable_not_earning",
+        "transition_reason_code": null
+      },
+      "readiness_state": "ready",
+      "runtime_source": "mlx_cache",
+      "served_model_ref": "mlx-community/Tiny-1B-4bit",
+      "warning_codes": [
+        "capability_unevaluated",
+        "evaluation_required"
+      ]
+    },
+    {
+      "admission_state": "offerable",
+      "admission_state_source": "local_default",
+      "candidate_id": "byom_ma54n3hvotbe2c7dkqf6or7s3i5kxlyb7xndgst3qk5cxh7kurda",
+      "capabilities": {
+        "chat_completions": true,
+        "family": "llama",
+        "json_mode": null,
+        "max_context_tokens": null,
+        "quantization": "Q4_0",
+        "runtime_version": null,
+        "streaming": null,
+        "structured_output_passthrough": null,
+        "tool_call_passthrough": null,
+        "usage_reporting": null
+      },
+      "catalog_model_key": null,
+      "context_window_tokens": null,
+      "display_name": "tiny-ollama-1b-q4",
+      "estimated_gb": 1,
+      "evaluation_state": "not_evaluated",
+      "fit_state": "fits",
+      "identity_state": "runtime_reported",
+      "locality": "loopback_runtime",
+      "provider_guidance": {
+        "earning_path_class": "local_inventory_only",
+        "next_action": "evaluate",
+        "state_label_key": "byom.local.offerable",
+        "state_meaning_key": "byom.local.offerable_not_earning",
+        "transition_reason_code": null
+      },
+      "readiness_state": "ready",
+      "runtime_source": "ollama_loopback",
+      "served_model_ref": "ollama:tiny-ollama-1b-q4",
+      "warning_codes": [
+        "capability_unevaluated",
+        "evaluation_required"
+      ]
+    },
+    {
+      "admission_state": "local_only",
+      "admission_state_source": "local_default",
+      "candidate_id": "byom_c6bidtyyoqnlutdfwflcoaq22bbnw6udi343rl64c4wooqumoshq",
+      "capabilities": {
+        "chat_completions": null,
+        "family": null,
+        "json_mode": null,
+        "max_context_tokens": null,
+        "quantization": null,
+        "runtime_version": null,
+        "streaming": null,
+        "structured_output_passthrough": null,
+        "tool_call_passthrough": null,
+        "usage_reporting": null
+      },
+      "catalog_model_key": null,
+      "context_window_tokens": null,
+      "display_name": "opaque-mini-1b",
+      "estimated_gb": null,
+      "evaluation_state": "not_evaluated",
+      "fit_state": "unknown",
+      "identity_state": "opaque_endpoint",
+      "locality": "opaque_local_endpoint",
+      "provider_guidance": {
+        "earning_path_class": "local_inventory_only",
+        "next_action": "evaluate",
+        "state_label_key": "byom.local.local_only",
+        "state_meaning_key": "byom.local.opaque_endpoint_not_earning",
+        "transition_reason_code": "capability_unevaluated"
+      },
+      "readiness_state": "ready",
+      "runtime_source": "openai_compatible_loopback",
+      "served_model_ref": "openai_compatible:opaque-mini-1b",
+      "warning_codes": [
+        "capability_unevaluated",
+        "evaluation_required"
+      ]
     }
   ],
-  "schema": "provider_byom_discovery.v1"
+  "cli_version": "1.8.123",
+  "generated_at": "2026-09-09T03:46:11.182Z",
+  "projection_sequence": 1,
+  "schema": "provider_byom_discovery.v1",
+  "warnings": [
+    "capability_unevaluated",
+    "evaluation_required"
+  ]
 }

--- a/scripts/tests/fixtures/byom_journeys/discovery/captures/evaluate-candidate.json
+++ b/scripts/tests/fixtures/byom_journeys/discovery/captures/evaluate-candidate.json
@@ -1,8 +1,71 @@
 {
+  "adapter_identity": "openai_compatible_loopback",
+  "candidate_id": "byom_c6bidtyyoqnlutdfwflcoaq22bbnw6udi343rl64c4wooqumoshq",
+  "capability_results": {
+    "chat_completions": {
+      "reason_code": null,
+      "result": "passed",
+      "source": "evaluation"
+    },
+    "json_mode": {
+      "reason_code": null,
+      "result": "not_tested",
+      "source": "not_evaluated"
+    },
+    "streaming": {
+      "reason_code": null,
+      "result": "not_tested",
+      "source": "not_evaluated"
+    },
+    "structured_output_passthrough": {
+      "reason_code": null,
+      "result": "not_tested",
+      "source": "not_evaluated"
+    },
+    "tool_call_passthrough": {
+      "reason_code": null,
+      "result": "not_tested",
+      "source": "not_evaluated"
+    },
+    "usage_reporting": {
+      "reason_code": null,
+      "result": "passed",
+      "source": "runtime_reported"
+    }
+  },
+  "catalog_model_key": null,
+  "cli_version": "1.8.123",
+  "completion_tokens": 2,
+  "diagnostic_hashes": {
+    "prompt_sha256": "13a60ffccf3f63064f0589c50606be1f0668e4409008d8ef2d23aaa8ef345cf5",
+    "response_body_sha256": "68040dbec65f3af8db4a0df81eda9ef1965f31346c808ebd69cf46322605c11c"
+  },
+  "fit_estimate_source": "discovery_fit_state",
+  "generated_at": "2026-09-09T03:46:10.954Z",
   "health_result": "passed",
+  "latency_ms": 1,
   "mutation_summary": {
     "coordinator_state_mutated": false,
-    "production_config_mutated": false
+    "downloads_started": false,
+    "production_config_mutated": false,
+    "production_model_switched": false,
+    "runtime_started": false,
+    "temporary_files_created": false
   },
-  "schema": "provider_byom_evaluation.v1"
+  "offer_preconditions_appear_satisfied": false,
+  "output_bytes": 235,
+  "provider_guidance": {
+    "earning_path_class": "local_inventory_only",
+    "next_action": "offer_dry_run",
+    "state_label_key": "byom.evaluation.passed",
+    "state_meaning_key": "byom.evaluation.passed_not_earning",
+    "transition_reason_code": null
+  },
+  "request_count": 1,
+  "runtime_source": "openai_compatible_loopback",
+  "schema": "provider_byom_evaluation.v1",
+  "served_model_ref": "openai_compatible:opaque-mini-1b",
+  "tokens_per_second": 1357.82,
+  "usage_reporting_source": "runtime_reported",
+  "warnings": []
 }

--- a/scripts/tests/fixtures/byom_journeys/discovery/captures/offer-dry-run.json
+++ b/scripts/tests/fixtures/byom_journeys/discovery/captures/offer-dry-run.json
@@ -1,6 +1,23 @@
 {
-  "likely_admission_state": "offerable",
+  "candidate_id": "byom_c6bidtyyoqnlutdfwflcoaq22bbnw6udi343rl64c4wooqumoshq",
+  "catalog_model_key": null,
+  "cli_version": "1.8.123",
+  "generated_at": "2026-09-09T03:46:11.067Z",
+  "likely_admission_state": "local_only",
   "likely_admission_state_source": "local_default",
+  "provider_guidance": {
+    "earning_path_class": "local_inventory_only",
+    "next_action": "fix_local_blocker",
+    "state_label_key": "byom.offer_dry_run.blocked",
+    "state_meaning_key": "byom.offer_dry_run.not_submitted_not_earning",
+    "transition_reason_code": "no_trusted_catalog_match"
+  },
+  "reason_code": "no_trusted_catalog_match",
   "schema": "model_admission_offer_dry_run.v1",
-  "would_submit": true
+  "served_model_ref": "openai_compatible:opaque-mini-1b",
+  "warnings": [
+    "capability_unevaluated",
+    "evaluation_required"
+  ],
+  "would_submit": false
 }

--- a/scripts/tests/fixtures/byom_journeys/discovery/run-manifest.json
+++ b/scripts/tests/fixtures/byom_journeys/discovery/run-manifest.json
@@ -5,7 +5,7 @@
   "environment_class": "hermetic-loopback",
   "cli_version": "0.0.0-fixture",
   "harness": {
-    "name": "test/e2e/byom/run-cli-onboarding-e2e.py",
+    "name": "test/e2e/byom/run-discovery-journey.py",
     "status": "pass"
   },
   "steps": [

--- a/scripts/tests/test_byom_journey_evidence.py
+++ b/scripts/tests/test_byom_journey_evidence.py
@@ -212,6 +212,64 @@ class BYOMJourneyCaptureTests(unittest.TestCase):
 
         self.assert_capture_fails("discovery", mutator, fragment)
 
+    def complete_discovery_document(self) -> dict:
+        """A COMPLETE closed discovery document, taken from the golden fixture.
+
+        `_digest_document` validates every capture against the full closed key
+        set, so a test that wants a capture ACCEPTED has to start from a
+        complete document; a hand-written partial one is exactly what the
+        contract now refuses.
+        """
+        return json.loads(
+            (FIXTURES / "discovery" / "captures" / "discover-mlx-cache.json").read_text(
+                encoding="utf-8"
+            )
+        )
+
+    def guidance_document(self, **guidance) -> dict:
+        document = self.complete_discovery_document()
+        document["candidates"][0]["provider_guidance"].update(guidance)
+        return document
+
+    # SPEC-046-R003 requires the two localization keys in every
+    # `provider_guidance` object, so captured documents are archived whole and
+    # the scanner validates those two paths against a closed grammar instead of
+    # the shape-based hostname rule.
+    def test_accepts_localization_keys_inside_provider_guidance(self) -> None:
+        manifest, manifest_path = self.mutate(
+            "discovery", lambda _manifest, root: self.write_capture(root, self.guidance_document())
+        )
+        self.capture("discovery", manifest, manifest_path)
+
+    def test_rejects_a_hostname_at_a_localization_key_path(self) -> None:
+        for field in ("state_label_key", "state_meaning_key"):
+            with self.subTest(field=field):
+                self.assert_captured_document_rejected(
+                    self.guidance_document(**{field: "coordinator.malibu.tech"}),
+                    "must be a closed byom localization key",
+                )
+
+    def test_rejects_a_localization_key_shape_outside_the_two_exempt_fields(self) -> None:
+        # Another field of the same guidance object.
+        self.assert_captured_document_rejected(
+            self.guidance_document(next_action="byom.local.local_only"),
+            "contains a hostname",
+        )
+        # And a field outside provider_guidance entirely.
+        document = self.guidance_document()
+        document["candidates"][0]["display_name"] = "byom.local.local_only"
+        self.assert_captured_document_rejected(document, "contains a hostname")
+
+    def test_rejects_a_hostname_hidden_behind_json_escapes_in_a_captured_document(self) -> None:
+        def mutator(_manifest, root):
+            (root / "captures" / "discover-mlx-cache.json").write_text(
+                '{"schema": "provider_byom_discovery.v1", '
+                '"note": "coordinator\\u002emalibu\\u002etech"}',
+                encoding="utf-8",
+            )
+
+        self.assert_capture_fails("discovery", mutator, "contains a hostname")
+
     def test_rejects_captured_document_whose_schema_differs_from_the_manifest(self) -> None:
         self.assert_captured_document_rejected(
             {"schema": "model_admission_status.v1", "candidates": []},
@@ -231,6 +289,207 @@ class BYOMJourneyCaptureTests(unittest.TestCase):
             )
 
         self.assert_capture_fails("discovery", mutator, "must be a JSON object document")
+
+    # R3 MEDIUM: closed-schema validation lives at the capture boundary, so a
+    # document that is redaction-clean but INCOMPLETE (or carries a field the
+    # spec does not define) cannot be digested into evidence -- whoever produced
+    # it. These go through the real capture path, not the driver's copy.
+    #
+    # Scoped to the DISCOVERY journey in this slice (epic #1453 slice 1b), which
+    # is why every case below mutates a discovery capture: the admission
+    # contract keeps redaction plus top-level `schema` equality until its own
+    # journey can be captured (slice 7). See
+    # `JourneyContract.typed_capture_validation`.
+    def test_rejects_captured_document_missing_an_envelope_field(self) -> None:
+        document = self.complete_discovery_document()
+        del document["projection_sequence"]
+        self.assert_captured_document_rejected(
+            document, "is missing required fields: projection_sequence"
+        )
+
+    def test_rejects_captured_document_with_an_unknown_envelope_field(self) -> None:
+        document = self.complete_discovery_document()
+        document["settlement_capable"] = True
+        self.assert_captured_document_rejected(
+            document, "carries unknown fields: settlement_capable"
+        )
+
+    def test_rejects_captured_document_missing_a_nested_candidate_field(self) -> None:
+        document = self.complete_discovery_document()
+        del document["candidates"][0]["admission_state_source"]
+        self.assert_captured_document_rejected(
+            document, "candidates[0] is missing required fields: admission_state_source"
+        )
+
+    def test_rejects_captured_document_missing_a_nested_capability_field(self) -> None:
+        document = self.complete_discovery_document()
+        del document["candidates"][0]["capabilities"]["usage_reporting"]
+        self.assert_captured_document_rejected(
+            document, "capabilities is missing required fields: usage_reporting"
+        )
+
+    def test_rejects_captured_document_with_an_unknown_nested_capability_field(self) -> None:
+        document = self.complete_discovery_document()
+        document["candidates"][0]["capabilities"]["verified_throughput"] = True
+        self.assert_captured_document_rejected(
+            document, "capabilities carries unknown fields: verified_throughput"
+        )
+
+    def test_rejects_captured_document_missing_a_nested_guidance_field(self) -> None:
+        document = self.complete_discovery_document()
+        del document["candidates"][0]["provider_guidance"]["earning_path_class"]
+        self.assert_captured_document_rejected(
+            document, "provider_guidance is missing required fields: earning_path_class"
+        )
+
+    def test_rejects_captured_document_with_an_unknown_nested_guidance_field(self) -> None:
+        document = self.complete_discovery_document()
+        document["candidates"][0]["provider_guidance"]["settlement_hint"] = "yes"
+        self.assert_captured_document_rejected(
+            document, "provider_guidance carries unknown fields: settlement_hint"
+        )
+
+    def test_rejects_captured_document_missing_a_nested_adapter_field(self) -> None:
+        document = self.complete_discovery_document()
+        del document["adapters"][0]["warning_codes"]
+        self.assert_captured_document_rejected(
+            document, "adapters[0] is missing required fields: warning_codes"
+        )
+
+    # R4 MEDIUM: exact key sets proved a captured document was COMPLETE but said
+    # nothing about its values, so `identity_state: declared_local`, capability
+    # results as strings, and `next_action: serve_traffic` all validated. These
+    # go through the real capture path, like the key-set cases above.
+    def test_rejects_captured_document_with_an_out_of_enum_identity_state(self) -> None:
+        document = self.complete_discovery_document()
+        document["candidates"][0]["identity_state"] = "declared_local"
+        self.assert_captured_document_rejected(
+            document, "identity_state is not a permitted value: 'declared_local'"
+        )
+
+    def test_rejects_captured_document_with_an_out_of_enum_locality(self) -> None:
+        document = self.complete_discovery_document()
+        document["candidates"][0]["locality"] = "local_weights"
+        self.assert_captured_document_rejected(
+            document, "locality is not a permitted value: 'local_weights'"
+        )
+
+    def test_rejects_captured_document_with_an_out_of_enum_evaluation_state(self) -> None:
+        document = self.complete_discovery_document()
+        document["candidates"][0]["evaluation_state"] = "evaluated"
+        self.assert_captured_document_rejected(
+            document, "evaluation_state is not a permitted value: 'evaluated'"
+        )
+
+    def test_rejects_captured_document_with_an_out_of_enum_next_action(self) -> None:
+        document = self.complete_discovery_document()
+        document["candidates"][0]["provider_guidance"]["next_action"] = "serve_traffic"
+        self.assert_captured_document_rejected(
+            document, "next_action is not a permitted value: 'serve_traffic'"
+        )
+
+    def test_rejects_captured_document_with_an_out_of_enum_warning_code(self) -> None:
+        document = self.complete_discovery_document()
+        document["candidates"][0]["warning_codes"] = ["adapter_response_malformed"]
+        self.assert_captured_document_rejected(
+            document, "warning_codes[0] is not a permitted value: 'adapter_response_malformed'"
+        )
+
+    def test_rejects_captured_document_with_an_out_of_enum_adapter_status(self) -> None:
+        document = self.complete_discovery_document()
+        document["adapters"][0]["status"] = "failed"
+        self.assert_captured_document_rejected(
+            document, "adapters[0].status is not a permitted value: 'failed'"
+        )
+
+    def test_rejects_captured_document_with_a_wrong_typed_capability(self) -> None:
+        # SPEC-046-R004: unknown is null, so a string standing in for a nullable
+        # boolean is a capability claim the CLI never made.
+        document = self.complete_discovery_document()
+        document["candidates"][0]["capabilities"]["chat_completions"] = "yes"
+        self.assert_captured_document_rejected(
+            document, "capabilities.chat_completions must be a JSON boolean"
+        )
+
+    def test_rejects_captured_document_with_a_wrong_typed_projection_sequence(self) -> None:
+        document = self.complete_discovery_document()
+        document["projection_sequence"] = "1"
+        self.assert_captured_document_rejected(
+            document, "projection_sequence must be a JSON integer"
+        )
+
+    def test_rejects_captured_document_with_a_null_in_a_non_nullable_field(self) -> None:
+        document = self.complete_discovery_document()
+        document["candidates"][0]["display_name"] = None
+        self.assert_captured_document_rejected(
+            document, "display_name must be a non-empty JSON string"
+        )
+
+    def test_rejects_captured_document_with_a_null_admission_state(self) -> None:
+        document = self.complete_discovery_document()
+        document["candidates"][0]["admission_state"] = None
+        self.assert_captured_document_rejected(
+            document, "admission_state must be a JSON string"
+        )
+
+    def test_rejects_captured_document_promoting_a_network_state_locally(self) -> None:
+        # The SPEC-046-R003 cross-field rule: with `local_default` the CLI may
+        # only report its own ladder, never a coordinator admission state.
+        document = self.complete_discovery_document()
+        document["candidates"][0]["admission_state"] = "settlement_capable"
+        document["candidates"][0]["admission_state_source"] = "local_default"
+        self.assert_captured_document_rejected(
+            document,
+            "admission_state 'settlement_capable' is not a permitted state for "
+            "admission_state_source 'local_default'",
+        )
+
+    def test_rejects_captured_evaluation_with_string_capability_results(self) -> None:
+        def mutator(_manifest, root):
+            path = root / "captures" / "evaluate-candidate.json"
+            document = json.loads(path.read_text(encoding="utf-8"))
+            document["capability_results"]["chat_completions"] = "passed"
+            path.write_text(json.dumps(document), encoding="utf-8")
+
+        self.assert_capture_fails("discovery", mutator, "must be a JSON object")
+
+    def test_rejects_captured_evaluation_with_a_renamed_diagnostic_hash(self) -> None:
+        def mutator(_manifest, root):
+            path = root / "captures" / "evaluate-candidate.json"
+            document = json.loads(path.read_text(encoding="utf-8"))
+            hashes = document["diagnostic_hashes"]
+            hashes["completion_sha256"] = hashes.pop("response_body_sha256")
+            path.write_text(json.dumps(document), encoding="utf-8")
+
+        self.assert_capture_fails(
+            "discovery", mutator, "diagnostic_hashes is missing required fields: response_body_sha256"
+        )
+
+    def test_rejects_captured_evaluation_missing_a_mutation_summary_field(self) -> None:
+        def mutator(_manifest, root):
+            document = json.loads(
+                (root / "captures" / "evaluate-candidate.json").read_text(encoding="utf-8")
+            )
+            del document["mutation_summary"]["downloads_started"]
+            (root / "captures" / "evaluate-candidate.json").write_text(
+                json.dumps(document), encoding="utf-8"
+            )
+
+        self.assert_capture_fails(
+            "discovery", mutator, "mutation_summary is missing required fields: downloads_started"
+        )
+
+    def test_rejects_a_captured_document_whose_schema_is_not_enumerated(self) -> None:
+        def mutator(manifest, root):
+            (root / "captures" / "discover-mlx-cache.json").write_text(
+                json.dumps({"schema": "models_browse.v1", "models": []}), encoding="utf-8"
+            )
+            for step in manifest["steps"]:
+                for document in step.get("documents", []):
+                    if document["path"] == "captures/discover-mlx-cache.json":
+                        document["schema"] = "models_browse.v1"
+
+        self.assert_capture_fails("discovery", mutator, "has an unvalidated schema")
 
     def test_rejects_captured_document_with_an_absolute_path(self) -> None:
         def mutator(manifest, root):
@@ -371,6 +630,33 @@ class BYOMJourneyCaptureTests(unittest.TestCase):
                     "credential-like value",
                 )
 
+    # R4 MEDIUM: each journey has exactly one harness that can produce its run
+    # manifest. "Any existing repository-relative source file" let a discovery
+    # manifest be signed under the admission harness's provenance.
+    def test_rejects_manifest_naming_another_journeys_harness(self) -> None:
+        def mutator(manifest, _root):
+            manifest["harness"]["name"] = "test/e2e/byom/run-cli-onboarding-e2e.py"
+
+        self.assert_capture_fails(
+            "discovery", mutator, "harness.name must equal 'test/e2e/byom/run-discovery-journey.py'"
+        )
+
+    def test_rejects_admission_manifest_naming_the_discovery_driver(self) -> None:
+        def mutator(manifest, _root):
+            manifest["harness"]["name"] = "test/e2e/byom/run-discovery-journey.py"
+
+        self.assert_capture_fails(
+            "admission", mutator, "harness.name must equal 'test/e2e/byom/run-cli-onboarding-e2e.py'"
+        )
+
+    def test_rejects_manifest_naming_an_unrelated_repository_file(self) -> None:
+        def mutator(manifest, _root):
+            manifest["harness"]["name"] = "scripts/byom_journey_evidence.py"
+
+        self.assert_capture_fails(
+            "discovery", mutator, "harness.name must equal 'test/e2e/byom/run-discovery-journey.py'"
+        )
+
     def test_legitimate_dns_shaped_values_still_capture(self) -> None:
         # The tightened rule must not reject the DNS-shaped value shapes the
         # contract legitimately emits, so prove them through a real capture.
@@ -384,7 +670,10 @@ class BYOMJourneyCaptureTests(unittest.TestCase):
         manifest, manifest_path = self.mutate("discovery", mutator)
         evidence = self.capture("discovery", manifest, manifest_path)
         self.assertIn("SnapshotManifestV1", evidence["steps"][0]["assertion"])
-        self.assertEqual("test/e2e/byom/run-cli-onboarding-e2e.py", evidence["harness"]["name"])
+        # The discovery journey's evidence carries the discovery driver's own
+        # identity, not "whichever repository file the manifest happened to
+        # name" -- see test_rejects_manifest_naming_another_journeys_harness.
+        self.assertEqual("test/e2e/byom/run-discovery-journey.py", evidence["harness"]["name"])
 
     def test_rejects_secret_bearing_observation_key(self) -> None:
         def mutator(manifest, _root):

--- a/scripts/tests/test_byom_journey_evidence.py
+++ b/scripts/tests/test_byom_journey_evidence.py
@@ -108,6 +108,20 @@ class BYOMJourneyCaptureTests(unittest.TestCase):
             self.capture(selector, manifest, manifest_path)
         self.assertIn(fragment, str(caught.exception))
 
+    def test_accepts_a_timed_out_evaluation_capture(self) -> None:
+        # A real physical run can time out on the probe; the CLI encodes that as
+        # health_result "timed_out" and capture must not fail closed on it.
+        def mutator(_manifest, root):
+            path = root / "captures" / "evaluate-candidate.json"
+            document = json.loads(path.read_text(encoding="utf-8"))
+            document["health_result"] = "timed_out"
+            document["warnings"] = sorted(set(document["warnings"]) | {"adapter_timeout", "evaluation_failed"})
+            path.write_text(json.dumps(document, indent=2) + "\n", encoding="utf-8")
+
+        manifest, manifest_path = self.mutate("discovery", mutator)
+        evidence = self.capture("discovery", manifest, manifest_path)
+        self.assertEqual("macprovider.provider-byom-discovery-evidence.v1", evidence["schema_version"])
+
     def test_discovery_fixture_produces_schema_valid_evidence(self) -> None:
         evidence = self.capture("discovery")
         self.assertEqual("macprovider.provider-byom-discovery-evidence.v1", evidence["schema_version"])

--- a/scripts/tests/test_discovery_journey_driver.py
+++ b/scripts/tests/test_discovery_journey_driver.py
@@ -1,0 +1,952 @@
+"""Tests for the hermetic BYOM discovery-journey driver's manifest emitter.
+
+These cover the parts of `test/e2e/byom/run-discovery-journey.py` that decide
+what the signed evidence will eventually say: the step/requirement tables, the
+observation truthfulness rules, and the fail-closed redaction of captured
+documents and step assertions. Running the ten CLI steps needs a built macOS
+`macprovider-cli` and is covered by `make test-byom-discovery-journey`.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+import unittest.mock
+from pathlib import Path
+
+from scripts.check_spec_governance import (
+    PROVIDER_BYOM_DISCOVERY_FALSE_OBSERVATIONS,
+    PROVIDER_BYOM_DISCOVERY_JOURNEY_ID,
+    PROVIDER_BYOM_DISCOVERY_STEP_ID_ORDER,
+    PROVIDER_BYOM_DISCOVERY_STEP_REQUIREMENT_IDS,
+    PROVIDER_BYOM_DISCOVERY_TRUE_OBSERVATIONS,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DRIVER_PATH = REPO_ROOT / "test" / "e2e" / "byom" / "run-discovery-journey.py"
+OPERATOR_FINGERPRINT = "b" * 64
+
+
+def load_driver():
+    spec = importlib.util.spec_from_file_location("byom_discovery_journey_driver", DRIVER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+driver = load_driver()
+evidence = driver.evidence_contract
+
+
+def head_commit() -> str:
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=REPO_ROOT, capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+PROVIDER_GUIDANCE = {
+    "state_label_key": "byom.local.local_only",
+    "state_meaning_key": "byom.local.opaque_endpoint_not_earning",
+    "next_action": "evaluate",
+    "transition_reason_code": "capability_unevaluated",
+    "earning_path_class": "local_inventory_only",
+}
+# Complete closed documents: the driver validates every capture against the full
+# SPEC-046-R003/R004/R005 and SPEC-047-R002 field sets AND against their wire
+# types and closed enums (R4), so every value below is one the CLI can actually
+# emit -- a plausible-looking invention would not be a valid capture to test
+# with.
+DISCOVERY_DOCUMENT = {
+    "schema": "provider_byom_discovery.v1",
+    "generated_at": "2026-09-09T00:00:00Z",
+    "cli_version": "1.2.3",
+    "projection_sequence": 1,
+    "adapters": [
+        {
+            "runtime_source": "openai_compatible_loopback",
+            "origin_class": "loopback_http",
+            "status": "ok",
+            "warning_codes": [],
+        }
+    ],
+    "candidates": [
+        {
+            "candidate_id": "byom_" + "a" * 52,
+            "runtime_source": "openai_compatible_loopback",
+            "display_name": "opaque endpoint model",
+            "served_model_ref": "openai_compatible:opaque-mini-1b",
+            "catalog_model_key": None,
+            "identity_state": "opaque_endpoint",
+            "locality": "opaque_local_endpoint",
+            "estimated_gb": None,
+            "context_window_tokens": None,
+            "capabilities": {key: None for key in sorted(evidence.CAPABILITY_KEYS)},
+            "readiness_state": "ready",
+            "fit_state": "unknown",
+            "evaluation_state": "not_evaluated",
+            "admission_state": "local_only",
+            "admission_state_source": "local_default",
+            "provider_guidance": dict(PROVIDER_GUIDANCE),
+            "warning_codes": ["capability_unevaluated"],
+        }
+    ],
+    "warnings": [],
+}
+EVALUATION_DOCUMENT = {
+    "schema": "provider_byom_evaluation.v1",
+    "generated_at": "2026-09-09T00:00:00Z",
+    "cli_version": "1.2.3",
+    "candidate_id": "byom_" + "a" * 52,
+    "runtime_source": "openai_compatible_loopback",
+    "served_model_ref": "openai_compatible:opaque-mini-1b",
+    "catalog_model_key": None,
+    "adapter_identity": "openai_compatible_loopback",
+    "health_result": "passed",
+    "latency_ms": 12,
+    "tokens_per_second": None,
+    "completion_tokens": 4,
+    "output_bytes": 128,
+    "request_count": 1,
+    "usage_reporting_source": "runtime_reported",
+    "capability_results": {
+        "chat_completions": {"result": "passed", "source": "evaluation", "reason_code": None},
+    },
+    "fit_estimate_source": "discovery_fit_state",
+    "mutation_summary": {key: False for key in sorted(evidence.EVALUATION_MUTATION_SUMMARY_KEYS)},
+    "diagnostic_hashes": {"prompt_sha256": "b" * 64, "response_body_sha256": "c" * 64},
+    "provider_guidance": dict(PROVIDER_GUIDANCE),
+    "offer_preconditions_appear_satisfied": False,
+    "warnings": [],
+}
+DRY_RUN_DOCUMENT = {
+    "schema": "model_admission_offer_dry_run.v1",
+    "generated_at": "2026-09-09T00:00:00Z",
+    "cli_version": "1.2.3",
+    "candidate_id": "byom_" + "a" * 52,
+    "served_model_ref": "openai_compatible:opaque-mini-1b",
+    "catalog_model_key": None,
+    "would_submit": False,
+    "likely_admission_state": "local_only",
+    "likely_admission_state_source": "local_default",
+    "provider_guidance": dict(PROVIDER_GUIDANCE),
+    "reason_code": None,
+    "warnings": [],
+}
+
+
+class DriverContractTests(unittest.TestCase):
+    """The driver's own tables must mirror the governance tables exactly."""
+
+    def test_step_requirement_table_stays_inside_governance(self) -> None:
+        """Each step may claim only the requirements it exercises, plus the
+        release-evidence requirement the journey proves as a whole; the union
+        must still cover every requirement mapped to the journey."""
+        contract = evidence.DISCOVERY_CONTRACT
+        covered: set[str] = set()
+        for step, requirements in driver.STEP_REQUIREMENT_IDS.items():
+            allowed = contract.allowed_step_requirement_ids(step)
+            self.assertEqual(len(set(requirements)), len(requirements), step)
+            self.assertLessEqual(set(requirements), allowed, step)
+            self.assertLessEqual(
+                set(PROVIDER_BYOM_DISCOVERY_STEP_REQUIREMENT_IDS[step]),
+                set(requirements),
+                f"{step} dropped a requirement subject it exercises",
+            )
+            covered |= set(requirements)
+        self.assertEqual(covered, set(contract.promotable_requirement_ids))
+
+    def test_step_ids_cover_the_normative_journey(self) -> None:
+        self.assertEqual(sorted(driver.STEP_REQUIREMENT_IDS), sorted(PROVIDER_BYOM_DISCOVERY_STEP_ID_ORDER))
+
+    def test_observation_names_match_governance(self) -> None:
+        self.assertEqual(set(driver.TRUE_OBSERVATIONS), set(PROVIDER_BYOM_DISCOVERY_TRUE_OBSERVATIONS))
+        self.assertEqual(set(driver.FALSE_OBSERVATIONS), set(PROVIDER_BYOM_DISCOVERY_FALSE_OBSERVATIONS))
+        self.assertEqual(
+            set(driver.TRUE_OBSERVATIONS) & set(driver.FALSE_OBSERVATIONS),
+            set(),
+            "an observation cannot be both required-true and required-false",
+        )
+
+    def test_journey_identity_constants(self) -> None:
+        self.assertEqual(driver.JOURNEY_ID, PROVIDER_BYOM_DISCOVERY_JOURNEY_ID)
+        self.assertEqual(driver.RUN_MANIFEST_SCHEMA, evidence.RUN_MANIFEST_SCHEMA)
+        self.assertEqual(driver.ENVIRONMENT_CLASS, "hermetic-loopback")
+        self.assertTrue((REPO_ROOT / driver.HARNESS_NAME).is_file())
+
+
+class ManifestEmitterTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = Path(tempfile.mkdtemp(prefix="byom-discovery-driver-"))
+        self.addCleanup(shutil.rmtree, self.temp, True)
+        self.builder = driver.ManifestBuilder(
+            self.temp, "byom-discovery-unit", "1.2.3", evidence_mode=True
+        )
+
+    def build_all_steps(self) -> None:
+        self.builder.capture("discovery", DISCOVERY_DOCUMENT)
+        self.builder.capture("evaluation", EVALUATION_DOCUMENT)
+        self.builder.capture("dry-run", DRY_RUN_DOCUMENT)
+        for step_id in PROVIDER_BYOM_DISCOVERY_STEP_ID_ORDER:
+            if step_id == "step-06-evaluate-candidate":
+                document = self.builder.document("evaluate-candidate", "provider_byom_evaluation.v1", "evaluation")
+            elif step_id == "step-07-no-production-mutation":
+                document = self.builder.document("evaluate-mutation-summary", "provider_byom_evaluation.v1", "evaluation")
+            elif step_id == "step-09-state-boundary":
+                document = self.builder.document("offer-dry-run", "model_admission_offer_dry_run.v1", "dry-run")
+            else:
+                document = self.builder.document(
+                    step_id.replace("step-", "doc-"), "provider_byom_discovery.v1", "discovery"
+                )
+            self.builder.add_step(step_id, "Hermetic loopback step passed with a bounded projection.", [document])
+        for name in driver.TRUE_OBSERVATIONS:
+            self.builder.observe(name, True)
+        for name in driver.FALSE_OBSERVATIONS:
+            self.builder.observe(name, False)
+
+    def test_emitted_manifest_is_accepted_by_the_capture_contract(self) -> None:
+        self.build_all_steps()
+        manifest_path = self.builder.write()
+        artifact = evidence.build_evidence(
+            REPO_ROOT,
+            evidence.DISCOVERY_CONTRACT,
+            manifest_path,
+            source_sha=head_commit(),
+            operator_role="release-operator",
+            operator_identity_fingerprint=OPERATOR_FINGERPRINT,
+            hardware_profile="ci-hermetic-runner",
+            candidate="1.2.3",
+            captured_at=None,
+            expires_at=None,
+            summary="hermetic discovery journey",
+        )
+        self.assertEqual(artifact["journey_id"], PROVIDER_BYOM_DISCOVERY_JOURNEY_ID)
+        self.assertEqual(
+            [step["id"] for step in artifact["steps"]], list(PROVIDER_BYOM_DISCOVERY_STEP_ID_ORDER)
+        )
+        self.assertEqual(
+            artifact["requirement_ids"], [f"SPEC-046-R{index:03d}" for index in range(1, 9)]
+        )
+        self.assertEqual(artifact["harness"]["name"], driver.HARNESS_NAME)
+        self.assertEqual(artifact["environment"]["class"], "hermetic-loopback")
+
+    def test_manifest_shape_is_the_run_manifest_contract(self) -> None:
+        self.build_all_steps()
+        manifest = json.loads(self.builder.write().read_text(encoding="utf-8"))
+        self.assertEqual(
+            set(manifest),
+            {
+                "schema_version",
+                "journey_id",
+                "run_id",
+                "environment_class",
+                "cli_version",
+                "harness",
+                "steps",
+                "observations",
+            },
+        )
+        self.assertEqual(manifest["harness"], {"name": driver.HARNESS_NAME, "status": "pass"})
+        self.assertEqual(
+            [step["id"] for step in manifest["steps"]], list(PROVIDER_BYOM_DISCOVERY_STEP_ID_ORDER)
+        )
+        for step in manifest["steps"]:
+            self.assertEqual(set(step), {"id", "status", "assertion", "requirement_ids", "documents"})
+            self.assertEqual(step["status"], "pass")
+            for document in step["documents"]:
+                self.assertEqual(set(document), {"id", "schema", "path"})
+                self.assertTrue(document["path"].startswith("captures/"))
+                self.assertTrue((self.temp / document["path"]).is_file())
+
+    def test_unset_observation_is_refused(self) -> None:
+        self.build_all_steps()
+        self.builder.observations["candidate_evaluated"] = None
+        with self.assertRaises(driver.HarnessFailure) as caught:
+            self.builder.write()
+        self.assertIn("candidate_evaluated", str(caught.exception))
+
+    def test_required_true_observation_cannot_be_emitted_false(self) -> None:
+        self.build_all_steps()
+        self.builder.observe("non_loopback_rejected", False)
+        with self.assertRaises(driver.HarnessFailure):
+            self.builder.write()
+
+    def test_required_false_observation_cannot_be_emitted_true(self) -> None:
+        self.build_all_steps()
+        self.builder.observe("buyer_traffic_sent", True)
+        with self.assertRaises(driver.HarnessFailure):
+            self.builder.write()
+
+    def test_unknown_observation_name_is_refused(self) -> None:
+        with self.assertRaises(driver.HarnessFailure):
+            self.builder.observe("provider_paid_out", True)
+
+    def test_unknown_step_id_is_refused(self) -> None:
+        with self.assertRaises(driver.HarnessFailure):
+            self.builder.add_step("step-11-invented", "nope", [])
+
+    def test_missing_step_is_refused(self) -> None:
+        self.build_all_steps()
+        self.builder.steps = [step for step in self.builder.steps if step["id"] != "step-04-reject-non-loopback"]
+        with self.assertRaises(driver.HarnessFailure):
+            self.builder.write()
+
+    def test_capture_keeps_the_whole_document_including_localization_keys(self) -> None:
+        """Captures are archived whole (audit R1 F1).
+
+        The digest the signed evidence binds to must cover the CLI's complete
+        SPEC-046-R003 envelope, so nothing is stripped before hashing.
+        """
+        path = self.builder.capture("discovery", DISCOVERY_DOCUMENT)
+        stored = json.loads(path.read_text(encoding="utf-8"))
+        self.assertEqual(stored, DISCOVERY_DOCUMENT)
+        guidance = stored["candidates"][0]["provider_guidance"]
+        self.assertEqual(guidance["state_label_key"], "byom.local.local_only")
+        self.assertEqual(guidance["state_meaning_key"], "byom.local.opaque_endpoint_not_earning")
+        self.assertEqual(guidance["next_action"], "evaluate")
+        self.assertEqual(guidance["transition_reason_code"], "capability_unevaluated")
+        self.assertEqual(guidance["earning_path_class"], "local_inventory_only")
+
+    def test_capture_refuses_a_hostname_at_a_localization_key_path(self) -> None:
+        """The exemption is a closed grammar, not a hole: a real hostname at
+        exactly those paths still fails closed."""
+        for field in ("state_label_key", "state_meaning_key"):
+            document = json.loads(json.dumps(DISCOVERY_DOCUMENT))
+            document["candidates"][0]["provider_guidance"][field] = "coordinator.malibu.tech"
+            with self.subTest(field=field):
+                with self.assertRaises(driver.HarnessFailure):
+                    self.builder.capture("leaky-guidance", document)
+                self.assertFalse((self.temp / "captures" / "leaky-guidance.json").exists())
+
+    def test_capture_refuses_a_localization_key_shape_in_any_other_field(self) -> None:
+        """The exemption is field-scoped: the same string elsewhere is a
+        hostname, in another guidance field or outside guidance entirely."""
+        for path in (
+            ("candidates", 0, "provider_guidance", "next_action"),
+            ("candidates", 0, "display_name"),
+            ("note",),
+        ):
+            document = json.loads(json.dumps(DISCOVERY_DOCUMENT))
+            target = document
+            for key in path[:-1]:
+                target = target[key]
+            target[path[-1]] = "byom.local.local_only"
+            with self.subTest(path=path):
+                with self.assertRaises(driver.HarnessFailure):
+                    self.builder.capture("leaky-shape", document)
+                self.assertFalse((self.temp / "captures" / "leaky-shape.json").exists())
+
+    def test_capture_refuses_a_document_carrying_unredacted_material(self) -> None:
+        for leak in (
+            {"schema": "provider_byom_discovery.v1", "origin": "http://127.0.0.1:11434"},
+            {"schema": "provider_byom_discovery.v1", "cache": "/Users/someone/.cache/huggingface"},
+            {"schema": "provider_byom_discovery.v1", "host": "coordinator.malibu.tech"},
+            {"schema": "provider_byom_discovery.v1", "note": "reachable on localhost"},
+            {"schema": "provider_byom_discovery.v1", "token": "Authorization: Bearer abcdefghijklmnopqrst"},
+        ):
+            with self.subTest(leak=sorted(leak)[0]):
+                with self.assertRaises(driver.HarnessFailure):
+                    self.builder.capture("leaky", leak)
+                self.assertFalse((self.temp / "captures" / "leaky.json").exists())
+
+    def test_step_assertions_survive_the_shared_redaction_scan(self) -> None:
+        self.build_all_steps()
+        manifest = json.loads(self.builder.write().read_text(encoding="utf-8"))
+        for step in manifest["steps"]:
+            evidence.reject_unredacted_text(step["assertion"], step["id"])
+
+    def test_redaction_review_detects_leaked_material(self) -> None:
+        captures = self.temp / "captures"
+        captures.mkdir(exist_ok=True)
+        forbidden = [("adapter_origin", "http://127.0.0.1:1")]
+        self.assertTrue(driver.redaction_review(["clean output"], captures, forbidden))
+        with self.assertRaises(driver.HarnessFailure):
+            driver.redaction_review(["saw http://127.0.0.1:1 once"], captures, forbidden)
+
+    def test_redaction_review_failure_does_not_re_emit_the_forbidden_value(self) -> None:
+        """R4 LOW: the top-level handler prints this exception to stderr, so a
+        diagnostic quoting the leaked value would break the very invariant the
+        step exists to enforce. The category and index locate it instead."""
+        captures = self.temp / "captures"
+        captures.mkdir(exist_ok=True)
+        secret = "http://127.0.0.1:54321/v1/chat/completions"
+        with self.assertRaises(driver.HarnessFailure) as caught:
+            driver.redaction_review(["leaked " + secret], captures, [("adapter_origin", secret)])
+        message = str(caught.exception)
+        self.assertNotIn(secret, message)
+        # Not even a prefix: the previous diagnostic embedded the first 24 bytes.
+        self.assertNotIn(secret[:24], message)
+        self.assertNotIn("127.0.0.1", message)
+        self.assertIn("adapter_origin", message)
+        self.assertIn("entry 0", message)
+
+    def test_captured_documents_are_written_user_private(self) -> None:
+        """R4 LOW: a capture is redaction-clean but is still this operator's
+        local model inventory, so neither it nor its directory may be left at
+        whatever the umask happened to allow."""
+        path = self.builder.capture("discovery", DISCOVERY_DOCUMENT)
+        self.assertEqual(path.stat().st_mode & 0o777, 0o600)
+        self.assertEqual(path.parent.stat().st_mode & 0o777, 0o700)
+
+    def test_captured_document_digest_survives_the_capture_contract(self) -> None:
+        """The whole-document capture is what capture-time validation digests,
+        so the same document must pass the contract's own document scan."""
+        path = self.builder.capture("discovery", DISCOVERY_DOCUMENT)
+        digested = evidence._digest_document(
+            self.temp,
+            evidence.DISCOVERY_CONTRACT,
+            {"id": "doc", "schema": "provider_byom_discovery.v1", "path": "captures/discovery.json"},
+            "step-01-discover-mlx-cache",
+            0,
+        )
+        self.assertEqual(digested["bytes"], len(path.read_bytes()))
+        self.assertEqual(digested["schema"], "provider_byom_discovery.v1")
+
+
+class RunnerStdoutScanTests(unittest.TestCase):
+    """`run_text` owns the full plaintext scan; only `run()` defers the hostname
+    rule, and only because its very next act is the structured document scan
+    that decides the SPEC-046-R003 localization keys field by field (R3 LOW)."""
+
+    def setUp(self) -> None:
+        self.temp = Path(tempfile.mkdtemp(prefix="byom-runner-scan-"))
+        self.addCleanup(shutil.rmtree, self.temp, True)
+
+    def runner_for(self, stdout: str) -> "object":
+        fake = self.temp / "fake-cli"
+        fake.write_text("#!/bin/sh\ncat <<'EOF'\n%s\nEOF\n" % stdout, encoding="utf-8")
+        fake.chmod(0o755)
+        return driver.Runner(fake, dict(os.environ), self.temp)
+
+    def test_a_clean_version_string_passes(self) -> None:
+        self.assertEqual(self.runner_for("1.8.122").run_text(["--version"]).strip(), "1.8.122")
+
+    def test_a_dns_shaped_version_string_is_refused(self) -> None:
+        """`--version` has no follow-up structured scan, so it may not use the
+        hostname exemption the JSON path relies on."""
+        runner = self.runner_for("1.8.122 (coordinator.malibu.tech)")
+        with self.assertRaises(driver.HarnessFailure) as caught:
+            runner.run_text(["--version"])
+        self.assertIn("contains a hostname", str(caught.exception))
+
+    def test_the_json_path_still_accepts_localization_keys(self) -> None:
+        document = {
+            "schema": "provider_byom_discovery.v1",
+            "candidates": [{"provider_guidance": {"state_label_key": "byom.local.offerable"}}],
+        }
+        runner = self.runner_for(json.dumps(document))
+        self.assertEqual(runner.run(["models", "discover", "--json"]), document)
+
+
+class CapturedDocumentScanTests(unittest.TestCase):
+    """The scanner rule the driver and capture both run over captured documents."""
+
+    def test_escaped_hostname_in_a_captured_document_still_fails(self) -> None:
+        """A JSON escape must not hide a hostname from the decoded walk."""
+        temp = Path(tempfile.mkdtemp(prefix="byom-capture-scan-"))
+        self.addCleanup(shutil.rmtree, temp, True)
+        captures = temp / "captures"
+        captures.mkdir()
+        escaped = (
+            '{"schema": "provider_byom_discovery.v1", '
+            '"note": "coordinator\\u002emalibu\\u002etech"}\n'
+        )
+        (captures / "escaped.json").write_text(escaped, encoding="utf-8")
+        with self.assertRaises(evidence.BYOMEvidenceError):
+            evidence._digest_document(
+                temp,
+                evidence.DISCOVERY_CONTRACT,
+                {"id": "doc", "schema": "provider_byom_discovery.v1", "path": "captures/escaped.json"},
+                "step-01-discover-mlx-cache",
+                0,
+            )
+
+    def test_localization_key_rule_is_a_closed_grammar(self) -> None:
+        for value in (
+            "byom.local.offerable",
+            "byom.offer_dry_run.not_submitted_not_earning",
+        ):
+            with self.subTest(accepted=value):
+                evidence.reject_unredacted_localization_key(value, "$.provider_guidance.state_label_key")
+        for value in (
+            "coordinator.malibu.tech",
+            "byom.local",
+            "BYOM.Local.Offerable",
+            "byom.local.offerable.",
+            "notbyom.local.offerable",
+            "byom.local.offerable http://127.0.0.1:1",
+        ):
+            with self.subTest(rejected=value):
+                with self.assertRaises(evidence.BYOMEvidenceError):
+                    evidence.reject_unredacted_localization_key(
+                        value, "$.provider_guidance.state_label_key"
+                    )
+
+    def test_emitted_evidence_scan_keeps_no_exemption(self) -> None:
+        """`assert_redacted` is unchanged: evidence never carries guidance."""
+        with self.assertRaises(evidence.BYOMEvidenceError):
+            evidence.assert_redacted({"provider_guidance": {"state_label_key": "byom.local.offerable"}})
+
+
+class OutputDirectoryTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = Path(tempfile.mkdtemp(prefix="byom-discovery-out-"))
+        self.addCleanup(shutil.rmtree, self.temp, True)
+
+    def test_new_directory_is_created_user_private(self) -> None:
+        out = self.temp / "fresh"
+        driver.prepare_out_dir(out)
+        self.assertTrue(out.is_dir())
+        self.assertEqual(out.stat().st_mode & 0o777, 0o700)
+
+    def test_existing_empty_directory_is_accepted(self) -> None:
+        out = self.temp / "empty"
+        out.mkdir()
+        driver.prepare_out_dir(out)
+
+    def test_existing_permissive_directory_is_narrowed(self) -> None:
+        """R4 LOW: POSIX applies `mkdir`'s mode only when it creates the
+        directory, so a pre-existing world-readable `--out` stayed
+        world-readable and published every capture written into it."""
+        out = self.temp / "permissive"
+        out.mkdir(mode=0o755)
+        out.chmod(0o755)
+        driver.prepare_out_dir(out)
+        self.assertEqual(out.stat().st_mode & 0o777, 0o700)
+
+    def test_a_failed_rerun_cannot_reuse_a_stale_manifest_directory(self) -> None:
+        """Regression for the stale-manifest finding: a directory that already
+        holds a previous run's manifest is refused outright, so a failing rerun
+        can never leave that pass manifest sitting there as if it were current."""
+        out = self.temp / "used"
+        out.mkdir()
+        (out / "run-manifest.json").write_text("{}", encoding="utf-8")
+        with self.assertRaises(driver.HarnessFailure):
+            driver.prepare_out_dir(out)
+        # The operator's data is refused, never deleted.
+        self.assertTrue((out / "run-manifest.json").is_file())
+
+    def test_a_failed_run_publishes_no_manifest(self) -> None:
+        out = self.temp / "failing"
+        driver.prepare_out_dir(out)
+        builder = driver.ManifestBuilder(out, "byom-discovery-unit", "1.2.3")
+        with self.assertRaises(driver.HarnessFailure):
+            builder.write()
+        self.assertFalse((out / "run-manifest.json").exists())
+        self.assertFalse((out / ".run-manifest.json.tmp").exists())
+
+
+class EvidenceModeBindingTests(unittest.TestCase):
+    """Evidence runs must execute the source they name (audit R1 F5)."""
+
+    def test_evidence_mode_refuses_a_binary_override(self) -> None:
+        with self.assertRaises(driver.HarnessFailure) as caught:
+            driver.build_cli(REPO_ROOT, "/usr/bin/true", True)
+        self.assertIn("MACPROVIDER_CLI_BINARY", str(caught.exception))
+
+    def test_non_evidence_mode_keeps_the_local_override(self) -> None:
+        self.assertEqual(driver.build_cli(REPO_ROOT, "/usr/bin/true", False), Path("/usr/bin/true"))
+
+    def test_evidence_source_paths_cover_the_executed_surface(self) -> None:
+        self.assertEqual(
+            sorted(driver.EVIDENCE_SOURCE_PATHS),
+            [
+                "phase3-binary/Package.resolved",
+                "phase3-binary/Package.swift",
+                "phase3-binary/Sources",
+                "phase3-binary/Tests",
+                "scripts",
+                "test/e2e/byom",
+            ],
+        )
+
+    def scratch_repo(self) -> Path:
+        """A throwaway repository shaped like this one, so a concurrent run of
+        this suite can never touch the checkout under test."""
+        root = Path(tempfile.mkdtemp(prefix="byom-dirty-tree-"))
+        self.addCleanup(shutil.rmtree, root, True)
+        git = ["git", "-c", "user.email=t@example.invalid", "-c", "user.name=t"]
+        subprocess.run(["git", "init", "-q", str(root)], check=True)
+        for relative, contents in (
+            ("scripts/byom_journey_evidence.py", "original\n"),
+            ("phase3-binary/Sources/macprovider-cli/Main.swift", "// original\n"),
+            ("phase3-binary/Package.resolved", '{"pins": []}\n'),
+        ):
+            path = root / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(contents, encoding="utf-8")
+        subprocess.run(git + ["add", "."], cwd=root, check=True)
+        subprocess.run(git + ["commit", "-qm", "seed"], cwd=root, check=True)
+        return root
+
+    def test_evidence_mode_refuses_a_dirty_tracked_source_tree(self) -> None:
+        root = self.scratch_repo()
+        driver.require_clean_evidence_source(root, "before the build")
+        (root / "scripts" / "byom_journey_evidence.py").write_text("modified\n", encoding="utf-8")
+        with self.assertRaises(driver.HarnessFailure) as caught:
+            driver.require_clean_evidence_source(root, "before the build")
+        self.assertIn("scripts/byom_journey_evidence.py", str(caught.exception))
+
+    def test_evidence_mode_refuses_an_untracked_swift_source_file(self) -> None:
+        """Reverses the R1 test that endorsed untracked files (audit R2).
+
+        SwiftPM's executable target selects the whole `Sources/macprovider-cli`
+        directory with no closed source list, so an untracked `.swift` file
+        there is a build input and the manifest would name a commit that did
+        not produce the binary.
+        """
+        root = self.scratch_repo()
+        driver.require_clean_evidence_source(root, "before the build")
+        untracked = root / "phase3-binary" / "Sources" / "macprovider-cli" / "Injected.swift"
+        untracked.write_text("// not committed\n", encoding="utf-8")
+        with self.assertRaises(driver.HarnessFailure) as caught:
+            driver.require_clean_evidence_source(root, "before the build")
+        self.assertIn("Injected.swift", str(caught.exception))
+
+    def test_lockfile_drift_after_the_build_fails_closed(self) -> None:
+        """The post-build check is the one that catches a build which rewrote
+        its own inputs after the pre-build check passed (audit R2 HIGH)."""
+        root = self.scratch_repo()
+        lockfile = root / driver.EVIDENCE_RESTORED_LOCKFILE
+        lockfile.write_text('{"pins": ["rewritten by the build"]}\n', encoding="utf-8")
+        with self.assertRaises(driver.HarnessFailure) as caught:
+            driver.require_clean_evidence_source(root, "after the build")
+        self.assertIn("after the build", str(caught.exception))
+        self.assertIn("Package.resolved", str(caught.exception))
+
+    def test_a_clean_lockfile_passes_untouched(self) -> None:
+        """The common case writes nothing at all."""
+        root = self.scratch_repo()
+        lockfile = root / driver.EVIDENCE_RESTORED_LOCKFILE
+        before = lockfile.read_bytes()
+        driver.restore_locked_package_resolved(root, environ={})
+        self.assertEqual(lockfile.read_bytes(), before)
+        driver.require_clean_evidence_source(root, "before the build")
+
+    def test_the_committed_lockfile_is_restored_in_an_ephemeral_ci_checkout(self) -> None:
+        """An earlier CI `swift test` step rewrites the lockfile; that drift is
+        step ordering, not a fact about this run, and the checkout is thrown
+        away with the job, so evidence mode restores the committed bytes."""
+        for environ in ({"GITHUB_ACTIONS": "true"}, {"CI": "true"}):
+            with self.subTest(environ=environ):
+                root = self.scratch_repo()
+                lockfile = root / driver.EVIDENCE_RESTORED_LOCKFILE
+                original = lockfile.read_text(encoding="utf-8")
+                lockfile.write_text('{"pins": ["swift test rewrote this"]}\n', encoding="utf-8")
+                driver.restore_locked_package_resolved(root, environ=environ)
+                self.assertEqual(lockfile.read_text(encoding="utf-8"), original)
+                driver.require_clean_evidence_source(root, "before the build")
+
+    def test_a_dirty_lockfile_on_a_local_run_is_refused_and_left_alone(self) -> None:
+        """R3 MEDIUM: outside an ephemeral CI checkout the difference is the
+        operator's own uncommitted work, and `git checkout HEAD --` would
+        destroy it with no copy anywhere. Refuse, and do not touch the bytes."""
+        root = self.scratch_repo()
+        lockfile = root / driver.EVIDENCE_RESTORED_LOCKFILE
+        local_work = '{"pins": ["local work nobody committed"]}\n'
+        lockfile.write_text(local_work, encoding="utf-8")
+        with self.assertRaises(driver.HarnessFailure) as caught:
+            driver.restore_locked_package_resolved(root, environ={})
+        self.assertIn("will not discard your uncommitted", str(caught.exception))
+        self.assertEqual(lockfile.read_text(encoding="utf-8"), local_work)
+
+    def test_a_staged_lockfile_change_is_refused_even_in_ci(self) -> None:
+        """A staged lockfile is deliberate work, not an earlier step's
+        resolution, wherever the run happens."""
+        root = self.scratch_repo()
+        lockfile = root / driver.EVIDENCE_RESTORED_LOCKFILE
+        staged = '{"pins": ["staged on purpose"]}\n'
+        lockfile.write_text(staged, encoding="utf-8")
+        subprocess.run(
+            ["git", "add", "--", driver.EVIDENCE_RESTORED_LOCKFILE], cwd=root, check=True
+        )
+        with self.assertRaises(driver.HarnessFailure) as caught:
+            driver.restore_locked_package_resolved(root, environ={"GITHUB_ACTIONS": "true"})
+        self.assertIn("the lockfile is staged", str(caught.exception))
+        self.assertEqual(lockfile.read_text(encoding="utf-8"), staged)
+
+    def test_the_ci_flag_must_actually_say_true(self) -> None:
+        self.assertTrue(driver.in_ephemeral_ci_checkout({"CI": "true"}))
+        self.assertTrue(driver.in_ephemeral_ci_checkout({"GITHUB_ACTIONS": "1"}))
+        self.assertFalse(driver.in_ephemeral_ci_checkout({"CI": "false"}))
+        self.assertFalse(driver.in_ephemeral_ci_checkout({}))
+
+    def test_evidence_builds_with_locked_resolution(self) -> None:
+        """Locked resolution is what stops the build from rewriting the
+        lockfile after the pre-build check; it is the same lock the
+        `phase3-binary (locked SwiftPM resolve)` CI job applies."""
+        self.assertEqual(
+            driver.SWIFT_LOCKED_RESOLUTION_FLAG, "--only-use-versions-from-resolved-file"
+        )
+        verifier = (REPO_ROOT / "scripts" / "verify-swift-package-lock.sh").read_text(encoding="utf-8")
+        self.assertIn("-onlyUsePackageVersionsFromResolvedFile", verifier)
+
+        commands: list[list[str]] = []
+        real_run = driver.subprocess.run
+
+        def record(command, **kwargs):
+            commands.append(list(command))
+            # Only the build is stubbed. `git` still runs for real, so the
+            # lockfile reconciliation sees the scratch repository's actual state
+            # instead of an empty mocked stdout.
+            if list(command)[:1] == ["git"]:
+                return real_run(command, **kwargs)
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+        root = self.scratch_repo()
+        binary = root / "phase3-binary" / ".build" / "debug" / "macprovider-cli"
+        binary.parent.mkdir(parents=True)
+        binary.write_text("#!/bin/sh\n", encoding="utf-8")
+        with unittest.mock.patch.object(driver.subprocess, "run", side_effect=record):
+            driver.build_cli(root, None, True)
+        build = [command for command in commands if command[:2] == ["swift", "build"]]
+        self.assertEqual(len(build), 1)
+        self.assertIn(driver.SWIFT_LOCKED_RESOLUTION_FLAG, build[0])
+
+    def test_the_ci_wrapper_runs_the_driver_in_evidence_mode(self) -> None:
+        wrapper = (REPO_ROOT / "scripts" / "test-byom-discovery-journey.sh").read_text(encoding="utf-8")
+        self.assertIn("run-discovery-journey.py --evidence --out", wrapper)
+        # The commit is recorded only after the driver's post-build check has
+        # passed -- so the wrapper cannot name a commit whose run drifted.
+        run = wrapper.index("run-discovery-journey.py --evidence --out")
+        record = wrapper.index('SOURCE_SHA="$(git rev-parse HEAD)"')
+        self.assertLess(run, record)
+
+    def test_the_ci_wrapper_does_no_lockfile_surgery_of_its_own(self) -> None:
+        """R3 MEDIUM: the wrapper's unconditional restore destroyed local
+        uncommitted lockfile work. The rule lives in the driver, which refuses
+        outside an ephemeral CI checkout instead of overwriting."""
+        wrapper = (REPO_ROOT / "scripts" / "test-byom-discovery-journey.sh").read_text(encoding="utf-8")
+        self.assertNotIn("git checkout HEAD -- phase3-binary/Package.resolved", wrapper)
+
+    def test_the_ci_wrapper_only_removes_directories_it_created(self) -> None:
+        """R3 MEDIUM: the EXIT trap used to delete the pre-existing evidence
+        file it had just refused to overwrite. Both cleanup targets now come
+        from this invocation's own `mktemp -d`."""
+        wrapper = (REPO_ROOT / "scripts" / "test-byom-discovery-journey.sh").read_text(encoding="utf-8")
+        self.assertNotIn("refusing to overwrite", wrapper)
+        self.assertIn('EVIDENCE_DIR="$(mktemp -d "journeys/evidence/', wrapper)
+        self.assertIn('[ -n "$EVIDENCE_DIR" ] && rm -rf "$EVIDENCE_DIR"', wrapper)
+        # The trap is armed with both variables empty, so an early failure
+        # cannot make it remove anything.
+        empty = wrapper.index('EVIDENCE_DIR=""')
+        trap = wrapper.index("trap cleanup EXIT")
+        created = wrapper.index('EVIDENCE_DIR="$(mktemp -d')
+        self.assertLess(empty, trap)
+        self.assertLess(trap, created)
+
+
+class WrapperEvidenceArtifactTests(unittest.TestCase):
+    """The CI wrapper must only ever delete artifacts it created (R3 MEDIUM).
+
+    These run the wrapper's REAL artifact prologue -- everything from `set -e`
+    down to the last path assignment, taken verbatim out of the shipped script
+    -- inside a scratch tree, with a trailer standing in for the pipeline.
+    """
+
+    def setUp(self) -> None:
+        self.scratch = Path(tempfile.mkdtemp(prefix="byom-wrapper-artifacts-"))
+        self.addCleanup(shutil.rmtree, self.scratch, True)
+        self.evidence_dir = self.scratch / "journeys" / "evidence"
+        self.evidence_dir.mkdir(parents=True)
+        # A pre-existing artifact from some other run, in the directory this
+        # gate writes into.
+        self.collision = self.evidence_dir / "provider-byom-discovery-ci-collision.redacted.json"
+        self.collision_bytes = b'{"schema_version": "someone-elses-run"}\n'
+        self.collision.write_bytes(self.collision_bytes)
+
+    def run_prologue(self, trailer: str) -> subprocess.CompletedProcess:
+        wrapper = (REPO_ROOT / "scripts" / "test-byom-discovery-journey.sh").read_text(encoding="utf-8")
+        head, marker, _ = wrapper.partition("REQUIREMENT_IDS=")
+        self.assertTrue(marker, "wrapper prologue marker moved")
+        script = self.scratch / "scripts" / "test-byom-discovery-journey.sh"
+        script.parent.mkdir(parents=True, exist_ok=True)
+        script.write_text(head + trailer, encoding="utf-8")
+        return subprocess.run(["bash", str(script)], capture_output=True, text=True)
+
+    def test_a_failed_run_leaves_another_runs_artifact_byte_identical(self) -> None:
+        completed = self.run_prologue(
+            'echo "$EVIDENCE_DIR"\n'
+            'printf \'{"schema_version": "this run"}\\n\' > "$EVIDENCE"\n'
+            "exit 1\n"
+        )
+        self.assertEqual(completed.returncode, 1)
+        self.assertEqual(self.collision.read_bytes(), self.collision_bytes)
+        # `mktemp -d` runs on a repository-relative template, so the wrapper
+        # reports a path relative to the tree root it `cd`-ed into.
+        created = completed.stdout.strip()
+        self.assertTrue(
+            created.startswith("journeys/evidence/provider-byom-discovery-ci-"), created
+        )
+        self.assertFalse(
+            (self.scratch / created).exists(),
+            "the run's own evidence directory survived cleanup",
+        )
+
+    def test_an_early_failure_deletes_nothing(self) -> None:
+        """The trap is armed before the directories exist, so a failure between
+        `trap` and `mktemp` must not remove anyone's artifact."""
+        completed = self.run_prologue("exit 1\n")
+        self.assertEqual(completed.returncode, 1)
+        self.assertEqual(self.collision.read_bytes(), self.collision_bytes)
+        self.assertEqual(
+            sorted(path.name for path in self.evidence_dir.iterdir()), [self.collision.name]
+        )
+
+    def test_two_same_second_runs_cannot_collide(self) -> None:
+        directories = {
+            self.run_prologue('echo "$EVIDENCE_DIR"\nexit 1\n').stdout.strip()
+            for _ in range(4)
+        }
+        self.assertEqual(len(directories), 4)
+
+
+class ManifestPublicationModeTests(unittest.TestCase):
+    """Only an `--evidence` run may publish a capturable manifest (audit R2)."""
+
+    def setUp(self) -> None:
+        self.temp = Path(tempfile.mkdtemp(prefix="byom-discovery-mode-"))
+        self.addCleanup(shutil.rmtree, self.temp, True)
+
+    def populate(self, builder: "driver.ManifestBuilder") -> None:
+        builder.capture("discovery", DISCOVERY_DOCUMENT)
+        for step_id in PROVIDER_BYOM_DISCOVERY_STEP_ID_ORDER:
+            builder.add_step(
+                step_id,
+                "Hermetic loopback step passed with a bounded projection.",
+                [builder.document(step_id.replace("step-", "doc-"), "provider_byom_discovery.v1", "discovery")],
+            )
+        for name in driver.TRUE_OBSERVATIONS:
+            builder.observe(name, True)
+        for name in driver.FALSE_OBSERVATIONS:
+            builder.observe(name, False)
+
+    def test_evidence_mode_publishes_the_run_manifest(self) -> None:
+        builder = driver.ManifestBuilder(self.temp, "byom-discovery-unit", "1.2.3", evidence_mode=True)
+        self.populate(builder)
+        self.assertEqual(builder.write().name, "run-manifest.json")
+
+    def test_a_non_evidence_run_publishes_no_manifest(self) -> None:
+        builder = driver.ManifestBuilder(self.temp, "byom-discovery-unit", "1.2.3")
+        self.populate(builder)
+        path = builder.write()
+        self.assertEqual(path.name, "run-summary.json")
+        self.assertFalse((self.temp / "run-manifest.json").exists())
+        # Same content, a name the capture tool does not consume.
+        self.assertEqual(
+            json.loads(path.read_text(encoding="utf-8"))["journey_id"],
+            PROVIDER_BYOM_DISCOVERY_JOURNEY_ID,
+        )
+
+    def test_the_runbook_evidence_step_passes_evidence(self) -> None:
+        runbook = (REPO_ROOT / "docs" / "runbooks" / "byom-journey-evidence.md").read_text(encoding="utf-8")
+        self.assertIn("run-discovery-journey.py --evidence", runbook)
+
+
+class ClosedCaptureSchemaTests(unittest.TestCase):
+    """Captured documents must match their complete closed schemas (audit R2).
+
+    Redaction-clean is not the same as complete: a document that had dropped a
+    required field would otherwise be digested into signed evidence as if the
+    CLI had emitted it.
+    """
+
+    def setUp(self) -> None:
+        self.temp = Path(tempfile.mkdtemp(prefix="byom-discovery-schema-"))
+        self.addCleanup(shutil.rmtree, self.temp, True)
+        self.builder = driver.ManifestBuilder(
+            self.temp, "byom-discovery-unit", "1.2.3", evidence_mode=True
+        )
+
+    def capture_refused(self, document: dict, fragment: str) -> None:
+        with self.assertRaises(driver.HarnessFailure) as caught:
+            self.builder.capture("candidate-document", document)
+        self.assertIn(fragment, str(caught.exception))
+        self.assertFalse((self.temp / "captures" / "candidate-document.json").exists())
+
+    def test_complete_documents_are_accepted(self) -> None:
+        for name, document in (
+            ("discovery", DISCOVERY_DOCUMENT),
+            ("evaluation", EVALUATION_DOCUMENT),
+            ("dry-run", DRY_RUN_DOCUMENT),
+        ):
+            with self.subTest(name=name):
+                self.assertTrue(self.builder.capture(name, document).is_file())
+
+    def test_a_missing_envelope_field_is_refused(self) -> None:
+        document = json.loads(json.dumps(DISCOVERY_DOCUMENT))
+        del document["projection_sequence"]
+        self.capture_refused(document, "missing required fields: projection_sequence")
+
+    def test_an_unknown_envelope_field_is_refused(self) -> None:
+        document = json.loads(json.dumps(DISCOVERY_DOCUMENT))
+        document["settlement_capable"] = True
+        self.capture_refused(document, "unknown fields: settlement_capable")
+
+    def test_a_missing_candidate_field_is_refused(self) -> None:
+        document = json.loads(json.dumps(DISCOVERY_DOCUMENT))
+        del document["candidates"][0]["admission_state_source"]
+        self.capture_refused(document, "missing required fields: admission_state_source")
+
+    def test_a_missing_capability_field_is_refused(self) -> None:
+        """The step-03 "no asserted capability" check was vacuously true for an
+        absent or partial capability object."""
+        document = json.loads(json.dumps(DISCOVERY_DOCUMENT))
+        del document["candidates"][0]["capabilities"]["usage_reporting"]
+        self.capture_refused(document, "capabilities is missing required fields: usage_reporting")
+
+    def test_an_unknown_capability_field_is_refused(self) -> None:
+        document = json.loads(json.dumps(DISCOVERY_DOCUMENT))
+        document["candidates"][0]["capabilities"]["verified_throughput"] = True
+        self.capture_refused(document, "capabilities carries unknown fields: verified_throughput")
+
+    def test_a_missing_guidance_field_is_refused(self) -> None:
+        document = json.loads(json.dumps(DISCOVERY_DOCUMENT))
+        del document["candidates"][0]["provider_guidance"]["earning_path_class"]
+        self.capture_refused(document, "provider_guidance is missing required fields: earning_path_class")
+
+    def test_a_missing_mutation_summary_field_is_refused(self) -> None:
+        """Step 07 accepted any nonempty subset of false mutation fields."""
+        document = json.loads(json.dumps(EVALUATION_DOCUMENT))
+        del document["mutation_summary"]["downloads_started"]
+        self.capture_refused(document, "mutation_summary is missing required fields: downloads_started")
+
+    def test_an_unknown_mutation_summary_field_is_refused(self) -> None:
+        document = json.loads(json.dumps(EVALUATION_DOCUMENT))
+        document["mutation_summary"]["weights_deleted"] = False
+        self.capture_refused(document, "mutation_summary carries unknown fields: weights_deleted")
+
+    def test_a_missing_dry_run_field_is_refused(self) -> None:
+        document = json.loads(json.dumps(DRY_RUN_DOCUMENT))
+        del document["would_submit"]
+        self.capture_refused(document, "missing required fields: would_submit")
+
+    def test_an_unvalidated_schema_is_refused(self) -> None:
+        self.capture_refused({"schema": "models_browse.v1"}, "unvalidated schema")
+
+    def test_the_capability_field_set_is_the_spec_046_r004_list(self) -> None:
+        self.assertEqual(
+            sorted(evidence.CAPABILITY_KEYS),
+            [
+                "chat_completions",
+                "family",
+                "json_mode",
+                "max_context_tokens",
+                "quantization",
+                "runtime_version",
+                "streaming",
+                "structured_output_passthrough",
+                "tool_call_passthrough",
+                "usage_reporting",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/e2e/byom/run-discovery-journey.py
+++ b/test/e2e/byom/run-discovery-journey.py
@@ -1,0 +1,1421 @@
+#!/usr/bin/env python3
+"""Hermetic JOURNEY-PROVIDER-BYOM-DISCOVERY driver (#1453 slice 1).
+
+Runs all ten normative steps of `journeys/JOURNEY-PROVIDER-BYOM-DISCOVERY.md`
+against loopback stubs and an on-disk MLX-cache fixture, saves every CLI JSON
+document it produced, and -- in `--evidence` mode only -- emits the
+`macprovider.byom-journey-run.v1` run manifest that
+`scripts/capture-byom-journey-evidence.py` consumes. A run without `--evidence`
+may execute an arbitrary MACPROVIDER_CLI_BINARY against a dirty tree, so it
+writes `run-summary.json` instead: local debugging output that no capture step
+reads, which makes an unbound run non-promotable by construction.
+
+Every observation in the manifest is set from this driver's own assertions, not
+declared: the two negative observations are read off harness-owned ledgers (a
+recording coordinator sink configured as the CLI's coordinator, and the adapter
+stubs' own request logs). A failed assertion aborts the run, and the manifest is
+published atomically only after every step and observation check has passed, so
+a manifest only ever exists for a run where all ten steps passed.
+
+Captured CLI documents are archived whole and validated against their complete
+closed schemas -- a missing or unknown field fails the step. Nothing is stripped
+before hashing, so the digest the signed evidence binds to covers the CLI's
+complete closed envelope; the evidence contract's fail-closed scanner is
+imported and run over every one of them, and over every command's real stdout
+and stderr. The closed-schema validation itself lives in the shared capture
+contract, so it covers hand-authored runs too, not only this driver's captures.
+
+Nothing here signs or promotes anything, and nothing is written into the
+repository: the captures and the manifest go to `--out`, which the operator
+keeps locally. Only their digests reach the evidence artifact.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import pathlib
+import secrets
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+JOURNEY_ID = "JOURNEY-PROVIDER-BYOM-DISCOVERY"
+RUN_MANIFEST_SCHEMA = "macprovider.byom-journey-run.v1"
+HARNESS_NAME = "test/e2e/byom/run-discovery-journey.py"
+ENVIRONMENT_CLASS = "hermetic-loopback"
+
+MLX_MODEL_ID = "mlx-community/Tiny-1B-4bit"
+MLX_SNAPSHOT_REVISION = "0123456789abcdef0123456789abcdef01234567"
+OLLAMA_MODEL_NAME = "tiny-ollama-1b-q4"
+OPAQUE_MODEL_ID = "opaque-mini-1b"
+OPAQUE_SERVED_MODEL_REF = "openai_compatible:" + OPAQUE_MODEL_ID
+# Local provider identity for the step-10 status readback. `models admission
+# status` needs a provider id even when it never reaches a coordinator, because
+# `model_admission_status.v1` carries one; it is local config, not a credential.
+LADDER_PROVIDER_ID = "provider-byom-discovery-journey"
+# SPEC-046-R003 `provider_guidance.next_action` enum, closed.
+NEXT_ACTIONS = (
+    "fix_local_blocker", "evaluate", "offer_dry_run", "submit_offer",
+    "revise_and_reoffer", "check_status", "withdraw", "wait_for_coordinator",
+    "maintain_runtime", "none",
+)
+# Distinctive so the step-08 scan can prove no completion text was ever echoed.
+COMPLETION_MARKER = "byomprobecompletionmarker"
+
+# Per-step SPEC-046 requirement subjects. These are the mapped requirement ids
+# from scripts/check_spec_governance.py (PROVIDER_BYOM_DISCOVERY_STEP_REQUIREMENT_IDS);
+# capture re-validates them, so this table must not invent one.
+STEP_REQUIREMENT_IDS = {
+    "step-01-discover-mlx-cache": ["SPEC-046-R001", "SPEC-046-R002", "SPEC-046-R003"],
+    "step-02-discover-loopback-runtime": ["SPEC-046-R001", "SPEC-046-R002", "SPEC-046-R003"],
+    "step-03-discover-opaque-endpoint": ["SPEC-046-R002", "SPEC-046-R003", "SPEC-046-R004"],
+    "step-04-reject-non-loopback": ["SPEC-046-R002", "SPEC-046-R007"],
+    "step-05-handle-adapter-failure": ["SPEC-046-R002", "SPEC-046-R004"],
+    "step-06-evaluate-candidate": ["SPEC-046-R001", "SPEC-046-R005"],
+    "step-07-no-production-mutation": ["SPEC-046-R006"],
+    "step-08-redaction-review": ["SPEC-046-R007"],
+    "step-09-state-boundary": ["SPEC-046-R003"],
+    "step-10-local-state-ladder": ["SPEC-046-R003", "SPEC-046-R008"],
+}
+
+TRUE_OBSERVATIONS = (
+    "adapter_failure_warned",
+    "candidate_evaluated",
+    "local_state_ladder_verified",
+    "loopback_runtime_discovered",
+    "mlx_cache_discovered",
+    "non_loopback_rejected",
+    "opaque_endpoint_candidate_discovered",
+    "redacted_artifacts_reviewed",
+    "state_boundary_preserved",
+)
+FALSE_OBSERVATIONS = (
+    "buyer_traffic_sent",
+    "provider_credit_created",
+    "raw_completion_logged",
+    "raw_prompt_logged",
+    "runtime_installed",
+    "weights_downloaded",
+)
+
+
+class HarnessFailure(Exception):
+    pass
+
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3] / "scripts"))
+import byom_journey_evidence as evidence_contract  # noqa: E402
+
+
+# --- Closed capture schemas (R2 MEDIUM, moved to the contract in R3) --------
+#
+# Capture checks that a document is JSON, names the expected schema id, and is
+# redaction-clean. None of that proves the document is COMPLETE: a CLI that
+# stopped emitting `capabilities`, or emitted a mutation summary with one field
+# in it, would still pass. The signed evidence binds a digest of these
+# documents, so an incomplete one is a false conformance claim.
+#
+# The closed key sets and the validator now live in `byom_journey_evidence.py`
+# and run inside `_digest_document`, so they cover every capture that reaches
+# evidence -- this driver's and the hand-authored physical/admission runs' alike
+# (R3 MEDIUM). This driver keeps calling them at capture time so a bad document
+# fails the step that produced it instead of the pipeline three commands later.
+
+
+def assert_exact_object(value, expected_keys, where):
+    """Contract's exact-key check, reported as a step failure.
+
+    Steps 03 and 07 assert over one closed object each (the SPEC-046-R004
+    capability object, the SPEC-046-R005 mutation summary), so they use the same
+    key sets the capture contract enforces rather than a second copy.
+    """
+    try:
+        evidence_contract.assert_exact_object(value, expected_keys, where)
+    except evidence_contract.BYOMEvidenceError as exc:
+        raise HarnessFailure(str(exc))
+
+
+def validate_captured_document(name, document):
+    """Validate one captured CLI document against its complete closed schema."""
+    try:
+        evidence_contract.validate_captured_cli_document(document.get("schema"), document, name)
+    except evidence_contract.BYOMEvidenceError as exc:
+        raise HarnessFailure(str(exc))
+
+
+# Paths whose contents decide what an evidence run actually executed. In
+# `--evidence` mode every one of them must be clean -- tracked AND untracked --
+# both before and after the CLI is built, before `source_sha` may be recorded
+# against the run (R1 F5, R2 HIGH). SwiftPM's executable target selects the
+# whole `Sources/macprovider-cli` directory with no closed source list, so an
+# untracked `.swift` file there is a build input; ignoring untracked files would
+# let the manifest name a commit that did not produce the binary.
+EVIDENCE_SOURCE_PATHS = (
+    "phase3-binary/Sources",
+    "phase3-binary/Tests",
+    "phase3-binary/Package.swift",
+    "phase3-binary/Package.resolved",
+    "scripts",
+    "test/e2e/byom",
+)
+
+# The one tracked file an earlier CI step is expected to have rewritten. The
+# `swift test` step that runs before this gate resolves the package graph under
+# the runner's default toolchain, which writes a different (still valid)
+# `Package.resolved` than the committed one. That drift says nothing about what
+# this run executes, and HEAD's lockfile is already proven consistent by the
+# separate `phase3-binary (locked SwiftPM resolve)` CI job. Everything else in
+# EVIDENCE_SOURCE_PATHS still fails closed, and the build below is locked to
+# this lockfile so it cannot rewrite it again.
+#
+# Restoring it is NOT unconditional (R3 MEDIUM): outside an ephemeral CI
+# checkout, a differing lockfile is the operator's own uncommitted work, and
+# `git checkout HEAD --` would destroy it with nothing to restore from. The rule
+# is in `restore_locked_package_resolved`.
+EVIDENCE_RESTORED_LOCKFILE = "phase3-binary/Package.resolved"
+
+# An ephemeral CI checkout is the only place a differing lockfile may be thrown
+# away: the checkout is created for the job and discarded with it, so nothing
+# uncommitted there can be work anyone wanted to keep. GitHub Actions sets both;
+# either alone is enough for other CI systems.
+CI_ENVIRONMENT_FLAGS = ("GITHUB_ACTIONS", "CI")
+CI_ENVIRONMENT_TRUE_VALUES = frozenset({"true", "1"})
+
+# Same lock the `phase3-binary (locked SwiftPM resolve)` CI job applies through
+# xcodebuild's `-onlyUsePackageVersionsFromResolvedFile`
+# (scripts/verify-swift-package-lock.sh): resolution may only use the versions
+# in Package.resolved and fails if that file is out of date. Without it the
+# build itself can rewrite the lockfile after the pre-build cleanliness check
+# and publish evidence against a tree it has already changed.
+SWIFT_LOCKED_RESOLUTION_FLAG = "--only-use-versions-from-resolved-file"
+
+
+def assert_true(condition, message):
+    if not condition:
+        raise HarnessFailure(message)
+
+
+def repo_root():
+    return pathlib.Path(__file__).resolve().parents[3]
+
+
+def in_ephemeral_ci_checkout(environ=None):
+    """True when this process runs in a throwaway CI checkout."""
+    environ = os.environ if environ is None else environ
+    return any(
+        environ.get(name, "").strip().lower() in CI_ENVIRONMENT_TRUE_VALUES
+        for name in CI_ENVIRONMENT_FLAGS
+    )
+
+
+def restore_locked_package_resolved(root, environ=None):
+    """Reconcile `Package.resolved` with HEAD before the cleanliness check.
+
+    Three cases, and only one of them writes:
+
+    * The working-tree lockfile already equals HEAD -- nothing to do.
+    * It differs, this is an ephemeral CI checkout, and nothing is staged for
+      it: the difference is the earlier `swift test` step's resolution under the
+      runner's default toolchain, so HEAD's bytes are restored with a notice.
+      HEAD's lockfile is separately proven by the `phase3-binary (locked SwiftPM
+      resolve)` job, and the build below is locked to it.
+    * Anything else -- a local run, or a CI run with the lockfile staged -- is
+      someone's uncommitted work. `git checkout HEAD --` would destroy it with
+      no copy anywhere, so the run REFUSES and says what to do instead (R3
+      MEDIUM).
+    """
+    lockfile = root / EVIDENCE_RESTORED_LOCKFILE
+    if not lockfile.exists():
+        return
+    committed = subprocess.run(
+        ["git", "show", "HEAD:" + EVIDENCE_RESTORED_LOCKFILE],
+        cwd=str(root),
+        capture_output=True,
+        check=True,
+    ).stdout
+    if lockfile.read_bytes() == committed:
+        return
+    staged = subprocess.run(
+        ["git", "diff", "--cached", "--quiet", "--", EVIDENCE_RESTORED_LOCKFILE],
+        cwd=str(root),
+        capture_output=True,
+    ).returncode != 0
+    assert_true(
+        in_ephemeral_ci_checkout(environ) and not staged,
+        "evidence mode will not discard your uncommitted %s. Commit it, or "
+        "restore it with `git checkout HEAD -- %s`, then re-run. (This run is "
+        "not an ephemeral CI checkout%s.)"
+        % (
+            EVIDENCE_RESTORED_LOCKFILE,
+            EVIDENCE_RESTORED_LOCKFILE,
+            " and the lockfile is staged" if staged else "",
+        ),
+    )
+    print(
+        "evidence mode: restoring HEAD's %s in this ephemeral CI checkout; the "
+        "difference is an earlier step's package resolution, and HEAD's "
+        "lockfile is proven by the locked SwiftPM resolve job"
+        % EVIDENCE_RESTORED_LOCKFILE
+    )
+    subprocess.run(
+        ["git", "checkout", "HEAD", "--", EVIDENCE_RESTORED_LOCKFILE],
+        cwd=str(root),
+        check=True,
+    )
+
+
+def require_clean_evidence_source(root, phase):
+    """Refuse to record `source_sha` for a tree that is not what ran (F5, R2).
+
+    Tracked AND untracked files count: SwiftPM builds every `.swift` file under
+    the executable's source directory, so an untracked one is as much a build
+    input as a modified tracked one. Anything reported fails closed.
+
+    `phase` names when the check ran ("before the build" / "after the build");
+    the post-build call is what catches a build that mutated its own inputs.
+    """
+    completed = subprocess.run(
+        ["git", "status", "--porcelain", "--untracked-files=all", "--"]
+        + list(EVIDENCE_SOURCE_PATHS),
+        cwd=str(root),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    dirty = sorted(line[3:] for line in completed.stdout.splitlines() if line.strip())
+    assert_true(
+        not dirty,
+        "evidence mode needs a clean source tree %s; dirty: %s"
+        % (phase, ", ".join(dirty)),
+    )
+
+
+def build_cli(root, explicit_binary, evidence_mode):
+    # An evidence run is attributed to a commit, so it must execute that commit:
+    # an arbitrary prebuilt binary would let the manifest claim a source it never
+    # ran. Local non-evidence runs keep the override for iteration speed.
+    if evidence_mode:
+        assert_true(
+            not explicit_binary,
+            "MACPROVIDER_CLI_BINARY is refused in --evidence mode: evidence must "
+            "execute the binary built from the recorded source",
+        )
+        restore_locked_package_resolved(root)
+        require_clean_evidence_source(root, "before the build")
+        explicit_binary = None
+    if explicit_binary:
+        path = pathlib.Path(explicit_binary).expanduser().resolve()
+        assert_true(path.exists(), "MACPROVIDER_CLI_BINARY does not exist: " + str(path))
+        return path
+    command = ["swift", "build", "--product", "macprovider-cli"]
+    if evidence_mode:
+        command.append(SWIFT_LOCKED_RESOLUTION_FLAG)
+    subprocess.run(command, cwd=str(root / "phase3-binary"), check=True)
+    path = root / "phase3-binary" / ".build" / "debug" / "macprovider-cli"
+    assert_true(path.exists(), "swift build did not produce " + str(path))
+    if evidence_mode:
+        # The build is an input mutation risk of its own: a resolution or a
+        # generated file landing under the executable's source directory would
+        # make the binary something other than what the pre-build check saw.
+        require_clean_evidence_source(root, "after the build")
+    return path
+
+
+class ConnectionRecordingHTTPServer(ThreadingHTTPServer):
+    """Counts accepted connections, not just parsed requests.
+
+    A request that never becomes valid HTTP -- a TLS handshake against a plain
+    socket, a half-open probe -- still contacted the port, and for the
+    coordinator sink that is exactly what must never happen.
+    """
+
+    def verify_request(self, request, client_address):
+        self.state["connections"] += 1
+        return True
+
+
+class LocalHTTPServer:
+    def __init__(self, handler_class, state, server_class=ThreadingHTTPServer):
+        state.setdefault("connections", 0)
+        self.state = state
+        self.httpd = server_class(("127.0.0.1", 0), handler_class)
+        self.httpd.state = state
+        self.started = False
+        self.ready = threading.Event()
+        self.thread = threading.Thread(target=self._serve, daemon=True)
+
+    def _serve(self):
+        self.ready.set()
+        self.httpd.serve_forever()
+
+    @property
+    def port(self):
+        return self.httpd.server_address[1]
+
+    @property
+    def origin(self):
+        host, port = self.httpd.server_address
+        return "http://%s:%d" % (host, port)
+
+    def start(self):
+        if self.started:
+            return
+        self.thread.start()
+        self.ready.wait(timeout=5)
+        self.started = True
+
+    def stop(self):
+        if self.started:
+            self.httpd.shutdown()
+            self.thread.join(timeout=5)
+            self.started = False
+        self.httpd.server_close()
+
+
+class JSONHandler(BaseHTTPRequestHandler):
+    def log_message(self, *_args):
+        pass
+
+    def send_json(self, payload, raw=None):
+        if raw is None:
+            encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        else:
+            encoded = raw.encode("utf-8")
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+
+class OllamaHandler(JSONHandler):
+    def do_GET(self):
+        self.server.state["paths"].append(self.path)
+        if self.path != "/api/tags":
+            self.send_error(404)
+            return
+        self.send_json({
+            "models": [{
+                "name": OLLAMA_MODEL_NAME,
+                "details": {"family": "llama", "quantization_level": "Q4_0"},
+            }],
+        })
+
+
+class OpenAICompatibleHandler(JSONHandler):
+    def do_GET(self):
+        self.server.state["paths"].append(self.path)
+        if self.path != "/v1/models":
+            self.send_error(404)
+            return
+        self.send_json({"object": "list", "data": [{"id": OPAQUE_MODEL_ID, "object": "model"}]})
+
+    def do_POST(self):
+        self.server.state["paths"].append(self.path)
+        if self.path != "/v1/chat/completions":
+            self.send_error(404)
+            return
+        length = int(self.headers.get("content-length", "0"))
+        body = self.rfile.read(length)
+        self.server.state["chat_bodies"].append(body.decode("utf-8", errors="replace"))
+        self.send_json({
+            "id": "chatcmpl-local",
+            "object": "chat.completion",
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": COMPLETION_MARKER},
+                "finish_reason": "stop",
+            }],
+            "usage": {"prompt_tokens": 11, "completion_tokens": 2, "total_tokens": 13},
+        })
+
+
+class MalformedOpenAIHandler(JSONHandler):
+    """Answers `/v1/models` with well-formed JSON of the wrong shape.
+
+    Deterministic where a closed-port probe would race the port allocator, and it
+    exercises the same closed `adapter_malformed_response` code path.
+    """
+
+    def do_GET(self):
+        self.server.state["paths"].append(self.path)
+        self.send_json(None, raw='{"object":"list","data":"not-an-array"}')
+
+
+class CoordinatorSinkHandler(BaseHTTPRequestHandler):
+    """Records every request it receives and serves nothing.
+
+    This is the harness-owned ledger behind the two negative observations
+    (F4). It is configured as the CLI's coordinator for the whole run, so
+    `buyer_traffic_sent` and `provider_credit_created` are read off an empty
+    ledger rather than declared: discovery, evaluation, and the offer dry run
+    are local-only commands and must never reach a coordinator. It answers 503
+    so that a leaked request is recorded and then fails, never satisfied by a
+    fabricated document.
+    """
+
+    def log_message(self, *_args):
+        pass
+
+    def _record(self):
+        self.server.state["requests"].append("%s %s" % (self.command, self.path))
+        self.send_error(503)
+
+    do_GET = _record
+    do_HEAD = _record
+    do_POST = _record
+    do_PUT = _record
+    do_PATCH = _record
+    do_DELETE = _record
+
+
+def create_mlx_cache_fixture(cache_root):
+    """HuggingFace cache layout the MLX adapter recognizes: a `models--<org>--<name>`
+    repo directory holding `snapshots/<rev>/` with a config and a weights file."""
+    snapshot = (
+        cache_root
+        / ("models--" + MLX_MODEL_ID.replace("/", "--"))
+        / "snapshots"
+        / MLX_SNAPSHOT_REVISION
+    )
+    snapshot.mkdir(parents=True)
+    (snapshot / "config.json").write_text(
+        json.dumps({"max_position_embeddings": 4096}), encoding="utf-8"
+    )
+    (snapshot / "model.safetensors").write_bytes(b"\x7a" * 4096)
+
+
+def directory_digest(root):
+    """Content digest over every regular file under `root`, so step-07 can prove
+    the cache and the local salt were not mutated."""
+    digest = hashlib.sha256()
+    for path in sorted(p for p in root.rglob("*") if p.is_file()):
+        digest.update(str(path.relative_to(root)).encode("utf-8"))
+        digest.update(b"\x00")
+        digest.update(hashlib.sha256(path.read_bytes()).digest())
+    return digest.hexdigest()
+
+
+class Runner:
+    def __init__(self, cli, env, cwd):
+        self.cli = cli
+        self.env = env
+        self.cwd = cwd
+        self.transcript = []
+
+    def run_text(self, args, env=None, defer_hostname_scan=False):
+        """Run one CLI command and return its stdout, scanned.
+
+        EVERY command goes through here, including ones whose output is not JSON
+        (`--version`), so the step-08 claim that the scan covers every command's
+        real stdout and stderr is true rather than nearly true. Both streams also
+        enter `transcript`, which the step-08 review re-scans for this run's
+        origins, paths, prompt, and completion marker.
+
+        By default stdout gets the FULL plaintext scan, hostname rule included.
+        `defer_hostname_scan` is set only by `run()`, whose stdout is a JSON
+        document carrying the SPEC-046-R003 localization keys -- DNS-shaped by
+        coincidence -- and which immediately runs the structured document scan
+        that decides those keys field by field. Plain-text output such as
+        `--version` has no such follow-up, so it may not skip the rule (R3 LOW).
+        """
+        label = " ".join(args[:3])
+        completed = subprocess.run(
+            [str(self.cli)] + args,
+            cwd=str(self.cwd),
+            env=self.env if env is None else env,
+            text=True,
+            capture_output=True,
+        )
+        self.transcript.append(completed.stdout)
+        self.transcript.append(completed.stderr)
+        if completed.returncode != 0:
+            raise HarnessFailure(
+                "CLI failed (%d): %s" % (completed.returncode, label)
+            )
+        # Step 08's real scan (F2), run here so it covers every command's actual
+        # output rather than only the documents that end up captured, and so an
+        # unexpected forbidden-shaped value fails the run even though it is not
+        # in the run-specific `forbidden` list. The scanner functions are the
+        # evidence contract's own, imported rather than reimplemented.
+        stdout_scan = (
+            evidence_contract.reject_unredacted_text_except_hostname
+            if defer_hostname_scan
+            else evidence_contract.reject_unredacted_text
+        )
+        try:
+            stdout_scan(completed.stdout, "cli stdout for " + label)
+            evidence_contract.reject_unredacted_text(
+                completed.stderr, "cli stderr for " + label
+            )
+        except evidence_contract.BYOMEvidenceError as exc:
+            raise HarnessFailure("CLI output for %s is not redaction-clean: %s" % (label, exc))
+        return completed.stdout
+
+    def run(self, args, env=None):
+        """Run one CLI command that emits a JSON document. `env` overrides the
+        runner's environment for a command that must see a different one -- step
+        10 runs `models admission status` with no coordinator configured at
+        all."""
+        label = " ".join(args[:3])
+        stdout = self.run_text(args, env=env, defer_hostname_scan=True)
+        try:
+            document = json.loads(stdout)
+        except json.JSONDecodeError as exc:
+            raise HarnessFailure("invalid JSON stdout for %s: %s" % (label, exc))
+        try:
+            evidence_contract.assert_captured_document_redacted(
+                document, "cli stdout for " + label
+            )
+        except evidence_contract.BYOMEvidenceError as exc:
+            raise HarnessFailure("CLI output for %s is not redaction-clean: %s" % (label, exc))
+        return document
+
+
+def candidate_by_runtime_source(document, runtime_source):
+    for candidate in document.get("candidates", []):
+        if candidate.get("runtime_source") == runtime_source:
+            return candidate
+    raise HarnessFailure("no %s candidate in discovery output" % runtime_source)
+
+
+def adapter_by_runtime_source(document, runtime_source):
+    for adapter in document.get("adapters", []):
+        if adapter.get("runtime_source") == runtime_source:
+            return adapter
+    raise HarnessFailure("no %s adapter in discovery output" % runtime_source)
+
+
+class ManifestBuilder:
+    """Collects per-step verdicts and captured documents, then emits the manifest.
+
+    `assertion` strings are short prose and must stay free of URLs, absolute
+    paths, hostnames and IP literals: capture's redaction scan runs over them.
+    """
+
+    def __init__(self, out_dir, run_id, cli_version, evidence_mode=False):
+        self.out_dir = out_dir
+        self.captures = out_dir / "captures"
+        self.captures.mkdir(parents=True, mode=0o700, exist_ok=True)
+        # POSIX ignores `mode` for a directory that already exists, so say it
+        # outright: captures are operator-local inventory documents and the
+        # directory holding them stays user-private on a shared host (F7).
+        self.captures.chmod(0o700)
+        self.run_id = run_id
+        self.cli_version = cli_version
+        self.evidence_mode = evidence_mode
+        self.steps = []
+        self.observations = {name: None for name in TRUE_OBSERVATIONS + FALSE_OBSERVATIONS}
+
+    def capture(self, name, document):
+        """Write one captured CLI document WHOLE, re-scanned fail-closed.
+
+        Nothing is stripped: the digest the signed evidence binds to has to
+        cover the CLI's complete closed envelope, including the SPEC-046-R003
+        `provider_guidance` localization keys. The document is first validated
+        against that complete closed schema -- a missing or unknown field fails
+        the step, so redaction-clean but incomplete captures cannot support
+        evidence (R2). The scan is the capture tool's
+        own, imported rather than reimplemented, so this driver can never emit a
+        manifest whose documents capture would reject -- same field-scoped rule,
+        same fail-closed outcome.
+        """
+        payload = json.dumps(document, indent=2, sort_keys=True) + "\n"
+        try:
+            evidence_contract.assert_captured_document_redacted(
+                document, "captured document " + name
+            )
+            evidence_contract.reject_unredacted_text_except_hostname(
+                payload, "captured document " + name
+            )
+        except evidence_contract.BYOMEvidenceError as exc:
+            raise HarnessFailure("captured document %s is not redaction-clean: %s" % (name, exc))
+        validate_captured_document("captured document " + name, document)
+        path = self.captures / (name + ".json")
+        path.write_text(payload, encoding="utf-8")
+        # Created 0600 rather than umask-dependent: the document is
+        # redaction-clean, but it is still this operator's local model
+        # inventory, and a permissive default would publish it to every account
+        # on the host (F7).
+        path.chmod(0o600)
+        return path
+
+    def add_step(self, step_id, assertion, documents):
+        assert_true(step_id in STEP_REQUIREMENT_IDS, "unknown step id: " + step_id)
+        self.steps.append({
+            "id": step_id,
+            "status": "pass",
+            "assertion": assertion,
+            "requirement_ids": list(STEP_REQUIREMENT_IDS[step_id]),
+            "documents": documents,
+        })
+
+    def document(self, document_id, schema, capture_name):
+        return {
+            "id": document_id,
+            "schema": schema,
+            "path": "captures/" + capture_name + ".json",
+        }
+
+    def observe(self, name, value):
+        assert_true(name in self.observations, "unknown observation: " + name)
+        self.observations[name] = value
+
+    def write(self):
+        missing = sorted(name for name, value in self.observations.items() if value is None)
+        assert_true(not missing, "observations never set by a check: " + ", ".join(missing))
+        for name in TRUE_OBSERVATIONS:
+            assert_true(self.observations[name] is True, "observation must be true: " + name)
+        for name in FALSE_OBSERVATIONS:
+            assert_true(self.observations[name] is False, "observation must be false: " + name)
+        ordered = sorted(STEP_REQUIREMENT_IDS)
+        assert_true(
+            [step["id"] for step in self.steps] == ordered,
+            "manifest steps must cover every journey step exactly once",
+        )
+        manifest = {
+            "schema_version": RUN_MANIFEST_SCHEMA,
+            "journey_id": JOURNEY_ID,
+            "run_id": self.run_id,
+            "environment_class": ENVIRONMENT_CLASS,
+            "cli_version": self.cli_version,
+            "harness": {"name": HARNESS_NAME, "status": "pass"},
+            "steps": self.steps,
+            "observations": {name: self.observations[name] for name in sorted(self.observations)},
+        }
+        # Published atomically and only here, after every step and observation
+        # check has passed: a consumer must never be able to read a half-written
+        # manifest, and a failed run must leave none at all (F7).
+        #
+        # Only an `--evidence` run publishes `run-manifest.json`. A local
+        # debugging run -- which may execute an arbitrary MACPROVIDER_CLI_BINARY
+        # against a dirty tree -- writes the same content as `run-summary.json`,
+        # a name the capture tool does not consume. Non-promotable by
+        # construction rather than by operator discipline (R2 HIGH): there is no
+        # sequence of local commands that produces a capturable manifest without
+        # the source binding.
+        name = "run-manifest.json" if self.evidence_mode else "run-summary.json"
+        path = self.out_dir / name
+        temporary = self.out_dir / ("." + name + ".tmp")
+        temporary.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+        temporary.chmod(0o600)
+        os.replace(str(temporary), str(path))
+        return path
+
+
+def prepare_out_dir(out_dir):
+    """`--out` must be new or empty, and is created user-private (F7).
+
+    Reusing a directory that already holds a manifest is refused rather than
+    cleaned: a failed rerun into last week's passing output would otherwise
+    leave that stale pass manifest sitting there, consumable, while the run that
+    actually just happened failed. Operator data is never deleted here.
+    """
+    existed = out_dir.exists()
+    if existed:
+        assert_true(out_dir.is_dir(), "--out must be a directory: " + str(out_dir))
+        assert_true(
+            not any(out_dir.iterdir()),
+            "--out must be a new or empty directory; refusing to reuse one that may "
+            "hold a stale run manifest",
+        )
+    out_dir.mkdir(parents=True, mode=0o700, exist_ok=True)
+    if existed:
+        # POSIX applies `mode` only when mkdir actually creates the directory, so
+        # an operator's pre-existing world-readable `--out` would have stayed
+        # world-readable and published every capture written into it. The
+        # directory is empty, so narrowing it destroys nothing.
+        out_dir.chmod(0o700)
+    return out_dir
+
+
+def redaction_review(transcript, capture_dir, forbidden):
+    """Step-08: no origin, port, local path, prompt or completion text anywhere in
+    the CLI's stdout, stderr, or the captured JSON documents.
+
+    `forbidden` is a list of `(category, value)` pairs. The failure names the
+    category and the pair's index and NOTHING ELSE: the forbidden set is exactly
+    the origins, absolute paths, probe prompt, and completion marker this step
+    exists to keep out of the operator's terminal, and the top-level handler
+    prints the raised exception to stderr. Echoing even a prefix of the leaked
+    value would make the detector break the invariant it detects (R4 LOW). The
+    category and index are enough to identify which needle matched.
+    """
+    haystacks = list(transcript)
+    for path in sorted(capture_dir.glob("*.json")):
+        haystacks.append(path.read_text(encoding="utf-8"))
+    for index, (category, needle) in enumerate(forbidden):
+        if not needle:
+            continue
+        for haystack in haystacks:
+            if needle in haystack:
+                raise HarnessFailure(
+                    "redaction review found leaked material of category %s (forbidden "
+                    "entry %d); the value is withheld from this diagnostic by design"
+                    % (category, index)
+                )
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run the hermetic BYOM discovery journey.")
+    parser.add_argument("--out", required=True, help="Directory for captures/ and run-manifest.json.")
+    parser.add_argument("--keep-temp", action="store_true", help="Keep the temporary harness directory.")
+    parser.add_argument(
+        "--evidence",
+        action="store_true",
+        help="Evidence mode: refuse MACPROVIDER_CLI_BINARY, require a clean source "
+             "tree (tracked and untracked) before and after a lock-resolved build of "
+             "the CLI, and publish run-manifest.json. Without it the run writes only "
+             "run-summary.json, which the capture tool does not consume.",
+    )
+    args = parser.parse_args()
+
+    root = repo_root()
+    out_dir = pathlib.Path(args.out).expanduser().resolve()
+    temp_root = pathlib.Path(tempfile.mkdtemp(prefix="macprovider-byom-discovery-"))
+    ollama = LocalHTTPServer(OllamaHandler, {"paths": []})
+    openai = LocalHTTPServer(OpenAICompatibleHandler, {"paths": [], "chat_bodies": []})
+    broken = LocalHTTPServer(MalformedOpenAIHandler, {"paths": []})
+    # Configured as the CLI's coordinator for the whole run and expected to stay
+    # untouched; its ledger is what the two negative observations are read from.
+    coordinator = LocalHTTPServer(
+        CoordinatorSinkHandler, {"requests": []}, server_class=ConnectionRecordingHTTPServer
+    )
+    # No buyer gateway is started at any point in this journey. The harness owns
+    # the complete list of servers it runs, so this is a checkable fact rather
+    # than an assumption, and step 06 re-checks that the only chat request in the
+    # run is the evaluation's single local probe.
+    started_servers = {
+        "ollama_adapter_stub": ollama,
+        "openai_compatible_adapter_stub": openai,
+        "malformed_adapter_stub": broken,
+        "coordinator_sink": coordinator,
+    }
+    try:
+        prepare_out_dir(out_dir)
+        cli = build_cli(root, os.environ.get("MACPROVIDER_CLI_BINARY"), args.evidence)
+        ollama.start()
+        openai.start()
+        broken.start()
+        coordinator.start()
+
+        home = temp_root / "home"
+        home.mkdir(mode=0o700)
+        # `models discover` is read-only by SPEC-046-R001 and will not provision
+        # the salt itself, so seed it: without it every candidate id is
+        # byom_unstable_* and the state ladder collapses to local_only.
+        namespace = temp_root / "local-discovery.namespace"
+        namespace.write_bytes(secrets.token_bytes(32))
+        namespace.chmod(0o600)
+        hf_cache = temp_root / "hf-cache"
+        create_mlx_cache_fixture(hf_cache)
+
+        env = os.environ.copy()
+        env.update({
+            "HOME": str(home),
+            # The MLX fixture would report does_not_fit on a small CI runner and
+            # block the ladder this journey exercises; the fit logic still runs.
+            "MACPROVIDER_BYOM_E2E_DETECTED_RAM_GB": "64",
+            # A coordinator IS configured for every command in this run, and it
+            # is the recording sink. `buyer_traffic_sent` and
+            # `provider_credit_created` are then read off its ledger: a command
+            # that tried to reach a coordinator would land here and be recorded.
+            "MACPROVIDER_COORDINATOR_URL": coordinator.origin,
+        })
+        for stale in ("MACPROVIDER_CONFIG", "HF_HOME", "HF_HUB_CACHE"):
+            env.pop(stale, None)
+
+        local_args = [
+            "--local-discovery-namespace-path", str(namespace),
+            "--mlx-cache-dir", str(hf_cache),
+        ]
+        runner = Runner(cli, env, root)
+        cli_version = runner.run_text(["--version"]).strip()
+        run_id = "byom-discovery-" + datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        manifest = ManifestBuilder(out_dir, run_id, cli_version, evidence_mode=args.evidence)
+
+        cache_digest_before = directory_digest(hf_cache)
+        namespace_before = namespace.read_bytes()
+        home_digest_before = directory_digest(home)
+
+        # Step 01 - MLX-cache discovery.
+        mlx_document = runner.run(
+            ["models", "discover", "--json", "--skip-ollama"] + local_args
+        )
+        assert_true(mlx_document.get("schema") == "provider_byom_discovery.v1", "wrong discovery schema")
+        mlx_candidate = candidate_by_runtime_source(mlx_document, "mlx_cache")
+        assert_true(mlx_candidate.get("served_model_ref") == MLX_MODEL_ID, "mlx served ref changed")
+        assert_true(mlx_candidate.get("locality") == "local_artifact", "mlx locality changed")
+        assert_true(mlx_candidate.get("readiness_state") == "ready", "mlx fixture not ready")
+        assert_true(
+            mlx_candidate.get("candidate_id", "").startswith("byom_")
+            and not mlx_candidate["candidate_id"].startswith("byom_unstable_"),
+            "mlx candidate id is not namespace-stable",
+        )
+        assert_true(
+            mlx_candidate.get("admission_state_source") == "local_default",
+            "mlx candidate claimed coordinator authority",
+        )
+        manifest.capture("discover-mlx-cache", mlx_document)
+        manifest.add_step(
+            "step-01-discover-mlx-cache",
+            "MLX-cache candidate discovered read-only with a stable namespace-scoped candidate id.",
+            [manifest.document("discover-mlx-cache", "provider_byom_discovery.v1", "discover-mlx-cache")],
+        )
+        manifest.observe("mlx_cache_discovered", True)
+
+        # Step 02 - loopback runtime discovery.
+        ollama_document = runner.run(
+            ["models", "discover", "--json", "--ollama-origin", ollama.origin] + local_args
+        )
+        ollama_candidate = candidate_by_runtime_source(ollama_document, "ollama_loopback")
+        assert_true(
+            ollama_candidate.get("served_model_ref") == "ollama:" + OLLAMA_MODEL_NAME,
+            "ollama served ref changed",
+        )
+        assert_true(ollama_candidate.get("locality") == "loopback_runtime", "ollama locality changed")
+        assert_true(
+            adapter_by_runtime_source(ollama_document, "ollama_loopback").get("status") == "ok",
+            "ollama adapter did not report ok",
+        )
+        assert_true(ollama.state["paths"] == ["/api/tags"], "ollama adapter probed an unexpected path")
+        manifest.capture("discover-loopback-runtime", ollama_document)
+        manifest.add_step(
+            "step-02-discover-loopback-runtime",
+            "Loopback Ollama adapter enumerated one candidate without leaving the host.",
+            [manifest.document(
+                "discover-loopback-runtime", "provider_byom_discovery.v1", "discover-loopback-runtime"
+            )],
+        )
+        manifest.observe("loopback_runtime_discovered", True)
+
+        # Step 03 - opaque OpenAI-compatible endpoint.
+        opaque_document = runner.run(
+            ["models", "discover", "--json", "--skip-ollama",
+             "--openai-compatible-origin", openai.origin] + local_args
+        )
+        opaque_candidate = candidate_by_runtime_source(opaque_document, "openai_compatible_loopback")
+        opaque_candidate_id = opaque_candidate["candidate_id"]
+        assert_true(
+            opaque_candidate.get("served_model_ref") == OPAQUE_SERVED_MODEL_REF,
+            "opaque served ref changed",
+        )
+        assert_true(
+            opaque_candidate.get("identity_state") == "opaque_endpoint",
+            "opaque candidate did not report an opaque identity",
+        )
+        assert_true(
+            opaque_candidate.get("locality") == "opaque_local_endpoint",
+            "opaque candidate did not report an opaque locality",
+        )
+        assert_true(opaque_candidate.get("catalog_model_key") is None, "opaque candidate claimed a catalog key")
+        assert_true(
+            opaque_candidate.get("admission_state") in ("local_only", "not_offered"),
+            "opaque candidate left the non-earning local states",
+        )
+        assert_true(
+            opaque_candidate.get("admission_state_source") == "local_default",
+            "opaque candidate claimed coordinator authority",
+        )
+        # The exact SPEC-046-R004 capability object, every value null. An
+        # absent or partial object would otherwise make "no asserted
+        # capability" vacuously true (R2).
+        capabilities = opaque_candidate.get("capabilities")
+        assert_exact_object(
+            capabilities, evidence_contract.CAPABILITY_KEYS,
+            "opaque candidate capabilities",
+        )
+        assert_true(
+            all(value is None for value in capabilities.values()),
+            "opaque candidate asserted an unevaluated capability",
+        )
+        assert_true(
+            (opaque_candidate.get("provider_guidance") or {}).get("earning_path_class")
+            == "local_inventory_only",
+            "opaque candidate claimed an earning path",
+        )
+        assert_true(openai.state["paths"] == ["/v1/models"], "opaque adapter probed an unexpected path")
+        manifest.capture("discover-opaque-endpoint", opaque_document)
+        manifest.add_step(
+            "step-03-discover-opaque-endpoint",
+            "Opaque OpenAI-compatible candidate reported identity_state opaque_endpoint, "
+            "null capabilities, and a non-earning local state.",
+            [manifest.document(
+                "discover-opaque-endpoint", "provider_byom_discovery.v1", "discover-opaque-endpoint"
+            )],
+        )
+        manifest.observe("opaque_endpoint_candidate_discovered", True)
+
+        # Step 04 - non-loopback origin rejected before dispatch. The wildcard
+        # address resolves to this host, so a leaked request would reach the stub
+        # and the request-count assertion would fail.
+        openai_paths_before = list(openai.state["paths"])
+        rejected_document = runner.run(
+            ["models", "discover", "--json", "--skip-ollama",
+             "--openai-compatible-origin", "http://0.0.0.0:%d" % openai.port] + local_args
+        )
+        rejected_adapter = adapter_by_runtime_source(rejected_document, "openai_compatible_loopback")
+        assert_true(rejected_adapter.get("status") == "rejected", "non-loopback origin was not rejected")
+        assert_true(
+            rejected_adapter.get("warning_codes") == ["adapter_rejected_non_loopback"],
+            "rejection did not use the closed warning code",
+        )
+        assert_true(
+            not any(c.get("runtime_source") == "openai_compatible_loopback"
+                    for c in rejected_document.get("candidates", [])),
+            "rejected adapter fabricated a candidate",
+        )
+        assert_true(
+            openai.state["paths"] == openai_paths_before,
+            "a request left the host for a non-loopback origin",
+        )
+        manifest.capture("discover-non-loopback-rejected", rejected_document)
+        manifest.add_step(
+            "step-04-reject-non-loopback",
+            "Non-loopback adapter origin rejected before any request was issued, "
+            "and the endpoint never appeared in the projection.",
+            [manifest.document(
+                "discover-non-loopback-rejected",
+                "provider_byom_discovery.v1",
+                "discover-non-loopback-rejected",
+            )],
+        )
+        manifest.observe("non_loopback_rejected", True)
+
+        # Step 05 - adapter failure is a warning, not a trust claim.
+        failure_document = runner.run(
+            ["models", "discover", "--json", "--skip-ollama",
+             "--openai-compatible-origin", broken.origin] + local_args
+        )
+        failure_adapter = adapter_by_runtime_source(failure_document, "openai_compatible_loopback")
+        assert_true(failure_adapter.get("status") == "malformed", "malformed adapter was not reported")
+        assert_true(
+            failure_adapter.get("warning_codes") == ["adapter_malformed_response"],
+            "adapter failure did not use the closed warning code",
+        )
+        assert_true(
+            "adapter_malformed_response" in (failure_document.get("warnings") or []),
+            "adapter failure was not surfaced in the top-level warnings",
+        )
+        assert_true(
+            not any(c.get("runtime_source") == "openai_compatible_loopback"
+                    for c in failure_document.get("candidates", [])),
+            "malformed adapter fabricated a candidate",
+        )
+        manifest.capture("discover-adapter-failure", failure_document)
+        manifest.add_step(
+            "step-05-handle-adapter-failure",
+            "Malformed adapter response surfaced as a closed warning code, not a trust claim.",
+            [manifest.document(
+                "discover-adapter-failure", "provider_byom_discovery.v1", "discover-adapter-failure"
+            )],
+        )
+        manifest.observe("adapter_failure_warned", True)
+
+        # Step 06 - bounded local evaluation of the opaque candidate.
+        evaluation = runner.run(
+            ["models", "evaluate", opaque_candidate_id, "--json", "--skip-ollama",
+             "--openai-compatible-origin", openai.origin] + local_args
+        )
+        assert_true(evaluation.get("schema") == "provider_byom_evaluation.v1", "wrong evaluation schema")
+        assert_true(evaluation.get("candidate_id") == opaque_candidate_id, "evaluation resolved another candidate")
+        assert_true(
+            evaluation.get("runtime_source") == "openai_compatible_loopback",
+            "evaluation changed the runtime source",
+        )
+        assert_true(evaluation.get("health_result") == "passed", "evaluation did not pass")
+        assert_true(evaluation.get("request_count") == 1, "evaluation exceeded its request budget")
+        assert_true(
+            evaluation.get("usage_reporting_source") == "runtime_reported",
+            "evaluation lost the usage-reporting source",
+        )
+        assert_true(
+            evaluation.get("offer_preconditions_appear_satisfied") is False,
+            "an opaque endpoint claimed satisfied offer preconditions",
+        )
+        assert_true(len(openai.state["chat_bodies"]) == 1, "evaluation sent more than one probe")
+        manifest.capture("evaluate-candidate", evaluation)
+        manifest.add_step(
+            "step-06-evaluate-candidate",
+            "models evaluate ran the bounded local harness against the opaque endpoint "
+            "and reported health_result passed with one request.",
+            [manifest.document("evaluate-candidate", "provider_byom_evaluation.v1", "evaluate-candidate")],
+        )
+        manifest.observe("candidate_evaluated", True)
+
+        # Step 07 - no production mutation. The mutation summary is the CLI's own
+        # claim; the fixture digests are the independent check on it.
+        # The exact SPEC-046-R005 mutation-summary field set, every value
+        # false. Any nonempty subset used to satisfy this; a document that had
+        # dropped a mutation field would have passed (R2).
+        mutations = evaluation.get("mutation_summary")
+        assert_exact_object(
+            mutations, evidence_contract.EVALUATION_MUTATION_SUMMARY_KEYS,
+            "evaluation mutation_summary",
+        )
+        assert_true(
+            all(value is False for value in mutations.values()),
+            "evaluation claimed a mutation: %s" % sorted(k for k, v in mutations.items() if v),
+        )
+        assert_true(directory_digest(hf_cache) == cache_digest_before, "the model cache was mutated")
+        assert_true(namespace.read_bytes() == namespace_before, "the discovery namespace was rewritten")
+        assert_true(directory_digest(home) == home_digest_before, "provider config under home was mutated")
+        manifest.add_step(
+            "step-07-no-production-mutation",
+            "mutation_summary reported no config, cache, weight, or coordinator mutation, "
+            "and the fixture digests were unchanged after the run.",
+            [manifest.document(
+                "evaluate-mutation-summary", "provider_byom_evaluation.v1", "evaluate-candidate"
+            )],
+        )
+        manifest.observe("weights_downloaded", False)
+        manifest.observe("runtime_installed", False)
+
+        # Step 09 runs before 08 so its output is inside the redaction review.
+        dry_run = runner.run(
+            ["models", "offer", opaque_candidate_id, "--dry-run", "--json", "--skip-ollama",
+             "--openai-compatible-origin", openai.origin] + local_args
+        )
+        assert_true(
+            dry_run.get("schema") == "model_admission_offer_dry_run.v1", "wrong dry-run schema"
+        )
+        assert_true(dry_run.get("candidate_id") == opaque_candidate_id, "dry-run resolved another candidate")
+        assert_true(dry_run.get("would_submit") is False, "an opaque endpoint predicted a submittable offer")
+        assert_true(dry_run.get("catalog_model_key") is None, "dry-run invented a catalog key")
+        assert_true(
+            dry_run.get("likely_admission_state") in ("local_only", "not_offered"),
+            "dry-run promoted the local admission state",
+        )
+        assert_true(
+            dry_run.get("likely_admission_state_source") == "local_default",
+            "dry-run claimed coordinator authority",
+        )
+        dry_run_guidance = dry_run.get("provider_guidance") or {}
+        assert_true(
+            dry_run_guidance.get("earning_path_class") == "local_inventory_only",
+            "dry-run claimed an earning path",
+        )
+        assert_true(
+            dry_run_guidance.get("state_meaning_key")
+            != "byom.offer_dry_run.catalog_path_missing_trusted_binding",
+            "dry-run claimed a catalog path for an opaque endpoint",
+        )
+        manifest.capture("offer-dry-run", dry_run)
+
+        # Step 10 - the local state ladder, before step 08 for the same reason.
+        ladder_document = runner.run(
+            ["models", "discover", "--json",
+             "--ollama-origin", ollama.origin,
+             "--openai-compatible-origin", openai.origin] + local_args
+        )
+        ladder_states = {
+            candidate["runtime_source"]: candidate for candidate in ladder_document.get("candidates", [])
+        }
+        offerable = [c for c in ladder_document.get("candidates", []) if c.get("admission_state") == "offerable"]
+        local_only = [c for c in ladder_document.get("candidates", []) if c.get("admission_state") == "local_only"]
+        assert_true(offerable, "no offerable candidate in the ladder projection")
+        assert_true(local_only, "no local_only candidate in the ladder projection")
+        assert_true(
+            "openai_compatible_loopback" in ladder_states
+            and ladder_states["openai_compatible_loopback"].get("admission_state") == "local_only",
+            "the opaque candidate left local_only in the ladder projection",
+        )
+        for candidate in offerable + local_only:
+            guidance = candidate.get("provider_guidance") or {}
+            assert_true(
+                guidance.get("next_action") in NEXT_ACTIONS,
+                "a ladder candidate reported no closed next action",
+            )
+            assert_true(
+                candidate.get("admission_state_source") == "local_default",
+                "a ladder candidate claimed coordinator authority",
+            )
+        for candidate in local_only:
+            assert_true(
+                (candidate.get("provider_guidance") or {}).get("transition_reason_code"),
+                "a local_only candidate reported no local transition reason",
+            )
+        for candidate in offerable:
+            # SPEC-046-R003 makes `transition_reason_code` nullable and the
+            # `offerable` ladder row has no reason to carry: nothing has moved the
+            # candidate and nothing is blocking it. The field must still be
+            # reported rather than omitted, and it must not carry an invented code.
+            guidance = candidate.get("provider_guidance") or {}
+            assert_true(
+                "transition_reason_code" in guidance,
+                "an offerable candidate omitted the local transition reason field",
+            )
+            assert_true(
+                guidance.get("transition_reason_code") is None,
+                "an offerable candidate reported a transition reason with no blocker",
+            )
+        manifest.capture("discover-state-ladder", ladder_document)
+
+        # local-default `not_offered` is the third ladder row: the candidate is
+        # locally eligible, but no coordinator offer state is known because no
+        # coordinator has been queried. Run the status readback with NO
+        # coordinator configured, so the CLI must answer from local inventory and
+        # the coordinator sink ledger stays empty (F4).
+        # A harness-owned config with a provider id and no `coordinator_url`.
+        # `models admission status` is the one journey command that reads the
+        # config file, and config-path expansion resolves `~` from the account
+        # rather than from `HOME`, so an operator's real config would otherwise
+        # supply this run's provider id and coordinator.
+        harness_config = temp_root / "harness-config.yaml"
+        harness_config.write_text("provider_id: %s\n" % LADDER_PROVIDER_ID, encoding="utf-8")
+        harness_config.chmod(0o600)
+        ladder_status_env = dict(env)
+        ladder_status_env.pop("MACPROVIDER_COORDINATOR_URL", None)
+        coordinator_requests_before = len(coordinator.state["requests"])
+        coordinator_connections_before = coordinator.state["connections"]
+        status_document = runner.run(
+            ["models", "admission", "status", MLX_MODEL_ID, "--json", "--skip-ollama",
+             "--config", str(harness_config),
+             "--provider-id", LADDER_PROVIDER_ID] + local_args,
+            env=ladder_status_env,
+        )
+        assert_true(
+            status_document.get("schema") == "model_admission_status.v1",
+            "wrong admission status schema",
+        )
+        assert_true(
+            status_document.get("admission_state_source") == "local_default",
+            "the unqueried-coordinator readback claimed coordinator authority",
+        )
+        assert_true(
+            status_document.get("admission_state") == "not_offered",
+            "the unqueried-coordinator readback did not report not_offered",
+        )
+        assert_true(
+            status_document.get("coordinator_event_id") is None
+            and status_document.get("state_observed_at") is None,
+            "a local-default readback carried coordinator event material",
+        )
+        assert_true(
+            status_document.get("allowed_next_states") == [],
+            "a local-default readback offered coordinator next states",
+        )
+        status_guidance = status_document.get("provider_guidance") or {}
+        assert_true(
+            status_guidance.get("next_action") in NEXT_ACTIONS,
+            "the not_offered row reported no closed next action",
+        )
+        assert_true(
+            status_guidance.get("transition_reason_code") == "coordinator_state_unavailable",
+            "the not_offered row reported no local transition reason",
+        )
+        assert_true(
+            status_guidance.get("earning_path_class") == "local_inventory_only",
+            "the not_offered row claimed an earning path",
+        )
+        assert_true(
+            "coordinator_state_unavailable" in (status_document.get("warnings") or []),
+            "the not_offered row did not disclose why coordinator state is absent",
+        )
+        assert_true(
+            len(coordinator.state["requests"]) == coordinator_requests_before
+            and coordinator.state["connections"] == coordinator_connections_before,
+            "the unconfigured-coordinator readback reached a coordinator",
+        )
+        manifest.capture("admission-status-state-ladder", status_document)
+
+        # A missing namespace is the other route into local_only: the candidate id
+        # is unstable, so the CLI must refuse to treat the candidate as offerable.
+        unstable_document = runner.run(
+            ["models", "discover", "--json", "--skip-ollama",
+             "--local-discovery-namespace-path", str(temp_root / "absent.namespace"),
+             "--mlx-cache-dir", str(hf_cache)]
+        )
+        unstable_candidate = candidate_by_runtime_source(unstable_document, "mlx_cache")
+        assert_true(
+            unstable_candidate.get("admission_state") == "local_only",
+            "an unstable candidate was reported offerable",
+        )
+        assert_true(
+            "candidate_id_unstable" in (unstable_candidate.get("warning_codes") or []),
+            "an unstable candidate lost its transition reason",
+        )
+        assert_true(
+            not (temp_root / "absent.namespace").exists(),
+            "discovery provisioned the namespace it was told to read",
+        )
+        manifest.capture("discover-state-ladder-unstable", unstable_document)
+
+        # The catalog-economics projection reports the same coordinator-unqueried
+        # label for catalog rows that have no local candidate at all, and gates
+        # settlement and catalog economics closed on it. Discovery itself still
+        # reports only local_only and offerable; the status readback above is the
+        # surface that reports `not_offered` with guidance.
+        economics = runner.run(
+            ["models", "catalog-economics", "--json", "--skip-coordinator-status", "--skip-ollama"]
+            + local_args
+        )
+        assert_true(
+            economics.get("schema") == "model_catalog_economics.v1", "wrong catalog economics schema"
+        )
+        not_offered = [
+            row for row in economics.get("rows", [])
+            if (row.get("admission") or {}).get("state") == "not_offered"
+            and (row.get("admission") or {}).get("source") == "local_default"
+        ]
+        assert_true(not_offered, "no local-default not_offered row in the economics projection")
+        for row in not_offered:
+            admission = row.get("admission") or {}
+            assert_true(admission.get("settlement_capable") is False, "a not_offered row claimed settlement")
+            assert_true(
+                admission.get("catalog_economics_permitted") is False,
+                "a not_offered row permitted catalog economics",
+            )
+        manifest.capture("catalog-economics-state-ladder", economics)
+
+        manifest.add_step(
+            "step-09-state-boundary",
+            "Evaluated candidate stayed non-routable and non-earning with no coordinator state "
+            "and no catalog earning path.",
+            [manifest.document(
+                "offer-dry-run-state-boundary", "model_admission_offer_dry_run.v1", "offer-dry-run"
+            )],
+        )
+        manifest.observe("state_boundary_preserved", True)
+        manifest.add_step(
+            "step-10-local-state-ladder",
+            "local_only, offerable, and local-default not_offered each reported a closed next "
+            "action; local_only and not_offered each reported a non-null local transition reason, "
+            "and offerable reported the nullable reason field with no blocker to name.",
+            [
+                manifest.document(
+                    "discover-state-ladder", "provider_byom_discovery.v1", "discover-state-ladder"
+                ),
+                manifest.document(
+                    "admission-status-state-ladder",
+                    "model_admission_status.v1",
+                    "admission-status-state-ladder",
+                ),
+                manifest.document(
+                    "discover-state-ladder-unstable",
+                    "provider_byom_discovery.v1",
+                    "discover-state-ladder-unstable",
+                ),
+                manifest.document(
+                    "catalog-economics-state-ladder",
+                    "model_catalog_economics.v1",
+                    "catalog-economics-state-ladder",
+                ),
+            ],
+        )
+        manifest.observe("local_state_ladder_verified", True)
+
+        # Step 08 - redaction review over every command's output and every capture.
+        probe_prompt = json.loads(openai.state["chat_bodies"][0])["messages"][0]["content"]
+        # `(category, value)` pairs: a match reports only the category and the
+        # entry's index, never the value itself.
+        forbidden = [
+            ("adapter_origin", ollama.origin),
+            ("adapter_origin", openai.origin),
+            ("adapter_origin", broken.origin),
+            ("coordinator_origin", coordinator.origin),
+            # host:port rather than a bare port: a bare 5-digit number would
+            # collide with digests and byte counts and make this scan flaky.
+            ("loopback_host_port", "127.0.0.1:%d" % ollama.port),
+            ("loopback_host_port", "127.0.0.1:%d" % openai.port),
+            ("loopback_host_port", "127.0.0.1:%d" % broken.port),
+            ("loopback_host_port", "127.0.0.1:%d" % coordinator.port),
+            ("local_path", str(temp_root)),
+            ("local_path", str(home)),
+            ("local_path", str(namespace)),
+            ("local_path", str(hf_cache)),
+            ("probe_prompt", probe_prompt),
+            ("completion_marker", COMPLETION_MARKER),
+        ]
+        assert_true(
+            redaction_review(runner.transcript, manifest.captures, forbidden),
+            "redaction review failed",
+        )
+        manifest.add_step(
+            "step-08-redaction-review",
+            "JSON and stderr carried no prompt, completion, credential, endpoint, or local path material.",
+            [manifest.document(
+                "discover-redaction-review", "provider_byom_discovery.v1", "discover-opaque-endpoint"
+            )],
+        )
+        manifest.observe("redacted_artifacts_reviewed", True)
+        manifest.observe("raw_prompt_logged", False)
+        manifest.observe("raw_completion_logged", False)
+
+        # The two negative observations, read off harness-owned ledgers at the
+        # end of the run rather than declared (F4).
+        #
+        # No buyer gateway exists in this journey. The harness owns the complete
+        # list of servers it started, so that is a checked fact, and the only
+        # chat request anywhere in the run is the evaluation's single local probe
+        # to the adapter stub.
+        assert_true(
+            not any("buyer" in name or "gateway" in name for name in started_servers),
+            "the harness started a buyer gateway; buyer traffic is out of scope here",
+        )
+        chat_requests = {
+            name: [path for path in server.state.get("paths", []) if "completions" in path]
+            for name, server in started_servers.items()
+        }
+        assert_true(
+            chat_requests["openai_compatible_adapter_stub"] == ["/v1/chat/completions"],
+            "the evaluation probe was not the only chat request to the adapter stub",
+        )
+        assert_true(
+            not any(paths for name, paths in chat_requests.items()
+                    if name != "openai_compatible_adapter_stub"),
+            "a chat request reached a stub other than the evaluated endpoint",
+        )
+        manifest.observe("buyer_traffic_sent", False)
+
+        # Provider credit is coordinator-side state. Every command in this run
+        # had the sink configured as its coordinator, and every one of them is a
+        # local-only command, so the sink must have been contacted zero times --
+        # not one request, not even one accepted connection.
+        assert_true(
+            coordinator.state["requests"] == [],
+            "a request reached the coordinator sink: %s"
+            % ", ".join(coordinator.state["requests"][:3]),
+        )
+        assert_true(
+            coordinator.state["connections"] == 0,
+            "a connection reached the coordinator sink; local-only commands must not "
+            "contact a coordinator",
+        )
+        manifest.observe("provider_credit_created", False)
+
+        manifest.steps.sort(key=lambda step: step["id"])
+        manifest_path = manifest.write()
+        print("BYOM discovery journey passed")
+        print("run_id=%s cli_version=%s steps=%d" % (run_id, cli_version, len(manifest.steps)))
+        if args.evidence:
+            print("manifest=%s" % manifest_path)
+        else:
+            print("summary=%s (not evidence: no run manifest was published)" % manifest_path)
+        return 0
+    except Exception as exc:
+        print("BYOM discovery journey failed: %s" % exc, file=sys.stderr)
+        if args.keep_temp:
+            print("temp_root=%s" % temp_root, file=sys.stderr)
+        return 1
+    finally:
+        for server in (ollama, openai, broken, coordinator):
+            try:
+                server.stop()
+            except Exception:
+                pass
+        if args.keep_temp:
+            print("kept temp_root=%s" % temp_root)
+        else:
+            shutil.rmtree(str(temp_root), ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

BYOM v0.2 **slice 1b** (epic #1453), stacked on slice 1a (#1457): a hermetic driver that runs all ten `JOURNEY-PROVIDER-BYOM-DISCOVERY` steps and emits signable evidence, plus typed closed-schema validation at the evidence capture boundary. With 1a merged, the discovery journey becomes capturable for the first time (v0.1 could not produce step 03's `opaque_endpoint` or step 10's local-default `not_offered`).

### Driver (`test/e2e/byom/run-discovery-journey.py`, SPEC-046-R008)
- Steps 01–10 against loopback stubs: MLX-cache fixture, Ollama stub, OpenAI-compatible stub, malformed stub, wildcard-origin rejection with a zero-request assertion, evaluation, before/after fixture hashing, the real redaction scanner over every command's stdout/stderr, dry-run state boundary, and the `local_only` / `offerable` / `not_offered` ladder through real CLI surfaces.
- Emits `run-manifest.json` (`macprovider.byom-journey-run.v1`) + whole captured CLI documents. Observations are measured (recording coordinator sink ledger, no gateway, single probe), never literals; no override interface exists.
- `--evidence` mode: refuses `MACPROVIDER_CLI_BINARY`, builds with `--only-use-versions-from-resolved-file`, requires a clean tracked+untracked tree under the executable/harness paths before AND after the build, restores the lockfile only in an ephemeral CI checkout (refuses a dirty local lockfile, bytes untouched), publishes the manifest atomically only after all ten steps pass; non-evidence runs publish a summary only and cannot be captured. Per-run `mktemp` dirs; owned cleanup.
- `make test-byom-discovery-journey` runs driver → capture → build → preflight in CI beside `test-byom-e2e` (CI-order simulation with a lockfile-rewriting `swift test` step passes).

### Evidence capture boundary (`scripts/byom_journey_evidence.py`)
- Captured documents stay whole: a field-scoped closed-grammar rule for exactly `provider_guidance.state_label_key` / `state_meaning_key` (`^byom\.[a-z0-9_]+(?:\.[a-z0-9_]+)+$`); every other field keeps the full hostname rule; the decoded structural walk is the hostname authority for captured JSON.
- `validate_captured_cli_document` enforces exact key sets, types, nullability, closed enums (SPEC-046-R003/R004, SPEC-047-R001/R002, plus implementation-defined sets frozen from the Swift source with comments), nested shapes, and the `local_default ⇒ {local_only, not_offered, offerable}` rule, for the discovery journey's document schemas. **Scoped:** typed validation of admission-journey captures lands with the admission-journey slice (#1453 slice 7), since that journey cannot be captured before catalog binding; admission fixtures are unchanged from main.
- Harness identity bound per journey (`expected_harness_name`). Golden discovery fixtures are real CLI output (provenance README).

## Audit
Four codex rounds on the combined slice-1 diff, records in `audits/2026-09-09-byom-v02-slice1/`: R1 8 M → R2 1 H / 3 M (CI-order race in evidence binding) → R3 3 M → R4 1 convergent M (typed enums, real fixtures). All fixed; no fifth round by rule. Independent review: `/code-review ultra` on this PR. Carried: executable-digest binding into the manifest needs a journey-contract change; config-path `~` expansion is pre-existing (driver passes an explicit `--config`).

## Validation
`scripts.tests.test_discovery_journey_driver` + `test_byom_journey_evidence` + `test_spec_governance` OK; `make test-byom-discovery-journey` (evidence mode, 10 steps, capture/build/preflight) passed locally and under `CI=true` after a lockfile-rewriting `swift test`; `make test-byom-e2e` passed; governance check + spec-index lint ok; `git diff --check` clean.

## What this does not do
Does not sign or promote; SPEC-046 rows stay `pending` until the operator signs (`docs/runbooks/byom-journey-evidence.md`). Does not change SPEC text, journey contracts, or CONFORMANCE states.

BYOM epic gates:
- Parent epic: #1453 (slice 1b)
- Slice issue: #1453
- Authority boundary: SPEC-046-R008 release-evidence path (journey driver + capture validation)
- SPEC requirements: SPEC-046-R007, SPEC-046-R008
- User-facing state/copy: none
- Machine schema: none new (manifest/evidence schemas unchanged)
- Security/privacy: field-scoped scanner rule; whole-document captures; evidence-only manifests; source binding
- Runtime/liveness: n/a
- Identity/economics/settlement provenance: negative money-path observations measured from a recording coordinator sink
- Evidence/tests: see Validation
- Rollout/rollback/compatibility: test/CI tooling only; no runtime change
- Explicitly deferred or not applicable: signing/promotion (operator); admission-journey typed validation (slice 7); executable-digest binding (contract change)

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "issue": "https://github.com/Augustas11/macprovider/issues/1453",
  "specs": ["SPEC-046"],
  "requirements": ["SPEC-046-R007", "SPEC-046-R008"],
  "authority_domains": ["provider-byom-discovery"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "scripts/tests/test_discovery_journey_driver.py",
    "scripts/tests/test_byom_journey_evidence.py",
    "make test-byom-discovery-journey",
    "make test-byom-e2e"
  ],
  "journeys": ["JOURNEY-PROVIDER-BYOM-DISCOVERY"]
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
