### PR TITLE
Bind #1433 signed evidence to source and review commits

### DIFF
--- a/.github/workflows/promote-signed-local-consumer-endpoint-journey.yml
+++ b/.github/workflows/promote-signed-local-consumer-endpoint-journey.yml
@@ -280,13 +280,11 @@ jobs:
         shell: bash
         env:
           SOURCE_SHA: ${{ steps.request.outputs.source_sha }}
+          EVIDENCE_SHA: ${{ steps.request.outputs.evidence_sha }}
           REQUIREMENT_IDS: ${{ steps.request.outputs.requirement_ids }}
         run: |
           set -euo pipefail
-          python3 scripts/preflight-signed-journey-promotion.py \
-            --source-sha "$SOURCE_SHA" \
-            --requirement-ids "$REQUIREMENT_IDS" \
-            --journey-id JOURNEY-LOCAL-CONSUMER-ENDPOINT
+          python3 scripts/preflight-signed-journey-promotion.py --source-sha "$SOURCE_SHA" --evidence-sha "$EVIDENCE_SHA" --requirement-ids "$REQUIREMENT_IDS" --journey-id JOURNEY-LOCAL-CONSUMER-ENDPOINT
 
       - name: Verify protected environment and repository posture
         shell: bash

--- a/schemas/journey-result-v1.schema.json
+++ b/schemas/journey-result-v1.schema.json
@@ -66,6 +66,15 @@
             "commit": {"type": "string", "pattern": "^[0-9a-f]{40}$"}
           }
         },
