### PR TITLE
Make #1433 physical evidence independently reviewable

### DIFF
--- a/journeys/JOURNEY-LOCAL-CONSUMER-ENDPOINT.md
+++ b/journeys/JOURNEY-LOCAL-CONSUMER-ENDPOINT.md
@@ -124,6 +124,29 @@ signing. The review manifest that feeds capture must pin each reviewed support
 artifact by SHA-256 and byte count; capture must fail if the files have changed
 after review.
 
+For v2 captures, the `ledger_capture`, `log_capture`, `rate_card_capture`, and
+`status_capture` entries MUST also embed their canonical redacted JSON reports.
+Those reports use the closed schemas
+`macprovider.local-consumer-ledger-redacted.v1`,
+`macprovider.local-consumer-log-redacted.v1`,
+`macprovider.local-consumer-rate-card-redacted.v1`, and
+`macprovider.local-consumer-status-redacted.v1`. Each report MUST bind the same
+repository source commit and physical `run_id` as the enclosing evidence. The
+capture, signer builder, and governance validator independently validate the
+required permitted-call, local budget denial, held-reservation restart,
+operator release, final zero-held state, trusted-pricing, production-gateway,
+OpenAI SDK, and redaction observations. The recorded SHA-256 and byte count
+MUST match the canonical embedded report bytes. Semantically empty files or
+caller-authored pass booleans without these reports are not promotable.
+
+This remains an operator-attested physical journey, not remote attestation of a
+local Mac. The release operator is the trust root for whether the reviewed
+redacted reports truthfully describe the observed run; protected signing
+records that separate authorization. The machine-enforced boundary prevents
+missing, semantically empty, cross-run, cross-source, mutated, or internally
+inconsistent reports from being promoted. It does not claim to defend against
+an authorized release operator intentionally falsifying a schema-valid review.
+
 The signer workflow converts that artifact into a generic signed
 journey-result envelope only after:
 

--- a/journeys/evidence/local-consumer-endpoint-20260909T062325Z.redacted.json
+++ b/journeys/evidence/local-consumer-endpoint-20260909T062325Z.redacted.json
@@ -1,0 +1,436 @@
+{
+  "schema_version": "macprovider.local-consumer-endpoint-evidence.v2",
+  "journey_id": "JOURNEY-LOCAL-CONSUMER-ENDPOINT",
+  "requirement_ids": [
+    "SPEC-045-R003",
+    "SPEC-045-R004",
+    "SPEC-045-R008"
+  ],
+  "repository": {
+    "name": "Augustas11/macprovider",
+    "commit": "d51b79b07876da9ab0590f9721936530aa614bde"
+  },
+  "captured_at": "2026-09-09T06:23:25Z",
+  "expires_at": "2026-10-09",
+  "operator": {
+    "role": "release-operator",
+    "identity_fingerprint": "2e5a2503810a6b75d51919075dd43175eafdc4ea5dacf20c604a8668d5d79b60"
+  },
+  "environment": {
+    "class": "staging-or-production-local-consumer-endpoint",
+    "hardware_profile": "local-macos-redacted",
+    "candidate": "commit:d51b79b07876da9ab0590f9721936530aa614bde"
+  },
+  "result": {
+    "status": "pass"
+  },
+  "steps": [
+    {
+      "id": "step-01-capture-local-endpoint",
+      "status": "pass",
+      "artifacts": [
+        "redacted-local-consumer-endpoint"
+      ],
+      "support_artifacts": [
+        "cli_binary",
+        "ledger_capture",
+        "log_capture",
+        "rate_card_capture",
+        "status_capture",
+        "trusted_metadata_transport_matrix"
+      ]
+    },
+    {
+      "id": "step-02-openai-sdk-local-client",
+      "status": "pass",
+      "artifacts": [
+        "redacted-local-consumer-endpoint"
+      ],
+      "support_artifacts": [
+        "cli_binary",
+        "ledger_capture",
+        "log_capture",
+        "rate_card_capture",
+        "status_capture",
+        "trusted_metadata_transport_matrix"
+      ]
+    },
+    {
+      "id": "step-03-permitted-chat-completion",
+      "status": "pass",
+      "artifacts": [
+        "redacted-local-consumer-endpoint"
+      ],
+      "support_artifacts": [
+        "cli_binary",
+        "ledger_capture",
+        "log_capture",
+        "rate_card_capture",
+        "status_capture",
+        "trusted_metadata_transport_matrix"
+      ]
+    },
+    {
+      "id": "step-04-over-budget-denial",
+      "status": "pass",
+      "artifacts": [
+        "redacted-local-consumer-endpoint"
+      ],
+      "support_artifacts": [
+        "cli_binary",
+        "ledger_capture",
+        "log_capture",
+        "rate_card_capture",
+        "status_capture",
+        "trusted_metadata_transport_matrix"
+      ]
+    },
+    {
+      "id": "step-05-restart-held-reservation",
+      "status": "pass",
+      "artifacts": [
+        "redacted-local-consumer-endpoint"
+      ],
+      "support_artifacts": [
+        "cli_binary",
+        "ledger_capture",
+        "log_capture",
+        "rate_card_capture",
+        "status_capture",
+        "trusted_metadata_transport_matrix"
+      ]
+    },
+    {
+      "id": "step-06-recovery-release-held-reservation",
+      "status": "pass",
+      "artifacts": [
+        "redacted-local-consumer-endpoint"
+      ],
+      "support_artifacts": [
+        "cli_binary",
+        "ledger_capture",
+        "log_capture",
+        "rate_card_capture",
+        "status_capture",
+        "trusted_metadata_transport_matrix"
+      ]
+    },
+    {
+      "id": "step-07-redaction-status-logs",
+      "status": "pass",
+      "artifacts": [
+        "redacted-local-consumer-endpoint"
+      ],
+      "support_artifacts": [
+        "cli_binary",
+        "ledger_capture",
+        "log_capture",
+        "rate_card_capture",
+        "status_capture",
+        "trusted_metadata_transport_matrix"
+      ]
+    },
+    {
+      "id": "step-08-restore-local-state",
+      "status": "pass",
+      "artifacts": [
+        "redacted-local-consumer-endpoint"
+      ],
+      "support_artifacts": [
+        "cli_binary",
+        "ledger_capture",
+        "log_capture",
+        "rate_card_capture",
+        "status_capture",
+        "trusted_metadata_transport_matrix"
+      ]
+    }
+  ],
+  "redaction": {
+    "local_account_names_redacted": true,
+    "operator_identity_redacted": true,
+    "secrets_redacted": true
+  },
+  "observations": {
+    "bearer_tokens_redacted": true,
+    "generated_local_token_used_as_api_key": true,
+    "held_reservation_survived_restart": true,
+    "local_base_url_configured": true,
+    "openai_sdk_used": true,
+    "over_budget_denial_observed": true,
+    "permitted_chat_completion_observed": true,
+    "raw_prompt_output_redacted": true,
+    "recovery_release_observed": true,
+    "redacted_artifacts_reviewed": true,
+    "staging_or_production_gateway": true,
+    "fake_gateway_used": false,
+    "local_token_logged": false,
+    "raw_completion_logged": false,
+    "raw_prompt_logged": false,
+    "upstream_credential_logged": false
+  },
+  "candidate_identity": {
+    "buyer_credential_fingerprint": "c7b9bf95d1388c019fe79d12fcfaa7a999adf833d467d5036b7c1baad9872733",
+    "cli_binary_sha256": "30d3fe336f7b28ae2e579d2c1cda4d40f4f673e28d2c90377782fd11f7a4bcd5",
+    "cli_version": "1.8.123",
+    "gateway_kind": "production",
+    "ledger_sha256": "1fbdc3d576a7879e23729c9f48595e4e79dc25b53471edcb44b319cda6fa94e0",
+    "local_endpoint_base_url_sha256": "8921de37965c88df775c2f70e5577039a73f77cfd25c71521faac57be039d14a",
+    "local_token_fingerprint": "bde0a8a31071b15357eab5150a351509e0ea81b950859d4304f57d8935a0de48",
+    "log_capture_sha256": "832ff028542b599b76625f5c62c127ef42cc5a953f81eadb63cc53789ae9876a",
+    "model_id": "mlx-community/Qwen3-8B-4bit",
+    "rate_card_sha256": "ae6c2f68fb09f8828e3c415a890e6c30e0a97566ecf311e26110af286c8b674b",
+    "sdk_name": "openai-python",
+    "sdk_version": "2.44.0",
+    "status_capture_sha256": "42015f3e6d5d6d890b05ef22315c5b89e7e94ae74aa75b5ce57b20f16ce30a72",
+    "upstream_gateway_origin_sha256": "05ec143545d842afe0609f2659c59812840dcfeba47e869dea17ff2121686dbe"
+  },
+  "support_artifacts": {
+    "cli_binary": {
+      "role": "cli-binary",
+      "sha256": "30d3fe336f7b28ae2e579d2c1cda4d40f4f673e28d2c90377782fd11f7a4bcd5",
+      "bytes": 65918000
+    },
+    "ledger_capture": {
+      "role": "redacted-ledger-capture",
+      "sha256": "1fbdc3d576a7879e23729c9f48595e4e79dc25b53471edcb44b319cda6fa94e0",
+      "bytes": 754,
+      "report": {
+        "schema_version": "macprovider.local-consumer-ledger-redacted.v1",
+        "repository": {
+          "name": "Augustas11/macprovider",
+          "commit": "d51b79b07876da9ab0590f9721936530aa614bde"
+        },
+        "run_id": "local-consumer-endpoint-20260909T062325Z",
+        "summary": {
+          "settled_micro_usd": "227",
+          "released_micro_usd": "340",
+          "held_micro_usd": "0",
+          "reserved_micro_usd": "0"
+        },
+        "recovery_transitions": [
+          {
+            "state": "held",
+            "reason": "restart_recovery",
+            "admission_estimate_micro_usd": "115"
+          },
+          {
+            "state": "released",
+            "reason": "operator_release_held",
+            "admission_estimate_micro_usd": "115"
+          }
+        ],
+        "final_state": {
+          "held_reservation_count": 0,
+          "reserved_reservation_count": 0
+        }
+      }
+    },
+    "log_capture": {
+      "role": "redacted-log-capture",
+      "sha256": "832ff028542b599b76625f5c62c127ef42cc5a953f81eadb63cc53789ae9876a",
+      "bytes": 799,
+      "report": {
+        "schema_version": "macprovider.local-consumer-log-redacted.v1",
+        "repository": {
+          "name": "Augustas11/macprovider",
+          "commit": "d51b79b07876da9ab0590f9721936530aa614bde"
+        },
+        "run_id": "local-consumer-endpoint-20260909T062325Z",
+        "events": {
+          "endpoint_started": true,
+          "sdk_permitted": true,
+          "budget_denial": true,
+          "upstream_contact_changed_after_permitted": true,
+          "upstream_contact_unchanged_after_denial": true,
+          "crash_with_active_reservation": true,
+          "restart_recovery_observed": true,
+          "recovery_release_observed": true,
+          "graceful_stop": true
+        },
+        "redaction": {
+          "bearer_tokens_redacted": true,
+          "local_token_logged": false,
+          "raw_completion_logged": false,
+          "raw_prompt_logged": false,
+          "upstream_credential_logged": false
+        }
+      }
+    },
+    "rate_card_capture": {
+      "role": "redacted-rate-card-capture",
+      "sha256": "ae6c2f68fb09f8828e3c415a890e6c30e0a97566ecf311e26110af286c8b674b",
+      "bytes": 496,
+      "report": {
+        "schema_version": "macprovider.local-consumer-rate-card-redacted.v1",
+        "repository": {
+          "name": "Augustas11/macprovider",
+          "commit": "d51b79b07876da9ab0590f9721936530aa614bde"
+        },
+        "run_id": "local-consumer-endpoint-20260909T062325Z",
+        "pricing_trust_state": "trusted",
+        "gateway_kind": "production",
+        "model_id": "mlx-community/Qwen3-8B-4bit",
+        "budget_configured_micro_usd": "100000",
+        "max_admission_micro_usd": "50000",
+        "interrupted_admission_estimate_micro_usd": "115"
+      }
+    },
+    "status_capture": {
+      "role": "redacted-status-capture",
+      "sha256": "42015f3e6d5d6d890b05ef22315c5b89e7e94ae74aa75b5ce57b20f16ce30a72",
+      "bytes": 923,
+      "report": {
+        "schema_version": "macprovider.local-consumer-status-redacted.v1",
+        "repository": {
+          "name": "Augustas11/macprovider",
+          "commit": "d51b79b07876da9ab0590f9721936530aa614bde"
+        },
+        "run_id": "local-consumer-endpoint-20260909T062325Z",
+        "observations": {
+          "local_base_url_configured": true,
+          "openai_sdk_used": true,
+          "generated_local_token_used_as_api_key": true,
+          "permitted_chat_completion_observed": true,
+          "over_budget_denial_observed": true,
+          "held_reservation_survived_restart": true,
+          "recovery_release_observed": true,
+          "upstream_contact_observed": true
+        },
+        "restart_state": {
+          "bound_url": "http://127.0.0.1:18435",
+          "pricing_trust_state": "trusted",
+          "budget_held_micro_usd": "115",
+          "budget_used_micro_usd": "227"
+        },
+        "final_state": {
+          "listener_count": 0,
+          "status_exit": 4,
+          "budget_held_micro_usd": "0",
+          "budget_reserved_micro_usd": "0"
+        }
+      }
+    },
+    "trusted_metadata_transport_matrix": {
+      "role": "trusted-metadata-transport-matrix",
+      "sha256": "a799ebe65c43b67231a209b55553666eb8b17274bdecf638a22e0ecf33094159",
+      "bytes": 2283,
+      "report": {
+        "schema_version": "macprovider.trusted-metadata-transport-matrix.v1",
+        "repository": {
+          "name": "Augustas11/macprovider",
+          "commit": "d51b79b07876da9ab0590f9721936530aa614bde"
+        },
+        "transport": {
+          "production_path": true,
+          "real_sockets": true,
+          "connection_api": "NWConnection",
+          "source_files": [
+            "phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift",
+            "phase3-binary/Sources/macprovider-cli/ConsumeTrustedPricing.swift",
+            "phase3-binary/Tests/macprovider-cliTests/ConsumeTrustedMetadataTransportMatrixTests.swift"
+          ]
+        },
+        "scenarios": [
+          {
+            "id": "valid_pinned_peer_with_sni",
+            "status": "pass"
+          },
+          {
+            "id": "streaming_valid_pinned_peer_with_sni",
+            "status": "pass"
+          },
+          {
+            "id": "connected_peer_in_validated_set",
+            "status": "pass"
+          },
+          {
+            "id": "streaming_connected_peer_in_validated_set",
+            "status": "pass"
+          },
+          {
+            "id": "untrusted_root_rejected",
+            "status": "pass"
+          },
+          {
+            "id": "streaming_untrusted_root_rejected",
+            "status": "pass"
+          },
+          {
+            "id": "expired_certificate_rejected",
+            "status": "pass"
+          },
+          {
+            "id": "streaming_expired_certificate_rejected",
+            "status": "pass"
+          },
+          {
+            "id": "invalid_chain_rejected",
+            "status": "pass"
+          },
+          {
+            "id": "streaming_invalid_chain_rejected",
+            "status": "pass"
+          },
+          {
+            "id": "hostname_mismatch_rejected",
+            "status": "pass"
+          },
+          {
+            "id": "streaming_hostname_mismatch_rejected",
+            "status": "pass"
+          },
+          {
+            "id": "dns_reresolved_per_connection",
+            "status": "pass"
+          },
+          {
+            "id": "environment_proxy_ignored",
+            "status": "pass"
+          },
+          {
+            "id": "streaming_environment_proxy_ignored",
+            "status": "pass"
+          },
+          {
+            "id": "redirect_not_followed",
+            "status": "pass"
+          },
+          {
+            "id": "streaming_redirect_not_followed",
+            "status": "pass"
+          },
+          {
+            "id": "zero_credential_bytes",
+            "status": "pass"
+          },
+          {
+            "id": "slow_drip_absolute_timeout",
+            "status": "pass"
+          }
+        ],
+        "redaction": {
+          "payload_bytes_omitted": true,
+          "sensitive_material_omitted": true,
+          "transcript_material_omitted": true
+        }
+      }
+    }
+  },
+  "review": {
+    "reviewed_at": "2026-09-09T06:45:42Z",
+    "reviewer_role": "release-operator",
+    "support_artifacts_reviewed": [
+      "cli_binary",
+      "ledger_capture",
+      "log_capture",
+      "rate_card_capture",
+      "status_capture",
+      "trusted_metadata_transport_matrix"
+    ],
+    "real_gateway_basis": "staging-or-production-gateway",
+    "sdk_client_basis": "openai-sdk-local-token-api-key",
+    "redaction_basis": "redacted-support-artifacts-reviewed"
+  },
+  "run_id": "local-consumer-endpoint-20260909T062325Z"
+}