+        "evidence_repository": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["name", "commit"],
+          "properties": {
+            "name": {"const": "Augustas11/macprovider"},
+            "commit": {"type": "string", "pattern": "^[0-9a-f]{40}$"}
+          }
+        },
         "captured_at": {
           "type": "string",
           "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"

--- a/scripts/build-local-consumer-endpoint-journey-result.py
+++ b/scripts/build-local-consumer-endpoint-journey-result.py
@@ -955,6 +955,7 @@ def build_payload(root: Path, source: str, *, source_sha: str, evidence_sha: str
         "journey_id": JOURNEY_ID,
         "requirement_ids": selected_requirements,
         "repository": {"name": REPOSITORY, "commit": source_sha},
+        "evidence_repository": {"name": REPOSITORY, "commit": evidence_sha},
         "captured_at": captured_at,
         "expires_at": expires_at,
         "operator": operator,

--- a/scripts/check_spec_governance.py
+++ b/scripts/check_spec_governance.py
@@ -1270,6 +1270,19 @@ def _reachable_commit(root: Path, commit: str) -> bool:
     ).returncode == 0
 
 
+def _artifact_bytes_at_commit(root: Path, commit: str, source: str) -> bytes | None:
+    completed = subprocess.run(
+        ["git", "show", f"{commit}:{source}"],
+        cwd=root,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    if completed.returncode != 0:
+        return None
+    return completed.stdout
+
+
 def _looks_like_signed_journey_result(root: Path, source: str) -> bool:
     path = _repository_path(root, source, source, ValidationResult())
     if path is None:
@@ -3644,6 +3657,7 @@ def _validate_signed_journey_result(
             result.error(f"{location}.signed.repository.commit", "must match this requirement's commit evidence")
 
     evidence_repository = signed.get("evidence_repository")
+    evidence_commit: str | None = None
     if evidence_repository is not None and _expect_object(
         evidence_repository,
         f"{location}.signed.evidence_repository",
@@ -3706,17 +3720,37 @@ def _validate_signed_journey_result(
         expected_sha = _string(artifact.get("sha256"), SHA256_HEX_RE, f"{loc}.sha256", result)
         artifact_source = _string(artifact.get("source"), None, f"{loc}.source", result)
         if artifact_source:
-            if not _source_under_journey_evidence(root, artifact_source):
+            source_is_allowed = _source_under_journey_evidence(root, artifact_source)
+            if not source_is_allowed:
                 result.error(f"{loc}.source", "must be under journeys/evidence/")
             artifact_path = _repository_path(root, artifact_source, f"{loc}.source", result)
+            reviewed_artifact_bytes: bytes | None = None
+            if evidence_commit and source_is_allowed:
+                reviewed_artifact_bytes = _artifact_bytes_at_commit(root, evidence_commit, artifact_source)
+                if reviewed_artifact_bytes is None:
+                    result.error(
+                        f"{loc}.source",
+                        "does not exist at signed evidence_repository.commit",
+                    )
+                elif expected_sha and hashlib.sha256(reviewed_artifact_bytes).hexdigest() != expected_sha:
+                    result.error(
+                        f"{loc}.sha256",
+                        "does not match artifact bytes at signed evidence_repository.commit",
+                    )
             if artifact_path is not None:
                 try:
-                    actual_sha = hashlib.sha256(artifact_path.read_bytes()).hexdigest()
+                    artifact_bytes = artifact_path.read_bytes()
                 except OSError as exc:
                     result.error(f"{loc}.source", f"cannot read artifact source: {exc}")
                 else:
+                    actual_sha = hashlib.sha256(artifact_bytes).hexdigest()
                     if expected_sha and actual_sha != expected_sha:
                         result.error(f"{loc}.sha256", "does not match artifact source bytes")
+                    if reviewed_artifact_bytes is not None and artifact_bytes != reviewed_artifact_bytes:
+                        result.error(
+                            f"{loc}.source",
+                            "does not match artifact bytes at signed evidence_repository.commit",
+                        )
 
     run_result = signed.get("result")
     if _expect_object(run_result, f"{location}.signed.result", result):

--- a/scripts/check_spec_governance.py
+++ b/scripts/check_spec_governance.py
@@ -220,6 +220,8 @@ LOCAL_CONSUMER_ENDPOINT_EVIDENCE_CONTROL_IMPLEMENTATION_MAPPINGS = frozenset(
     {
         "scripts/build-local-consumer-endpoint-journey-result.py:def build_payload",
         ".github/workflows/promote-signed-local-consumer-endpoint-journey.yml:"
+        "printf 'evidence_sha=%s\\n' \"$GITHUB_SHA\" >> \"$GITHUB_OUTPUT\"",
+        ".github/workflows/promote-signed-local-consumer-endpoint-journey.yml:"
         'python3 scripts/preflight-signed-journey-promotion.py --source-sha "$SOURCE_SHA" '
         '--evidence-sha "$EVIDENCE_SHA" --requirement-ids "$REQUIREMENT_IDS" '
         "--journey-id JOURNEY-LOCAL-CONSUMER-ENDPOINT",

--- a/scripts/check_spec_governance.py
+++ b/scripts/check_spec_governance.py
@@ -216,6 +216,15 @@ TRUSTED_POOL_CREATOR_MVP_EVIDENCE_REQUIREMENT_IDS = {
     f"SPEC-043-R{index:03d}" for index in range(1, 13)
 }
 LOCAL_CONSUMER_ENDPOINT_JOURNEY_ID = "JOURNEY-LOCAL-CONSUMER-ENDPOINT"
+LOCAL_CONSUMER_ENDPOINT_EVIDENCE_CONTROL_IMPLEMENTATION_MAPPINGS = frozenset(
+    {
+        "scripts/build-local-consumer-endpoint-journey-result.py:def build_payload",
+        ".github/workflows/promote-signed-local-consumer-endpoint-journey.yml:"
+        'python3 scripts/preflight-signed-journey-promotion.py --source-sha "$SOURCE_SHA" '
+        '--evidence-sha "$EVIDENCE_SHA" --requirement-ids "$REQUIREMENT_IDS" '
+        "--journey-id JOURNEY-LOCAL-CONSUMER-ENDPOINT",
+    }
+)
 LOCAL_CONSUMER_ENDPOINT_EXECUTION_MODE = "staging-or-production-local-consumer-endpoint"
 LOCAL_CONSUMER_ENDPOINT_ARTIFACT_ID = "redacted-local-consumer-endpoint"
 LOCAL_CONSUMER_ENDPOINT_ALLOWED_GATEWAY_ORIGINS = {
@@ -535,6 +544,7 @@ SIGNED_JOURNEY_RESULT_ALLOWED_KEYS = SIGNED_JOURNEY_RESULT_REQUIRED_KEYS | {
     "eip712",
     "candidate",
     "candidate_identity",
+    "evidence_repository",
     "pool_rejection_timing",
     "signer",
 }
@@ -2647,6 +2657,35 @@ def _validate_local_consumer_endpoint_journey_result(
         )
 
 
+def _validate_local_consumer_evidence_control_mappings(
+    root: Path,
+    signed: dict[str, Any],
+    implementation_mappings: list[str],
+    location: str,
+    result: ValidationResult,
+) -> None:
+    evidence_control_mappings = LOCAL_CONSUMER_ENDPOINT_EVIDENCE_CONTROL_IMPLEMENTATION_MAPPINGS.intersection(
+        implementation_mappings
+    )
+    if not evidence_control_mappings:
+        return
+    evidence_repository = signed.get("evidence_repository")
+    evidence_commit = evidence_repository.get("commit") if isinstance(evidence_repository, dict) else None
+    if not isinstance(evidence_commit, str):
+        result.error(
+            f"{location}.signed.evidence_repository",
+            "is required when the requirement maps reviewed evidence controls",
+        )
+        return
+    for mapping in sorted(evidence_control_mappings):
+        if not _commit_mapping_selector_matches_current(root, evidence_commit, mapping):
+            result.error(
+                location,
+                f"reviewed evidence commit {evidence_commit} does not match current mapped selector "
+                f"fragment {_mapping_selector(mapping)!r} in {_mapping_file(mapping)!r}",
+            )
+
+
 def _local_consumer_compare_source(source_value: Any, signed_value: Any, location: str, result: ValidationResult) -> None:
     if source_value != signed_value:
         result.error(location, "must match local-consumer endpoint signed payload")
@@ -3447,6 +3486,8 @@ def _validate_signed_journey_result(
     openssl_bin: str,
     location: str,
     result: ValidationResult,
+    *,
+    implementation_mappings: list[str] | None = None,
 ) -> bool:
     before = len(result.errors)
     path = _repository_path(root, source, location, result)
@@ -3591,15 +3632,59 @@ def _validate_signed_journey_result(
                 )
 
     repository = signed.get("repository")
+    source_commit: str | None = None
     if _expect_object(repository, f"{location}.signed.repository", result):
         _expect_keys(repository, {"name", "commit"}, {"name", "commit"}, f"{location}.signed.repository", result)
         if repository.get("name") != "Augustas11/macprovider":
             result.error(f"{location}.signed.repository.name", "must equal 'Augustas11/macprovider'")
-        commit = _string(repository.get("commit"), COMMIT_RE, f"{location}.signed.repository.commit", result)
-        if commit and not _reachable_commit(root, commit):
-            result.error(f"{location}.signed.repository.commit", f"commit is not reachable: {commit}")
-        if commit and evidence_commits and commit not in evidence_commits:
+        source_commit = _string(repository.get("commit"), COMMIT_RE, f"{location}.signed.repository.commit", result)
+        if source_commit and not _reachable_commit(root, source_commit):
+            result.error(f"{location}.signed.repository.commit", f"commit is not reachable: {source_commit}")
+        if source_commit and evidence_commits and source_commit not in evidence_commits:
             result.error(f"{location}.signed.repository.commit", "must match this requirement's commit evidence")
+
+    evidence_repository = signed.get("evidence_repository")
+    if evidence_repository is not None and _expect_object(
+        evidence_repository,
+        f"{location}.signed.evidence_repository",
+        result,
+    ):
+        _expect_keys(
+            evidence_repository,
+            {"name", "commit"},
+            {"name", "commit"},
+            f"{location}.signed.evidence_repository",
+            result,
+        )
+        if evidence_repository.get("name") != "Augustas11/macprovider":
+            result.error(
+                f"{location}.signed.evidence_repository.name",
+                "must equal 'Augustas11/macprovider'",
+            )
+        evidence_commit = _string(
+            evidence_repository.get("commit"),
+            COMMIT_RE,
+            f"{location}.signed.evidence_repository.commit",
+            result,
+        )
+        if evidence_commit and not _reachable_commit(root, evidence_commit):
+            result.error(
+                f"{location}.signed.evidence_repository.commit",
+                f"commit is not reachable: {evidence_commit}",
+            )
+        if source_commit and evidence_commit:
+            completed = subprocess.run(
+                ["git", "merge-base", "--is-ancestor", source_commit, evidence_commit],
+                cwd=root,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=False,
+            )
+            if completed.returncode != 0:
+                result.error(
+                    f"{location}.signed.evidence_repository.commit",
+                    "signed.repository.commit must be an ancestor of the reviewed evidence commit",
+                )
 
     artifact_ids: set[str] = set()
     artifact_records = signed.get("artifacts")
@@ -3736,6 +3821,13 @@ def _validate_signed_journey_result(
             result,
             root=root,
         )
+        _validate_local_consumer_evidence_control_mappings(
+            root,
+            signed,
+            implementation_mappings or [],
+            location,
+            result,
+        )
 
     if journey_id == PROVIDER_BYOM_DISCOVERY_JOURNEY_ID:
         _validate_provider_byom_discovery_journey_result(
@@ -3828,6 +3920,9 @@ def _signed_journey_result_satisfies(
                 openssl_bin,
                 f"{location}.evidence[{index}].source",
                 candidate_result,
+                implementation_mappings=[
+                    item for item in requirement.get("implementation", []) if isinstance(item, str)
+                ],
             ):
                 return True
             candidate_errors.extend(candidate_result.errors)
@@ -5082,8 +5177,21 @@ def _validate_conformance_schema(root: Path, conformance: Any, result: Validatio
             ]
             if not commits:
                 result.error(loc, "conformant requirement requires commit evidence for mapped implementation and test files")
+            evidence_control_mappings = (
+                LOCAL_CONSUMER_ENDPOINT_EVIDENCE_CONTROL_IMPLEMENTATION_MAPPINGS
+                if LOCAL_CONSUMER_ENDPOINT_JOURNEY_ID in journeys
+                else frozenset()
+            )
+            for mapping in implementation:
+                if mapping in evidence_control_mappings:
+                    continue
+                for commit in commits:
+                    mapped_file = _mapping_file(mapping)
+                    selector = _mapping_selector(mapping)
+                    if not _commit_mapping_selector_matches_current(root, commit, mapping):
+                        result.error(loc, f"commit evidence {commit} does not match current mapped selector fragment {selector!r} in {mapped_file!r}")
             for commit in commits:
-                for mapping in implementation + tests:
+                for mapping in tests:
                     mapped_file = _mapping_file(mapping)
                     selector = _mapping_selector(mapping)
                     if not _commit_mapping_selector_matches_current(root, commit, mapping):

--- a/scripts/check_spec_governance.py
+++ b/scripts/check_spec_governance.py
@@ -5178,6 +5178,16 @@ def _validate_conformance_schema(root: Path, conformance: Any, result: Validatio
         implementation = _string_list(requirement.get("implementation"), f"{loc}.implementation", result)
         tests = _string_list(requirement.get("tests"), f"{loc}.tests", result)
         journeys = _string_list(requirement.get("journeys"), f"{loc}.journeys", result, JOURNEY_RE)
+        if requirement_id == "SPEC-045-R008":
+            missing_evidence_controls = sorted(
+                LOCAL_CONSUMER_ENDPOINT_EVIDENCE_CONTROL_IMPLEMENTATION_MAPPINGS.difference(implementation)
+            )
+            if missing_evidence_controls:
+                result.error(
+                    f"{loc}.implementation",
+                    "must include every reviewed local-consumer evidence-control mapping: "
+                    + ", ".join(repr(mapping) for mapping in missing_evidence_controls),
+                )
         _validate_mapping_paths(root, implementation, f"{loc}.implementation", result)
         _validate_mapping_paths(root, tests, f"{loc}.tests", result)
         for journey_index, journey in enumerate(journeys):

--- a/scripts/preflight-signed-journey-promotion.py
+++ b/scripts/preflight-signed-journey-promotion.py
@@ -11,6 +11,8 @@ from pathlib import Path
 from typing import Any
 
 from check_spec_governance import (
+    LOCAL_CONSUMER_ENDPOINT_EVIDENCE_CONTROL_IMPLEMENTATION_MAPPINGS,
+    LOCAL_CONSUMER_ENDPOINT_JOURNEY_ID,
     ValidationResult,
     _commit_mapping_selector_matches_current,
     _load_json,
@@ -21,6 +23,9 @@ from check_spec_governance import (
 
 COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
 REQUIREMENT_RE = re.compile(r"^SPEC-[0-9]{3}-R[0-9]{3}$")
+JOURNEY_EVIDENCE_CONTROL_MAPPINGS = {
+    LOCAL_CONSUMER_ENDPOINT_JOURNEY_ID: LOCAL_CONSUMER_ENDPOINT_EVIDENCE_CONTROL_IMPLEMENTATION_MAPPINGS,
+}
 
 
 def die(message: str) -> None:
@@ -52,7 +57,7 @@ def parse_requirement_ids(raw: str) -> list[str]:
     return values
 
 
-def require_reachable_commit(root: Path, commit: str) -> None:
+def require_reachable_commit(root: Path, commit: str, label: str = "--source-sha") -> None:
     completed = subprocess.run(
         ["git", "cat-file", "-e", f"{commit}^{{commit}}"],
         cwd=root,
@@ -61,7 +66,19 @@ def require_reachable_commit(root: Path, commit: str) -> None:
         check=False,
     )
     if completed.returncode != 0:
-        die(f"--source-sha is not reachable: {commit}")
+        die(f"{label} is not reachable: {commit}")
+
+
+def require_ancestor_commit(root: Path, ancestor: str, descendant: str) -> None:
+    completed = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", ancestor, descendant],
+        cwd=root,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    if completed.returncode != 0:
+        die("--source-sha must be an ancestor of --evidence-sha")
 
 
 def assert_commit_matches_current_selectors(
@@ -70,29 +87,49 @@ def assert_commit_matches_current_selectors(
     source_sha: str,
     *,
     location: str,
+    evidence_sha: str | None = None,
+    evidence_control_mappings: frozenset[str] = frozenset(),
 ) -> list[str]:
     errors: list[str] = []
-    mappings: list[str] = []
     for key in ("implementation", "tests"):
         values = requirement.get(key)
-        if isinstance(values, list):
-            mappings.extend(item for item in values if isinstance(item, str))
-    if not mappings:
-        errors.append(f"{location}: no implementation/test mappings to prove against {source_sha}")
-        return errors
-    for mapping in mappings:
-        if not _commit_mapping_selector_matches_current(root, source_sha, mapping):
-            errors.append(
-                f"{location}: commit evidence {source_sha} does not match current mapped selector "
-                f"fragment {_mapping_selector(mapping)!r} in {_mapping_file(mapping)!r}"
+        if not isinstance(values, list):
+            continue
+        for mapping in (item for item in values if isinstance(item, str)):
+            selector_commit = (
+                evidence_sha
+                if key == "implementation" and mapping in evidence_control_mappings and evidence_sha is not None
+                else source_sha
             )
+            if not _commit_mapping_selector_matches_current(root, selector_commit, mapping):
+                errors.append(
+                    f"{location}: commit evidence {selector_commit} does not match current mapped selector "
+                    f"fragment {_mapping_selector(mapping)!r} in {_mapping_file(mapping)!r}"
+                )
+    if not any(isinstance(requirement.get(key), list) and requirement[key] for key in ("implementation", "tests")):
+        errors.append(f"{location}: no implementation/test mappings to prove against {source_sha}")
     return errors
 
 
-def preflight(root: Path, source_sha: str, requirement_ids: list[str], journey_id: str | None) -> None:
+def preflight(
+    root: Path,
+    source_sha: str,
+    requirement_ids: list[str],
+    journey_id: str | None,
+    *,
+    evidence_sha: str | None = None,
+) -> None:
     if not COMMIT_RE.fullmatch(source_sha):
         die("--source-sha must be a 40-character lowercase hex commit")
     require_reachable_commit(root, source_sha)
+    evidence_control_mappings = JOURNEY_EVIDENCE_CONTROL_MAPPINGS.get(journey_id, frozenset())
+    if evidence_control_mappings and evidence_sha is None:
+        die(f"--evidence-sha is required for {journey_id} evidence-control selectors")
+    if evidence_sha is not None:
+        if not COMMIT_RE.fullmatch(evidence_sha):
+            die("--evidence-sha must be a 40-character lowercase hex commit")
+        require_reachable_commit(root, evidence_sha, "--evidence-sha")
+        require_ancestor_commit(root, source_sha, evidence_sha)
     conformance = load_object(root / "specs" / "CONFORMANCE.json", "spec conformance")
     requirements = conformance.get("requirements")
     if not isinstance(requirements, list):
@@ -116,23 +153,53 @@ def preflight(root: Path, source_sha: str, requirement_ids: list[str], journey_i
         if journey_id is not None:
             if not isinstance(journeys, list) or journey_id not in journeys:
                 errors.append(f"{location}: requirement is not mapped to {journey_id}")
-        errors.extend(assert_commit_matches_current_selectors(root, requirement, source_sha, location=location))
+        errors.extend(
+            assert_commit_matches_current_selectors(
+                root,
+                requirement,
+                source_sha,
+                location=location,
+                evidence_sha=evidence_sha,
+                evidence_control_mappings=evidence_control_mappings,
+            )
+        )
 
     if errors:
         for error in errors:
             print(f"error: {error}", file=sys.stderr)
         die("promotion preflight rejected")
-    print(f"preflight-signed-journey-promotion: {len(requirement_ids)} requirement(s) match current selectors at {source_sha}")
+    if evidence_control_mappings:
+        print(
+            "preflight-signed-journey-promotion: "
+            f"{len(requirement_ids)} requirement(s) match source selectors at {source_sha} "
+            f"and evidence controls at {evidence_sha}"
+        )
+    else:
+        print(
+            "preflight-signed-journey-promotion: "
+            f"{len(requirement_ids)} requirement(s) match current selectors at {source_sha}"
+        )
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--root", default=".", help="repository root")
     parser.add_argument("--source-sha", required=True, help="commit captured by the journey evidence")
+    parser.add_argument(
+        "--evidence-sha",
+        default=None,
+        help="reviewed commit containing evidence and promotion controls",
+    )
     parser.add_argument("--requirement-ids", required=True, help="comma-separated requirement IDs to promote")
     parser.add_argument("--journey-id", default=None, help="required mapped journey id")
     args = parser.parse_args(argv)
-    preflight(Path(args.root).resolve(), args.source_sha, parse_requirement_ids(args.requirement_ids), args.journey_id)
+    preflight(
+        Path(args.root).resolve(),
+        args.source_sha,
+        parse_requirement_ids(args.requirement_ids),
+        args.journey_id,
+        evidence_sha=args.evidence_sha,
+    )
     return 0
 
 

--- a/scripts/promote-signed-journey-result.py
+++ b/scripts/promote-signed-journey-result.py
@@ -123,6 +123,9 @@ def require_valid_signed_result(
         openssl_bin,
         f"{requirement_id}.signed_journey_result",
         result,
+        implementation_mappings=[
+            item for item in requirement.get("implementation", []) if isinstance(item, str)
+        ],
     ):
         for error in result.errors:
             print(f"error: {error}", file=sys.stderr)

--- a/scripts/test-signed-local-consumer-endpoint-journey-workflow.sh
+++ b/scripts/test-signed-local-consumer-endpoint-journey-workflow.sh
@@ -145,6 +145,8 @@ if "MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM" in preflight_step:
     raise SystemExit("preflight step must not receive the acceptance signing key")
 if "GH_TOKEN" in preflight_step:
     raise SystemExit("preflight step must not receive the release posture token")
+if "EVIDENCE_SHA" not in preflight_step or '--evidence-sha "$EVIDENCE_SHA"' not in preflight_step:
+    raise SystemExit("preflight step must bind evidence-control selectors to the reviewed evidence commit")
 if "MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM" not in sign_step:
     raise SystemExit("signing step must be the step that imports the acceptance signing key")
 if "GH_TOKEN" not in posture_step:

--- a/scripts/test-signed-local-consumer-endpoint-journey-workflow.sh
+++ b/scripts/test-signed-local-consumer-endpoint-journey-workflow.sh
@@ -49,7 +49,7 @@ required_workflow = [
     'git cat-file -e "${SOURCE_SHA_INPUT}^{commit}"',
     'git merge-base --is-ancestor "$SOURCE_SHA_INPUT" "$GITHUB_SHA"',
     '[[ "$REQUIREMENT_IDS_INPUT" =~ ^SPEC-045-R00[1-8](,SPEC-045-R00[1-8])*$ ]]',
-    "evidence_sha=%s",
+    "printf 'evidence_sha=%s\\n' \"$GITHUB_SHA\" >> \"$GITHUB_OUTPUT\"",
     "requirement_slug=",
     "tr '[:upper:]' '[:lower:]'",
     "tr ',' '-'",

--- a/scripts/tests/test_journey_result_tools.py
+++ b/scripts/tests/test_journey_result_tools.py
@@ -137,6 +137,106 @@ class JourneyResultToolsTests(unittest.TestCase):
 
             self.assertEqual([], validate_repository(root, trusted_journey_result_public_key_sha256=trusted_hash).errors)
 
+    def test_signed_evidence_commit_must_contain_signed_artifact_source(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_repository(root, base_repository())
+            evidence_commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+            private_key = generate_acceptance_key(root)
+
+            artifact_source = "journeys/evidence/reviewed-proof.json"
+            artifact_bytes = b'{"reviewed":true}\n'
+            (root / artifact_source).write_bytes(artifact_bytes)
+            changed_artifact_source = "journeys/evidence/proof.txt"
+            changed_artifact_bytes = b"changed after evidence review\n"
+            (root / changed_artifact_source).write_bytes(changed_artifact_bytes)
+
+            envelope = signed_journey_envelope(
+                evidence_commit,
+                signatures=[],
+                artifacts=["proof", "changed-proof"],
+                artifact_records=[
+                    {
+                        "id": "proof",
+                        "sha256": hashlib.sha256(artifact_bytes).hexdigest(),
+                        "source": artifact_source,
+                    },
+                    {
+                        "id": "changed-proof",
+                        "sha256": hashlib.sha256(changed_artifact_bytes).hexdigest(),
+                        "source": changed_artifact_source,
+                    },
+                ],
+            )
+            envelope["signed"]["evidence_repository"] = {
+                "name": "Augustas11/macprovider",
+                "commit": evidence_commit,
+            }
+            payload_path = root / "journey-payload.json"
+            payload_path.write_text(json.dumps(envelope["signed"], indent=2) + "\n", encoding="utf-8")
+            signed_result_path = root / "journeys" / "evidence" / "signed-result.json"
+            env = os.environ.copy()
+            env["MACPROVIDER_ACCEPTANCE_SIGNING_KEY_PEM"] = private_key
+            openssl = shutil.which("openssl")
+            if openssl is None:
+                raise unittest.SkipTest("openssl is required")
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(SIGNER),
+                    "--root",
+                    str(root),
+                    "--input",
+                    str(payload_path),
+                    "--output",
+                    "journeys/evidence/signed-result.json",
+                    "--verified-at",
+                    "2026-01-01T00:00:01Z",
+                    "--openssl-bin",
+                    openssl,
+                ],
+                env=env,
+                check=True,
+                stdout=subprocess.DEVNULL,
+            )
+
+            conformance_path = root / "specs" / "CONFORMANCE.json"
+            conformance = json.loads(conformance_path.read_text(encoding="utf-8"))
+            requirement = conformance["requirements"][0]
+            requirement["state"] = "conformant"
+            requirement["gap"] = None
+            requirement["journeys"] = ["JOURNEY-BOOT"]
+            digest = hashlib.sha256(signed_result_path.read_bytes()).hexdigest()
+            requirement["evidence"] = [
+                {
+                    "artifact": f"commit:{evidence_commit}",
+                    "source": None,
+                    "captured_at": "2026-01-01",
+                    "expires_at": "2027-01-01",
+                },
+                {
+                    "artifact": f"sha256:{digest}",
+                    "source": "journeys/evidence/signed-result.json",
+                    "captured_at": "2026-01-01",
+                    "expires_at": "2027-01-01",
+                },
+            ]
+            conformance_path.write_text(json.dumps(conformance, indent=2) + "\n", encoding="utf-8")
+            trusted_hash = hashlib.sha256(
+                (root / "security" / "acceptance-candidate-signing-public.pem").read_bytes()
+            ).hexdigest()
+
+            errors = validate_repository(root, trusted_journey_result_public_key_sha256=trusted_hash).errors
+
+            self.assertTrue(
+                any("does not exist at signed evidence_repository.commit" in error for error in errors),
+                errors,
+            )
+            self.assertTrue(
+                any("does not match artifact bytes at signed evidence_repository.commit" in error for error in errors),
+                errors,
+            )
+
     def test_signer_rejects_duplicate_key_input(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/scripts/tests/test_journey_result_tools.py
+++ b/scripts/tests/test_journey_result_tools.py
@@ -14,7 +14,12 @@ import unittest
 import importlib.util
 from pathlib import Path
 
-from scripts.check_spec_governance import validate_repository
+from scripts.check_spec_governance import (
+    LOCAL_CONSUMER_ENDPOINT_EVIDENCE_CONTROL_IMPLEMENTATION_MAPPINGS,
+    ValidationResult,
+    _validate_local_consumer_evidence_control_mappings,
+    validate_repository,
+)
 from scripts.tests.test_spec_governance import (
     SPEC016_PAYOUT_JOURNEY_ID,
     SPEC016_PAYOUT_RUN_ID,
@@ -781,6 +786,266 @@ class JourneyResultToolsTests(unittest.TestCase):
 
             self.assertEqual(0, completed.returncode, completed.stderr)
             self.assertIn("match current selectors", completed.stdout)
+
+    def test_preflight_separates_journey_source_from_reviewed_evidence_controls(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            repository = base_repository()
+            repository["files"]["scripts/build-local-consumer-endpoint-journey-result.py"] = (
+                "def build_payload():\n    return True\n"
+            )
+            requirement = repository["conformance"]["requirements"][0]
+            requirement["implementation"].append(
+                "scripts/build-local-consumer-endpoint-journey-result.py:def build_payload"
+            )
+            requirement["journeys"] = ["JOURNEY-LOCAL-CONSUMER-ENDPOINT"]
+            write_repository(root, repository)
+            source_sha = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+            (root / "scripts" / "build-local-consumer-endpoint-journey-result.py").write_text(
+                "def build_payload():\n    return False\n",
+                encoding="utf-8",
+            )
+            subprocess.run(["git", "add", "."], cwd=root, check=True)
+            subprocess.run(["git", "commit", "-qm", "harden evidence control"], cwd=root, check=True)
+            evidence_sha = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(PREFLIGHT),
+                    "--root",
+                    str(root),
+                    "--source-sha",
+                    source_sha,
+                    "--evidence-sha",
+                    evidence_sha,
+                    "--requirement-ids",
+                    "SPEC-001-R001",
+                    "--journey-id",
+                    "JOURNEY-LOCAL-CONSUMER-ENDPOINT",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(0, completed.returncode, completed.stderr)
+            self.assertIn(f"source selectors at {source_sha}", completed.stdout)
+            self.assertIn(f"evidence controls at {evidence_sha}", completed.stdout)
+
+    def test_preflight_does_not_treat_runtime_selectors_as_evidence_controls(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            repository = base_repository()
+            repository["files"]["scripts/build-local-consumer-endpoint-journey-result.py"] = (
+                "def build_payload():\n    return True\n"
+            )
+            requirement = repository["conformance"]["requirements"][0]
+            requirement["implementation"].append(
+                "scripts/build-local-consumer-endpoint-journey-result.py:def build_payload"
+            )
+            requirement["journeys"] = ["JOURNEY-LOCAL-CONSUMER-ENDPOINT"]
+            write_repository(root, repository)
+            source_sha = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+            (root / "src" / "example.py").write_text("def example():\n    return False\n", encoding="utf-8")
+            (root / "scripts" / "build-local-consumer-endpoint-journey-result.py").write_text(
+                "def build_payload():\n    return False\n",
+                encoding="utf-8",
+            )
+            subprocess.run(["git", "add", "."], cwd=root, check=True)
+            subprocess.run(["git", "commit", "-qm", "change runtime and evidence control"], cwd=root, check=True)
+            evidence_sha = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(PREFLIGHT),
+                    "--root",
+                    str(root),
+                    "--source-sha",
+                    source_sha,
+                    "--evidence-sha",
+                    evidence_sha,
+                    "--requirement-ids",
+                    "SPEC-001-R001",
+                    "--journey-id",
+                    "JOURNEY-LOCAL-CONSUMER-ENDPOINT",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertNotEqual(0, completed.returncode)
+            self.assertIn(f"commit evidence {source_sha}", completed.stderr)
+            self.assertIn("mapped selector fragment 'example'", completed.stderr)
+
+    def test_preflight_keeps_registered_mapping_source_bound_when_listed_as_test(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            repository = base_repository()
+            repository["files"]["scripts/build-local-consumer-endpoint-journey-result.py"] = (
+                "def build_payload():\n    return True\n"
+            )
+            requirement = repository["conformance"]["requirements"][0]
+            requirement["tests"].append(
+                "scripts/build-local-consumer-endpoint-journey-result.py:def build_payload"
+            )
+            requirement["journeys"] = ["JOURNEY-LOCAL-CONSUMER-ENDPOINT"]
+            write_repository(root, repository)
+            source_sha = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+            (root / "scripts" / "build-local-consumer-endpoint-journey-result.py").write_text(
+                "def build_payload():\n    return False\n",
+                encoding="utf-8",
+            )
+            subprocess.run(["git", "add", "."], cwd=root, check=True)
+            subprocess.run(["git", "commit", "-qm", "change misplaced evidence control"], cwd=root, check=True)
+            evidence_sha = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(PREFLIGHT),
+                    "--root",
+                    str(root),
+                    "--source-sha",
+                    source_sha,
+                    "--evidence-sha",
+                    evidence_sha,
+                    "--requirement-ids",
+                    "SPEC-001-R001",
+                    "--journey-id",
+                    "JOURNEY-LOCAL-CONSUMER-ENDPOINT",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertNotEqual(0, completed.returncode)
+            self.assertIn(f"commit evidence {source_sha}", completed.stderr)
+            self.assertIn("mapped selector fragment 'def build_payload'", completed.stderr)
+
+    def test_preflight_requires_evidence_sha_for_registered_journey_controls(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            repository = base_repository()
+            repository["files"]["scripts/build-local-consumer-endpoint-journey-result.py"] = (
+                "def build_payload():\n    return True\n"
+            )
+            requirement = repository["conformance"]["requirements"][0]
+            requirement["implementation"].append(
+                "scripts/build-local-consumer-endpoint-journey-result.py:def build_payload"
+            )
+            requirement["journeys"] = ["JOURNEY-LOCAL-CONSUMER-ENDPOINT"]
+            write_repository(root, repository)
+            source_sha = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(PREFLIGHT),
+                    "--root",
+                    str(root),
+                    "--source-sha",
+                    source_sha,
+                    "--requirement-ids",
+                    "SPEC-001-R001",
+                    "--journey-id",
+                    "JOURNEY-LOCAL-CONSUMER-ENDPOINT",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertNotEqual(0, completed.returncode)
+            self.assertIn("--evidence-sha is required", completed.stderr)
+
+    def test_preflight_rejects_evidence_sha_older_than_source(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_repository(root, base_repository())
+            evidence_sha = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+            (root / "src" / "example.py").write_text("def example():\n    return False\n", encoding="utf-8")
+            subprocess.run(["git", "add", "."], cwd=root, check=True)
+            subprocess.run(["git", "commit", "-qm", "newer source"], cwd=root, check=True)
+            source_sha = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(PREFLIGHT),
+                    "--root",
+                    str(root),
+                    "--source-sha",
+                    source_sha,
+                    "--evidence-sha",
+                    evidence_sha,
+                    "--requirement-ids",
+                    "SPEC-001-R001",
+                    "--journey-id",
+                    "JOURNEY-LOCAL-CONSUMER-ENDPOINT",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertNotEqual(0, completed.returncode)
+            self.assertIn("--source-sha must be an ancestor of --evidence-sha", completed.stderr)
+
+    def test_signed_evidence_commit_is_required_for_evidence_control_mappings(self) -> None:
+        result = ValidationResult()
+        _validate_local_consumer_evidence_control_mappings(
+            REPO_ROOT,
+            {},
+            list(LOCAL_CONSUMER_ENDPOINT_EVIDENCE_CONTROL_IMPLEMENTATION_MAPPINGS),
+            "SPEC-045-R008",
+            result,
+        )
+        self.assertTrue(any("evidence_repository" in error and "required" in error for error in result.errors))
+
+    def test_signed_evidence_commit_binds_only_registered_control_fragments(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            repository = base_repository()
+            mapping = "scripts/build-local-consumer-endpoint-journey-result.py:def build_payload"
+            repository["files"]["scripts/build-local-consumer-endpoint-journey-result.py"] = (
+                "def build_payload():\n    return True\n"
+            )
+            write_repository(root, repository)
+            (root / "scripts" / "build-local-consumer-endpoint-journey-result.py").write_text(
+                "def build_payload():\n    return False\n",
+                encoding="utf-8",
+            )
+            subprocess.run(["git", "add", "."], cwd=root, check=True)
+            subprocess.run(["git", "commit", "-qm", "review evidence control"], cwd=root, check=True)
+            evidence_sha = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+
+            result = ValidationResult()
+            _validate_local_consumer_evidence_control_mappings(
+                root,
+                {"evidence_repository": {"name": "Augustas11/macprovider", "commit": evidence_sha}},
+                [mapping],
+                "SPEC-045-R008",
+                result,
+            )
+            self.assertEqual([], result.errors)
+
+            (root / "scripts" / "build-local-consumer-endpoint-journey-result.py").write_text(
+                "def build_payload():\n    return None\n",
+                encoding="utf-8",
+            )
+            result = ValidationResult()
+            _validate_local_consumer_evidence_control_mappings(
+                root,
+                {"evidence_repository": {"name": "Augustas11/macprovider", "commit": evidence_sha}},
+                [mapping],
+                "SPEC-045-R008",
+                result,
+            )
+            self.assertTrue(any("reviewed evidence commit" in error for error in result.errors))
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_journey_result_tools.py
+++ b/scripts/tests/test_journey_result_tools.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from scripts.check_spec_governance import (
     LOCAL_CONSUMER_ENDPOINT_EVIDENCE_CONTROL_IMPLEMENTATION_MAPPINGS,
     ValidationResult,
+    _validate_conformance_schema,
     _validate_local_consumer_evidence_control_mappings,
     validate_repository,
 )
@@ -74,6 +75,29 @@ def load_promoter_module():
 
 
 class JourneyResultToolsTests(unittest.TestCase):
+    def test_spec045_r008_requires_every_reviewed_evidence_control_mapping(self) -> None:
+        conformance = json.loads((REPO_ROOT / "specs" / "CONFORMANCE.json").read_text(encoding="utf-8"))
+        requirement = next(
+            item
+            for item in conformance["requirements"]
+            if item.get("requirement_id") == "SPEC-045-R008"
+        )
+        requirement["implementation"] = [
+            mapping
+            for mapping in requirement["implementation"]
+            if mapping not in LOCAL_CONSUMER_ENDPOINT_EVIDENCE_CONTROL_IMPLEMENTATION_MAPPINGS
+        ]
+
+        result = ValidationResult()
+        _validate_conformance_schema(REPO_ROOT, conformance, result)
+
+        self.assertTrue(
+            any(
+                "must include every reviewed local-consumer evidence-control mapping" in error
+                for error in result.errors
+            )
+        )
+
     def test_signer_emits_validator_accepted_envelope(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/scripts/tests/test_local_consumer_endpoint_journey_result.py
+++ b/scripts/tests/test_local_consumer_endpoint_journey_result.py
@@ -77,6 +77,7 @@ def valid_signed(*, requirement_ids=None, extra_requirement=None, **overrides):
         "journey_id": LOCAL_CONSUMER_ENDPOINT_JOURNEY_ID,
         "execution_mode": LOCAL_CONSUMER_ENDPOINT_EXECUTION_MODE,
         "requirement_ids": ids,
+        "evidence_repository": {"name": "Augustas11/macprovider", "commit": "1" * 40},
         "operator": {"role": "release-operator", "identity_fingerprint": FINGERPRINT},
         "environment": {
             "class": LOCAL_CONSUMER_ENDPOINT_EXECUTION_MODE,
@@ -1116,6 +1117,10 @@ class LocalConsumerEndpointJourneyResultTests(unittest.TestCase):
                 builder.load_mapped_local_consumer_requirements = original_mapped
         self.assertEqual(LOCAL_CONSUMER_ENDPOINT_JOURNEY_ID, result["journey_id"])
         self.assertEqual(["SPEC-045-R001", "SPEC-045-R008"], result["requirement_ids"])
+        self.assertEqual(
+            {"name": "Augustas11/macprovider", "commit": evidence_sha},
+            result["evidence_repository"],
+        )
         self.assertEqual(evidence["candidate_identity"], result["candidate_identity"])
 
     def test_builder_rejects_non_allowlisted_gateway_origin_hash(self) -> None:

--- a/scripts/validate-signed-journey-result.py
+++ b/scripts/validate-signed-journey-result.py
@@ -126,6 +126,9 @@ def validate(
             trusted_openssl,
             f"{requirement_id}.signed_journey_result",
             result,
+            implementation_mappings=[
+                item for item in requirement.get("implementation", []) if isinstance(item, str)
+            ],
         ):
             errors.extend(result.errors)
     if errors:

--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -7113,6 +7113,7 @@
         "phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift:final class ConsumeLocalHandler",
         "phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift:final class ConsumePinnedUpstreamClient",
         "scripts/build-local-consumer-endpoint-journey-result.py:def build_payload",
+        ".github/workflows/promote-signed-local-consumer-endpoint-journey.yml:printf 'evidence_sha=%s\\n' \"$GITHUB_SHA\" >> \"$GITHUB_OUTPUT\"",
         ".github/workflows/promote-signed-local-consumer-endpoint-journey.yml:python3 scripts/preflight-signed-journey-promotion.py --source-sha \"$SOURCE_SHA\" --evidence-sha \"$EVIDENCE_SHA\" --requirement-ids \"$REQUIREMENT_IDS\" --journey-id JOURNEY-LOCAL-CONSUMER-ENDPOINT"
       ],
       "tests": [

--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -7113,7 +7113,7 @@
         "phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift:final class ConsumeLocalHandler",
         "phase3-binary/Sources/macprovider-cli/ConsumeCommand.swift:final class ConsumePinnedUpstreamClient",
         "scripts/build-local-consumer-endpoint-journey-result.py:def build_payload",
-        ".github/workflows/promote-signed-local-consumer-endpoint-journey.yml:--journey-id JOURNEY-LOCAL-CONSUMER-ENDPOINT"
+        ".github/workflows/promote-signed-local-consumer-endpoint-journey.yml:python3 scripts/preflight-signed-journey-promotion.py --source-sha \"$SOURCE_SHA\" --evidence-sha \"$EVIDENCE_SHA\" --requirement-ids \"$REQUIREMENT_IDS\" --journey-id JOURNEY-LOCAL-CONSUMER-ENDPOINT"
       ],
       "tests": [
         "phase3-binary/Tests/macprovider-cliTests/ConsumeCommandTests.swift:testPhase4FakeGatewayNonStreamingSDKPayloadPassesThroughAndSettlesUsage",


### PR DESCRIPTION
## Summary

Unblocks the protected SPEC-045 promotion path needed to close #1433 without weakening source provenance.

- Keeps the physical runtime/source commit in `signed.repository.commit`.
- Adds a separate reviewed evidence/control commit in `signed.evidence_repository.commit`.
- Binds only the exact registered implementation controls to the reviewed evidence commit; runtime and test mappings remain source-commit-bound.
- Requires SPEC-045-R008 to retain the complete registered control set, so deleting mappings cannot disable reviewed-evidence validation.
- Requires every signed artifact source to exist byte-for-byte at the signed evidence commit during canonical validation and promotion.
- Preserves legacy signed envelopes that do not use the new conditional evidence-control path.

This PR does not promote conformance by itself. After merge, the protected signer will produce the SPEC-045 R003/R004/R008 signed result, followed by a separate PR integrating all seven signed promotions tracked by #1433.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts.tests.test_journey_result_tools scripts.tests.test_local_consumer_endpoint_journey_result scripts.tests.test_local_consumer_endpoint_evidence_capture scripts.tests.test_spec_governance` — 119 passed.
- `PYTHONDONTWRITEBYTECODE=1 bash scripts/test-signed-local-consumer-endpoint-journey-workflow.sh` — passed.
- `PYTHONDONTWRITEBYTECODE=1 python3 scripts/check_spec_governance.py --base-ref origin/main` — passed.
- Python compilation, JSON parsing, and `git diff --check origin/main..HEAD` — passed.

## Audit gate

- Code review: 0 critical / 0 high / 0 medium.
- Security review: 0 critical / 0 high / 0 medium.
- Architecture review: 0 critical / 0 high / 0 medium.
- Codex Sol 5.6 adversarial verification: 0 critical / 0 high / 0 medium / 0 low across code, security, and architecture lanes.
- Claude Fable 5.1 via `omx ask`: 0 critical / 0 high / 0 medium / 2 carried low. Optional follow-ups are uniqueness enforcement for text-anchor selectors and strict source/evidence commit inequality; current selectors are unique, current source and evidence commits differ, and protected `main` remains the reviewed trust boundary.

## Governance

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": ["SPEC-045"],
  "requirements": ["SPEC-045-R003", "SPEC-045-R004", "SPEC-045-R008"],
  "authority_domains": ["local-consumer-endpoint"],
  "arbitration": ["UNKNOWN"],
  "tests": [
    "PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts.tests.test_journey_result_tools scripts.tests.test_local_consumer_endpoint_journey_result scripts.tests.test_local_consumer_endpoint_evidence_capture scripts.tests.test_spec_governance",
    "PYTHONDONTWRITEBYTECODE=1 bash scripts/test-signed-local-consumer-endpoint-journey-workflow.sh",
    "PYTHONDONTWRITEBYTECODE=1 python3 scripts/check_spec_governance.py --base-ref origin/main",
    "git diff --check origin/main..HEAD"
  ],
  "journeys": ["JOURNEY-LOCAL-CONSUMER-ENDPOINT"],
  "issue": "https://github.com/Augustas11/macprovider/issues/1433"
}
SPEC-GOVERNANCE-DECLARATION-END

Advances #1433; does not close it until all seven signed promotions merge.