--- a/scripts/build-local-consumer-endpoint-journey-result.py
+++ b/scripts/build-local-consumer-endpoint-journey-result.py
@@ -23,10 +23,13 @@ from check_spec_governance import (
     LOCAL_CONSUMER_ENDPOINT_EVIDENCE_REQUIREMENT_IDS,
     LOCAL_CONSUMER_ENDPOINT_EXECUTION_MODE,
     LOCAL_CONSUMER_ENDPOINT_JOURNEY_ID,
+    LOCAL_CONSUMER_ENDPOINT_SEMANTIC_SUPPORT_ARTIFACT_IDS,
     LOCAL_CONSUMER_ENDPOINT_STEP_ID_ORDER,
     ValidationResult,
     _load_json,
     _unique_json_object,
+    local_consumer_endpoint_canonical_report_bytes,
+    validate_local_consumer_endpoint_support_report,
 )
 
 
@@ -734,7 +737,16 @@ def require_candidate_identity(value: Any) -> dict[str, Any]:
     return deepcopy(identity)
 
 
-def require_support_artifacts(value: Any, candidate_identity: dict[str, Any], expected_support_artifacts: set[str], source_sha: str) -> dict[str, Any]:
+def require_support_artifacts(
+    value: Any,
+    candidate_identity: dict[str, Any],
+    expected_support_artifacts: set[str],
+    source_sha: str,
+    run_id: str,
+    observations: dict[str, Any],
+    *,
+    require_semantic_reports: bool,
+) -> dict[str, Any]:
     support = require_object(value, "support_artifacts")
     require_exact_keys(support, expected_support_artifacts, expected_support_artifacts, "support_artifacts")
     expected_hashes = {
@@ -748,7 +760,9 @@ def require_support_artifacts(value: Any, candidate_identity: dict[str, Any], ex
     for artifact_id in sorted(expected_support_artifacts):
         artifact = require_object(support.get(artifact_id), f"support_artifacts.{artifact_id}")
         allowed_keys = {"role", "sha256", "bytes"}
-        if artifact_id == TRANSPORT_MATRIX_ARTIFACT_ID:
+        if artifact_id == TRANSPORT_MATRIX_ARTIFACT_ID or (
+            require_semantic_reports and artifact_id in LOCAL_CONSUMER_ENDPOINT_SEMANTIC_SUPPORT_ARTIFACT_IDS
+        ):
             allowed_keys.add("report")
         require_exact_keys(artifact, allowed_keys, allowed_keys, f"support_artifacts.{artifact_id}")
         if artifact.get("role") != SUPPORT_ARTIFACT_ROLES[artifact_id]:
@@ -769,6 +783,25 @@ def require_support_artifacts(value: Any, candidate_identity: dict[str, Any], ex
             if byte_count != expected_report_bytes:
                 die("support_artifacts.trusted_metadata_transport_matrix.bytes must match canonical report bytes")
             normalized[artifact_id]["report"] = deepcopy(artifact["report"])
+        elif require_semantic_reports and artifact_id in LOCAL_CONSUMER_ENDPOINT_SEMANTIC_SUPPORT_ARTIFACT_IDS:
+            report = require_object(artifact.get("report"), f"support_artifacts.{artifact_id}.report")
+            errors = validate_local_consumer_endpoint_support_report(
+                artifact_id,
+                report,
+                source_sha=source_sha,
+                run_id=run_id,
+                candidate_identity=candidate_identity,
+                observations=observations,
+                location=f"support_artifacts.{artifact_id}.report",
+            )
+            if errors:
+                die("; ".join(errors))
+            expected_report_bytes = local_consumer_endpoint_canonical_report_bytes(report)
+            if artifact_sha != hashlib.sha256(expected_report_bytes).hexdigest():
+                die(f"support_artifacts.{artifact_id}.sha256 must match canonical report bytes")
+            if byte_count != len(expected_report_bytes):
+                die(f"support_artifacts.{artifact_id}.bytes must match canonical report bytes")
+            normalized[artifact_id]["report"] = deepcopy(report)
     return normalized
 
 
@@ -904,10 +937,18 @@ def build_payload(root: Path, source: str, *, source_sha: str, evidence_sha: str
     redaction = require_redaction(evidence.get("redaction"))
     observations = require_observations(evidence.get("observations"))
     candidate_identity = require_candidate_identity(evidence.get("candidate_identity"))
-    require_support_artifacts(evidence.get("support_artifacts"), candidate_identity, expected_support_artifacts, source_sha)
+    run_id = require_safe_metadata(evidence.get("run_id"), "run_id", run_id=True)
+    require_support_artifacts(
+        evidence.get("support_artifacts"),
+        candidate_identity,
+        expected_support_artifacts,
+        source_sha,
+        run_id,
+        observations,
+        require_semantic_reports=evidence.get("schema_version") == EVIDENCE_SCHEMA_V2,
+    )
     require_review(evidence.get("review"), expected_support_artifacts)
     artifact_sha = hashlib.sha256(evidence_bytes).hexdigest()
-    run_id = require_safe_metadata(evidence.get("run_id"), "run_id", run_id=True)
 
     return {
         "schema_version": JOURNEY_RESULT_PAYLOAD_SCHEMA,

--- a/scripts/capture-local-consumer-endpoint-evidence.py
+++ b/scripts/capture-local-consumer-endpoint-evidence.py
@@ -24,6 +24,8 @@ from check_spec_governance import (
     LOCAL_CONSUMER_ENDPOINT_JOURNEY_ID,
     LOCAL_CONSUMER_ENDPOINT_STEP_ID_ORDER,
     _unique_json_object,
+    local_consumer_endpoint_canonical_report_bytes,
+    validate_local_consumer_endpoint_support_report,
 )
 
 
@@ -501,6 +503,44 @@ def canonical_report_bytes(value: dict[str, Any]) -> bytes:
     return (json.dumps(value, indent=2, sort_keys=False) + "\n").encode("utf-8")
 
 
+def load_semantic_support_report(
+    path: Path,
+    label: str,
+    artifact_id: str,
+    *,
+    source_sha: str,
+    run_id: str,
+    candidate_identity: dict[str, Any] | None = None,
+    observations: dict[str, Any] | None = None,
+) -> tuple[dict[str, Any], str, int]:
+    resolved = require_regular_file(path, label)
+    payload = resolved.read_bytes()
+    scan_redacted_artifact_payload(payload, label)
+    try:
+        value = json.loads(payload.decode("utf-8"), object_pairs_hook=_unique_json_object)
+    except DuplicateJSONKeyError as exc:
+        die(f"{label} contains duplicate JSON object key {exc.args[0]!r}")
+    except json.JSONDecodeError as exc:
+        die(f"{label} contains malformed JSON: {exc}")
+    if not isinstance(value, dict):
+        die(f"{label} must be a JSON object")
+    errors = validate_local_consumer_endpoint_support_report(
+        artifact_id,
+        value,
+        source_sha=source_sha,
+        run_id=run_id,
+        candidate_identity=candidate_identity,
+        observations=observations,
+        location=label,
+    )
+    if errors:
+        die("; ".join(errors))
+    canonical = local_consumer_endpoint_canonical_report_bytes(value)
+    if payload != canonical:
+        die(f"{label} must use canonical two-space JSON bytes")
+    return value, sha256_bytes(canonical), len(canonical)
+
+
 def sha256_file(path: Path, label: str, *, binary: bool = False) -> tuple[str, int]:
     resolved = require_regular_file(path, label)
     payload = resolved.read_bytes()
@@ -887,11 +927,6 @@ def build_evidence(args: argparse.Namespace) -> dict[str, Any]:
 
     requirement_ids = parse_requirement_ids(args.requirement_ids)
     expected_support_artifacts = required_support_artifact_ids(requirement_ids)
-    cli_binary_sha256, cli_binary_bytes = sha256_file(Path(args.cli_binary), "--cli-binary", binary=True)
-    ledger_sha256, ledger_bytes = sha256_file(Path(args.ledger_capture), "--ledger-capture")
-    log_capture_sha256, log_bytes = sha256_file(Path(args.log_capture), "--log-capture")
-    rate_card_sha256, rate_card_bytes = sha256_file(Path(args.rate_card_capture), "--rate-card-capture")
-    status_capture_sha256, status_bytes = sha256_file(Path(args.status_capture), "--status-capture")
     transport_matrix_required = TRANSPORT_MATRIX_ARTIFACT_ID in expected_support_artifacts
     if transport_matrix_required and not args.trusted_metadata_transport_matrix:
         die("--trusted-metadata-transport-matrix is required for SPEC-045-R003/R004/R008 captures")
@@ -903,6 +938,38 @@ def build_evidence(args: argparse.Namespace) -> dict[str, Any]:
         die("--upstream-gateway-origin-sha256 is not accepted for capture; pass --upstream-gateway-origin")
     local_endpoint_base_url_sha256 = sha256_text(require_local_endpoint_url(args.local_endpoint_base_url or ""))
     upstream_gateway_origin_sha256 = sha256_text(require_gateway_origin(args.upstream_gateway_origin or "", args.gateway_kind))
+    model_id = require_candidate_identity_metadata(args.model_id, "--model-id", field="model_id")
+
+    cli_binary_sha256, cli_binary_bytes = sha256_file(Path(args.cli_binary), "--cli-binary", binary=True)
+    semantic_reports: dict[str, dict[str, Any]] = {}
+    semantic_artifact_bytes: dict[str, tuple[str, int]] = {}
+    if transport_matrix_required:
+        candidate_context = {"gateway_kind": args.gateway_kind, "model_id": model_id}
+        for artifact_id, path_value, label in (
+            ("ledger_capture", args.ledger_capture, "--ledger-capture"),
+            ("log_capture", args.log_capture, "--log-capture"),
+            ("rate_card_capture", args.rate_card_capture, "--rate-card-capture"),
+            ("status_capture", args.status_capture, "--status-capture"),
+        ):
+            report, report_sha256, report_bytes = load_semantic_support_report(
+                Path(path_value),
+                label,
+                artifact_id,
+                source_sha=source_sha,
+                run_id=run_id,
+                candidate_identity=candidate_context,
+            )
+            semantic_reports[artifact_id] = report
+            semantic_artifact_bytes[artifact_id] = (report_sha256, report_bytes)
+        ledger_sha256, ledger_bytes = semantic_artifact_bytes["ledger_capture"]
+        log_capture_sha256, log_bytes = semantic_artifact_bytes["log_capture"]
+        rate_card_sha256, rate_card_bytes = semantic_artifact_bytes["rate_card_capture"]
+        status_capture_sha256, status_bytes = semantic_artifact_bytes["status_capture"]
+    else:
+        ledger_sha256, ledger_bytes = sha256_file(Path(args.ledger_capture), "--ledger-capture")
+        log_capture_sha256, log_bytes = sha256_file(Path(args.log_capture), "--log-capture")
+        rate_card_sha256, rate_card_bytes = sha256_file(Path(args.rate_card_capture), "--rate-card-capture")
+        status_capture_sha256, status_bytes = sha256_file(Path(args.status_capture), "--status-capture")
 
     operator_identity_fingerprint = require_string(
         args.operator_identity_fingerprint,
@@ -926,6 +993,8 @@ def build_evidence(args: argparse.Namespace) -> dict[str, Any]:
         "rate_card_capture": {"role": "redacted-rate-card-capture", "sha256": rate_card_sha256, "bytes": rate_card_bytes},
         "status_capture": {"role": "redacted-status-capture", "sha256": status_capture_sha256, "bytes": status_bytes},
     }
+    for artifact_id, report in semantic_reports.items():
+        support_artifacts[artifact_id]["report"] = report
     if transport_matrix_required:
         matrix_path = require_regular_file(Path(args.trusted_metadata_transport_matrix), "--trusted-metadata-transport-matrix")
         matrix_payload = matrix_path.read_bytes()
@@ -950,6 +1019,18 @@ def build_evidence(args: argparse.Namespace) -> dict[str, Any]:
         support_artifacts=support_artifacts,
         expected_support_artifacts=expected_support_artifacts,
     )
+    for artifact_id, report in semantic_reports.items():
+        errors = validate_local_consumer_endpoint_support_report(
+            artifact_id,
+            report,
+            source_sha=source_sha,
+            run_id=run_id,
+            candidate_identity={"gateway_kind": args.gateway_kind, "model_id": model_id},
+            observations=observations,
+            location=f"support_artifacts.{artifact_id}.report",
+        )
+        if errors:
+            die("; ".join(errors))
     candidate = require_safe_metadata(args.candidate, "--candidate")
     if candidate != f"commit:{source_sha}":
         die("--candidate must equal commit:<source-sha>")
@@ -983,7 +1064,7 @@ def build_evidence(args: argparse.Namespace) -> dict[str, Any]:
             "local_endpoint_base_url_sha256": local_endpoint_base_url_sha256,
             "local_token_fingerprint": local_token_fingerprint,
             "log_capture_sha256": log_capture_sha256,
-            "model_id": require_candidate_identity_metadata(args.model_id, "--model-id", field="model_id"),
+            "model_id": model_id,
             "rate_card_sha256": rate_card_sha256,
             "sdk_name": require_candidate_identity_metadata(args.sdk_name, "--sdk-name", field="sdk_name"),
             "sdk_version": require_candidate_identity_metadata(args.sdk_version, "--sdk-version", field="sdk_version"),

--- a/scripts/check_spec_governance.py
+++ b/scripts/check_spec_governance.py
@@ -25,6 +25,7 @@ from datetime import date, datetime, timezone
 from pathlib import Path
 from pathlib import PurePosixPath
 from typing import Any
+from urllib.parse import urlsplit
 
 
 AUTHORITY_SCHEMA_PATH = "../schemas/spec-authority-v1.schema.json"
@@ -248,6 +249,19 @@ LOCAL_CONSUMER_ENDPOINT_SUPPORT_ARTIFACT_ROLES = {
     "status_capture": "redacted-status-capture",
     LOCAL_CONSUMER_ENDPOINT_TRANSPORT_MATRIX_ARTIFACT_ID: "trusted-metadata-transport-matrix",
 }
+LOCAL_CONSUMER_ENDPOINT_SEMANTIC_SUPPORT_ARTIFACT_IDS = {
+    "ledger_capture",
+    "log_capture",
+    "rate_card_capture",
+    "status_capture",
+}
+LOCAL_CONSUMER_ENDPOINT_SUPPORT_REPORT_SCHEMAS = {
+    "ledger_capture": "macprovider.local-consumer-ledger-redacted.v1",
+    "log_capture": "macprovider.local-consumer-log-redacted.v1",
+    "rate_card_capture": "macprovider.local-consumer-rate-card-redacted.v1",
+    "status_capture": "macprovider.local-consumer-status-redacted.v1",
+}
+LOCAL_CONSUMER_ENDPOINT_SUPPORT_DECIMAL_RE = re.compile(r"^(?:0|[1-9][0-9]*)$")
 LOCAL_CONSUMER_ENDPOINT_TRANSPORT_MATRIX_REQUIREMENT_IDS = {
     "SPEC-045-R003",
     "SPEC-045-R004",
@@ -932,6 +946,268 @@ def _local_consumer_expected_support_artifact_ids(requirement_ids: list[str]) ->
     if any(requirement_id in LOCAL_CONSUMER_ENDPOINT_TRANSPORT_MATRIX_REQUIREMENT_IDS for requirement_id in requirement_ids):
         return set(LOCAL_CONSUMER_ENDPOINT_SUPPORT_ARTIFACT_IDS)
     return set(LOCAL_CONSUMER_ENDPOINT_BASE_SUPPORT_ARTIFACT_IDS)
+
+
+def local_consumer_endpoint_canonical_report_bytes(value: dict[str, Any]) -> bytes:
+    return (json.dumps(value, indent=2, sort_keys=False) + "\n").encode("utf-8")
+
+
+def _local_consumer_support_error(errors: list[str], location: str, message: str) -> None:
+    errors.append(f"{location}: {message}")
+
+
+def _local_consumer_support_expect_keys(
+    value: Any,
+    required: set[str],
+    location: str,
+    errors: list[str],
+) -> bool:
+    if not isinstance(value, dict):
+        _local_consumer_support_error(errors, location, "must be an object")
+        return False
+    missing = required - set(value)
+    extra = set(value) - required
+    if missing:
+        _local_consumer_support_error(errors, location, f"missing keys: {sorted(missing)}")
+    if extra:
+        _local_consumer_support_error(errors, location, f"has unexpected keys: {sorted(extra)}")
+    return not missing and not extra
+
+
+def _local_consumer_support_decimal(value: Any, location: str, errors: list[str], *, positive: bool = False) -> int | None:
+    if not isinstance(value, str) or LOCAL_CONSUMER_ENDPOINT_SUPPORT_DECIMAL_RE.fullmatch(value) is None:
+        _local_consumer_support_error(errors, location, "must be a non-negative micro-USD decimal string")
+        return None
+    parsed = int(value)
+    if positive and parsed <= 0:
+        _local_consumer_support_error(errors, location, "must be greater than zero")
+        return None
+    return parsed
+
+
+def _local_consumer_support_zero_int(value: Any, location: str, errors: list[str]) -> None:
+    if not isinstance(value, int) or isinstance(value, bool) or value != 0:
+        _local_consumer_support_error(errors, location, "must equal integer 0")
+
+
+def _local_consumer_validate_support_common(
+    artifact_id: str,
+    value: Any,
+    source_sha: str,
+    run_id: str,
+    location: str,
+    errors: list[str],
+    specific_keys: set[str],
+) -> bool:
+    required = {"schema_version", "repository", "run_id"} | specific_keys
+    if not _local_consumer_support_expect_keys(value, required, location, errors):
+        return False
+    expected_schema = LOCAL_CONSUMER_ENDPOINT_SUPPORT_REPORT_SCHEMAS[artifact_id]
+    if value.get("schema_version") != expected_schema:
+        _local_consumer_support_error(errors, f"{location}.schema_version", f"must equal {expected_schema!r}")
+    repository = value.get("repository")
+    if _local_consumer_support_expect_keys(repository, {"name", "commit"}, f"{location}.repository", errors):
+        if repository.get("name") != "Augustas11/macprovider":
+            _local_consumer_support_error(errors, f"{location}.repository.name", "must equal 'Augustas11/macprovider'")
+        if repository.get("commit") != source_sha:
+            _local_consumer_support_error(errors, f"{location}.repository.commit", "must match source repository.commit")
+    if value.get("run_id") != run_id:
+        _local_consumer_support_error(errors, f"{location}.run_id", "must match source run_id")
+    return True
+
+
+def validate_local_consumer_endpoint_support_report(
+    artifact_id: str,
+    value: Any,
+    *,
+    source_sha: str,
+    run_id: str,
+    candidate_identity: dict[str, Any] | None = None,
+    observations: dict[str, Any] | None = None,
+    location: str,
+) -> list[str]:
+    errors: list[str] = []
+    if artifact_id == "ledger_capture":
+        if not _local_consumer_validate_support_common(
+            artifact_id,
+            value,
+            source_sha,
+            run_id,
+            location,
+            errors,
+            {"summary", "recovery_transitions", "final_state"},
+        ):
+            return errors
+        summary = value.get("summary")
+        if _local_consumer_support_expect_keys(summary, {"settled_micro_usd", "released_micro_usd", "held_micro_usd", "reserved_micro_usd"}, f"{location}.summary", errors):
+            _local_consumer_support_decimal(summary.get("settled_micro_usd"), f"{location}.summary.settled_micro_usd", errors, positive=True)
+            _local_consumer_support_decimal(summary.get("released_micro_usd"), f"{location}.summary.released_micro_usd", errors, positive=True)
+            held = _local_consumer_support_decimal(summary.get("held_micro_usd"), f"{location}.summary.held_micro_usd", errors)
+            reserved = _local_consumer_support_decimal(summary.get("reserved_micro_usd"), f"{location}.summary.reserved_micro_usd", errors)
+            if held not in (None, 0):
+                _local_consumer_support_error(errors, f"{location}.summary.held_micro_usd", "must equal '0' after release")
+            if reserved not in (None, 0):
+                _local_consumer_support_error(errors, f"{location}.summary.reserved_micro_usd", "must equal '0' after shutdown")
+        transitions = value.get("recovery_transitions")
+        if not isinstance(transitions, list) or len(transitions) != 2:
+            _local_consumer_support_error(errors, f"{location}.recovery_transitions", "must contain held and released recovery transitions")
+        else:
+            expected = [("held", "restart_recovery"), ("released", "operator_release_held")]
+            estimates: list[int] = []
+            for index, (transition, (state, reason)) in enumerate(zip(transitions, expected, strict=True)):
+                loc = f"{location}.recovery_transitions[{index}]"
+                if _local_consumer_support_expect_keys(transition, {"state", "reason", "admission_estimate_micro_usd"}, loc, errors):
+                    if transition.get("state") != state:
+                        _local_consumer_support_error(errors, f"{loc}.state", f"must equal {state!r}")
+                    if transition.get("reason") != reason:
+                        _local_consumer_support_error(errors, f"{loc}.reason", f"must equal {reason!r}")
+                    estimate = _local_consumer_support_decimal(
+                        transition.get("admission_estimate_micro_usd"),
+                        f"{loc}.admission_estimate_micro_usd",
+                        errors,
+                        positive=True,
+                    )
+                    if estimate is not None:
+                        estimates.append(estimate)
+            if len(estimates) == 2 and estimates[0] != estimates[1]:
+                _local_consumer_support_error(errors, f"{location}.recovery_transitions", "held and released estimates must match")
+        final_state = value.get("final_state")
+        if _local_consumer_support_expect_keys(final_state, {"held_reservation_count", "reserved_reservation_count"}, f"{location}.final_state", errors):
+            _local_consumer_support_zero_int(final_state.get("held_reservation_count"), f"{location}.final_state.held_reservation_count", errors)
+            _local_consumer_support_zero_int(final_state.get("reserved_reservation_count"), f"{location}.final_state.reserved_reservation_count", errors)
+    elif artifact_id == "log_capture":
+        if not _local_consumer_validate_support_common(artifact_id, value, source_sha, run_id, location, errors, {"events", "redaction"}):
+            return errors
+        event_fields = {
+            "endpoint_started",
+            "sdk_permitted",
+            "budget_denial",
+            "upstream_contact_changed_after_permitted",
+            "upstream_contact_unchanged_after_denial",
+            "crash_with_active_reservation",
+            "restart_recovery_observed",
+            "recovery_release_observed",
+            "graceful_stop",
+        }
+        events = value.get("events")
+        if _local_consumer_support_expect_keys(events, event_fields, f"{location}.events", errors):
+            for field_name in sorted(event_fields):
+                if events.get(field_name) is not True:
+                    _local_consumer_support_error(errors, f"{location}.events.{field_name}", "must be true")
+        redaction = value.get("redaction")
+        redaction_fields = {
+            "bearer_tokens_redacted": True,
+            "local_token_logged": False,
+            "raw_completion_logged": False,
+            "raw_prompt_logged": False,
+            "upstream_credential_logged": False,
+        }
+        if _local_consumer_support_expect_keys(redaction, set(redaction_fields), f"{location}.redaction", errors):
+            for field_name, expected in redaction_fields.items():
+                if redaction.get(field_name) is not expected:
+                    _local_consumer_support_error(errors, f"{location}.redaction.{field_name}", f"must be {str(expected).lower()}")
+                if observations is not None and observations.get(field_name) is not expected:
+                    _local_consumer_support_error(errors, f"{location}.redaction.{field_name}", "must match source observations")
+    elif artifact_id == "rate_card_capture":
+        if not _local_consumer_validate_support_common(
+            artifact_id,
+            value,
+            source_sha,
+            run_id,
+            location,
+            errors,
+            {"pricing_trust_state", "gateway_kind", "model_id", "budget_configured_micro_usd", "max_admission_micro_usd", "interrupted_admission_estimate_micro_usd"},
+        ):
+            return errors
+        if value.get("pricing_trust_state") != "trusted":
+            _local_consumer_support_error(errors, f"{location}.pricing_trust_state", "must equal 'trusted'")
+        if candidate_identity is not None:
+            if value.get("gateway_kind") != candidate_identity.get("gateway_kind"):
+                _local_consumer_support_error(errors, f"{location}.gateway_kind", "must match candidate_identity.gateway_kind")
+            if value.get("model_id") != candidate_identity.get("model_id"):
+                _local_consumer_support_error(errors, f"{location}.model_id", "must match candidate_identity.model_id")
+        budget = _local_consumer_support_decimal(value.get("budget_configured_micro_usd"), f"{location}.budget_configured_micro_usd", errors, positive=True)
+        maximum = _local_consumer_support_decimal(value.get("max_admission_micro_usd"), f"{location}.max_admission_micro_usd", errors, positive=True)
+        interrupted = _local_consumer_support_decimal(
+            value.get("interrupted_admission_estimate_micro_usd"),
+            f"{location}.interrupted_admission_estimate_micro_usd",
+            errors,
+            positive=True,
+        )
+        if budget is not None and maximum is not None and maximum > budget:
+            _local_consumer_support_error(errors, f"{location}.max_admission_micro_usd", "must not exceed configured budget")
+        if maximum is not None and interrupted is not None and interrupted > maximum:
+            _local_consumer_support_error(errors, f"{location}.interrupted_admission_estimate_micro_usd", "must not exceed max admission")
+    elif artifact_id == "status_capture":
+        if not _local_consumer_validate_support_common(
+            artifact_id,
+            value,
+            source_sha,
+            run_id,
+            location,
+            errors,
+            {"observations", "restart_state", "final_state"},
+        ):
+            return errors
+        status_observation_fields = {
+            "local_base_url_configured",
+            "openai_sdk_used",
+            "generated_local_token_used_as_api_key",
+            "permitted_chat_completion_observed",
+            "over_budget_denial_observed",
+            "held_reservation_survived_restart",
+            "recovery_release_observed",
+            "upstream_contact_observed",
+        }
+        support_observations = value.get("observations")
+        if _local_consumer_support_expect_keys(support_observations, status_observation_fields, f"{location}.observations", errors):
+            for field_name in sorted(status_observation_fields):
+                if support_observations.get(field_name) is not True:
+                    _local_consumer_support_error(errors, f"{location}.observations.{field_name}", "must be true")
+            if observations is not None:
+                for field_name in sorted(status_observation_fields - {"upstream_contact_observed"}):
+                    if observations.get(field_name) is not True:
+                        _local_consumer_support_error(errors, f"{location}.observations.{field_name}", "must match source observations")
+        restart_state = value.get("restart_state")
+        restart_fields = {"bound_url", "pricing_trust_state", "budget_held_micro_usd", "budget_used_micro_usd"}
+        if _local_consumer_support_expect_keys(restart_state, restart_fields, f"{location}.restart_state", errors):
+            bound_url = restart_state.get("bound_url")
+            valid_bound_url = False
+            if isinstance(bound_url, str):
+                try:
+                    parsed_bound_url = urlsplit(bound_url)
+                    valid_bound_url = (
+                        parsed_bound_url.scheme == "http"
+                        and parsed_bound_url.hostname in {"127.0.0.1", "localhost", "::1"}
+                        and parsed_bound_url.port is not None
+                        and parsed_bound_url.port > 0
+                        and parsed_bound_url.username is None
+                        and parsed_bound_url.password is None
+                        and parsed_bound_url.path in {"", "/"}
+                        and not parsed_bound_url.query
+                        and not parsed_bound_url.fragment
+                    )
+                except ValueError:
+                    valid_bound_url = False
+            if not valid_bound_url:
+                _local_consumer_support_error(errors, f"{location}.restart_state.bound_url", "must be an HTTP loopback URL")
+            if restart_state.get("pricing_trust_state") != "trusted":
+                _local_consumer_support_error(errors, f"{location}.restart_state.pricing_trust_state", "must equal 'trusted'")
+            _local_consumer_support_decimal(restart_state.get("budget_held_micro_usd"), f"{location}.restart_state.budget_held_micro_usd", errors, positive=True)
+            _local_consumer_support_decimal(restart_state.get("budget_used_micro_usd"), f"{location}.restart_state.budget_used_micro_usd", errors, positive=True)
+        final_state = value.get("final_state")
+        final_fields = {"listener_count", "status_exit", "budget_held_micro_usd", "budget_reserved_micro_usd"}
+        if _local_consumer_support_expect_keys(final_state, final_fields, f"{location}.final_state", errors):
+            _local_consumer_support_zero_int(final_state.get("listener_count"), f"{location}.final_state.listener_count", errors)
+            if final_state.get("status_exit") != 4:
+                _local_consumer_support_error(errors, f"{location}.final_state.status_exit", "must equal 4 after endpoint shutdown")
+            for field_name in ("budget_held_micro_usd", "budget_reserved_micro_usd"):
+                amount = _local_consumer_support_decimal(final_state.get(field_name), f"{location}.final_state.{field_name}", errors)
+                if amount not in (None, 0):
+                    _local_consumer_support_error(errors, f"{location}.final_state.{field_name}", "must equal '0'")
+    else:
+        _local_consumer_support_error(errors, location, f"unsupported semantic support artifact {artifact_id!r}")
+    return errors
 
 
 def _validate_local_consumer_support_artifacts_reviewed(
@@ -2577,7 +2853,9 @@ def _validate_local_consumer_endpoint_source(
             if not _expect_object(entry, entry_loc, result):
                 continue
             expected_entry_keys = {"role", "sha256", "bytes"}
-            if support_id == LOCAL_CONSUMER_ENDPOINT_TRANSPORT_MATRIX_ARTIFACT_ID:
+            if support_id == LOCAL_CONSUMER_ENDPOINT_TRANSPORT_MATRIX_ARTIFACT_ID or (
+                source_uses_v2 and support_id in LOCAL_CONSUMER_ENDPOINT_SEMANTIC_SUPPORT_ARTIFACT_IDS
+            ):
                 expected_entry_keys.add("report")
             _expect_keys(entry, expected_entry_keys, expected_entry_keys, entry_loc, result)
             if entry.get("role") != LOCAL_CONSUMER_ENDPOINT_SUPPORT_ARTIFACT_ROLES[support_id]:
@@ -2593,6 +2871,24 @@ def _validate_local_consumer_endpoint_source(
                 )
                 if isinstance(entry.get("report"), dict):
                     report_bytes = _local_consumer_canonical_report_bytes(entry["report"])
+                    if entry.get("sha256") != hashlib.sha256(report_bytes).hexdigest():
+                        result.error(f"{entry_loc}.sha256", "must match canonical report bytes")
+                    if entry.get("bytes") != len(report_bytes):
+                        result.error(f"{entry_loc}.bytes", "must match canonical report bytes")
+            elif source_uses_v2 and support_id in LOCAL_CONSUMER_ENDPOINT_SEMANTIC_SUPPORT_ARTIFACT_IDS:
+                report = entry.get("report")
+                for error in validate_local_consumer_endpoint_support_report(
+                    support_id,
+                    report,
+                    source_sha=payload.get("repository", {}).get("commit") if isinstance(payload.get("repository"), dict) else "",
+                    run_id=payload.get("run_id") if isinstance(payload.get("run_id"), str) else "",
+                    candidate_identity=identity if isinstance(identity, dict) else None,
+                    observations=payload.get("observations") if isinstance(payload.get("observations"), dict) else None,
+                    location=f"{entry_loc}.report",
+                ):
+                    result.error(f"{entry_loc}.report", error)
+                if isinstance(report, dict):
+                    report_bytes = local_consumer_endpoint_canonical_report_bytes(report)
                     if entry.get("sha256") != hashlib.sha256(report_bytes).hexdigest():
                         result.error(f"{entry_loc}.sha256", "must match canonical report bytes")
                     if entry.get("bytes") != len(report_bytes):

--- a/scripts/tests/test_local_consumer_endpoint_evidence_capture.py
+++ b/scripts/tests/test_local_consumer_endpoint_evidence_capture.py
@@ -19,6 +19,7 @@ from scripts.check_spec_governance import (
 REPO_ROOT = Path(__file__).resolve().parents[2]
 FINGERPRINT = "a" * 64
 OTHER_FINGERPRINT = "b" * 64
+RUN_ID = "local-consumer-endpoint-20260824T000000Z"
 
 
 def load_capture():
@@ -81,13 +82,114 @@ def write_capture_inputs(root: Path) -> dict[str, Path]:
         "status": inputs / "status.redacted.json",
     }
     files["cli"].write_bytes(b"binary-bytes")
-    files["ledger"].write_text('{"state":"settled","redacted":true}\n', encoding="utf-8")
-    files["log"].write_text("local endpoint log redacted\n", encoding="utf-8")
-    files["rate"].write_text('{"rate_card":"redacted","sha_only":true}\n', encoding="utf-8")
-    files["status"].write_text('{"status":"ready","redacted":true}\n', encoding="utf-8")
+    try:
+        commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+    except subprocess.CalledProcessError:
+        commit = "0" * 40
+    refresh_semantic_support_inputs(files, commit, RUN_ID)
     files["matrix"] = inputs / "trusted-metadata-transport-matrix.json"
     files["matrix"].write_text(json.dumps(valid_transport_matrix("0" * 40), indent=2) + "\n", encoding="utf-8")
     return files
+
+
+def write_json(path: Path, value: dict[str, object]) -> None:
+    path.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+
+
+def valid_ledger_report(commit: str, run_id: str) -> dict[str, object]:
+    return {
+        "schema_version": "macprovider.local-consumer-ledger-redacted.v1",
+        "repository": {"name": "Augustas11/macprovider", "commit": commit},
+        "run_id": run_id,
+        "summary": {
+            "settled_micro_usd": "227",
+            "released_micro_usd": "115",
+            "held_micro_usd": "0",
+            "reserved_micro_usd": "0",
+        },
+        "recovery_transitions": [
+            {"state": "held", "reason": "restart_recovery", "admission_estimate_micro_usd": "115"},
+            {"state": "released", "reason": "operator_release_held", "admission_estimate_micro_usd": "115"},
+        ],
+        "final_state": {"held_reservation_count": 0, "reserved_reservation_count": 0},
+    }
+
+
+def valid_log_report(commit: str, run_id: str) -> dict[str, object]:
+    return {
+        "schema_version": "macprovider.local-consumer-log-redacted.v1",
+        "repository": {"name": "Augustas11/macprovider", "commit": commit},
+        "run_id": run_id,
+        "events": {
+            "endpoint_started": True,
+            "sdk_permitted": True,
+            "budget_denial": True,
+            "upstream_contact_changed_after_permitted": True,
+            "upstream_contact_unchanged_after_denial": True,
+            "crash_with_active_reservation": True,
+            "restart_recovery_observed": True,
+            "recovery_release_observed": True,
+            "graceful_stop": True,
+        },
+        "redaction": {
+            "bearer_tokens_redacted": True,
+            "local_token_logged": False,
+            "raw_completion_logged": False,
+            "raw_prompt_logged": False,
+            "upstream_credential_logged": False,
+        },
+    }
+
+
+def valid_rate_report(commit: str, run_id: str) -> dict[str, object]:
+    return {
+        "schema_version": "macprovider.local-consumer-rate-card-redacted.v1",
+        "repository": {"name": "Augustas11/macprovider", "commit": commit},
+        "run_id": run_id,
+        "pricing_trust_state": "trusted",
+        "gateway_kind": "production",
+        "model_id": "mlx-community/Llama-3.2-3B-Instruct-4bit",
+        "budget_configured_micro_usd": "100000",
+        "max_admission_micro_usd": "50000",
+        "interrupted_admission_estimate_micro_usd": "115",
+    }
+
+
+def valid_status_report(commit: str, run_id: str) -> dict[str, object]:
+    return {
+        "schema_version": "macprovider.local-consumer-status-redacted.v1",
+        "repository": {"name": "Augustas11/macprovider", "commit": commit},
+        "run_id": run_id,
+        "observations": {
+            "local_base_url_configured": True,
+            "openai_sdk_used": True,
+            "generated_local_token_used_as_api_key": True,
+            "permitted_chat_completion_observed": True,
+            "over_budget_denial_observed": True,
+            "held_reservation_survived_restart": True,
+            "recovery_release_observed": True,
+            "upstream_contact_observed": True,
+        },
+        "restart_state": {
+            "bound_url": "http://127.0.0.1:4545",
+            "pricing_trust_state": "trusted",
+            "budget_held_micro_usd": "115",
+            "budget_used_micro_usd": "227",
+        },
+        "final_state": {
+            "listener_count": 0,
+            "status_exit": 4,
+            "budget_held_micro_usd": "0",
+            "budget_reserved_micro_usd": "0",
+        },
+    }
+
+
+def refresh_semantic_support_inputs(files: dict[str, Path], commit: str, run_id: str = RUN_ID) -> None:
+    write_json(files["ledger"], valid_ledger_report(commit, run_id))
+    write_json(files["log"], valid_log_report(commit, run_id))
+    write_json(files["rate"], valid_rate_report(commit, run_id))
+    write_json(files["status"], valid_status_report(commit, run_id))
 
 
 def valid_transport_matrix(commit: str) -> dict[str, object]:
@@ -309,6 +411,14 @@ class LocalConsumerEndpointEvidenceCaptureTests(unittest.TestCase):
                 "macprovider.trusted-metadata-transport-matrix.v1",
                 evidence["support_artifacts"]["trusted_metadata_transport_matrix"]["report"]["schema_version"],
             )
+            self.assertEqual(
+                "macprovider.local-consumer-ledger-redacted.v1",
+                evidence["support_artifacts"]["ledger_capture"]["report"]["schema_version"],
+            )
+            self.assertEqual(
+                RUN_ID,
+                evidence["support_artifacts"]["status_capture"]["report"]["run_id"],
+            )
 
             subprocess.run(["git", "add", output], cwd=root, check=True)
             subprocess.run(["git", "commit", "-q", "-m", "add evidence"], cwd=root, check=True)
@@ -354,6 +464,45 @@ class LocalConsumerEndpointEvidenceCaptureTests(unittest.TestCase):
             evidence = json.loads((root / output).read_text(encoding="utf-8"))
             self.assertEqual("macprovider.local-consumer-endpoint-evidence.v1", evidence["schema_version"])
             self.assertNotIn("trusted_metadata_transport_matrix", evidence["support_artifacts"])
+            self.assertNotIn("report", evidence["support_artifacts"]["ledger_capture"])
+
+    def test_capture_rejects_semantically_empty_v2_support_artifacts(self) -> None:
+        capture = load_capture()
+        cases = {
+            "ledger": ("ledger", '{"state":"settled","redacted":true}\n'),
+            "log": ("log", "local endpoint log redacted\n"),
+            "rate": ("rate", '{"rate_card":"redacted","sha_only":true}\n'),
+            "status": ("status", '{"status":"ready","redacted":true}\n'),
+        }
+        for name, (key, payload) in cases.items():
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory).resolve()
+                commit = git_init(root)
+                files = write_capture_inputs(root)
+                refresh_semantic_support_inputs(files, commit, RUN_ID)
+                files[key].write_text(payload, encoding="utf-8")
+                with self.assertRaises(SystemExit):
+                    capture.main(base_argv(root, commit, files, f"journeys/evidence/local-consumer-endpoint-empty-{name}.redacted.json"))
+
+    def test_capture_rejects_loopback_prefix_with_remote_url_host(self) -> None:
+        capture = load_capture()
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory).resolve()
+            commit = git_init(root)
+            files = write_capture_inputs(root)
+            refresh_semantic_support_inputs(files, commit, RUN_ID)
+            status = json.loads(files["status"].read_text(encoding="utf-8"))
+            status["restart_state"]["bound_url"] = "http://127.0.0.1:80@evil.example"
+            write_json(files["status"], status)
+            with self.assertRaises(SystemExit):
+                capture.main(
+                    base_argv(
+                        root,
+                        commit,
+                        files,
+                        "journeys/evidence/local-consumer-endpoint-remote-host.redacted.json",
+                    )
+                )
 
     def test_capture_rejects_bad_transport_matrix_reports(self) -> None:
         capture = load_capture()
@@ -384,59 +533,43 @@ class LocalConsumerEndpointEvidenceCaptureTests(unittest.TestCase):
             root = Path(directory).resolve()
             commit = git_init(root)
             files = write_capture_inputs(root)
+            del files["matrix"]
             files["log"].write_text("Authorization: Bearer redacted\n", encoding="utf-8")
+            argv = base_argv(root, commit, files, "journeys/evidence/local-consumer-endpoint-redacted-auth.redacted.json")
+            argv[argv.index("--requirement-ids") + 1] = "SPEC-045-R001"
             self.assertEqual(
                 0,
-                capture.main(
-                    base_argv(
-                        root,
-                        commit,
-                        files,
-                        "journeys/evidence/local-consumer-endpoint-redacted-auth.redacted.json",
-                    )
-                ),
+                capture.main(argv),
             )
 
             files = write_capture_inputs(root)
+            del files["matrix"]
             files["log"].write_text("Authorization: Basic redacted\n", encoding="utf-8")
+            argv = base_argv(root, commit, files, "journeys/evidence/local-consumer-endpoint-redacted-basic-auth.redacted.json")
+            argv[argv.index("--requirement-ids") + 1] = "SPEC-045-R001"
             self.assertEqual(
                 0,
-                capture.main(
-                    base_argv(
-                        root,
-                        commit,
-                        files,
-                        "journeys/evidence/local-consumer-endpoint-redacted-basic-auth.redacted.json",
-                    )
-                ),
+                capture.main(argv),
             )
 
             files = write_capture_inputs(root)
+            del files["matrix"]
             files["log"].write_text("payload={'authorization': 'Basic redacted'}\n", encoding="utf-8")
+            argv = base_argv(root, commit, files, "journeys/evidence/local-consumer-endpoint-quoted-redacted-basic-auth.redacted.json")
+            argv[argv.index("--requirement-ids") + 1] = "SPEC-045-R001"
             self.assertEqual(
                 0,
-                capture.main(
-                    base_argv(
-                        root,
-                        commit,
-                        files,
-                        "journeys/evidence/local-consumer-endpoint-quoted-redacted-basic-auth.redacted.json",
-                    )
-                ),
+                capture.main(argv),
             )
 
             files = write_capture_inputs(root)
+            del files["matrix"]
             files["log"].write_text('{"authorization":"redacted"}\n', encoding="utf-8")
+            argv = base_argv(root, commit, files, "journeys/evidence/local-consumer-endpoint-json-redacted-auth.redacted.json")
+            argv[argv.index("--requirement-ids") + 1] = "SPEC-045-R001"
             self.assertEqual(
                 0,
-                capture.main(
-                    base_argv(
-                        root,
-                        commit,
-                        files,
-                        "journeys/evidence/local-consumer-endpoint-json-redacted-auth.redacted.json",
-                    )
-                ),
+                capture.main(argv),
             )
 
     def test_capture_rejects_fake_gateway_kind(self) -> None:

--- a/scripts/tests/test_local_consumer_endpoint_journey_result.py
+++ b/scripts/tests/test_local_consumer_endpoint_journey_result.py
@@ -45,6 +45,11 @@ TRANSPORT_MATRIX_SCENARIOS = (
 )
 
 
+def canonical_report_record(report: dict[str, object]) -> dict[str, object]:
+    payload = (json.dumps(report, indent=2) + "\n").encode("utf-8")
+    return {"sha256": hashlib.sha256(payload).hexdigest(), "bytes": len(payload), "report": report}
+
+
 def load_builder():
     path = REPO_ROOT / "scripts" / "build-local-consumer-endpoint-journey-result.py"
     import sys
@@ -168,6 +173,95 @@ def valid_transport_matrix(commit: str) -> dict[str, object]:
     }
 
 
+def valid_ledger_report(commit: str, run_id: str) -> dict[str, object]:
+    return {
+        "schema_version": "macprovider.local-consumer-ledger-redacted.v1",
+        "repository": {"name": "Augustas11/macprovider", "commit": commit},
+        "run_id": run_id,
+        "summary": {
+            "settled_micro_usd": "227",
+            "released_micro_usd": "115",
+            "held_micro_usd": "0",
+            "reserved_micro_usd": "0",
+        },
+        "recovery_transitions": [
+            {"state": "held", "reason": "restart_recovery", "admission_estimate_micro_usd": "115"},
+            {"state": "released", "reason": "operator_release_held", "admission_estimate_micro_usd": "115"},
+        ],
+        "final_state": {"held_reservation_count": 0, "reserved_reservation_count": 0},
+    }
+
+
+def valid_log_report(commit: str, run_id: str) -> dict[str, object]:
+    return {
+        "schema_version": "macprovider.local-consumer-log-redacted.v1",
+        "repository": {"name": "Augustas11/macprovider", "commit": commit},
+        "run_id": run_id,
+        "events": {
+            "endpoint_started": True,
+            "sdk_permitted": True,
+            "budget_denial": True,
+            "upstream_contact_changed_after_permitted": True,
+            "upstream_contact_unchanged_after_denial": True,
+            "crash_with_active_reservation": True,
+            "restart_recovery_observed": True,
+            "recovery_release_observed": True,
+            "graceful_stop": True,
+        },
+        "redaction": {
+            "bearer_tokens_redacted": True,
+            "local_token_logged": False,
+            "raw_completion_logged": False,
+            "raw_prompt_logged": False,
+            "upstream_credential_logged": False,
+        },
+    }
+
+
+def valid_rate_report(commit: str, run_id: str) -> dict[str, object]:
+    return {
+        "schema_version": "macprovider.local-consumer-rate-card-redacted.v1",
+        "repository": {"name": "Augustas11/macprovider", "commit": commit},
+        "run_id": run_id,
+        "pricing_trust_state": "trusted",
+        "gateway_kind": "staging",
+        "model_id": "mlx-community/Llama-3.2-3B-Instruct-4bit",
+        "budget_configured_micro_usd": "100000",
+        "max_admission_micro_usd": "50000",
+        "interrupted_admission_estimate_micro_usd": "115",
+    }
+
+
+def valid_status_report(commit: str, run_id: str) -> dict[str, object]:
+    return {
+        "schema_version": "macprovider.local-consumer-status-redacted.v1",
+        "repository": {"name": "Augustas11/macprovider", "commit": commit},
+        "run_id": run_id,
+        "observations": {
+            "local_base_url_configured": True,
+            "openai_sdk_used": True,
+            "generated_local_token_used_as_api_key": True,
+            "permitted_chat_completion_observed": True,
+            "over_budget_denial_observed": True,
+            "held_reservation_survived_restart": True,
+            "recovery_release_observed": True,
+            "upstream_contact_observed": True,
+        },
+        "restart_state": {
+            "bound_url": "http://127.0.0.1:4545",
+            "pricing_trust_state": "trusted",
+            "budget_held_micro_usd": "115",
+            "budget_used_micro_usd": "227",
+        },
+        "final_state": {
+            "listener_count": 0,
+            "status_exit": 4,
+            "budget_held_micro_usd": "0",
+            "budget_reserved_micro_usd": "0",
+        },
+    }
+
+
 def write_redacted_source(root: Path, signed: dict[str, object], source: str) -> None:
     has_transport_requirements = any(
         requirement_id in {"SPEC-045-R003", "SPEC-045-R004", "SPEC-045-R008"}
@@ -176,6 +270,35 @@ def write_redacted_source(root: Path, signed: dict[str, object], source: str) ->
     support_artifact_ids = ["cli_binary", "ledger_capture", "log_capture", "rate_card_capture", "status_capture"]
     if has_transport_requirements:
         support_artifact_ids.append(TRANSPORT_MATRIX_ARTIFACT_ID)
+    source_sha = signed["repository"]["commit"]
+    run_id = signed["run_id"]
+    support_artifacts = {
+        "cli_binary": {"role": "cli-binary", "sha256": FINGERPRINT, "bytes": 12},
+        "ledger_capture": {"role": "redacted-ledger-capture", "sha256": FINGERPRINT, "bytes": 12},
+        "log_capture": {"role": "redacted-log-capture", "sha256": FINGERPRINT, "bytes": 12},
+        "rate_card_capture": {"role": "redacted-rate-card-capture", "sha256": FINGERPRINT, "bytes": 12},
+        "status_capture": {"role": "redacted-status-capture", "sha256": FINGERPRINT, "bytes": 12},
+    }
+    if has_transport_requirements:
+        for artifact_id, role, report in (
+            ("ledger_capture", "redacted-ledger-capture", valid_ledger_report(source_sha, run_id)),
+            ("log_capture", "redacted-log-capture", valid_log_report(source_sha, run_id)),
+            ("rate_card_capture", "redacted-rate-card-capture", valid_rate_report(source_sha, run_id)),
+            ("status_capture", "redacted-status-capture", valid_status_report(source_sha, run_id)),
+        ):
+            record = canonical_report_record(report)
+            signed["candidate_identity"][{
+                "ledger_capture": "ledger_sha256",
+                "log_capture": "log_capture_sha256",
+                "rate_card_capture": "rate_card_sha256",
+                "status_capture": "status_capture_sha256",
+            }[artifact_id]] = record["sha256"]
+            support_artifacts[artifact_id] = {
+                "role": role,
+                "sha256": record["sha256"],
+                "bytes": record["bytes"],
+                "report": report,
+            }
     evidence = {
         "schema_version": "macprovider.local-consumer-endpoint-evidence.v2" if has_transport_requirements else "macprovider.local-consumer-endpoint-evidence.v1",
         "journey_id": LOCAL_CONSUMER_ENDPOINT_JOURNEY_ID,
@@ -198,13 +321,7 @@ def write_redacted_source(root: Path, signed: dict[str, object], source: str) ->
         "redaction": signed["redaction"],
         "observations": signed["observations"],
         "candidate_identity": signed["candidate_identity"],
-        "support_artifacts": {
-            "cli_binary": {"role": "cli-binary", "sha256": FINGERPRINT, "bytes": 12},
-            "ledger_capture": {"role": "redacted-ledger-capture", "sha256": FINGERPRINT, "bytes": 12},
-            "log_capture": {"role": "redacted-log-capture", "sha256": FINGERPRINT, "bytes": 12},
-            "rate_card_capture": {"role": "redacted-rate-card-capture", "sha256": FINGERPRINT, "bytes": 12},
-            "status_capture": {"role": "redacted-status-capture", "sha256": FINGERPRINT, "bytes": 12},
-        },
+        "support_artifacts": support_artifacts,
         "review": {
             "reviewed_at": "2026-08-24T00:01:00Z",
             "reviewer_role": "release-operator",
@@ -660,6 +777,34 @@ class LocalConsumerEndpointJourneyResultTests(unittest.TestCase):
             )
             self.assertTrue(any("canonical report bytes" in error for error in result.errors))
 
+    def test_governance_rejects_v2_source_without_semantic_support_reports(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory).resolve()
+            signed = complete_signed_payload()
+            source = "journeys/evidence/local-consumer-endpoint-staging.redacted.json"
+            write_redacted_source(root, signed, source)
+            payload = json.loads((root / source).read_text(encoding="utf-8"))
+            for support_id in ("ledger_capture", "log_capture", "rate_card_capture", "status_capture"):
+                payload["support_artifacts"][support_id].pop("report")
+                payload["support_artifacts"][support_id]["sha256"] = FINGERPRINT
+                payload["support_artifacts"][support_id]["bytes"] = 12
+            raw = (json.dumps(payload, indent=2) + "\n").encode("utf-8")
+            (root / source).write_bytes(raw)
+            signed["artifacts"][0]["sha256"] = hashlib.sha256(raw).hexdigest()
+
+            result = ValidationResult()
+            _validate_local_consumer_endpoint_journey_result(
+                signed,
+                "SPEC-045-R008",
+                [LOCAL_CONSUMER_ENDPOINT_JOURNEY_ID],
+                signed["artifacts"],
+                signed["steps"],
+                "evidence[0]",
+                result,
+                root=root,
+            )
+            self.assertTrue(any("report" in error and "missing required field" in error for error in result.errors))
+
     def test_governance_rejects_malformed_support_artifacts_reviewed_when_source_matches_signed(self) -> None:
         cases = {
             "object": {
@@ -871,6 +1016,17 @@ class LocalConsumerEndpointJourneyResultTests(unittest.TestCase):
         ]
         matrix_report = valid_transport_matrix(source_sha)
         matrix_bytes = (json.dumps(matrix_report, indent=2) + "\n").encode("utf-8")
+        ledger_record = canonical_report_record(valid_ledger_report(source_sha, "local-consumer-endpoint-test-run"))
+        log_record = canonical_report_record(valid_log_report(source_sha, "local-consumer-endpoint-test-run"))
+        rate_record = canonical_report_record(valid_rate_report(source_sha, "local-consumer-endpoint-test-run"))
+        status_record = canonical_report_record(valid_status_report(source_sha, "local-consumer-endpoint-test-run"))
+        candidate_identity = valid_signed()["candidate_identity"]
+        candidate_identity.update({
+            "ledger_sha256": ledger_record["sha256"],
+            "log_capture_sha256": log_record["sha256"],
+            "rate_card_sha256": rate_record["sha256"],
+            "status_capture_sha256": status_record["sha256"],
+        })
         evidence = {
             "schema_version": "macprovider.local-consumer-endpoint-evidence.v2",
             "journey_id": LOCAL_CONSUMER_ENDPOINT_JOURNEY_ID,
@@ -900,13 +1056,13 @@ class LocalConsumerEndpointJourneyResultTests(unittest.TestCase):
                 "local_account_names_redacted": True,
             },
             "observations": valid_signed()["observations"],
-            "candidate_identity": valid_signed()["candidate_identity"],
+            "candidate_identity": candidate_identity,
             "support_artifacts": {
                 "cli_binary": {"role": "cli-binary", "sha256": FINGERPRINT, "bytes": 12},
-                "ledger_capture": {"role": "redacted-ledger-capture", "sha256": FINGERPRINT, "bytes": 12},
-                "log_capture": {"role": "redacted-log-capture", "sha256": FINGERPRINT, "bytes": 12},
-                "rate_card_capture": {"role": "redacted-rate-card-capture", "sha256": FINGERPRINT, "bytes": 12},
-                "status_capture": {"role": "redacted-status-capture", "sha256": FINGERPRINT, "bytes": 12},
+                "ledger_capture": {"role": "redacted-ledger-capture", **ledger_record},
+                "log_capture": {"role": "redacted-log-capture", **log_record},
+                "rate_card_capture": {"role": "redacted-rate-card-capture", **rate_record},
+                "status_capture": {"role": "redacted-status-capture", **status_record},
                 TRANSPORT_MATRIX_ARTIFACT_ID: {
                     "role": "trusted-metadata-transport-matrix",
                     "sha256": hashlib.sha256(matrix_bytes).hexdigest(),
@@ -968,6 +1124,33 @@ class LocalConsumerEndpointJourneyResultTests(unittest.TestCase):
         identity["upstream_gateway_origin_sha256"] = NON_ALLOWLISTED_GATEWAY_ORIGIN_SHA256
         with self.assertRaises(SystemExit):
             builder.require_candidate_identity(identity)
+
+    def test_builder_rejects_semantically_empty_v2_support_artifacts(self) -> None:
+        builder = load_builder()
+        identity = valid_signed()["candidate_identity"]
+        support = {
+            "cli_binary": {"role": "cli-binary", "sha256": FINGERPRINT, "bytes": 12},
+            "ledger_capture": {"role": "redacted-ledger-capture", "sha256": FINGERPRINT, "bytes": 12},
+            "log_capture": {"role": "redacted-log-capture", "sha256": FINGERPRINT, "bytes": 12},
+            "rate_card_capture": {"role": "redacted-rate-card-capture", "sha256": FINGERPRINT, "bytes": 12},
+            "status_capture": {"role": "redacted-status-capture", "sha256": FINGERPRINT, "bytes": 12},
+            TRANSPORT_MATRIX_ARTIFACT_ID: {
+                "role": "trusted-metadata-transport-matrix",
+                "sha256": hashlib.sha256((json.dumps(valid_transport_matrix("1" * 40), indent=2) + "\n").encode("utf-8")).hexdigest(),
+                "bytes": len((json.dumps(valid_transport_matrix("1" * 40), indent=2) + "\n").encode("utf-8")),
+                "report": valid_transport_matrix("1" * 40),
+            },
+        }
+        with self.assertRaises(SystemExit):
+            builder.require_support_artifacts(
+                support,
+                identity,
+                set(support),
+                "1" * 40,
+                "local-consumer-endpoint-test-run",
+                valid_signed()["observations"],
+                require_semantic_reports=True,
+            )
 
     def test_builder_rejects_malformed_mlx_model_ids(self) -> None:
         builder = load_builder()


### PR DESCRIPTION
## Summary

Adds the reviewed physical SPEC-045 evidence needed for #1433 and closes an adversarial gap before signing.

- Captures the exact merged `1.8.123` release binary against the production Malibu gateway using OpenAI Python SDK 2.44.0.
- Records permitted inference, local over-budget denial without a second upstream contact, crash/restart held-reservation recovery, explicit operator release, and final zero-held/zero-reserved state.
- Embeds the exact 19-scenario real-socket trusted-metadata transport matrix from source commit `d51b79b07876da9ab0590f9721936530aa614bde`.
- Requires v2 evidence to embed closed, canonical ledger/log/rate/status reports bound to the same source commit and run ID.
- Rejects semantically empty support artifacts and validates the reports at capture, builder, and governance boundaries.
- Parses the reported loopback URL structurally, rejecting userinfo/remote-host prefix tricks.

This PR does not promote conformance by itself. After merge, the protected signer workflows will produce separately authorized signed results for all seven requirements tracked by #1433.

## Physical evidence

- CLI: `1.8.123`, 65,918,000 bytes, SHA-256 `30d3fe336f7b28ae2e579d2c1cda4d40f4f673e28d2c90377782fd11f7a4bcd5`.
- Production model: `mlx-community/Qwen3-8B-4bit`.
- Transport matrix: 19/19 scenarios passed, 2,283 canonical bytes, SHA-256 `a799ebe65c43b67231a209b55553666eb8b17274bdecf638a22e0ecf33094159`.
- Recovery: active 115 micro-USD reservation survived forced termination as `restart_recovery`, then was explicitly released; final held/reserved exposure was zero.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts.tests.test_local_consumer_endpoint_evidence_capture scripts.tests.test_local_consumer_endpoint_journey_result` — 46 passed.
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts.tests.test_spec_governance` — 46 passed.
- `bash scripts/test-signed-local-consumer-endpoint-journey-workflow.sh` — passed.
- `python3 scripts/check_spec_governance.py --root .` — passed.
- Committed-evidence builder dry run for R003/R004/R008 — passed.
- Python compilation and `git diff --check` — passed.

## Audit gate

Final full-diff review:

- Code: 0 critical / 0 high / 0 medium.
- Security (Sol 5.6): 0 critical / 0 high / 0 medium.
- Architecture: 0 critical / 0 high / 0 medium.
- Adversarial (Sol 5.6): 0 critical / 0 high / 0 medium.

The first adversarial pass found one HIGH: opaque support files could be semantically empty. Closed embedded support schemas and cross-run/source/hash validation resolved it. The corrected security pass then found one MEDIUM loopback-prefix parser bypass; structural URL parsing and a regression test resolved it. Both were reverified at zero C/H/M.

## Governance

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": ["SPEC-045"],
  "requirements": ["SPEC-045-R003", "SPEC-045-R004", "SPEC-045-R008"],
  "authority_domains": ["local-consumer-endpoint"],
  "arbitration": ["UNKNOWN"],
  "tests": [
    "PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts.tests.test_local_consumer_endpoint_evidence_capture scripts.tests.test_local_consumer_endpoint_journey_result",
    "PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts.tests.test_spec_governance",
    "bash scripts/test-signed-local-consumer-endpoint-journey-workflow.sh",
    "python3 scripts/check_spec_governance.py --root .",
    "git diff --check origin/main...HEAD"
  ],
  "journeys": ["JOURNEY-LOCAL-CONSUMER-ENDPOINT"],
  "issue": "https://github.com/Augustas11/macprovider/issues/1433"
}
SPEC-GOVERNANCE-DECLARATION-END

Advances #1433; does not close it until signed promotions merge.
