### PR TITLE
Enable measured SPEC-039 attach bridge

### DIFF
--- a/audits/2026-09-11/spec039-inc1-architect.prompt.md
+++ b/audits/2026-09-11/spec039-inc1-architect.prompt.md
@@ -1,0 +1,28 @@
+# Architecture review lane: SPEC-039 Phase-2 Increment 1 attach (#1474)
+
+Review the current working tree diff against `origin/main` in this MacProvider
+worktree. Do not edit files. Do not inspect `d-inference` / `Layr-Labs/*`.
+
+Architecture scope:
+- The implementation should consume the merged SPEC-039 engine and SPEC-038
+  scheduler without redefining storage layout, allocator internals, descriptor
+  schema, or scheduler lifecycle.
+- Attach must be a preflight observed-identity match against a trusted
+  descriptor; no advertised-field copying into observation.
+- Runtime bridge should be default-off / production-inert until a future
+  measured observation is wired.
+- Shared-forward backend should be a narrow `[B,1]` decode bridge, leaving
+  admission, block-table lifecycle, cancellation, and per-request isolation in
+  the existing scheduler.
+- Sticky/cross-turn reattach (#887 / FR-PKV10) must remain out of scope.
+
+Commands you may use:
+- `git status -sb`
+- `git diff --stat origin/main`
+- `git diff origin/main -- phase3-binary/Sources/MacProviderCore/PagedKVEngine.swift phase3-binary/Sources/macprovider-cli/ContinuousBatchScheduler.swift phase3-binary/Sources/macprovider-cli/ModelRuntime.swift phase3-binary/Sources/macprovider-cli/PagedKVCache.swift phase3-binary/Sources/macprovider-cli/PagedKVRuntimeBridge.swift phase3-binary/Tests/MacProviderCoreTests/PagedKVEngineTests.swift phase3-binary/Tests/macprovider-cliTests/ContinuousBatchSchedulerTests.swift phase3-binary/Tests/macprovider-cliTests/KVConversationColdTierTests.swift phase3-binary/Tests/macprovider-cliTests/PagedKVRuntimeBridgeTests.swift phase3-binary/Tests/macprovider-cliTests/ServingKnobsConfigTests.swift`
+
+Return:
+- Verdict: PASS or FAIL.
+- Findings grouped by CRITICAL/HIGH/MEDIUM/LOW/INFO.
+- Each finding must include concrete file/line evidence and a minimal fix.
+- Bar for this PR is 0 CRITICAL, 0 HIGH, 0 MEDIUM.

--- a/audits/2026-09-11/spec039-inc1-code-reviewer.prompt.md
+++ b/audits/2026-09-11/spec039-inc1-code-reviewer.prompt.md
@@ -1,0 +1,32 @@
+# Code review lane: SPEC-039 Phase-2 Increment 1 attach (#1474)
+
+Review the current working tree diff against `origin/main` in this MacProvider
+worktree. Do not edit files. Do not inspect `d-inference` / `Layr-Labs/*`.
+
+Scope:
+- Implements issue #1474 from
+  `audits/_prompts/BUILD_SPEC_039_PHASE2_INCREMENT1_ATTACH_IMPL_PROMPT.md`.
+- Must not implement #887 / FR-PKV10 sticky or contiguous cache reattach.
+- Changed files are expected under `phase3-binary/Sources/MacProviderCore`,
+  `phase3-binary/Sources/macprovider-cli`, and matching Swift tests.
+
+Commands you may use:
+- `git status -sb`
+- `git diff --stat origin/main`
+- `git diff origin/main -- phase3-binary/Sources/MacProviderCore/PagedKVEngine.swift phase3-binary/Sources/macprovider-cli/ContinuousBatchScheduler.swift phase3-binary/Sources/macprovider-cli/ModelRuntime.swift phase3-binary/Sources/macprovider-cli/PagedKVCache.swift phase3-binary/Sources/macprovider-cli/PagedKVRuntimeBridge.swift phase3-binary/Tests/MacProviderCoreTests/PagedKVEngineTests.swift phase3-binary/Tests/macprovider-cliTests/ContinuousBatchSchedulerTests.swift phase3-binary/Tests/macprovider-cliTests/KVConversationColdTierTests.swift phase3-binary/Tests/macprovider-cliTests/PagedKVRuntimeBridgeTests.swift phase3-binary/Tests/macprovider-cliTests/ServingKnobsConfigTests.swift`
+- Prefer targeted `rg` and `sed -n` reads over pasting whole files when
+  checking concrete locations.
+
+Adversarial questions:
+- Can attach activate without a real measured observed identity match?
+- Can advertised descriptor fields masquerade as observed fields?
+- Does shared-forward decode preserve per-row token, stop, usage, and sampler
+  isolation?
+- Does production serve remain inert/fail-closed when observation is nil?
+- Did the patch accidentally implement sticky/cross-turn cache reattach (#887)?
+
+Return:
+- Verdict: PASS or FAIL.
+- Findings grouped by CRITICAL/HIGH/MEDIUM/LOW/INFO.
+- Each finding must include concrete file/line evidence and a minimal fix.
+- Bar for this PR is 0 CRITICAL, 0 HIGH, 0 MEDIUM.

--- a/audits/2026-09-11/spec039-inc1-security-reviewer.prompt.md
+++ b/audits/2026-09-11/spec039-inc1-security-reviewer.prompt.md
@@ -1,0 +1,28 @@
+# Security review lane: SPEC-039 Phase-2 Increment 1 attach (#1474)
+
+Review the current working tree diff against `origin/main` in this MacProvider
+worktree. Do not edit files. Do not inspect `d-inference` / `Layr-Labs/*`.
+
+Security-critical scope:
+- Runtime attach must require a trusted descriptor and a separately measured
+  observed runtime identity. Self-asserted or advertised-as-observed provenance
+  must fail closed.
+- Empty/partial identity fields must not be admitted.
+- Production serve path must not manufacture a real observation; nil
+  observation must keep `engineBridgeAvailable` and `schedulerBackendAvailable`
+  false.
+- MoE dispatch proof must remain separate from advertised support.
+- Cross-request batched forward must not leak sampler, stop, state, cache, or
+  block-table data between requests.
+- #887 / FR-PKV10 sticky or contiguous reattach must remain unimplemented.
+
+Commands you may use:
+- `git status -sb`
+- `git diff --stat origin/main`
+- `git diff origin/main -- phase3-binary/Sources/MacProviderCore/PagedKVEngine.swift phase3-binary/Sources/macprovider-cli/ContinuousBatchScheduler.swift phase3-binary/Sources/macprovider-cli/ModelRuntime.swift phase3-binary/Sources/macprovider-cli/PagedKVCache.swift phase3-binary/Sources/macprovider-cli/PagedKVRuntimeBridge.swift phase3-binary/Tests/MacProviderCoreTests/PagedKVEngineTests.swift phase3-binary/Tests/macprovider-cliTests/ContinuousBatchSchedulerTests.swift phase3-binary/Tests/macprovider-cliTests/KVConversationColdTierTests.swift phase3-binary/Tests/macprovider-cliTests/PagedKVRuntimeBridgeTests.swift phase3-binary/Tests/macprovider-cliTests/ServingKnobsConfigTests.swift`
+
+Return:
+- Verdict: PASS or FAIL.
+- Findings grouped by CRITICAL/HIGH/MEDIUM/LOW/INFO.
+- Each finding must include concrete file/line evidence and a minimal fix.
+- Bar for this PR is 0 CRITICAL, 0 HIGH, 0 MEDIUM.

--- a/phase3-binary/Sources/MacProviderCore/PagedKVEngine.swift
+++ b/phase3-binary/Sources/MacProviderCore/PagedKVEngine.swift
@@ -75,14 +75,29 @@ public struct PagedKVDescriptor: Equatable, Sendable, Codable {
         parityLabel: String,
         poolEpoch: Int
     ) -> Bool {
-        self.modelID == modelID
+        guard let descriptorHardwareClass = self.hardwareClass,
+              !descriptorHardwareClass.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !hardwareClass.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !self.metallibSHA256.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !metallibSHA256.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !self.kernelIdentifier.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !kernelIdentifier.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !self.parityLabel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !parityLabel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              self.poolEpoch > 0,
+              poolEpoch > 0
+        else {
+            return false
+        }
+
+        return self.modelID == modelID
             && self.modelSHA256 == modelSHA256
             && self.tokenizerSHA256 == tokenizerSHA256
             && self.chatTemplateSHA256 == chatTemplateSHA256
             && allowedCacheClasses.contains(cacheClass)
             && self.kvDType == kvDType
             && (!requiresMoE || supportsMoEDispatch)
-            && self.hardwareClass == hardwareClass
+            && descriptorHardwareClass == hardwareClass
             && self.metallibSHA256 == metallibSHA256
             && self.kernelIdentifier == kernelIdentifier
             && self.parityLabel == parityLabel
@@ -155,7 +170,21 @@ public struct PagedKVHardwareSizingProof: Equatable, Sendable, Codable {
         observedParityLabel: String,
         poolEpoch: Int
     ) -> Bool {
-        self.modelID == modelID
+        guard !hardwareClass.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !observedHardwareClass.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !metallibSHA256.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !observedMetallibSHA256.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !kernelIdentifier.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !observedKernelIdentifier.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !parityLabel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !observedParityLabel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              self.poolEpoch > 0,
+              poolEpoch > 0
+        else {
+            return false
+        }
+
+        return self.modelID == modelID
             && self.modelSHA256 == modelSHA256
             && self.tokenizerSHA256 == tokenizerSHA256
             && self.chatTemplateSHA256 == chatTemplateSHA256
@@ -164,14 +193,53 @@ public struct PagedKVHardwareSizingProof: Equatable, Sendable, Codable {
             && self.metallibSHA256 == observedMetallibSHA256
             && self.kernelIdentifier == observedKernelIdentifier
             && self.parityLabel == observedParityLabel
-            && !hardwareClass.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            && !metallibSHA256.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            && !kernelIdentifier.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            && !parityLabel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             && blockSizeTokens == config.blockSizeTokens
             && maxPhysicalBlocks >= config.maxPhysicalBlocks
             && maxResidentTokens >= config.maxResidentTokens
             && self.poolEpoch == poolEpoch
+    }
+}
+
+public enum PagedKVObservedRuntimeIdentitySource: String, Equatable, Sendable, Codable {
+    case runtimeMeasurement
+    case advertisedDescriptor
+    case selfAsserted
+}
+
+public struct PagedKVObservedRuntimeIdentity: Equatable, Sendable, Codable {
+    public let hardwareClass: String
+    public let metallibSHA256: String
+    public let kernelIdentifier: String
+    public let parityLabel: String
+    public let moeDispatchProven: Bool
+    public let poolEpoch: Int
+    public let source: PagedKVObservedRuntimeIdentitySource
+
+    public init(
+        hardwareClass: String,
+        metallibSHA256: String,
+        kernelIdentifier: String,
+        parityLabel: String,
+        moeDispatchProven: Bool,
+        poolEpoch: Int,
+        source: PagedKVObservedRuntimeIdentitySource
+    ) {
+        self.hardwareClass = hardwareClass
+        self.metallibSHA256 = metallibSHA256
+        self.kernelIdentifier = kernelIdentifier
+        self.parityLabel = parityLabel
+        self.moeDispatchProven = moeDispatchProven
+        self.poolEpoch = poolEpoch
+        self.source = source
+    }
+
+    public var isCompleteRuntimeMeasurement: Bool {
+        source == .runtimeMeasurement
+            && !hardwareClass.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !metallibSHA256.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !kernelIdentifier.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !parityLabel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && poolEpoch > 0
     }
 }
 
@@ -187,6 +255,7 @@ public struct PagedKVGates: Equatable, Sendable {
     public let observedParityLabel: String?
     public let moeDispatchProven: Bool
     public let engineBridgeAvailable: Bool
+    public let observedRuntimeIdentity: PagedKVObservedRuntimeIdentity?
 
     public init(
         identityAvailable: Bool,
@@ -199,7 +268,8 @@ public struct PagedKVGates: Equatable, Sendable {
         observedKernelIdentifier: String? = nil,
         observedParityLabel: String? = nil,
         moeDispatchProven: Bool = false,
-        engineBridgeAvailable: Bool = false
+        engineBridgeAvailable: Bool = false,
+        observedRuntimeIdentity: PagedKVObservedRuntimeIdentity? = nil
     ) {
         self.identityAvailable = identityAvailable
         self.observedHardwareClass = observedHardwareClass
@@ -212,6 +282,7 @@ public struct PagedKVGates: Equatable, Sendable {
         self.observedParityLabel = observedParityLabel
         self.moeDispatchProven = moeDispatchProven
         self.engineBridgeAvailable = engineBridgeAvailable
+        self.observedRuntimeIdentity = observedRuntimeIdentity
     }
 
     public static let closed = PagedKVGates(
@@ -225,7 +296,8 @@ public struct PagedKVGates: Equatable, Sendable {
         observedKernelIdentifier: nil,
         observedParityLabel: nil,
         moeDispatchProven: false,
-        engineBridgeAvailable: false
+        engineBridgeAvailable: false,
+        observedRuntimeIdentity: nil
     )
 
     public static func runtimeClosed(identityAvailable: Bool, observedHardwareClass: String? = nil) -> PagedKVGates {
@@ -240,7 +312,8 @@ public struct PagedKVGates: Equatable, Sendable {
             observedKernelIdentifier: nil,
             observedParityLabel: nil,
             moeDispatchProven: false,
-            engineBridgeAvailable: false
+            engineBridgeAvailable: false,
+            observedRuntimeIdentity: nil
         )
     }
 }
@@ -303,10 +376,13 @@ public enum PagedKVAttachGate {
         guard gates.kernelRegistered else { return fail(.kernel) }
         guard gates.parityEstablished else { return fail(.parity) }
         guard let sizingProof = gates.hardwareSizingProof,
-              let observedHardwareClass = gates.observedHardwareClass,
-              let observedMetallibSHA256 = gates.observedMetallibSHA256,
-              let observedKernelIdentifier = gates.observedKernelIdentifier,
-              let observedParityLabel = gates.observedParityLabel,
+              let observedIdentity = gates.observedRuntimeIdentity,
+              observedIdentity.isCompleteRuntimeMeasurement,
+              gates.observedHardwareClass == observedIdentity.hardwareClass,
+              gates.observedMetallibSHA256 == observedIdentity.metallibSHA256,
+              gates.observedKernelIdentifier == observedIdentity.kernelIdentifier,
+              gates.observedParityLabel == observedIdentity.parityLabel,
+              gates.moeDispatchProven == observedIdentity.moeDispatchProven,
               sizingProof.covers(
                   config: config,
                   modelID: modelID,
@@ -314,16 +390,16 @@ public enum PagedKVAttachGate {
                   tokenizerSHA256: tokenizerSHA256,
                   chatTemplateSHA256: chatTemplateSHA256,
                   modelFamily: modelFamily,
-                  observedHardwareClass: observedHardwareClass,
-                  observedMetallibSHA256: observedMetallibSHA256,
-                  observedKernelIdentifier: observedKernelIdentifier,
-                  observedParityLabel: observedParityLabel,
-                  poolEpoch: 1
+                  observedHardwareClass: observedIdentity.hardwareClass,
+                  observedMetallibSHA256: observedIdentity.metallibSHA256,
+                  observedKernelIdentifier: observedIdentity.kernelIdentifier,
+                  observedParityLabel: observedIdentity.parityLabel,
+                  poolEpoch: observedIdentity.poolEpoch
               )
         else {
             return fail(.allocator)
         }
-        guard !requiresMoEDispatch || gates.moeDispatchProven else { return fail(.kernel) }
+        guard !requiresMoEDispatch || observedIdentity.moeDispatchProven else { return fail(.kernel) }
         guard gates.engineBridgeAvailable else { return fail(.kernel) }
 
         return .attached(PagedKVDescriptor(
@@ -336,12 +412,12 @@ public enum PagedKVAttachGate {
             supportedModelFamilies: [modelFamily],
             allowedCacheClasses: allowedCacheClasses,
             kvDType: .fp16,
-            supportsMoEDispatch: gates.moeDispatchProven,
-            hardwareClass: sizingProof.hardwareClass,
-            metallibSHA256: sizingProof.metallibSHA256,
-            kernelIdentifier: sizingProof.kernelIdentifier,
-            parityLabel: sizingProof.parityLabel,
-            poolEpoch: sizingProof.poolEpoch
+            supportsMoEDispatch: observedIdentity.moeDispatchProven,
+            hardwareClass: observedIdentity.hardwareClass,
+            metallibSHA256: observedIdentity.metallibSHA256,
+            kernelIdentifier: observedIdentity.kernelIdentifier,
+            parityLabel: observedIdentity.parityLabel,
+            poolEpoch: observedIdentity.poolEpoch
         ))
     }
 }

--- a/phase3-binary/Sources/macprovider-cli/ContinuousBatchScheduler.swift
+++ b/phase3-binary/Sources/macprovider-cli/ContinuousBatchScheduler.swift
@@ -274,6 +274,7 @@ struct ContinuousBatchDecodeInput: Sendable, Equatable {
     let topP: Double
     let presencePenalty: Double
     let frequencyPenalty: Double
+    let binding: PagedKVStorageBinding
     let blockTable: PagedKVBlockTable
     let committedKVTokenCount: Int
     let targetKVTokenCount: Int
@@ -311,8 +312,17 @@ protocol ContinuousBatchSchedulerBackend: Sendable {
     /// writes `currentToken` at `committedKVTokenCount` and returns one sampled
     /// token without advancing any other row's cursor.
     func decode(rows: [ContinuousBatchDecodeInput]) async throws -> [ContinuousBatchDecodeOutcome]
+    /// Row-local cleanup hook for backend state that is not owned by the
+    /// scheduler/allocator. Called after the scheduler has reached a terminal
+    /// result for the request. Implementations that keep no row-local state can
+    /// rely on the default no-op.
+    func finish(requestID: String)
     /// Returns only after in-flight calls have stopped accessing row bindings.
     func cancelInFlight() async
+}
+
+extension ContinuousBatchSchedulerBackend {
+    func finish(requestID: String) {}
 }
 
 enum ContinuousBatchSchedulerReplayClaim: Sendable, Equatable {
@@ -1281,6 +1291,7 @@ actor ContinuousBatchScheduler {
             do {
                 try await allocator.beginDecodeStep(row.handle)
                 beganDecode = true
+                let binding = try await allocator.binding(for: row.handle)
                 prepared.append((row, ContinuousBatchDecodeInput(
                     requestID: row.request.id,
                     currentToken: row.currentToken,
@@ -1291,7 +1302,8 @@ actor ContinuousBatchScheduler {
                     topP: row.request.topP,
                     presencePenalty: row.request.presencePenalty,
                     frequencyPenalty: row.request.frequencyPenalty,
-                    blockTable: try await allocator.table(for: row.handle),
+                    binding: binding,
+                    blockTable: binding.currentTable,
                     committedKVTokenCount: committedKVTokenCount,
                     targetKVTokenCount: targetKVTokenCount,
                     samplerStep: row.generatedTokens.count
@@ -1916,6 +1928,7 @@ actor ContinuousBatchScheduler {
         waiters: [Waiter],
         deliveryOutcomes: [UUID: Bool]? = nil
     ) {
+        backend.finish(requestID: requestID)
         terminalResultOrder.append(requestID)
         terminalResults[requestID] = result.withSettlementDisposition(
             result.settlementDisposition == .eligibleOwner ? .nonSettlingReplay : .notEligible

--- a/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
@@ -351,6 +351,12 @@ struct PagedKVRuntimeModelCapabilities: Equatable, Sendable {
     let requiresMoEDispatch: Bool
 }
 
+private struct ContinuousBatchRuntimeReplayAuthority: ContinuousBatchSchedulerReplayAuthority {
+    func claim(_ key: ContinuousBatchSchedulerReplayKey) throws -> ContinuousBatchSchedulerReplayClaim {
+        .claimed
+    }
+}
+
 public struct RequestHandle: @unchecked Sendable {
     public let snapshot: RuntimeSnapshot
     public let registrationID: Int
@@ -743,6 +749,13 @@ actor ModelRuntime: ModelRuntimeServing {
     private let prefillStepSize: Int
     private let pagedKVConfig: PagedKVConfig
     private var pagedKVAttachDecision: PagedKVAttachDecision
+    private var pagedKVRuntimeCacheClass: String
+    private var pagedKVObservedRuntimeIdentity: PagedKVObservedRuntimeIdentity?
+    private var pagedKVHardwareSizingProof: PagedKVHardwareSizingProof?
+    private var pagedKVSchedulerBackendInstalled: Bool
+    private var currentPagedKVModelCapabilities: PagedKVRuntimeModelCapabilities
+    private var continuousBatchScheduler: ContinuousBatchScheduler?
+    private let testContinuousBatchingBackend: (any ContinuousBatchSchedulerBackend)?
     private let conversationCache: ConversationCache
     /// SPEC-037 stage 5 — set once the serve process activates the encrypted disk
     /// cold tier (FR-KVP7). Gates all per-request cold-tier context construction;
@@ -870,11 +883,12 @@ actor ModelRuntime: ModelRuntimeServing {
         chatTemplateSHA256: String?,
         kvBitsOverride: Int?,
         runtimeCacheClass: String,
-        modelCapabilities: PagedKVRuntimeModelCapabilities? = nil
+        modelCapabilities: PagedKVRuntimeModelCapabilities? = nil,
+        observedRuntimeIdentity: PagedKVObservedRuntimeIdentity? = nil,
+        hardwareSizingProof: PagedKVHardwareSizingProof? = nil,
+        schedulerBackendInstalled: Bool = false
     ) -> PagedKVAttachDecision {
-        let cacheClassForDecision = runtimeCacheClass == Self.pagedKVUnavailableCacheClass
-            ? PagedKVAttachGate.allowedCacheClasses[0]
-            : runtimeCacheClass
+        let capabilities = modelCapabilities ?? Self.pagedKVModelCapabilities(modelID: modelID, configJSONData: nil)
         return pagedKVAttachDecision(
             config: config,
             modelID: modelID,
@@ -882,9 +896,66 @@ actor ModelRuntime: ModelRuntimeServing {
             tokenizerSHA256: tokenizerSHA256,
             chatTemplateSHA256: chatTemplateSHA256,
             kvBitsOverride: kvBitsOverride,
-            runtimeCacheClass: cacheClassForDecision,
-            gates: .runtimeClosed(identityAvailable: modelHash?.isEmpty == false),
-            modelCapabilities: modelCapabilities
+            runtimeCacheClass: runtimeCacheClass,
+            gates: Self.pagedKVRuntimeBridgeGates(
+                config: config,
+                modelID: modelID,
+                modelHash: modelHash,
+                tokenizerSHA256: tokenizerSHA256,
+                chatTemplateSHA256: chatTemplateSHA256,
+                modelCapabilities: capabilities,
+                observedRuntimeIdentity: observedRuntimeIdentity,
+                hardwareSizingProof: hardwareSizingProof,
+                schedulerBackendInstalled: schedulerBackendInstalled
+            ),
+            modelCapabilities: capabilities
+        )
+    }
+
+    private nonisolated static func pagedKVRuntimeBridgeGates(
+        config: PagedKVConfig,
+        modelID: String?,
+        modelHash: String?,
+        tokenizerSHA256: String?,
+        chatTemplateSHA256: String?,
+        modelCapabilities: PagedKVRuntimeModelCapabilities,
+        observedRuntimeIdentity: PagedKVObservedRuntimeIdentity?,
+        hardwareSizingProof: PagedKVHardwareSizingProof?,
+        schedulerBackendInstalled: Bool
+    ) -> PagedKVGates {
+        guard modelHash?.isEmpty == false,
+              let observedRuntimeIdentity,
+              let hardwareSizingProof,
+              observedRuntimeIdentity.isCompleteRuntimeMeasurement
+        else {
+            return .runtimeClosed(identityAvailable: modelHash?.isEmpty == false)
+        }
+        let preflightIdentityMatches = hardwareSizingProof.covers(
+            config: config,
+            modelID: modelID ?? "",
+            modelSHA256: modelHash ?? "",
+            tokenizerSHA256: tokenizerSHA256,
+            chatTemplateSHA256: chatTemplateSHA256,
+            modelFamily: modelCapabilities.modelFamily,
+            observedHardwareClass: observedRuntimeIdentity.hardwareClass,
+            observedMetallibSHA256: observedRuntimeIdentity.metallibSHA256,
+            observedKernelIdentifier: observedRuntimeIdentity.kernelIdentifier,
+            observedParityLabel: observedRuntimeIdentity.parityLabel,
+            poolEpoch: observedRuntimeIdentity.poolEpoch
+        )
+        return PagedKVGates(
+            identityAvailable: true,
+            observedHardwareClass: observedRuntimeIdentity.hardwareClass,
+            metallibAvailable: preflightIdentityMatches,
+            kernelRegistered: preflightIdentityMatches,
+            parityEstablished: preflightIdentityMatches,
+            hardwareSizingProof: hardwareSizingProof,
+            observedMetallibSHA256: observedRuntimeIdentity.metallibSHA256,
+            observedKernelIdentifier: observedRuntimeIdentity.kernelIdentifier,
+            observedParityLabel: observedRuntimeIdentity.parityLabel,
+            moeDispatchProven: observedRuntimeIdentity.moeDispatchProven,
+            engineBridgeAvailable: schedulerBackendInstalled && preflightIdentityMatches,
+            observedRuntimeIdentity: observedRuntimeIdentity
         )
     }
 
@@ -897,20 +968,16 @@ actor ModelRuntime: ModelRuntimeServing {
         prefillStepSize: Int
     ) async -> String {
         guard let container else { return Self.pagedKVUnavailableCacheClass }
-        do {
-            return try await container.perform { context in
-                let parameters = Self.makeServeGenerateParameters(
-                    maxTokens: 1,
-                    maxContextTokens: maxContextTokens,
-                    kvBitsOverride: kvBitsOverride,
-                    prefillStepSize: prefillStepSize,
-                    temperature: 0.0,
-                    topP: 1.0
-                )
-                return Self.pagedKVRuntimeCacheClass(model: context.model, baseParameters: parameters)
-            }
-        } catch {
-            return Self.pagedKVUnavailableCacheClass
+        return await container.perform { context in
+            let parameters = Self.makeServeGenerateParameters(
+                maxTokens: 1,
+                maxContextTokens: maxContextTokens,
+                kvBitsOverride: kvBitsOverride,
+                prefillStepSize: prefillStepSize,
+                temperature: 0.0,
+                topP: 1.0
+            )
+            return Self.pagedKVRuntimeCacheClass(model: context.model, baseParameters: parameters)
         }
     }
 
@@ -993,19 +1060,6 @@ actor ModelRuntime: ModelRuntimeServing {
     }
 
     nonisolated static func enforcePagedKVPreflight(_ decision: PagedKVAttachDecision) throws {
-        if case .attached = decision {
-            // This IMPL installs the default-off contract and attach gate only. Serving
-            // still requires a runtime owner that reserves a request lease, injects
-            // PagedKVCache, and releases/retains the handle around TokenIterator.
-            throw APIError(
-                status: 503,
-                message: "Inference engine unavailable",
-                type: "server_error",
-                code: "internal_error",
-                inferenceRan: false,
-                settlementRan: false
-            )
-        }
         if case .rejected = decision {
             throw APIError(
                 status: 503,
@@ -1084,6 +1138,13 @@ actor ModelRuntime: ModelRuntimeServing {
         self.kvBitsOverride = kvBitsOverride
         self.prefillStepSize = max(1, prefillStepSize)
         self.pagedKVConfig = pagedKVConfig
+        self.pagedKVRuntimeCacheClass = Self.pagedKVUnavailableCacheClass
+        self.pagedKVObservedRuntimeIdentity = nil
+        self.pagedKVHardwareSizingProof = nil
+        self.pagedKVSchedulerBackendInstalled = false
+        self.currentPagedKVModelCapabilities = Self.pagedKVModelCapabilities(modelID: modelID, configJSONData: nil)
+        self.continuousBatchScheduler = nil
+        self.testContinuousBatchingBackend = nil
         self.pagedKVAttachDecision = Self.pagedKVRuntimeCapabilityDecision(
             config: pagedKVConfig,
             modelID: modelID,
@@ -1166,6 +1227,8 @@ actor ModelRuntime: ModelRuntimeServing {
             )
             : Self.pagedKVUnavailableCacheClass
         let modelCapabilities = Self.pagedKVModelCapabilities(modelID: modelID, directory: directory)
+        self.pagedKVRuntimeCacheClass = runtimeCacheClass
+        self.currentPagedKVModelCapabilities = modelCapabilities
         self.pagedKVAttachDecision = Self.pagedKVRuntimeCapabilityDecision(
             config: self.pagedKVConfig,
             modelID: modelID,
@@ -1174,7 +1237,24 @@ actor ModelRuntime: ModelRuntimeServing {
             chatTemplateSHA256: tokenizerHashes.template,
             kvBitsOverride: self.kvBitsOverride,
             runtimeCacheClass: runtimeCacheClass,
-            modelCapabilities: modelCapabilities
+            modelCapabilities: modelCapabilities,
+            observedRuntimeIdentity: self.pagedKVObservedRuntimeIdentity,
+            hardwareSizingProof: self.pagedKVHardwareSizingProof,
+            schedulerBackendInstalled: self.pagedKVSchedulerBackendInstalled
+        )
+        self.continuousBatchScheduler = await Self.makeContinuousBatchScheduler(
+            decision: self.pagedKVAttachDecision,
+            tuple: self.continuousBatchingRequestedTuple(),
+            container: container,
+            backendOverride: self.testContinuousBatchingBackend,
+            maxBatch: self.maxBatch,
+            queueLimit: self.continuousBatchQueueLimit,
+            maxContextTokens: self.maxContextTokens,
+            modelID: modelID,
+            modelSHA256: self.currentModelHash,
+            weightsGeneration: self.currentSpecDecodeGeneration,
+            kvBitsOverride: self.kvBitsOverride,
+            prefillStepSize: self.prefillStepSize
         )
         Self.logPagedKVAttachDecision(self.pagedKVAttachDecision)
 
@@ -1232,6 +1312,13 @@ actor ModelRuntime: ModelRuntimeServing {
         catalogModelIDAlias: String? = nil,
         targetAuthorities: [String: ModelRuntimeTargetAuthority] = [:],
         authorizedSwitchModelIDs: [String] = [],
+        pagedKVObservedRuntimeIdentity: PagedKVObservedRuntimeIdentity? = nil,
+        pagedKVHardwareSizingProof: PagedKVHardwareSizingProof? = nil,
+        pagedKVRuntimeCacheClass: String = ModelRuntime.pagedKVUnavailableCacheClass,
+        pagedKVSchedulerBackendInstalled: Bool = false,
+        pagedKVModelCapabilities: PagedKVRuntimeModelCapabilities? = nil,
+        container: ModelContainer? = nil,
+        continuousBatchingBackend: (any ContinuousBatchSchedulerBackend)? = nil,
         loader: @escaping @Sendable (String) async throws -> (ModelContainer, String, String?),
         testLoader: (@Sendable (String) async throws -> (String, String?))? = nil,
         testCompletion: (@Sendable (RuntimeSnapshot, ChatCompletionRequest) async throws -> CompletionResult)? = nil,
@@ -1243,7 +1330,7 @@ actor ModelRuntime: ModelRuntimeServing {
         self.configuredModelLoadPath = nil
         self.catalogModelIDAlias = catalogModelIDAlias
         self.currentModelID = modelID
-        self.currentContainer = nil
+        self.currentContainer = container
         self.currentDraftModelID = normalizedDraftModelID
         self.currentDraftTargetModelID = normalizedDraftModelID == nil ? nil : modelID
         self.currentDraftContainer = nil
@@ -1265,6 +1352,15 @@ actor ModelRuntime: ModelRuntimeServing {
         self.kvBitsOverride = kvBitsOverride
         self.prefillStepSize = max(1, prefillStepSize)
         self.pagedKVConfig = pagedKVConfig
+        self.pagedKVRuntimeCacheClass = pagedKVRuntimeCacheClass
+        self.pagedKVObservedRuntimeIdentity = pagedKVObservedRuntimeIdentity
+        self.pagedKVHardwareSizingProof = pagedKVHardwareSizingProof
+        self.pagedKVSchedulerBackendInstalled = pagedKVSchedulerBackendInstalled
+        self.testContinuousBatchingBackend = continuousBatchingBackend
+        let boundedMaxBatch = min(max(1, maxBatch), ProviderCapacity.maxConcurrencyOverrideLimit)
+        let resolvedPagedKVModelCapabilities = pagedKVModelCapabilities
+            ?? Self.pagedKVModelCapabilities(modelID: modelID, configJSONData: nil)
+        self.currentPagedKVModelCapabilities = resolvedPagedKVModelCapabilities
         self.pagedKVAttachDecision = Self.pagedKVRuntimeCapabilityDecision(
             config: pagedKVConfig,
             modelID: modelID,
@@ -1272,10 +1368,25 @@ actor ModelRuntime: ModelRuntimeServing {
             tokenizerSHA256: nil,
             chatTemplateSHA256: nil,
             kvBitsOverride: kvBitsOverride,
-            runtimeCacheClass: Self.pagedKVUnavailableCacheClass
+            runtimeCacheClass: pagedKVRuntimeCacheClass,
+            modelCapabilities: resolvedPagedKVModelCapabilities,
+            observedRuntimeIdentity: pagedKVObservedRuntimeIdentity,
+            hardwareSizingProof: pagedKVHardwareSizingProof,
+            schedulerBackendInstalled: pagedKVSchedulerBackendInstalled
         )
+        let requestedTuple = Self.continuousBatchingRequestedTuple(
+            decision: self.pagedKVAttachDecision,
+            modelID: modelID,
+            modelSHA256: modelHash,
+            tokenizerSHA256: nil,
+            chatTemplateSHA256: nil,
+            kvBitsOverride: kvBitsOverride,
+            runtimeCacheClass: pagedKVRuntimeCacheClass,
+            modelCapabilities: resolvedPagedKVModelCapabilities,
+            observedRuntimeIdentity: pagedKVObservedRuntimeIdentity
+        )
+        self.continuousBatchScheduler = nil
         self.conversationCache = ConversationCache()
-        let boundedMaxBatch = min(max(1, maxBatch), ProviderCapacity.maxConcurrencyOverrideLimit)
         self.maxBatch = boundedMaxBatch
         self.inferenceGate = AsyncSemaphore(value: boundedMaxBatch)
         self.blockingInferenceExecutor = BlockingInferenceExecutor(label: "live.malibu.provider.inference")
@@ -1289,6 +1400,18 @@ actor ModelRuntime: ModelRuntimeServing {
         self.testCompletion = testCompletion
         self.testSpeculativeCompletion = testSpeculativeCompletion
         self.testSpeculativeStream = testSpeculativeStream
+        self.continuousBatchScheduler = Self.makeContinuousBatchScheduler(
+            decision: self.pagedKVAttachDecision,
+            tuple: requestedTuple,
+            backend: continuousBatchingBackend,
+            maxBatch: boundedMaxBatch,
+            queueLimit: continuousBatchQueueLimit,
+            maxContextTokens: self.maxContextTokens,
+            modelID: modelID,
+            modelSHA256: modelHash,
+            weightsGeneration: self.currentSpecDecodeGeneration,
+            prefillStepSize: self.prefillStepSize
+        )
     }
 
     func setProviderStatus(_ providerStatus: ProviderStatus) {
@@ -1864,10 +1987,24 @@ actor ModelRuntime: ModelRuntimeServing {
         stickyCacheEligible: Bool,
         requestStateRepresentable: Bool = true
     ) -> ContinuousBatchingCapability {
-        // The independently observed runtime tuple and scheduler backend are
-        // installed by the deferred SPEC-039 engine bridge. Do not manufacture
-        // a self-fulfilling tuple from the advertised descriptor.
-        let requestedTuple: ContinuousBatchingRequestedTuple? = nil
+        let requestedTuple = continuousBatchingRequestedTuple()
+        let schedulerBackendAvailable = requestedTuple.map {
+            continuousBatchScheduler != nil
+                && pagedKVAttachDecision.descriptor?.admits(
+                    modelID: $0.modelID,
+                    modelSHA256: $0.modelSHA256,
+                    tokenizerSHA256: $0.tokenizerSHA256,
+                    chatTemplateSHA256: $0.chatTemplateSHA256,
+                    cacheClass: $0.cacheClass,
+                    kvDType: $0.kvDType,
+                    requiresMoE: $0.requiresMoE,
+                    hardwareClass: $0.hardwareClass,
+                    metallibSHA256: $0.metallibSHA256,
+                    kernelIdentifier: $0.kernelIdentifier,
+                    parityLabel: $0.parityLabel,
+                    poolEpoch: $0.poolEpoch
+                ) == true
+        } ?? false
         return ContinuousBatchingPolicy.capability(
             mode: continuousBatchingMode,
             maxBatch: maxBatch,
@@ -1876,9 +2013,200 @@ actor ModelRuntime: ModelRuntimeServing {
             draftConfigured: draftConfigured,
             stickyCacheEligible: stickyCacheEligible,
             requestStateRepresentable: requestStateRepresentable,
-            schedulerBackendAvailable: false,
+            schedulerBackendAvailable: schedulerBackendAvailable,
             pagedKVDecision: pagedKVAttachDecision,
             requestedTuple: requestedTuple
+        )
+    }
+
+    private func continuousBatchingRequestedTuple() -> ContinuousBatchingRequestedTuple? {
+        Self.continuousBatchingRequestedTuple(
+            decision: pagedKVAttachDecision,
+            modelID: currentModelID,
+            modelSHA256: currentModelHash,
+            tokenizerSHA256: currentTokenizerConfigSHA256,
+            chatTemplateSHA256: currentChatTemplateSHA256,
+            kvBitsOverride: kvBitsOverride,
+            runtimeCacheClass: pagedKVRuntimeCacheClass,
+            modelCapabilities: currentPagedKVModelCapabilities,
+            observedRuntimeIdentity: pagedKVObservedRuntimeIdentity
+        )
+    }
+
+    private nonisolated static func continuousBatchingRequestedTuple(
+        decision: PagedKVAttachDecision,
+        modelID: String?,
+        modelSHA256: String?,
+        tokenizerSHA256: String?,
+        chatTemplateSHA256: String?,
+        kvBitsOverride: Int?,
+        runtimeCacheClass: String,
+        modelCapabilities: PagedKVRuntimeModelCapabilities,
+        observedRuntimeIdentity: PagedKVObservedRuntimeIdentity?
+    ) -> ContinuousBatchingRequestedTuple? {
+        guard kvBitsOverride == nil,
+              case .attached = decision,
+              let observedRuntimeIdentity,
+              observedRuntimeIdentity.isCompleteRuntimeMeasurement,
+              modelSHA256?.isEmpty == false,
+              runtimeCacheClass != Self.pagedKVUnavailableCacheClass
+        else {
+            return nil
+        }
+        return ContinuousBatchingRequestedTuple(
+            modelID: modelID ?? "",
+            modelSHA256: modelSHA256 ?? "",
+            tokenizerSHA256: tokenizerSHA256,
+            chatTemplateSHA256: chatTemplateSHA256,
+            cacheClass: runtimeCacheClass,
+            kvDType: .fp16,
+            requiresMoE: modelCapabilities.requiresMoEDispatch,
+            hardwareClass: observedRuntimeIdentity.hardwareClass,
+            metallibSHA256: observedRuntimeIdentity.metallibSHA256,
+            kernelIdentifier: observedRuntimeIdentity.kernelIdentifier,
+            parityLabel: observedRuntimeIdentity.parityLabel,
+            poolEpoch: observedRuntimeIdentity.poolEpoch
+        )
+    }
+
+    private nonisolated static func makeContinuousBatchScheduler(
+        decision: PagedKVAttachDecision,
+        tuple: ContinuousBatchingRequestedTuple?,
+        backend: (any ContinuousBatchSchedulerBackend)?,
+        maxBatch: Int,
+        queueLimit: Int?,
+        maxContextTokens: Int,
+        modelID: String?,
+        modelSHA256: String?,
+        weightsGeneration: Int,
+        prefillStepSize: Int
+    ) -> ContinuousBatchScheduler? {
+        guard case .attached(let descriptor) = decision,
+              let tuple,
+              let backend,
+              let modelID,
+              let modelSHA256,
+              tuple.isAdmitted(by: descriptor)
+        else {
+            return nil
+        }
+        guard let allocator = try? PagedKVBlockAllocator(
+            blockSizeTokens: descriptor.blockSizeTokens,
+            maxPhysicalBlocks: descriptor.maxPhysicalBlocks
+        ) else {
+            return nil
+        }
+        return ContinuousBatchScheduler(
+            configuration: ContinuousBatchSchedulerConfiguration(
+                descriptor: descriptor,
+                tuple: tuple,
+                maxActiveRows: maxBatch,
+                queueLimit: queueLimit,
+                decodeHeadroomTokens: 1,
+                maxPromptChunkTokens: max(1, prefillStepSize),
+                snapshot: ContinuousBatchSchedulerSnapshot(
+                    modelID: modelID,
+                    modelSHA256: modelSHA256,
+                    weightsGeneration: weightsGeneration
+                )
+            ),
+            allocator: allocator,
+            backend: backend,
+            replayAuthority: ContinuousBatchRuntimeReplayAuthority()
+        )
+    }
+
+    private static func makeContinuousBatchScheduler(
+        decision: PagedKVAttachDecision,
+        tuple: ContinuousBatchingRequestedTuple?,
+        container: ModelContainer?,
+        backendOverride: (any ContinuousBatchSchedulerBackend)?,
+        maxBatch: Int,
+        queueLimit: Int?,
+        maxContextTokens: Int,
+        modelID: String?,
+        modelSHA256: String?,
+        weightsGeneration: Int,
+        kvBitsOverride: Int?,
+        prefillStepSize: Int
+    ) async -> ContinuousBatchScheduler? {
+        if let backendOverride {
+            return makeContinuousBatchScheduler(
+                decision: decision,
+                tuple: tuple,
+                backend: backendOverride,
+                maxBatch: maxBatch,
+                queueLimit: queueLimit,
+                maxContextTokens: maxContextTokens,
+                modelID: modelID,
+                modelSHA256: modelSHA256,
+                weightsGeneration: weightsGeneration,
+                prefillStepSize: prefillStepSize
+            )
+        }
+        guard case .attached(let descriptor) = decision,
+              let container,
+              let layerCount = await pagedKVLayerCount(
+                  container: container,
+                  maxContextTokens: maxContextTokens,
+                  kvBitsOverride: kvBitsOverride,
+                  prefillStepSize: prefillStepSize
+              )
+        else {
+            return nil
+        }
+        return makeContinuousBatchScheduler(
+            decision: decision,
+            tuple: tuple,
+            backend: PagedKVSharedForwardBackend(
+                container: container,
+                descriptor: descriptor,
+                layerCount: layerCount
+            ),
+            maxBatch: maxBatch,
+            queueLimit: queueLimit,
+            maxContextTokens: maxContextTokens,
+            modelID: modelID,
+            modelSHA256: modelSHA256,
+            weightsGeneration: weightsGeneration,
+            prefillStepSize: prefillStepSize
+        )
+    }
+
+    private static func pagedKVLayerCount(
+        container: ModelContainer,
+        maxContextTokens: Int,
+        kvBitsOverride: Int?,
+        prefillStepSize: Int
+    ) async -> Int? {
+        await container.perform { context in
+            let parameters = Self.makeServeGenerateParameters(
+                maxTokens: 1,
+                maxContextTokens: maxContextTokens,
+                kvBitsOverride: kvBitsOverride,
+                prefillStepSize: prefillStepSize,
+                temperature: 0,
+                topP: 1
+            )
+            let layerCount = context.model.newCache(parameters: Self.cacheParameters(parameters, forceSimpleKV: true)).count
+            return layerCount > 0 ? layerCount : nil
+        }
+    }
+
+    private func rebuildContinuousBatchScheduler(container: ModelContainer?) async {
+        continuousBatchScheduler = await Self.makeContinuousBatchScheduler(
+            decision: pagedKVAttachDecision,
+            tuple: continuousBatchingRequestedTuple(),
+            container: container,
+            backendOverride: testContinuousBatchingBackend,
+            maxBatch: maxBatch,
+            queueLimit: continuousBatchQueueLimit,
+            maxContextTokens: maxContextTokens,
+            modelID: currentModelID,
+            modelSHA256: currentModelHash,
+            weightsGeneration: currentSpecDecodeGeneration,
+            kvBitsOverride: kvBitsOverride,
+            prefillStepSize: prefillStepSize
         )
     }
 
@@ -1904,6 +2232,16 @@ actor ModelRuntime: ModelRuntimeServing {
         if isActiveJSONValue(request.promptSource.logitBias) { return false }
         if isRequestedLogprobs(request.promptSource.logprobs) { return false }
         if isActiveJSONValue(request.promptSource.topLogprobs) { return false }
+        // Increment 1 proves exact greedy shared-forward parity only. Keep
+        // non-greedy or penalty-shaped requests on the existing serial path
+        // until a later sampler-isolated batching increment carries them.
+        guard request.temperature == 0.0,
+              request.topP == 1.0,
+              request.presencePenalty == 0.0,
+              request.frequencyPenalty == 0.0
+        else {
+            return false
+        }
         return true
     }
 
@@ -1932,7 +2270,7 @@ actor ModelRuntime: ModelRuntimeServing {
         request: ChatCompletionRequest,
         snapshot: RuntimeSnapshot,
         emitTelemetry: Bool = true
-    ) throws {
+    ) throws -> ContinuousBatchingCapability {
         let capability = continuousBatchingCapability(
             draftConfigured: snapshot.hasTargetCompatibleDraft || currentDraftModelID != nil,
             // v0.2 admits keyless fresh requests only. A conversation key is
@@ -1948,6 +2286,7 @@ actor ModelRuntime: ModelRuntimeServing {
             ContinuousBatchingPolicy.logSerialRouteIfNeeded(capability)
         }
         try ContinuousBatchingPolicy.validateStrictStartup(capability)
+        return capability
     }
 
     func maxContextTokensForTest() -> Int {
@@ -2067,6 +2406,8 @@ actor ModelRuntime: ModelRuntimeServing {
                 prefillStepSize: prefillStepSize
             )
             : Self.pagedKVUnavailableCacheClass
+        pagedKVRuntimeCacheClass = runtimeCacheClass
+        currentPagedKVModelCapabilities = modelCapabilities
         pagedKVAttachDecision = Self.pagedKVRuntimeCapabilityDecision(
             config: pagedKVConfig,
             modelID: modelID,
@@ -2075,8 +2416,12 @@ actor ModelRuntime: ModelRuntimeServing {
             chatTemplateSHA256: chatTemplateSHA256,
             kvBitsOverride: kvBitsOverride,
             runtimeCacheClass: runtimeCacheClass,
-            modelCapabilities: modelCapabilities
+            modelCapabilities: modelCapabilities,
+            observedRuntimeIdentity: pagedKVObservedRuntimeIdentity,
+            hardwareSizingProof: pagedKVHardwareSizingProof,
+            schedulerBackendInstalled: pagedKVSchedulerBackendInstalled
         )
+        await rebuildContinuousBatchScheduler(container: container)
         Self.logPagedKVAttachDecision(pagedKVAttachDecision)
         currentDraftModelID = draftModelID
         currentDraftTargetModelID = draftModelID == nil ? nil : modelID
@@ -2246,7 +2591,7 @@ actor ModelRuntime: ModelRuntimeServing {
         // preflight is observable (active_inference true) rather than reading idle.
         ModelLivenessTracker.shared.beginInference()
         defer { ModelLivenessTracker.shared.endInference() }
-        try applyContinuousBatchingPolicy(request: request, snapshot: handle.snapshot)
+        _ = try applyContinuousBatchingPolicy(request: request, snapshot: handle.snapshot)
         try Self.enforcePagedKVPreflight(pagedKVAttachDecision)
         try handle.drainCancelled.check()
         guard let container = handle.snapshot.container else {
@@ -2272,7 +2617,7 @@ actor ModelRuntime: ModelRuntimeServing {
     func relayBlindPrepare(_ request: ChatCompletionRequest) async throws -> RelayBlindPreparedRequest {
         let handle = try acquireRequestHandle(request)
         do {
-            try applyContinuousBatchingPolicy(request: request, snapshot: handle.snapshot)
+            _ = try applyContinuousBatchingPolicy(request: request, snapshot: handle.snapshot)
             try Self.enforcePagedKVPreflight(pagedKVAttachDecision)
             try handle.drainCancelled.check()
             guard let container = handle.snapshot.container else {
@@ -2298,9 +2643,334 @@ actor ModelRuntime: ModelRuntimeServing {
     }
 
     func pagedKVPreflight(_ request: ChatCompletionRequest, with handle: RequestHandle) async throws {
-        try applyContinuousBatchingPolicy(request: request, snapshot: handle.snapshot)
+        _ = try applyContinuousBatchingPolicy(request: request, snapshot: handle.snapshot)
         try Self.enforcePagedKVPreflight(pagedKVAttachDecision)
         try handle.drainCancelled.check()
+    }
+
+    private struct ContinuousBatchPreparedRequest: Sendable {
+        let promptTokens: [Int]
+        let stopTokenSequences: [[Int]]
+    }
+
+    private final class AttachedPagedKVStreamState: @unchecked Sendable {
+        private let lock = NSLock()
+        private var tokenIDs: [Int] = []
+        private var emittedText = ""
+        private var recordedError: APIError?
+
+        func appendTokens(_ tokens: [Int]) -> [Int] {
+            lock.lock()
+            defer { lock.unlock() }
+            tokenIDs.append(contentsOf: tokens)
+            return tokenIDs
+        }
+
+        func delta(to candidateText: String) -> String {
+            lock.lock()
+            defer { lock.unlock() }
+            guard candidateText.hasPrefix(emittedText) else { return "" }
+            let delta = String(candidateText.dropFirst(emittedText.count))
+            if !delta.isEmpty {
+                emittedText = candidateText
+            }
+            return delta
+        }
+
+        func record(_ error: APIError) {
+            lock.lock()
+            if recordedError == nil {
+                recordedError = error
+            }
+            lock.unlock()
+        }
+
+        func error() -> APIError? {
+            lock.lock()
+            defer { lock.unlock() }
+            return recordedError
+        }
+    }
+
+    private func attachedContinuousBatchCompletion(
+        request: ChatCompletionRequest,
+        snapshot: RuntimeSnapshot,
+        capability: ContinuousBatchingCapability,
+        completionStartedAt: Date,
+        shouldCancel: @escaping @Sendable () -> Bool,
+        drainCancelled: DrainCancelToken
+    ) async throws -> CompletionResult? {
+        guard capability.isRequested,
+              capability.unsupportedReason == nil,
+              !capability.shouldUseSerialPath,
+              case .attached = pagedKVAttachDecision
+        else {
+            return nil
+        }
+        guard let scheduler = continuousBatchScheduler else {
+            throw Self.attachedPagedKVUnavailableError(code: "continuous_batching_scheduler_unavailable")
+        }
+        guard let container = snapshot.container else {
+            throw APIError(status: 503, message: "Model not loaded", type: "server_error", code: "model_not_loaded")
+        }
+
+        let maxContextTokens = maxContextTokens
+        let stopTokenFilter = stopTokenFilter
+        let prepared = try await container.perform { context -> ContinuousBatchPreparedRequest in
+            try drainCancelled.check()
+            try Task.checkCancellation()
+            let input = try Self.userInput(for: request)
+            let lmInput = try await context.processor.prepare(input: input)
+            let promptTokens = lmInput.text.tokens.asArray(Int32.self).map(Int.init)
+            try Self.validatePromptTokenCount(promptTokens.count, maxContextTokens: maxContextTokens)
+            let stopTokenSequences = request.stop.map {
+                context.tokenizer.encode(text: $0, addSpecialTokens: false)
+            }.filter { !$0.isEmpty }
+            return ContinuousBatchPreparedRequest(
+                promptTokens: promptTokens,
+                stopTokenSequences: stopTokenSequences
+            )
+        }
+
+        try drainCancelled.check()
+        try Task.checkCancellation()
+        if shouldCancel() { throw CancellationError() }
+        let maxOutputTokens = request.maxTokens ?? max(1, maxContextTokens - prepared.promptTokens.count)
+        let result = try await Self.withDrainAndClientCancellation(drainCancelled, shouldCancel: shouldCancel) {
+            try await scheduler.submit(ContinuousBatchSchedulerRequest(
+                id: UUID().uuidString,
+                conversationKey: "",
+                promptTokens: prepared.promptTokens,
+                maxOutputTokens: maxOutputTokens,
+                stopTokenSequences: prepared.stopTokenSequences,
+                temperature: request.temperature,
+                topP: request.topP,
+                presencePenalty: request.presencePenalty,
+                frequencyPenalty: request.frequencyPenalty,
+                cachedPromptTokens: 0
+            ))
+        }
+        try drainCancelled.check()
+        try Task.checkCancellation()
+        if shouldCancel() { throw CancellationError() }
+        guard result.terminalStatus == .stop || result.terminalStatus == .length else {
+            throw Self.attachedPagedKVUnavailableError(code: result.errorCode ?? "continuous_batching_request_failed")
+        }
+        let completionEndedAt = Date()
+        return try await container.perform { context in
+            let decoded = context.tokenizer.decode(tokenIds: result.outputTokens)
+            guard decoded.utf8.count <= ToolCallParser.SPEC018_ARGUMENTS_PER_RESPONSE_BYTE_CAP else {
+                throw APIError(
+                    status: 502,
+                    message: "Model response exceeded 2097152 bytes",
+                    type: "upstream_provider_error",
+                    code: "response_byte_cap_exceeded",
+                    inferenceRan: true,
+                    settlementRan: true
+                )
+            }
+            let filtered = Self.applyOutputFilters(
+                decoded,
+                stopTokenFilter: stopTokenFilter,
+                requestStops: request.stop
+            )
+            let parserFinishReason = result.terminalStatus == .length && !filtered.hitStop
+                ? "length"
+                : (filtered.hitStop ? "request_stop" : "stop")
+            let parsed = try Self.parseGeneratedOutput(
+                filteredText: filtered.text,
+                generatedTokenIDs: result.outputTokens,
+                decode: { context.tokenizer.decode(tokenIds: $0) },
+                request: request,
+                mode: .complete(finishReason: parserFinishReason),
+                defaultCompletionTokens: result.completionTokens,
+                stopTokenFilter: stopTokenFilter,
+                requestStops: request.stop,
+                globalHitStop: filtered.hitStop
+            )
+            let finishReason: String
+            if !parsed.toolCalls.isEmpty {
+                finishReason = "tool_calls"
+            } else if result.terminalStatus == .length, !filtered.hitStop, !parsed.hitStop {
+                finishReason = "length"
+            } else {
+                finishReason = "stop"
+            }
+            return try Self.validateStructuredCompletion(CompletionResult(
+                content: parsed.content,
+                finishReason: finishReason,
+                promptTokens: prepared.promptTokens.count,
+                cachedPromptTokens: result.cachedPromptTokens,
+                completionTokens: parsed.completionTokens,
+                generatedCompletionTokens: parsed.generatedCompletionTokens,
+                ttftMilliseconds: nil,
+                generationMilliseconds: Int64(completionEndedAt.timeIntervalSince(completionStartedAt) * 1000),
+                toolCalls: parsed.toolCalls.isEmpty ? nil : parsed.toolCalls,
+                modelHashObserved: Self.validObservedModelHash(snapshot.modelHash)
+            ), request: request)
+        }
+    }
+
+    private func attachedContinuousBatchStreamingCompletion(
+        request: ChatCompletionRequest,
+        snapshot: RuntimeSnapshot,
+        capability: ContinuousBatchingCapability,
+        completionStartedAt: Date,
+        shouldCancel: @escaping @Sendable () -> Bool,
+        drainCancelled: DrainCancelToken,
+        structuredAccumulator: StructuredStreamingContentAccumulator,
+        idleState: StructuredStreamingIdleState,
+        onChunk: @escaping @Sendable (StreamChunk) -> Void
+    ) async throws -> CompletionResult? {
+        guard capability.isRequested,
+              capability.unsupportedReason == nil,
+              !capability.shouldUseSerialPath,
+              case .attached = pagedKVAttachDecision
+        else {
+            return nil
+        }
+        guard let scheduler = continuousBatchScheduler else {
+            throw Self.attachedPagedKVUnavailableError(code: "continuous_batching_scheduler_unavailable")
+        }
+        guard let container = snapshot.container else {
+            throw APIError(status: 503, message: "Model not loaded", type: "server_error", code: "model_not_loaded")
+        }
+
+        let maxContextTokens = maxContextTokens
+        let stopTokenFilter = stopTokenFilter
+        let requestStops = request.stop
+        let prepared = try await container.perform { context -> ContinuousBatchPreparedRequest in
+            try drainCancelled.check()
+            try Task.checkCancellation()
+            let input = try Self.userInput(for: request)
+            let lmInput = try await context.processor.prepare(input: input)
+            let promptTokens = lmInput.text.tokens.asArray(Int32.self).map(Int.init)
+            try Self.validatePromptTokenCount(promptTokens.count, maxContextTokens: maxContextTokens)
+            let stopTokenSequences = requestStops.map {
+                context.tokenizer.encode(text: $0, addSpecialTokens: false)
+            }.filter { !$0.isEmpty }
+            return ContinuousBatchPreparedRequest(
+                promptTokens: promptTokens,
+                stopTokenSequences: stopTokenSequences
+            )
+        }
+
+        try drainCancelled.check()
+        try Task.checkCancellation()
+        if shouldCancel() { throw CancellationError() }
+        let streamState = AttachedPagedKVStreamState()
+        let maxOutputTokens = request.maxTokens ?? max(1, maxContextTokens - prepared.promptTokens.count)
+        let result = try await Self.withDrainAndClientCancellation(drainCancelled, shouldCancel: shouldCancel) {
+            try await scheduler.submit(ContinuousBatchSchedulerRequest(
+                id: UUID().uuidString,
+                conversationKey: "",
+                promptTokens: prepared.promptTokens,
+                maxOutputTokens: maxOutputTokens,
+                stopTokenSequences: prepared.stopTokenSequences,
+                temperature: request.temperature,
+                topP: request.topP,
+                presencePenalty: request.presencePenalty,
+                frequencyPenalty: request.frequencyPenalty,
+                cachedPromptTokens: 0
+            ), tokenSink: { event in
+                let eventTokens = event.replayTokens ?? [event.token]
+                guard !eventTokens.isEmpty else { return }
+                let allTokens = streamState.appendTokens(eventTokens)
+                let candidate = await container.perform(nonSendable: allTokens) { context, allTokens in
+                    Self.streamingSafePrefix(
+                        context.tokenizer.decode(tokenIds: allTokens),
+                        stopTokenFilter: stopTokenFilter,
+                        requestStops: requestStops
+                    )
+                }
+                let delta = streamState.delta(to: candidate.text)
+                guard !delta.isEmpty else { return }
+                if let error = structuredAccumulator.append(delta) {
+                    streamState.record(error)
+                    return
+                }
+                idleState.noteContent()
+                onChunk(.content(delta))
+            })
+        }
+        if let error = streamState.error() {
+            throw error
+        }
+        try drainCancelled.check()
+        try Task.checkCancellation()
+        if shouldCancel() { throw CancellationError() }
+        guard result.terminalStatus == .stop || result.terminalStatus == .length else {
+            throw Self.attachedPagedKVUnavailableError(code: result.errorCode ?? "continuous_batching_request_failed")
+        }
+        let completionEndedAt = Date()
+        let completion = try await container.perform { context in
+            let decoded = context.tokenizer.decode(tokenIds: result.outputTokens)
+            guard decoded.utf8.count <= ToolCallParser.SPEC018_ARGUMENTS_PER_RESPONSE_BYTE_CAP else {
+                throw APIError(
+                    status: 502,
+                    message: "Model response exceeded 2097152 bytes",
+                    type: "upstream_provider_error",
+                    code: "response_byte_cap_exceeded",
+                    inferenceRan: true,
+                    settlementRan: true
+                )
+            }
+            let filtered = Self.applyOutputFilters(
+                decoded,
+                stopTokenFilter: stopTokenFilter,
+                requestStops: requestStops
+            )
+            let parserFinishReason = result.terminalStatus == .length && !filtered.hitStop
+                ? "length"
+                : (filtered.hitStop ? "request_stop" : "stop")
+            let parsed = try Self.parseGeneratedOutput(
+                filteredText: filtered.text,
+                generatedTokenIDs: result.outputTokens,
+                decode: { context.tokenizer.decode(tokenIds: $0) },
+                request: request,
+                mode: .complete(finishReason: parserFinishReason),
+                defaultCompletionTokens: result.completionTokens,
+                stopTokenFilter: stopTokenFilter,
+                requestStops: requestStops,
+                globalHitStop: filtered.hitStop
+            )
+            let finishReason: String
+            if !parsed.toolCalls.isEmpty {
+                finishReason = "tool_calls"
+            } else if result.terminalStatus == .length, !filtered.hitStop, !parsed.hitStop {
+                finishReason = "length"
+            } else {
+                finishReason = "stop"
+            }
+            return try Self.validateStructuredCompletion(CompletionResult(
+                content: parsed.content,
+                finishReason: finishReason,
+                promptTokens: prepared.promptTokens.count,
+                cachedPromptTokens: result.cachedPromptTokens,
+                completionTokens: parsed.completionTokens,
+                generatedCompletionTokens: parsed.generatedCompletionTokens,
+                ttftMilliseconds: nil,
+                generationMilliseconds: Int64(completionEndedAt.timeIntervalSince(completionStartedAt) * 1000),
+                toolCalls: parsed.toolCalls.isEmpty ? nil : parsed.toolCalls,
+                modelHashObserved: Self.validObservedModelHash(snapshot.modelHash)
+            ), request: request)
+        }
+        return try Self.validateStructuredStreamingCompletion(
+            completion,
+            request: request,
+            buyerVisibleContent: structuredAccumulator.content
+        )
+    }
+
+    private nonisolated static func attachedPagedKVUnavailableError(code: String) -> APIError {
+        APIError(
+            status: 503,
+            message: "Inference engine unavailable",
+            type: "server_error",
+            code: code,
+            inferenceRan: false,
+            settlementRan: false
+        )
     }
 
     func complete(
@@ -2455,9 +3125,23 @@ actor ModelRuntime: ModelRuntimeServing {
         // preflight (HTTP + relay), so it OWNS the single serial-route telemetry
         // emission for this request. (Streaming preflights first and suppresses
         // here to stay exactly-once.)
-        try applyContinuousBatchingPolicy(request: request, snapshot: snapshot, emitTelemetry: true)
+        let continuousBatchingCapability = try applyContinuousBatchingPolicy(
+            request: request,
+            snapshot: snapshot,
+            emitTelemetry: true
+        )
         try Self.enforcePagedKVPreflight(pagedKVAttachDecision)
         try drainCancelled.check()
+        if let completion = try await attachedContinuousBatchCompletion(
+            request: request,
+            snapshot: snapshot,
+            capability: continuousBatchingCapability,
+            completionStartedAt: completionStartedAt,
+            shouldCancel: shouldCancel,
+            drainCancelled: drainCancelled
+        ) {
+            return (completion, snapshot)
+        }
         if speculativeCacheWrapValidated,
            let testSpeculativeCompletion,
            Self.speculativeRoute(
@@ -2888,10 +3572,27 @@ actor ModelRuntime: ModelRuntimeServing {
         defer { ModelLivenessTracker.shared.endInference() }
         let snapshot = handle.snapshot
         let drainCancelled = handle.drainCancelled
-        try applyContinuousBatchingPolicy(request: request, snapshot: snapshot, emitTelemetry: false)
+        let continuousBatchingCapability = try applyContinuousBatchingPolicy(
+            request: request,
+            snapshot: snapshot,
+            emitTelemetry: false
+        )
         try Self.enforcePagedKVPreflight(pagedKVAttachDecision)
         let structuredAccumulator = StructuredStreamingContentAccumulator(enabled: Self.requiresStructuredValidation(request.responseFormat))
         let idleState = StructuredStreamingIdleState(enabled: Self.requiresStructuredValidation(request.responseFormat))
+        if let completion = try await attachedContinuousBatchStreamingCompletion(
+            request: request,
+            snapshot: snapshot,
+            capability: continuousBatchingCapability,
+            completionStartedAt: Date(),
+            shouldCancel: shouldCancel,
+            drainCancelled: drainCancelled,
+            structuredAccumulator: structuredAccumulator,
+            idleState: idleState,
+            onChunk: onChunk
+        ) {
+            return completion
+        }
         if speculativeCacheWrapValidated,
            let testSpeculativeStream,
            Self.speculativeRoute(
@@ -3862,6 +4563,35 @@ actor ModelRuntime: ModelRuntimeServing {
                     try await Task.sleep(nanoseconds: 10_000_000)
                 }
                 throw DrainCancelledError()
+            }
+            guard let result = try await group.next() else {
+                throw DrainCancelledError()
+            }
+            group.cancelAll()
+            return result
+        }
+    }
+
+    private nonisolated static func withDrainAndClientCancellation<T: Sendable>(
+        _ token: DrainCancelToken,
+        shouldCancel: @escaping @Sendable () -> Bool,
+        operation: @escaping @Sendable () async throws -> T
+    ) async throws -> T {
+        try await withThrowingTaskGroup(of: T.self) { group in
+            group.addTask {
+                try await operation()
+            }
+            group.addTask {
+                while !token.isFired {
+                    try await Task.sleep(nanoseconds: 10_000_000)
+                }
+                throw DrainCancelledError()
+            }
+            group.addTask {
+                while !shouldCancel() {
+                    try await Task.sleep(nanoseconds: 10_000_000)
+                }
+                throw CancellationError()
             }
             guard let result = try await group.next() else {
                 throw DrainCancelledError()

--- a/phase3-binary/Sources/macprovider-cli/PagedKVCache.swift
+++ b/phase3-binary/Sources/macprovider-cli/PagedKVCache.swift
@@ -52,11 +52,11 @@ struct PagedKVGatherKernel {
 
 /// Compile-time `KVCache` seam for the future installed paged runtime bridge.
 ///
-/// `ModelRuntime` deliberately never injects this class in the current merge:
-/// `engineBridgeAvailable` is false in runtime gates and `.attached` preflight
-/// fails closed. The class remains type-checked against `mlx-swift-lm` so the
-/// follow-up bridge can wire request-level reservation, real gather execution,
-/// and parity tests without changing public buyer behavior.
+/// Production `ModelRuntime` deliberately leaves the measured-observation path
+/// nil in this increment, so buyer traffic stays fail-closed. Attached test and
+/// future measured-runtime paths may instantiate this cache through the local
+/// bridge; the class remains type-checked against `mlx-swift-lm` so real gather
+/// execution and parity tests can evolve without changing public buyer behavior.
 final class PagedKVCache: KVCache, CustomDebugStringConvertible {
     let descriptor: PagedKVDescriptor
     let binding: PagedKVStorageBinding
@@ -90,12 +90,13 @@ final class PagedKVCache: KVCache, CustomDebugStringConvertible {
     init(
         descriptor: PagedKVDescriptor,
         binding: PagedKVStorageBinding,
-        gatherKernel: PagedKVGatherKernel = PagedKVGatherKernel()
+        gatherKernel: PagedKVGatherKernel = PagedKVGatherKernel(),
+        initialOffset: Int? = nil
     ) {
         self.descriptor = descriptor
         self.binding = binding
         self.gatherKernel = gatherKernel
-        self.offset = binding.currentTable.logicalTokenCount
+        self.offset = initialOffset ?? binding.currentTable.logicalTokenCount
     }
 
     var maxSize: Int? { maxResidentTokens }
@@ -264,6 +265,10 @@ final class PagedKVCache: KVCache, CustomDebugStringConvertible {
     }
 
     func copy() -> any KVCache {
+        concreteCopy()
+    }
+
+    func concreteCopy() -> PagedKVCache {
         let copied = PagedKVCache(descriptor: descriptor, binding: binding, gatherKernel: gatherKernel)
         copied.state = state
         return copied

--- a/phase3-binary/Sources/macprovider-cli/PagedKVRuntimeBridge.swift
+++ b/phase3-binary/Sources/macprovider-cli/PagedKVRuntimeBridge.swift
@@ -1,0 +1,345 @@
+import Foundation
+import MLX
+import MLXLMCommon
+import MacProviderCore
+
+/// SPEC-039 / SPEC-038 Increment 1 runtime bridge.
+///
+/// This backend is intentionally installable only after the attach gate has a
+/// separately measured runtime identity. Production construction still passes
+/// nil observation, so no buyer request reaches this path by default.
+final class PagedKVSharedForwardBackend: ContinuousBatchSchedulerBackend, @unchecked Sendable {
+    private struct RowState {
+        var caches: [PagedKVCache]
+        var state: LMOutput.State?
+    }
+
+    private let container: ModelContainer
+    private let descriptor: PagedKVDescriptor
+    private let layerCount: Int
+    private let lock = NSLock()
+    private var rows: [String: RowState] = [:]
+    private var activeOperations = 0
+    private var cancelRequested = false
+    private var cancellationWaiters: [CheckedContinuation<Void, Never>] = []
+
+    init(container: ModelContainer, descriptor: PagedKVDescriptor, layerCount: Int) {
+        self.container = container
+        self.descriptor = descriptor
+        self.layerCount = max(1, layerCount)
+    }
+
+    func prefill(rows inputs: [ContinuousBatchPrefillInput]) async throws -> [ContinuousBatchPrefillOutput] {
+        guard beginOperation() else {
+            throw ContinuousBatchSchedulerError.unsupported("continuous_batching_backend_cancelled")
+        }
+        defer { endOperation() }
+        return await container.perform(nonSendable: inputs) { context, inputs in
+            var outputs: [ContinuousBatchPrefillOutput] = []
+            outputs.reserveCapacity(inputs.count)
+            for input in inputs {
+                var state = self.rowState(for: input.requestID, binding: input.binding, initialOffset: input.committedKVTokenCount)
+                if !input.promptTokens.isEmpty {
+                    let prompt = MLXArray(input.promptTokens.map(Int32.init)).reshaped([1, input.promptTokens.count])
+                    let text = LMInput.Text(tokens: prompt)
+                    let output = withPreparedCache(state.caches, lengths: text.sequenceLengths) {
+                        context.model(text, cache: state.caches, state: state.state)
+                    }
+                    eval(output.logits)
+                    state.state = output.state
+                }
+                self.setRowState(state, for: input.requestID)
+                outputs.append(ContinuousBatchPrefillOutput(requestID: input.requestID))
+            }
+            return outputs
+        }
+    }
+
+    func decode(rows inputs: [ContinuousBatchDecodeInput]) async throws -> [ContinuousBatchDecodeOutcome] {
+        guard !inputs.isEmpty else { return [] }
+        guard beginOperation() else {
+            throw ContinuousBatchSchedulerError.unsupported("continuous_batching_backend_cancelled")
+        }
+        defer { endOperation() }
+        let supportedInputs = inputs.filter(Self.supportsGreedySampling)
+        var rowFailures = Set(inputs.map(\.requestID)).subtracting(supportedInputs.map(\.requestID))
+        guard !supportedInputs.isEmpty else {
+            return inputs.map { .rowFailure(requestID: $0.requestID) }
+        }
+
+        let decoded: [ContinuousBatchDecodeOutcome] = try await container.perform(nonSendable: supportedInputs) { context, supportedInputs in
+            var rowStates = supportedInputs.map {
+                self.rowState(
+                    for: $0.requestID,
+                    binding: $0.binding,
+                    initialOffset: $0.committedKVTokenCount
+                )
+            }
+            if supportedInputs.count > 1 && rowStates.contains(where: { $0.state != nil }) {
+                return supportedInputs.map { ContinuousBatchDecodeOutcome.rowFailure(requestID: $0.requestID) }
+            }
+            let batchedCaches = try Self.batchedCaches(from: rowStates.map(\.caches))
+            let tokenInput = MLXArray(supportedInputs.map { Int32($0.currentToken) }).reshaped([supportedInputs.count, 1])
+            let text = LMInput.Text(tokens: tokenInput)
+            let output = withPreparedCache(batchedCaches, lengths: text.sequenceLengths) {
+                context.model(text, cache: batchedCaches, state: supportedInputs.count == 1 ? rowStates[0].state : nil)
+            }
+            let sampled = argMax(output.logits[0..., -1, 0...], axis: -1).asArray(Int.self)
+            guard sampled.count == supportedInputs.count else {
+                throw ContinuousBatchSchedulerError.unsupported("continuous_batching_invalid_logits_shape")
+            }
+            if supportedInputs.count == 1 {
+                rowStates[0].state = output.state
+            } else if output.state != nil {
+                return supportedInputs.map { ContinuousBatchDecodeOutcome.rowFailure(requestID: $0.requestID) }
+            }
+            for (index, input) in supportedInputs.enumerated() {
+                self.setRowState(rowStates[index], for: input.requestID)
+            }
+            return zip(supportedInputs, sampled).map { input, token in
+                ContinuousBatchDecodeOutcome.output(ContinuousBatchDecodeOutput(
+                    requestID: input.requestID,
+                    token: token
+                ))
+            }
+        }
+        for outcome in decoded {
+            if case .rowFailure(let requestID) = outcome {
+                rowFailures.insert(requestID)
+            }
+        }
+        let byID: [String: ContinuousBatchDecodeOutcome] = Dictionary(
+            uniqueKeysWithValues: decoded.map { ($0.requestID, $0) }
+        )
+        return inputs.map { input in
+            if rowFailures.contains(input.requestID) { return .rowFailure(requestID: input.requestID) }
+            if let outcome = byID[input.requestID] { return outcome }
+            return .rowFailure(requestID: input.requestID)
+        }
+    }
+
+    func finish(requestID: String) {
+        removeRowState(for: requestID)
+    }
+
+    func cancelInFlight() async {
+        await withCheckedContinuation { continuation in
+            lock.lock()
+            cancelRequested = true
+            rows.removeAll()
+            if activeOperations == 0 {
+                lock.unlock()
+                continuation.resume()
+            } else {
+                cancellationWaiters.append(continuation)
+                lock.unlock()
+            }
+        }
+    }
+
+    private func beginOperation() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !cancelRequested else { return false }
+        activeOperations += 1
+        return true
+    }
+
+    private func endOperation() {
+        let waiters: [CheckedContinuation<Void, Never>]
+        lock.lock()
+        activeOperations = max(0, activeOperations - 1)
+        if cancelRequested && activeOperations == 0 {
+            waiters = cancellationWaiters
+            cancellationWaiters.removeAll()
+        } else {
+            waiters = []
+        }
+        lock.unlock()
+        for waiter in waiters {
+            waiter.resume()
+        }
+    }
+
+    private func rowState(
+        for requestID: String,
+        binding: PagedKVStorageBinding,
+        initialOffset: Int
+    ) -> RowState {
+        lock.lock()
+        defer { lock.unlock() }
+        if let existing = rows[requestID] {
+            return existing
+        }
+        return RowState(
+            caches: (0 ..< layerCount).map { _ in
+                PagedKVCache(
+                    descriptor: descriptor,
+                    binding: binding,
+                    initialOffset: initialOffset
+                )
+            },
+            state: nil
+        )
+    }
+
+    private func setRowState(_ state: RowState, for requestID: String) {
+        lock.lock()
+        if !cancelRequested {
+            rows[requestID] = state
+        }
+        lock.unlock()
+    }
+
+    private func removeRowState(for requestID: String) {
+        lock.lock()
+        rows.removeValue(forKey: requestID)
+        lock.unlock()
+    }
+
+    func retainedRowCountForTest() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return rows.count
+    }
+
+    private static func supportsGreedySampling(_ input: ContinuousBatchDecodeInput) -> Bool {
+        input.temperature == 0.0
+            && input.topP == 1.0
+            && input.presencePenalty == 0.0
+            && input.frequencyPenalty == 0.0
+    }
+
+    private static func batchedCaches(from rowCaches: [[PagedKVCache]]) throws -> [KVCache] {
+        guard let layerCount = rowCaches.first?.count,
+              rowCaches.allSatisfy({ $0.count == layerCount })
+        else {
+            throw ContinuousBatchSchedulerError.unsupported("continuous_batching_invalid_cache_layout")
+        }
+        return (0 ..< layerCount).map { layerIndex in
+            PagedKVBatchLayerCache(rowCaches: rowCaches.map { $0[layerIndex] })
+        }
+    }
+}
+
+private final class PagedKVBatchLayerCache: KVCache, @unchecked Sendable {
+    private let rowCaches: [PagedKVCache]
+    private var preparedLengths: [Int]?
+
+    init(rowCaches: [PagedKVCache]) {
+        self.rowCaches = rowCaches
+    }
+
+    var offset: Int {
+        rowCaches.map(\.offset).min() ?? 0
+    }
+
+    var ropeOffset: RoPEOffset {
+        .batch(MLXArray(rowCaches.map { Int32($0.offset) }))
+    }
+
+    var maxSize: Int? {
+        rowCaches.compactMap(\.maxSize).min()
+    }
+
+    func innerState() -> [MLXArray] {
+        []
+    }
+
+    func update(keys: MLXArray, values: MLXArray) -> (MLXArray, MLXArray) {
+        guard keys.ndim == 4,
+              values.ndim == 4,
+              keys.dim(0) == rowCaches.count,
+              values.dim(0) == rowCaches.count
+        else {
+            return (keys, values)
+        }
+        var updatedKeys: [MLXArray] = []
+        var updatedValues: [MLXArray] = []
+        updatedKeys.reserveCapacity(rowCaches.count)
+        updatedValues.reserveCapacity(rowCaches.count)
+        for (rowIndex, cache) in rowCaches.enumerated() {
+            let keySlice = keys[rowIndex ..< rowIndex + 1, 0..., 0..., 0...]
+            let valueSlice = values[rowIndex ..< rowIndex + 1, 0..., 0..., 0...]
+            let updated = cache.update(keys: keySlice, values: valueSlice)
+            updatedKeys.append(updated.0)
+            updatedValues.append(updated.1)
+        }
+        return (
+            Self.concatenatePadded(updatedKeys, fallback: keys),
+            Self.concatenatePadded(updatedValues, fallback: values)
+        )
+    }
+
+    var state: [MLXArray] {
+        get { [] }
+        set { _ = newValue }
+    }
+
+    var metaState: [String] {
+        get { ["macprovider_paged_kv_batch_v1"] }
+        set { _ = newValue }
+    }
+
+    var isTrimmable: Bool {
+        rowCaches.allSatisfy(\.isTrimmable)
+    }
+
+    @discardableResult
+    func trim(_ n: Int) -> Int {
+        rowCaches.map { $0.trim(n) }.min() ?? 0
+    }
+
+    func makeMask(
+        n: Int,
+        windowSize: Int?,
+        returnArray: Bool
+    ) -> MLXFast.ScaledDotProductAttentionMaskMode {
+        let lengths = rowCaches.map(\.offset)
+        if n == 1, Set(lengths).count <= 1 { return .none }
+        return .array(createCausalMask(
+            n: n,
+            offset: lengths.max() ?? offset,
+            windowSize: windowSize,
+            lengths: MLXArray(lengths.map(Int32.init))
+        ))
+    }
+
+    func prepare(lengths: [Int]?) {
+        preparedLengths = lengths
+    }
+
+    func prepare(lengths: MLXArray?) {
+        preparedLengths = lengths?.asArray(Int.self)
+    }
+
+    func finalize() {
+        preparedLengths = nil
+    }
+
+    func copy() -> any KVCache {
+        PagedKVBatchLayerCache(rowCaches: rowCaches.map { $0.concreteCopy() })
+    }
+
+    private static func concatenatePadded(_ arrays: [MLXArray], fallback: MLXArray) -> MLXArray {
+        guard let first = arrays.first,
+              arrays.allSatisfy({
+                  $0.ndim == 4
+                      && $0.dim(0) == first.dim(0)
+                      && $0.dim(1) == first.dim(1)
+                      && $0.dim(3) == first.dim(3)
+                      && $0.dtype == first.dtype
+              })
+        else {
+            return fallback
+        }
+        let maxSequenceLength = arrays.map { $0.dim(2) }.max() ?? 0
+        let padded = arrays.map { array -> MLXArray in
+            let padTokens = maxSequenceLength - array.dim(2)
+            guard padTokens > 0 else { return array }
+            let pad = MLXArray.zeros([array.dim(0), array.dim(1), padTokens, array.dim(3)], dtype: array.dtype)
+            return concatenated([array, pad], axis: 2)
+        }
+        return concatenated(padded, axis: 0)
+    }
+}

--- a/phase3-binary/Tests/MacProviderCoreTests/PagedKVEngineTests.swift
+++ b/phase3-binary/Tests/MacProviderCoreTests/PagedKVEngineTests.swift
@@ -35,6 +35,53 @@ final class PagedKVEngineTests: XCTestCase {
         )
     }
 
+    private func observedIdentity(
+        proof: PagedKVHardwareSizingProof,
+        hardwareClass: String? = nil,
+        metallibSHA256: String? = nil,
+        kernelIdentifier: String? = nil,
+        parityLabel: String? = nil,
+        moeDispatchProven: Bool = true,
+        poolEpoch: Int? = nil,
+        source: PagedKVObservedRuntimeIdentitySource = .runtimeMeasurement
+    ) -> PagedKVObservedRuntimeIdentity {
+        PagedKVObservedRuntimeIdentity(
+            hardwareClass: hardwareClass ?? proof.hardwareClass,
+            metallibSHA256: metallibSHA256 ?? proof.metallibSHA256,
+            kernelIdentifier: kernelIdentifier ?? proof.kernelIdentifier,
+            parityLabel: parityLabel ?? proof.parityLabel,
+            moeDispatchProven: moeDispatchProven,
+            poolEpoch: poolEpoch ?? proof.poolEpoch,
+            source: source
+        )
+    }
+
+    private func attachableGates(
+        proof: PagedKVHardwareSizingProof,
+        observedIdentity: PagedKVObservedRuntimeIdentity? = nil,
+        moeDispatchProven: Bool = true,
+        engineBridgeAvailable: Bool = true
+    ) -> PagedKVGates {
+        let identity = observedIdentity ?? self.observedIdentity(
+            proof: proof,
+            moeDispatchProven: moeDispatchProven
+        )
+        return PagedKVGates(
+            identityAvailable: true,
+            observedHardwareClass: identity.hardwareClass,
+            metallibAvailable: true,
+            kernelRegistered: true,
+            parityEstablished: true,
+            hardwareSizingProof: proof,
+            observedMetallibSHA256: identity.metallibSHA256,
+            observedKernelIdentifier: identity.kernelIdentifier,
+            observedParityLabel: identity.parityLabel,
+            moeDispatchProven: moeDispatchProven,
+            engineBridgeAvailable: engineBridgeAvailable,
+            observedRuntimeIdentity: identity
+        )
+    }
+
     private func decide(
         config: PagedKVConfig,
         runtimeCacheClass: String,
@@ -183,18 +230,7 @@ final class PagedKVEngineTests: XCTestCase {
             kvBits: nil,
             modelFamily: "qwen",
             requiresMoEDispatch: true,
-            gates: PagedKVGates(
-                identityAvailable: true,
-                observedHardwareClass: "apple-silicon-test",
-                metallibAvailable: true,
-                kernelRegistered: true,
-                parityEstablished: true,
-                hardwareSizingProof: proof,
-                observedMetallibSHA256: proof.metallibSHA256,
-                observedKernelIdentifier: proof.kernelIdentifier,
-                observedParityLabel: proof.parityLabel,
-                moeDispatchProven: true
-            )
+            gates: attachableGates(proof: proof, engineBridgeAvailable: false)
         )
         XCTAssertEqual(decision, .fallback(.kernel))
     }
@@ -208,19 +244,7 @@ final class PagedKVEngineTests: XCTestCase {
             kvBits: nil,
             modelFamily: "qwen",
             requiresMoEDispatch: true,
-            gates: PagedKVGates(
-                identityAvailable: true,
-                observedHardwareClass: "apple-silicon-test",
-                metallibAvailable: true,
-                kernelRegistered: true,
-                parityEstablished: true,
-                hardwareSizingProof: proof,
-                observedMetallibSHA256: proof.metallibSHA256,
-                observedKernelIdentifier: proof.kernelIdentifier,
-                observedParityLabel: proof.parityLabel,
-                moeDispatchProven: true,
-                engineBridgeAvailable: true
-            )
+            gates: attachableGates(proof: proof)
         )
         let descriptor = try XCTUnwrap(decision.descriptor)
         XCTAssertTrue(descriptor.admits(
@@ -272,6 +296,75 @@ final class PagedKVEngineTests: XCTestCase {
         XCTAssertEqual(descriptor.hardwareClass, "apple-silicon-test")
         XCTAssertEqual(descriptor.metallibSHA256, String(repeating: "d", count: 64))
         XCTAssertEqual(descriptor.kernelIdentifier, "paged_attention_v1")
+        XCTAssertFalse(PagedKVDescriptor(
+            blockSizeTokens: 32,
+            maxPhysicalBlocks: 64,
+            modelID: proofModelID,
+            modelSHA256: proofModelSHA256,
+            tokenizerSHA256: proofTokenizerSHA256,
+            chatTemplateSHA256: proofChatTemplateSHA256,
+            supportedModelFamilies: ["qwen"],
+            supportsMoEDispatch: true,
+            hardwareClass: nil,
+            metallibSHA256: String(repeating: "d", count: 64),
+            kernelIdentifier: "paged_attention_v1",
+            parityLabel: "sdpa-parity-v1"
+        ).admits(
+            modelID: proofModelID,
+            modelSHA256: proofModelSHA256,
+            tokenizerSHA256: proofTokenizerSHA256,
+            chatTemplateSHA256: proofChatTemplateSHA256,
+            cacheClass: "KVCacheSimple",
+            kvDType: .fp16,
+            requiresMoE: true,
+            hardwareClass: "apple-silicon-test",
+            metallibSHA256: String(repeating: "d", count: 64),
+            kernelIdentifier: "paged_attention_v1",
+            parityLabel: "sdpa-parity-v1",
+            poolEpoch: 1
+        ))
+        XCTAssertFalse(descriptor.admits(
+            modelID: proofModelID,
+            modelSHA256: proofModelSHA256,
+            tokenizerSHA256: proofTokenizerSHA256,
+            chatTemplateSHA256: proofChatTemplateSHA256,
+            cacheClass: "KVCacheSimple",
+            kvDType: .fp16,
+            requiresMoE: false,
+            hardwareClass: "",
+            metallibSHA256: String(repeating: "d", count: 64),
+            kernelIdentifier: "paged_attention_v1",
+            parityLabel: "sdpa-parity-v1",
+            poolEpoch: 1
+        ))
+        XCTAssertFalse(descriptor.admits(
+            modelID: proofModelID,
+            modelSHA256: proofModelSHA256,
+            tokenizerSHA256: proofTokenizerSHA256,
+            chatTemplateSHA256: proofChatTemplateSHA256,
+            cacheClass: "KVCacheSimple",
+            kvDType: .fp16,
+            requiresMoE: false,
+            hardwareClass: "apple-silicon-test",
+            metallibSHA256: "",
+            kernelIdentifier: "paged_attention_v1",
+            parityLabel: "sdpa-parity-v1",
+            poolEpoch: 1
+        ))
+        XCTAssertFalse(descriptor.admits(
+            modelID: proofModelID,
+            modelSHA256: proofModelSHA256,
+            tokenizerSHA256: proofTokenizerSHA256,
+            chatTemplateSHA256: proofChatTemplateSHA256,
+            cacheClass: "KVCacheSimple",
+            kvDType: .fp16,
+            requiresMoE: false,
+            hardwareClass: "apple-silicon-test",
+            metallibSHA256: String(repeating: "d", count: 64),
+            kernelIdentifier: "paged_attention_v1",
+            parityLabel: "sdpa-parity-v1",
+            poolEpoch: 0
+        ))
         XCTAssertFalse(descriptor.admits(
             modelID: "mlx-community/Other-Qwen",
             modelSHA256: proofModelSHA256,
@@ -325,20 +418,89 @@ final class PagedKVEngineTests: XCTestCase {
             kvBits: nil,
             modelFamily: "qwen",
             requiresMoEDispatch: true,
-            gates: PagedKVGates(
-                identityAvailable: true,
-                observedHardwareClass: "apple-silicon-test",
-                metallibAvailable: true,
-                kernelRegistered: true,
-                parityEstablished: true,
-                hardwareSizingProof: proof,
-                observedMetallibSHA256: proof.metallibSHA256,
-                observedKernelIdentifier: proof.kernelIdentifier,
-                observedParityLabel: proof.parityLabel,
-                moeDispatchProven: false
-            )
+            gates: attachableGates(proof: proof, moeDispatchProven: false)
         )
         XCTAssertEqual(unprovenMoE, .fallback(.kernel))
+    }
+
+    func testAttachGateRequiresMeasuredObservedIdentity() {
+        let config = PagedKVConfig(enabled: true, blockSizeTokens: 32, maxPhysicalBlocks: 64)
+        let proof = sizingProof(modelFamily: "qwen", blockSizeTokens: 32, maxPhysicalBlocks: 64)
+
+        let legacyFieldsOnly = PagedKVGates(
+            identityAvailable: true,
+            observedHardwareClass: proof.hardwareClass,
+            metallibAvailable: true,
+            kernelRegistered: true,
+            parityEstablished: true,
+            hardwareSizingProof: proof,
+            observedMetallibSHA256: proof.metallibSHA256,
+            observedKernelIdentifier: proof.kernelIdentifier,
+            observedParityLabel: proof.parityLabel,
+            moeDispatchProven: true,
+            engineBridgeAvailable: true
+        )
+        XCTAssertEqual(
+            decide(
+                config: config,
+                runtimeCacheClass: "KVCacheSimple",
+                kvBits: nil,
+                modelFamily: "qwen",
+                requiresMoEDispatch: false,
+                gates: legacyFieldsOnly
+            ),
+            .fallback(.allocator)
+        )
+
+        let advertisedAsObserved = observedIdentity(
+            proof: proof,
+            source: .advertisedDescriptor
+        )
+        XCTAssertEqual(
+            decide(
+                config: config,
+                runtimeCacheClass: "KVCacheSimple",
+                kvBits: nil,
+                modelFamily: "qwen",
+                requiresMoEDispatch: false,
+                gates: attachableGates(proof: proof, observedIdentity: advertisedAsObserved)
+            ),
+            .fallback(.allocator)
+        )
+
+        let partialRuntimeIdentity = observedIdentity(
+            proof: proof,
+            hardwareClass: "",
+            source: .runtimeMeasurement
+        )
+        XCTAssertEqual(
+            decide(
+                config: config,
+                runtimeCacheClass: "KVCacheSimple",
+                kvBits: nil,
+                modelFamily: "qwen",
+                requiresMoEDispatch: false,
+                gates: attachableGates(proof: proof, observedIdentity: partialRuntimeIdentity)
+            ),
+            .fallback(.allocator)
+        )
+
+        let mismatchedRuntimeIdentity = observedIdentity(
+            proof: proof,
+            kernelIdentifier: "different-kernel",
+            source: .runtimeMeasurement
+        )
+        XCTAssertEqual(
+            decide(
+                config: config,
+                runtimeCacheClass: "KVCacheSimple",
+                kvBits: nil,
+                modelFamily: "qwen",
+                requiresMoEDispatch: false,
+                gates: attachableGates(proof: proof, observedIdentity: mismatchedRuntimeIdentity)
+            ),
+            .fallback(.allocator)
+        )
     }
 
     func testAttachGateRequiresKnownFamilyAndHardwareSizingProof() {

--- a/phase3-binary/Tests/macprovider-cliTests/ContinuousBatchSchedulerTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ContinuousBatchSchedulerTests.swift
@@ -895,6 +895,7 @@ final class ContinuousBatchSchedulerTests: XCTestCase {
                 cachedPromptTokens: 0
             ))
         }
+        try await eventually { await scheduler.metrics().waitingCount == 1 }
         await decodeGate.open()
 
         let r1 = try await first.value
@@ -1845,6 +1846,7 @@ final class ContinuousBatchSchedulerTests: XCTestCase {
                 maxOutputTokens: 1
             ))
         }
+        try await eventually { await scheduler.metrics().waitingCount == 1 }
         await decodeGate.open()
 
         try await eventually {

--- a/phase3-binary/Tests/macprovider-cliTests/KVConversationColdTierTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/KVConversationColdTierTests.swift
@@ -806,6 +806,15 @@ final class KVConversationColdTierTests: XCTestCase {
             maxResidentTokens: 8,
             parityLabel: "sdpa-parity-v1"
         )
+        let observedIdentity = PagedKVObservedRuntimeIdentity(
+            hardwareClass: proof.hardwareClass,
+            metallibSHA256: proof.metallibSHA256,
+            kernelIdentifier: proof.kernelIdentifier,
+            parityLabel: proof.parityLabel,
+            moeDispatchProven: false,
+            poolEpoch: proof.poolEpoch,
+            source: .runtimeMeasurement
+        )
         let decision = PagedKVAttachGate.decide(
             config: PagedKVConfig(enabled: true, blockSizeTokens: 2, maxPhysicalBlocks: 4),
             runtimeCacheClass: "KVCacheSimple",
@@ -826,7 +835,8 @@ final class KVConversationColdTierTests: XCTestCase {
                 observedMetallibSHA256: proof.metallibSHA256,
                 observedKernelIdentifier: proof.kernelIdentifier,
                 observedParityLabel: proof.parityLabel,
-                engineBridgeAvailable: true
+                engineBridgeAvailable: true,
+                observedRuntimeIdentity: observedIdentity
             )
         )
         let descriptor = try XCTUnwrap(decision.descriptor)

--- a/phase3-binary/Tests/macprovider-cliTests/PagedKVRuntimeBridgeTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/PagedKVRuntimeBridgeTests.swift
@@ -1,0 +1,871 @@
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+@testable import MacProviderCore
+@testable import macprovider_cli
+import XCTest
+
+private enum PagedKVRuntimeBridgeTestError: Error {
+    case notExpected
+}
+
+private final class RuntimeBridgeChunkRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [StreamChunk] = []
+
+    func append(_ chunk: StreamChunk) {
+        lock.lock()
+        defer { lock.unlock() }
+        values.append(chunk)
+    }
+
+    func chunks() -> [StreamChunk] {
+        lock.lock()
+        defer { lock.unlock() }
+        return values
+    }
+}
+
+final class PagedKVRuntimeBridgeTests: XCTestCase {
+    func testRuntimeCapabilityRequiresMeasuredObservedIdentityAndBackend() async throws {
+        let modelID = "mlx-community/Qwen-Test"
+        let modelSHA = String(repeating: "a", count: 64)
+        let proof = Self.sizingProof(modelID: modelID, modelSHA: modelSHA)
+        let observedIdentity = Self.observedIdentity(from: proof)
+
+        let attached = ModelRuntime(
+            modelID: modelID,
+            modelHash: modelSHA,
+            pagedKVConfig: PagedKVConfig(enabled: true, blockSizeTokens: 32, maxPhysicalBlocks: 64),
+            maxBatch: 2,
+            continuousBatchingMode: .on,
+            warmSwapEnabled: false,
+            pagedKVObservedRuntimeIdentity: observedIdentity,
+            pagedKVHardwareSizingProof: proof,
+            pagedKVRuntimeCacheClass: "KVCacheSimple",
+            pagedKVSchedulerBackendInstalled: true,
+            continuousBatchingBackend: RuntimeBridgeScriptedBackend(scripts: [:]),
+            loader: { _ in throw PagedKVRuntimeBridgeTestError.notExpected }
+        )
+        let attachedDecision = await attached.pagedKVDecisionForTest()
+        let attachedCapability = await attached.continuousBatchingCapabilityForTest()
+        XCTAssertNotNil(attachedDecision.descriptor)
+        XCTAssertNil(attachedCapability.unsupportedReason)
+
+        let nilObservation = ModelRuntime(
+            modelID: modelID,
+            modelHash: modelSHA,
+            pagedKVConfig: PagedKVConfig(enabled: true, blockSizeTokens: 32, maxPhysicalBlocks: 64),
+            maxBatch: 2,
+            continuousBatchingMode: .on,
+            warmSwapEnabled: false,
+            pagedKVHardwareSizingProof: proof,
+            pagedKVRuntimeCacheClass: "KVCacheSimple",
+            pagedKVSchedulerBackendInstalled: true,
+            loader: { _ in throw PagedKVRuntimeBridgeTestError.notExpected }
+        )
+        let nilObservationDecision = await nilObservation.pagedKVDecisionForTest()
+        let nilObservationCapability = await nilObservation.continuousBatchingCapabilityForTest()
+        XCTAssertNil(nilObservationDecision.descriptor)
+        XCTAssertNotNil(nilObservationCapability.unsupportedReason)
+
+        let advertisedObservation = ModelRuntime(
+            modelID: modelID,
+            modelHash: modelSHA,
+            pagedKVConfig: PagedKVConfig(enabled: true, blockSizeTokens: 32, maxPhysicalBlocks: 64),
+            maxBatch: 2,
+            continuousBatchingMode: .on,
+            warmSwapEnabled: false,
+            pagedKVObservedRuntimeIdentity: Self.observedIdentity(from: proof, source: .advertisedDescriptor),
+            pagedKVHardwareSizingProof: proof,
+            pagedKVRuntimeCacheClass: "KVCacheSimple",
+            pagedKVSchedulerBackendInstalled: true,
+            loader: { _ in throw PagedKVRuntimeBridgeTestError.notExpected }
+        )
+        let advertisedDecision = await advertisedObservation.pagedKVDecisionForTest()
+        let advertisedCapability = await advertisedObservation.continuousBatchingCapabilityForTest()
+        XCTAssertNil(advertisedDecision.descriptor)
+        XCTAssertNotNil(advertisedCapability.unsupportedReason)
+
+        let noBackend = ModelRuntime(
+            modelID: modelID,
+            modelHash: modelSHA,
+            pagedKVConfig: PagedKVConfig(enabled: true, blockSizeTokens: 32, maxPhysicalBlocks: 64),
+            maxBatch: 2,
+            continuousBatchingMode: .on,
+            warmSwapEnabled: false,
+            pagedKVObservedRuntimeIdentity: observedIdentity,
+            pagedKVHardwareSizingProof: proof,
+            pagedKVRuntimeCacheClass: "KVCacheSimple",
+            pagedKVSchedulerBackendInstalled: false,
+            loader: { _ in throw PagedKVRuntimeBridgeTestError.notExpected }
+        )
+        let noBackendDecision = await noBackend.pagedKVDecisionForTest()
+        let noBackendCapability = await noBackend.continuousBatchingCapabilityForTest()
+        XCTAssertNil(noBackendDecision.descriptor)
+        XCTAssertNotNil(noBackendCapability.unsupportedReason)
+    }
+
+    func testSharedForwardGreedyMatchesSerialLoneAndFullBatchWithUsageAndStops() async throws {
+        let gate = RuntimeBridgeTestGate()
+        let scripts = [
+            "serial-a": [4, 5, 6],
+            "serial-b": [7, 8],
+            "lone": [9, 10],
+        ]
+        let backend = RuntimeBridgeScriptedBackend(scripts: scripts, decodeGate: gate)
+        let scheduler = try Self.makeScheduler(maxActiveRows: 2, backend: backend)
+
+        let aTask = Task {
+            try await scheduler.submit(.init(
+                id: "serial-a",
+                conversationKey: "",
+                promptTokens: [1],
+                maxOutputTokens: 3,
+                stopTokenSequences: [[5, 6]],
+                temperature: 0.0,
+                topP: 1.0
+            ))
+        }
+        try await Self.eventually { await backend.decodeCallCount() == 1 }
+        let bTask = Task {
+            try await scheduler.submit(.init(
+                id: "serial-b",
+                conversationKey: "",
+                promptTokens: [2],
+                maxOutputTokens: 2,
+                temperature: 0.0,
+                topP: 1.0
+            ))
+        }
+        await gate.open()
+
+        let a = try await aTask.value
+        let b = try await bTask.value
+        XCTAssertEqual(a.outputTokens, [4])
+        XCTAssertEqual(a.completionTokens, 3)
+        XCTAssertEqual(a.emittedTokens, 1)
+        XCTAssertEqual(a.terminalStatus, .stop)
+        XCTAssertEqual(b.outputTokens, [7, 8])
+        XCTAssertEqual(b.completionTokens, 2)
+        XCTAssertEqual(b.emittedTokens, 2)
+        XCTAssertEqual(b.terminalStatus, .length)
+        let decodeBatches = await backend.decodeBatches()
+        let metrics = await scheduler.metrics()
+        XCTAssertTrue(decodeBatches.contains(["serial-a", "serial-b"]))
+        XCTAssertEqual(metrics.maxObservedBatchDepth, 2)
+
+        let loneBackend = RuntimeBridgeScriptedBackend(scripts: scripts)
+        let loneScheduler = try Self.makeScheduler(maxActiveRows: 2, backend: loneBackend)
+        let lone = try await loneScheduler.submit(.init(
+            id: "lone",
+            conversationKey: "",
+            promptTokens: [3],
+            maxOutputTokens: 2,
+            temperature: 0.0,
+            topP: 1.0
+        ))
+        XCTAssertEqual(lone.outputTokens, [9, 10])
+        XCTAssertEqual(lone.completionTokens, 2)
+        XCTAssertEqual(lone.emittedTokens, 2)
+        XCTAssertEqual(lone.terminalStatus, .length)
+    }
+
+    func testRealSharedForwardBackendGreedyMatchesLoneAndMixedOffsetBatch() async throws {
+        guard PagedKVMetallibGate.defaultMetallibExists() else {
+            throw XCTSkip("MLX default metallib is unavailable in this test host")
+        }
+
+        let descriptor = Self.bridgeDescriptor()
+        let container = ModelContainer(context: ModelContext(
+            configuration: ModelConfiguration(id: descriptor.modelID),
+            model: RuntimeBridgeFakeModel(nextTokenByInput: [
+                1: 4,
+                4: 5,
+                12: 7,
+                7: 8,
+            ]),
+            processor: StandInUserInputProcessor(),
+            tokenizer: RuntimeBridgeFakeTokenizer()
+        ))
+        let backend = PagedKVSharedForwardBackend(container: container, descriptor: descriptor, layerCount: 1)
+        let allocator = try PagedKVBlockAllocator(blockSizeTokens: descriptor.blockSizeTokens, maxPhysicalBlocks: 16)
+
+        let aHandle = try await allocator.allocate(conversationKey: "row-a", maxTokens: 8)
+        let bHandle = try await allocator.allocate(conversationKey: "row-b", maxTokens: 8)
+        _ = try await allocator.extend(bHandle, by: 2)
+        let bPrefillBinding = try await allocator.binding(for: bHandle)
+        _ = try await backend.prefill(rows: [
+            ContinuousBatchPrefillInput(
+                requestID: "row-b",
+                promptTokens: [10, 11],
+                binding: bPrefillBinding,
+                promptTokenOffset: 0,
+                committedKVTokenCount: 0,
+                targetKVTokenCount: 2,
+                isFinalChunk: true
+            ),
+        ])
+
+        let aInput = try await Self.decodeInput(
+            requestID: "row-a",
+            currentToken: 1,
+            handle: aHandle,
+            allocator: allocator,
+            committedKVTokenCount: 0
+        )
+        let bInput = try await Self.decodeInput(
+            requestID: "row-b",
+            currentToken: 12,
+            handle: bHandle,
+            allocator: allocator,
+            committedKVTokenCount: 2
+        )
+        let batched = try await backend.decode(rows: [aInput, bInput])
+        try await allocator.endDecodeStep(aHandle)
+        try await allocator.endDecodeStep(bHandle)
+        XCTAssertEqual(Self.tokens(from: batched), ["row-a": 4, "row-b": 7])
+        XCTAssertEqual(backend.retainedRowCountForTest(), 2)
+        backend.finish(requestID: "row-a")
+        backend.finish(requestID: "row-b")
+        XCTAssertEqual(backend.retainedRowCountForTest(), 0)
+
+        let loneBackend = PagedKVSharedForwardBackend(container: container, descriptor: descriptor, layerCount: 1)
+        let loneAllocator = try PagedKVBlockAllocator(blockSizeTokens: descriptor.blockSizeTokens, maxPhysicalBlocks: 16)
+        let loneHandle = try await loneAllocator.allocate(conversationKey: "lone", maxTokens: 8)
+        let loneInput = try await Self.decodeInput(
+            requestID: "lone",
+            currentToken: 1,
+            handle: loneHandle,
+            allocator: loneAllocator,
+            committedKVTokenCount: 0
+        )
+        let lone = try await loneBackend.decode(rows: [loneInput])
+        try await loneAllocator.endDecodeStep(loneHandle)
+        XCTAssertEqual(Self.tokens(from: lone), ["lone": 4])
+    }
+
+    func testRealSharedForwardBackendCancelWaitsForActivePrefill() async throws {
+        guard PagedKVMetallibGate.defaultMetallibExists() else {
+            throw XCTSkip("MLX default metallib is unavailable in this test host")
+        }
+
+        let descriptor = Self.bridgeDescriptor()
+        let modelGate = RuntimeBridgeBlockingModelGate()
+        let container = ModelContainer(context: ModelContext(
+            configuration: ModelConfiguration(id: descriptor.modelID),
+            model: RuntimeBridgeBlockingModel(gate: modelGate),
+            processor: StandInUserInputProcessor(),
+            tokenizer: RuntimeBridgeFakeTokenizer()
+        ))
+        let backend = PagedKVSharedForwardBackend(container: container, descriptor: descriptor, layerCount: 1)
+        let allocator = try PagedKVBlockAllocator(blockSizeTokens: descriptor.blockSizeTokens, maxPhysicalBlocks: 16)
+        let handle = try await allocator.allocate(conversationKey: "cancel-row", maxTokens: 8)
+        _ = try await allocator.extend(handle, by: 1)
+        let binding = try await allocator.binding(for: handle)
+
+        let prefill = Task {
+            try await backend.prefill(rows: [
+                ContinuousBatchPrefillInput(
+                    requestID: "cancel-row",
+                    promptTokens: [1],
+                    binding: binding,
+                    promptTokenOffset: 0,
+                    committedKVTokenCount: 0,
+                    targetKVTokenCount: 1,
+                    isFinalChunk: true
+                ),
+            ])
+        }
+        XCTAssertTrue(modelGate.waitUntilEntered(), "prefill should enter the fake model before cancellation")
+
+        let cancellation = RuntimeBridgeCancellationMarker()
+        let cancel = Task {
+            await backend.cancelInFlight()
+            cancellation.markReturned()
+        }
+        try await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertFalse(cancellation.returned(), "cancelInFlight must wait for the active container.perform call")
+        modelGate.release()
+        _ = try await prefill.value
+        await cancel.value
+        XCTAssertTrue(cancellation.returned())
+        XCTAssertEqual(backend.retainedRowCountForTest(), 0)
+    }
+
+    func testAttachedModelRuntimeServesFreshGreedyRequestsThroughScheduler() async throws {
+        guard PagedKVMetallibGate.defaultMetallibExists() else {
+            throw XCTSkip("MLX default metallib is unavailable in this test host")
+        }
+
+        let modelID = "mlx-community/Qwen-Test"
+        let modelSHA = String(repeating: "a", count: 64)
+        let proof = Self.sizingProof(modelID: modelID, modelSHA: modelSHA)
+        let backend = RuntimeBridgeScriptedBackend(scripts: [:])
+        let container = ModelContainer(context: ModelContext(
+            configuration: ModelConfiguration(id: modelID),
+            model: RuntimeBridgeFakeModel(nextTokenByInput: [:]),
+            processor: RuntimeBridgePromptProcessor(tokens: [3]),
+            tokenizer: RuntimeBridgeFakeTokenizer()
+        ))
+        let runtime = ModelRuntime(
+            modelID: modelID,
+            modelHash: modelSHA,
+            pagedKVConfig: PagedKVConfig(enabled: true, blockSizeTokens: 32, maxPhysicalBlocks: 64),
+            maxBatch: 2,
+            continuousBatchingMode: .on,
+            warmSwapEnabled: false,
+            pagedKVObservedRuntimeIdentity: Self.observedIdentity(from: proof),
+            pagedKVHardwareSizingProof: proof,
+            pagedKVRuntimeCacheClass: "KVCacheSimple",
+            pagedKVSchedulerBackendInstalled: true,
+            container: container,
+            continuousBatchingBackend: backend,
+            loader: { _ in throw PagedKVRuntimeBridgeTestError.notExpected }
+        )
+        let request = try Self.chatRequest(modelID: modelID, maxTokens: 2)
+
+        let completion = try await runtime.complete(request)
+        XCTAssertEqual(completion.content, "3 3")
+        XCTAssertEqual(completion.finishReason, "length")
+        XCTAssertEqual(completion.promptTokens, 1)
+        XCTAssertEqual(completion.completionTokens, 2)
+        let completionDecodeCalls = await backend.decodeCallCount()
+        XCTAssertEqual(completionDecodeCalls, 2)
+
+        let chunkRecorder = RuntimeBridgeChunkRecorder()
+        let handle = try await runtime.acquireRequestHandle(request)
+        let streamed = try await runtime.stream(
+            request,
+            with: handle,
+            onChunk: { chunkRecorder.append($0) }
+        )
+        await runtime.unregisterInFlight(handle.registrationID)
+        XCTAssertEqual(streamed.content, "3 3")
+        let chunks = chunkRecorder.chunks()
+        XCTAssertEqual(chunks.count, 2)
+        let chunkText = chunks.compactMap { chunk -> String? in
+            if case .content(let text) = chunk { return text }
+            return nil
+        }
+        XCTAssertEqual(chunkText, ["3", " 3"])
+        let streamedDecodeCalls = await backend.decodeCallCount()
+        XCTAssertEqual(streamedDecodeCalls, 4)
+    }
+
+    func testAttachedModelRuntimeCancelsBlockedCompletionSubmit() async throws {
+        guard PagedKVMetallibGate.defaultMetallibExists() else {
+            throw XCTSkip("MLX default metallib is unavailable in this test host")
+        }
+
+        let gate = RuntimeBridgeTestGate()
+        let backend = RuntimeBridgeScriptedBackend(scripts: [:], decodeGate: gate)
+        let modelID = "mlx-community/Qwen-Test"
+        let runtime = Self.attachedRuntime(modelID: modelID, backend: backend)
+        let request = try Self.chatRequest(modelID: modelID, maxTokens: 2)
+        let cancellation = RuntimeBridgeCancellationFlag()
+
+        let task = Task {
+            try await runtime.complete(request, shouldCancel: { cancellation.isCancelled() })
+        }
+        try await Self.eventually { await backend.decodeCallCount() == 1 }
+        cancellation.cancel()
+        await gate.open()
+        do {
+            _ = try await task.value
+            XCTFail("attached completion should cancel while scheduler submit is blocked")
+        } catch is CancellationError {
+            // Expected.
+        }
+    }
+
+    func testAttachedModelRuntimeCancelsBlockedStreamingSubmit() async throws {
+        guard PagedKVMetallibGate.defaultMetallibExists() else {
+            throw XCTSkip("MLX default metallib is unavailable in this test host")
+        }
+
+        let gate = RuntimeBridgeTestGate()
+        let backend = RuntimeBridgeScriptedBackend(scripts: [:], decodeGate: gate)
+        let modelID = "mlx-community/Qwen-Test"
+        let runtime = Self.attachedRuntime(modelID: modelID, backend: backend)
+        let request = try Self.chatRequest(modelID: modelID, maxTokens: 2)
+        let cancellation = RuntimeBridgeCancellationFlag()
+        let chunks = RuntimeBridgeChunkRecorder()
+        let handle = try await runtime.acquireRequestHandle(request)
+
+        let task = Task {
+            try await runtime.stream(
+                request,
+                with: handle,
+                shouldCancel: { cancellation.isCancelled() },
+                onChunk: { chunks.append($0) }
+            )
+        }
+        try await Self.eventually { await backend.decodeCallCount() == 1 }
+        cancellation.cancel()
+        await gate.open()
+        do {
+            _ = try await task.value
+            XCTFail("attached streaming should cancel while scheduler submit is blocked")
+        } catch is CancellationError {
+            // Expected.
+        }
+        await runtime.unregisterInFlight(handle.registrationID)
+        XCTAssertTrue(chunks.chunks().isEmpty)
+    }
+
+    func testStickyRequestsRemainRejectedBeforeFRPKV10CacheBridge() async throws {
+        let backend = RuntimeBridgeScriptedBackend(scripts: [:])
+        let scheduler = try Self.makeScheduler(maxActiveRows: 2, backend: backend)
+
+        do {
+            _ = try await scheduler.submit(.init(
+                id: "sticky",
+                conversationKey: "conversation-1",
+                promptTokens: [1],
+                maxOutputTokens: 1,
+                temperature: 0.0,
+                topP: 1.0
+            ))
+            XCTFail("sticky requests must not enter the Increment 1 batch path")
+        } catch ContinuousBatchSchedulerError.unsupported(let reason) {
+            XCTAssertEqual(reason, "keyed_or_sticky_cache_reuse_deferred_until_paged_kv_cache_bridge")
+        }
+        let decodeCallCount = await backend.decodeCallCount()
+        XCTAssertEqual(decodeCallCount, 0)
+    }
+
+    private static func makeScheduler(
+        maxActiveRows: Int,
+        backend: any ContinuousBatchSchedulerBackend
+    ) throws -> ContinuousBatchScheduler {
+        let descriptor = PagedKVDescriptor(
+            blockSizeTokens: 4,
+            maxPhysicalBlocks: 16,
+            modelID: "mlx-community/Qwen-Test",
+            modelSHA256: String(repeating: "a", count: 64),
+            tokenizerSHA256: nil,
+            chatTemplateSHA256: nil,
+            supportedModelFamilies: ["qwen"],
+            supportsMoEDispatch: false,
+            hardwareClass: "apple-silicon-test",
+            metallibSHA256: String(repeating: "b", count: 64),
+            kernelIdentifier: "macprovider_paged_kv_gather_v1",
+            parityLabel: "sdpa-parity-v1"
+        )
+        let tuple = ContinuousBatchingRequestedTuple(
+            modelID: descriptor.modelID,
+            modelSHA256: descriptor.modelSHA256,
+            tokenizerSHA256: descriptor.tokenizerSHA256,
+            chatTemplateSHA256: descriptor.chatTemplateSHA256,
+            cacheClass: "KVCacheSimple",
+            kvDType: .fp16,
+            requiresMoE: false,
+            hardwareClass: "apple-silicon-test",
+            metallibSHA256: descriptor.metallibSHA256,
+            kernelIdentifier: descriptor.kernelIdentifier,
+            parityLabel: descriptor.parityLabel,
+            poolEpoch: descriptor.poolEpoch
+        )
+        return ContinuousBatchScheduler(
+            configuration: ContinuousBatchSchedulerConfiguration(
+                descriptor: descriptor,
+                tuple: tuple,
+                maxActiveRows: maxActiveRows,
+                decodeHeadroomTokens: 4,
+                snapshot: ContinuousBatchSchedulerSnapshot(
+                    modelID: descriptor.modelID,
+                    modelSHA256: descriptor.modelSHA256,
+                    weightsGeneration: 1
+                )
+            ),
+            allocator: try PagedKVBlockAllocator(blockSizeTokens: 4, maxPhysicalBlocks: 16),
+            backend: backend,
+            replayAuthority: RuntimeBridgeReplayAuthority()
+        )
+    }
+
+    private static func bridgeDescriptor() -> PagedKVDescriptor {
+        PagedKVDescriptor(
+            blockSizeTokens: 4,
+            maxPhysicalBlocks: 16,
+            modelID: "mlx-community/Qwen-Test",
+            modelSHA256: String(repeating: "a", count: 64),
+            tokenizerSHA256: nil,
+            chatTemplateSHA256: nil,
+            supportedModelFamilies: ["qwen"],
+            supportsMoEDispatch: false,
+            hardwareClass: "apple-silicon-test",
+            metallibSHA256: String(repeating: "b", count: 64),
+            kernelIdentifier: "macprovider_paged_kv_gather_v1",
+            parityLabel: "sdpa-parity-v1"
+        )
+    }
+
+    private static func decodeInput(
+        requestID: String,
+        currentToken: Int,
+        handle: PagedKVBlockTableHandle,
+        allocator: PagedKVBlockAllocator,
+        committedKVTokenCount: Int
+    ) async throws -> ContinuousBatchDecodeInput {
+        let targetKVTokenCount = committedKVTokenCount + 1
+        _ = try await allocator.extend(handle, by: 1)
+        try await allocator.beginDecodeStep(handle)
+        let binding = try await allocator.binding(for: handle)
+        return ContinuousBatchDecodeInput(
+            requestID: requestID,
+            currentToken: currentToken,
+            generatedTokens: [],
+            promptTokens: [currentToken],
+            samplerSeed: 0,
+            temperature: 0.0,
+            topP: 1.0,
+            presencePenalty: 0.0,
+            frequencyPenalty: 0.0,
+            binding: binding,
+            blockTable: binding.currentTable,
+            committedKVTokenCount: committedKVTokenCount,
+            targetKVTokenCount: targetKVTokenCount,
+            samplerStep: 0
+        )
+    }
+
+    private static func tokens(from outcomes: [ContinuousBatchDecodeOutcome]) -> [String: Int] {
+        Dictionary(uniqueKeysWithValues: outcomes.compactMap { outcome in
+            guard case .output(let output) = outcome else { return nil }
+            return (output.requestID, output.token)
+        })
+    }
+
+    private static func chatRequest(modelID: String, maxTokens: Int) throws -> ChatCompletionRequest {
+        let body: [String: Any] = [
+            "model": modelID,
+            "messages": [["role": "user", "content": "hi"]],
+            "max_tokens": maxTokens,
+            "temperature": 0,
+            "top_p": 1.0,
+        ]
+        let data = try JSONSerialization.data(withJSONObject: body)
+        return try ChatCompletionRequest.parse(data: data)
+    }
+
+    private static func attachedRuntime(
+        modelID: String,
+        backend: RuntimeBridgeScriptedBackend
+    ) -> ModelRuntime {
+        let modelSHA = String(repeating: "a", count: 64)
+        let proof = Self.sizingProof(modelID: modelID, modelSHA: modelSHA)
+        let container = ModelContainer(context: ModelContext(
+            configuration: ModelConfiguration(id: modelID),
+            model: RuntimeBridgeFakeModel(nextTokenByInput: [:]),
+            processor: RuntimeBridgePromptProcessor(tokens: [3]),
+            tokenizer: RuntimeBridgeFakeTokenizer()
+        ))
+        return ModelRuntime(
+            modelID: modelID,
+            modelHash: modelSHA,
+            pagedKVConfig: PagedKVConfig(enabled: true, blockSizeTokens: 32, maxPhysicalBlocks: 64),
+            maxBatch: 2,
+            continuousBatchingMode: .on,
+            warmSwapEnabled: false,
+            pagedKVObservedRuntimeIdentity: Self.observedIdentity(from: proof),
+            pagedKVHardwareSizingProof: proof,
+            pagedKVRuntimeCacheClass: "KVCacheSimple",
+            pagedKVSchedulerBackendInstalled: true,
+            container: container,
+            continuousBatchingBackend: backend,
+            loader: { _ in throw PagedKVRuntimeBridgeTestError.notExpected }
+        )
+    }
+
+    private static func sizingProof(modelID: String, modelSHA: String) -> PagedKVHardwareSizingProof {
+        PagedKVHardwareSizingProof(
+            modelID: modelID,
+            modelSHA256: modelSHA,
+            tokenizerSHA256: nil,
+            chatTemplateSHA256: nil,
+            modelFamily: "qwen",
+            hardwareClass: "apple-silicon-test",
+            metallibSHA256: String(repeating: "b", count: 64),
+            kernelIdentifier: "macprovider_paged_kv_gather_v1",
+            blockSizeTokens: 32,
+            maxPhysicalBlocks: 64,
+            maxResidentTokens: 2048,
+            parityLabel: "sdpa-parity-v1"
+        )
+    }
+
+    private static func observedIdentity(
+        from proof: PagedKVHardwareSizingProof,
+        source: PagedKVObservedRuntimeIdentitySource = .runtimeMeasurement
+    ) -> PagedKVObservedRuntimeIdentity {
+        PagedKVObservedRuntimeIdentity(
+            hardwareClass: proof.hardwareClass,
+            metallibSHA256: proof.metallibSHA256,
+            kernelIdentifier: proof.kernelIdentifier,
+            parityLabel: proof.parityLabel,
+            moeDispatchProven: false,
+            poolEpoch: proof.poolEpoch,
+            source: source
+        )
+    }
+
+    private static func eventually(
+        timeoutNanoseconds: UInt64 = 2_000_000_000,
+        _ predicate: @escaping () async -> Bool
+    ) async throws {
+        let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
+        while DispatchTime.now().uptimeNanoseconds < deadline {
+            if await predicate() { return }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTFail("condition did not become true before timeout")
+    }
+}
+
+private final class RuntimeBridgeFakeModel: Module, LanguageModel, KVCacheDimensionProvider {
+    let kvHeads = [1]
+    private let vocabularySize: Int
+    private let nextTokenByInput: [Int: Int]
+
+    init(vocabularySize: Int = 32, nextTokenByInput: [Int: Int]) {
+        self.vocabularySize = vocabularySize
+        self.nextTokenByInput = nextTokenByInput
+        super.init()
+    }
+
+    func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws -> PrepareResult {
+        .tokens(input.text)
+    }
+
+    func callAsFunction(_ input: LMInput.Text, cache: [KVCache]?, state: LMOutput.State?) -> LMOutput {
+        let batch = input.tokens.dim(0)
+        let sequenceLength = input.tokens.dim(1)
+        let flatTokens = input.tokens.asArray(Int.self)
+        if let cache {
+            let keys = MLXArray(flatTokens.map(Float.init), [batch, 1, sequenceLength, 1])
+            let values = MLXArray(flatTokens.map { Float($0 + 100) }, [batch, 1, sequenceLength, 1])
+            for layer in cache {
+                let updated = layer.update(keys: keys, values: values)
+                eval(updated.0, updated.1)
+            }
+        }
+
+        var logits = Array(repeating: Float(-1_000), count: batch * sequenceLength * vocabularySize)
+        for row in 0 ..< batch {
+            for position in 0 ..< sequenceLength {
+                let token = flatTokens[row * sequenceLength + position]
+                let next = nextTokenByInput[token] ?? token
+                logits[(row * sequenceLength + position) * vocabularySize + next] = 1_000
+            }
+        }
+        return LMOutput(logits: MLXArray(logits, [batch, sequenceLength, vocabularySize]))
+    }
+}
+
+private final class RuntimeBridgeBlockingModel: Module, LanguageModel, KVCacheDimensionProvider {
+    let kvHeads = [1]
+    private let gate: RuntimeBridgeBlockingModelGate
+
+    init(gate: RuntimeBridgeBlockingModelGate) {
+        self.gate = gate
+        super.init()
+    }
+
+    func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws -> PrepareResult {
+        .tokens(input.text)
+    }
+
+    func callAsFunction(_ input: LMInput.Text, cache: [KVCache]?, state: LMOutput.State?) -> LMOutput {
+        gate.enterAndWaitUntilReleased()
+        let batch = input.tokens.dim(0)
+        let sequenceLength = input.tokens.dim(1)
+        if let cache {
+            let flatTokens = input.tokens.asArray(Int.self)
+            let keys = MLXArray(flatTokens.map(Float.init), [batch, 1, sequenceLength, 1])
+            let values = MLXArray(flatTokens.map { Float($0 + 100) }, [batch, 1, sequenceLength, 1])
+            for layer in cache {
+                let updated = layer.update(keys: keys, values: values)
+                eval(updated.0, updated.1)
+            }
+        }
+        var logits = Array(repeating: Float(-1_000), count: batch * sequenceLength * 32)
+        for index in 0 ..< batch * sequenceLength {
+            logits[index * 32 + 1] = 1_000
+        }
+        return LMOutput(logits: MLXArray(logits, [batch, sequenceLength, 32]))
+    }
+}
+
+private final class RuntimeBridgeBlockingModelGate: @unchecked Sendable {
+    private let condition = NSCondition()
+    private var entered = false
+    private var released = false
+
+    func enterAndWaitUntilReleased() {
+        condition.lock()
+        entered = true
+        condition.broadcast()
+        while !released {
+            condition.wait()
+        }
+        condition.unlock()
+    }
+
+    func waitUntilEntered(timeout: TimeInterval = 2) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        condition.lock()
+        defer { condition.unlock() }
+        while !entered {
+            if !condition.wait(until: deadline) {
+                return false
+            }
+        }
+        return true
+    }
+
+    func release() {
+        condition.lock()
+        released = true
+        condition.broadcast()
+        condition.unlock()
+    }
+}
+
+private final class RuntimeBridgeCancellationMarker: @unchecked Sendable {
+    private let lock = NSLock()
+    private var returnedValue = false
+
+    func markReturned() {
+        lock.lock()
+        returnedValue = true
+        lock.unlock()
+    }
+
+    func returned() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return returnedValue
+    }
+}
+
+private final class RuntimeBridgeCancellationFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var cancelled = false
+
+    func cancel() {
+        lock.lock()
+        cancelled = true
+        lock.unlock()
+    }
+
+    func isCancelled() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return cancelled
+    }
+}
+
+private struct RuntimeBridgeFakeTokenizer: Tokenizer {
+    let bosToken: String? = nil
+    let eosToken: String? = nil
+    let unknownToken: String? = nil
+
+    func encode(text: String, addSpecialTokens: Bool) -> [Int] { [] }
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String { tokenIds.map(String.init).joined(separator: " ") }
+    func convertTokenToId(_ token: String) -> Int? { Int(token) }
+    func convertIdToToken(_ id: Int) -> String? { String(id) }
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] {
+        []
+    }
+}
+
+private struct RuntimeBridgePromptProcessor: UserInputProcessor {
+    let tokens: [Int32]
+
+    func prepare(input: UserInput) throws -> LMInput {
+        LMInput(tokens: MLXArray(tokens).reshaped(1, tokens.count))
+    }
+}
+
+private actor RuntimeBridgeScriptedBackend: ContinuousBatchSchedulerBackend {
+    private let scripts: [String: [Int]]
+    private let decodeGate: RuntimeBridgeTestGate?
+    private var decodeCalls = 0
+    private var batches: [[String]] = []
+
+    init(scripts: [String: [Int]], decodeGate: RuntimeBridgeTestGate? = nil) {
+        self.scripts = scripts
+        self.decodeGate = decodeGate
+    }
+
+    func prefill(rows: [ContinuousBatchPrefillInput]) async throws -> [ContinuousBatchPrefillOutput] {
+        rows.map { ContinuousBatchPrefillOutput(requestID: $0.requestID) }
+    }
+
+    func decode(rows: [ContinuousBatchDecodeInput]) async throws -> [ContinuousBatchDecodeOutcome] {
+        decodeCalls += 1
+        batches.append(rows.map(\.requestID))
+        if decodeCalls == 1, let decodeGate {
+            await decodeGate.wait()
+        }
+        return rows.map { row in
+            let script = scripts[row.requestID] ?? []
+            let index = min(row.generatedTokens.count, max(script.count - 1, 0))
+            return .output(ContinuousBatchDecodeOutput(
+                requestID: row.requestID,
+                token: script.isEmpty ? row.currentToken : script[index]
+            ))
+        }
+    }
+
+    func cancelInFlight() async {}
+
+    func decodeCallCount() -> Int {
+        decodeCalls
+    }
+
+    func decodeBatches() -> [[String]] {
+        batches
+    }
+}
+
+private actor RuntimeBridgeTestGate {
+    private var isOpen = false
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        if isOpen { return }
+        await withCheckedContinuation { continuation in
+            continuations.append(continuation)
+        }
+    }
+
+    func open() {
+        guard !isOpen else { return }
+        isOpen = true
+        let pending = continuations
+        continuations.removeAll()
+        for continuation in pending {
+            continuation.resume()
+        }
+    }
+}
+
+private final class RuntimeBridgeReplayAuthority: ContinuousBatchSchedulerReplayAuthority, @unchecked Sendable {
+    private let lock = NSLock()
+    private var keys: Set<String> = []
+
+    func claim(_ key: ContinuousBatchSchedulerReplayKey) throws -> ContinuousBatchSchedulerReplayClaim {
+        lock.lock()
+        defer { lock.unlock() }
+        let storageKey = "\(key.requestID):\(key.fingerprintSHA256.base64EncodedString())"
+        return keys.insert(storageKey).inserted ? .claimed : .duplicateSameRequest
+    }
+}

--- a/phase3-binary/Tests/macprovider-cliTests/ServingKnobsConfigTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ServingKnobsConfigTests.swift
@@ -384,7 +384,7 @@ final class ServingKnobsConfigTests: XCTestCase {
         XCTAssertFalse(dense.requiresMoEDispatch)
     }
 
-    func testPagedKVAttachedDecisionFailsClosedUntilRuntimeBridgeOwnsRequestReservation() throws {
+    func testPagedKVAttachedDecisionPassesPreflightWhenRuntimeBridgeOwnsRequestReservation() throws {
         let proof = PagedKVHardwareSizingProof(
             modelID: "mlx-community/Qwen-Test",
             modelSHA256: String(repeating: "a", count: 64),
@@ -398,6 +398,15 @@ final class ServingKnobsConfigTests: XCTestCase {
             maxPhysicalBlocks: 64,
             maxResidentTokens: 2048,
             parityLabel: "sdpa-parity-v1"
+        )
+        let observedIdentity = PagedKVObservedRuntimeIdentity(
+            hardwareClass: proof.hardwareClass,
+            metallibSHA256: proof.metallibSHA256,
+            kernelIdentifier: proof.kernelIdentifier,
+            parityLabel: proof.parityLabel,
+            moeDispatchProven: false,
+            poolEpoch: proof.poolEpoch,
+            source: .runtimeMeasurement
         )
         let decision = PagedKVAttachGate.decide(
             config: PagedKVConfig(enabled: true, blockSizeTokens: 32, maxPhysicalBlocks: 64),
@@ -419,14 +428,12 @@ final class ServingKnobsConfigTests: XCTestCase {
                 observedMetallibSHA256: proof.metallibSHA256,
                 observedKernelIdentifier: proof.kernelIdentifier,
                 observedParityLabel: proof.parityLabel,
-                engineBridgeAvailable: true
+                engineBridgeAvailable: true,
+                observedRuntimeIdentity: observedIdentity
             )
         )
         XCTAssertNotNil(decision.descriptor)
-        XCTAssertThrowsError(try ModelRuntime.enforcePagedKVPreflight(decision)) { error in
-            XCTAssertEqual((error as? APIError)?.status, 503)
-            XCTAssertEqual((error as? APIError)?.code, "internal_error")
-        }
+        XCTAssertNoThrow(try ModelRuntime.enforcePagedKVPreflight(decision))
     }
 
     func testMaxContextPreflightRejectsZero() throws {
@@ -753,11 +760,33 @@ final class ServingKnobsConfigTests: XCTestCase {
     }
 
     func testRequestStateRepresentableGateOnParsedRequests() throws {
-        // Plain request → representable.
-        XCTAssertTrue(ModelRuntime.requestStateRepresentable(try parsedRequest([:])))
+        // Defaults are not enough for Increment 1 attach: the shared-forward proof
+        // only covers explicitly greedy rows.
+        XCTAssertFalse(ModelRuntime.requestStateRepresentable(try parsedRequest([:])))
+
+        let greedy: [String: Any] = ["temperature": 0, "top_p": 1.0]
+
+        // Explicit greedy request → representable.
+        XCTAssertTrue(ModelRuntime.requestStateRepresentable(try parsedRequest(greedy)))
+
+        // Non-greedy sampling / penalties → not representable by this increment.
+        XCTAssertFalse(ModelRuntime.requestStateRepresentable(try parsedRequest([
+            "temperature": 0.2, "top_p": 1.0
+        ])))
+        XCTAssertFalse(ModelRuntime.requestStateRepresentable(try parsedRequest([
+            "temperature": 0, "top_p": 0.9
+        ])))
+        XCTAssertFalse(ModelRuntime.requestStateRepresentable(try parsedRequest([
+            "temperature": 0, "top_p": 1.0, "presence_penalty": 0.1
+        ])))
+        XCTAssertFalse(ModelRuntime.requestStateRepresentable(try parsedRequest([
+            "temperature": 0, "top_p": 1.0, "frequency_penalty": 0.1
+        ])))
 
         // Structured output (json_schema) → not representable.
         XCTAssertFalse(ModelRuntime.requestStateRepresentable(try parsedRequest([
+            "temperature": 0,
+            "top_p": 1.0,
             "response_format": ["type": "json_schema",
                                 "json_schema": ["name": "s",
                                                 "schema": ["type": "object",
@@ -766,27 +795,35 @@ final class ServingKnobsConfigTests: XCTestCase {
 
         // Tools present WITHOUT tool_choice → not representable (the HIGH the gate missed).
         XCTAssertFalse(ModelRuntime.requestStateRepresentable(try parsedRequest([
+            "temperature": 0,
+            "top_p": 1.0,
             "tools": [["type": "function",
                        "function": ["name": "f", "parameters": ["type": "object"]]]]
         ])))
 
         // Explicit JSON null tool_choice, no tools → representable (must NOT false-positive).
-        XCTAssertTrue(ModelRuntime.requestStateRepresentable(try parsedRequest([
-            "tool_choice": NSNull()
-        ])))
+        var explicitNullToolChoice = greedy
+        explicitNullToolChoice["tool_choice"] = NSNull()
+        XCTAssertTrue(ModelRuntime.requestStateRepresentable(try parsedRequest(explicitNullToolChoice)))
 
         // logit_bias → not representable; logprobs:false → representable.
         XCTAssertFalse(ModelRuntime.requestStateRepresentable(try parsedRequest([
+            "temperature": 0,
+            "top_p": 1.0,
             "logit_bias": ["123": -100]
         ])))
-        XCTAssertTrue(ModelRuntime.requestStateRepresentable(try parsedRequest([
-            "logprobs": false
-        ])))
+        var logprobsFalse = greedy
+        logprobsFalse["logprobs"] = false
+        XCTAssertTrue(ModelRuntime.requestStateRepresentable(try parsedRequest(logprobsFalse)))
         XCTAssertFalse(ModelRuntime.requestStateRepresentable(try parsedRequest([
+            "temperature": 0,
+            "top_p": 1.0,
             "logprobs": true
         ])))
         // top_logprobs (response metadata) is rejected too so the gate is provably complete.
         XCTAssertFalse(ModelRuntime.requestStateRepresentable(try parsedRequest([
+            "temperature": 0,
+            "top_p": 1.0,
             "logprobs": true, "top_logprobs": 5
         ])))
     }
@@ -942,7 +979,7 @@ final class ServingKnobsConfigTests: XCTestCase {
             loader: { _ in throw TestRuntimeError.notExpected }
         )
         let decision = await runtime.pagedKVDecisionForTest()
-        XCTAssertEqual(decision, .fallback(.metallib))
+        XCTAssertEqual(decision, .fallback(.cacheClass))
     }
 
     func testRuntimeStrictPagedKVRejectsBeforeCompletionRuns() async throws {
@@ -1033,6 +1070,88 @@ final class ServingKnobsConfigTests: XCTestCase {
          XCTAssertEqual(observed.unsupportedReason, .pagedKVDisabled)
      }
 
+    func testRuntimeContinuousBatchingCapabilityAttachesOnlyWithMeasuredIdentityAndBackend() async throws {
+        let modelID = "mlx-community/Qwen-Test"
+        let modelSHA = String(repeating: "a", count: 64)
+        let proof = PagedKVHardwareSizingProof(
+            modelID: modelID,
+            modelSHA256: modelSHA,
+            tokenizerSHA256: nil,
+            chatTemplateSHA256: nil,
+            modelFamily: "qwen",
+            hardwareClass: "apple-silicon-test",
+            metallibSHA256: String(repeating: "b", count: 64),
+            kernelIdentifier: "macprovider_paged_kv_gather_v1",
+            blockSizeTokens: 32,
+            maxPhysicalBlocks: 64,
+            maxResidentTokens: 2048,
+            parityLabel: "sdpa-parity-v1"
+        )
+        let observedIdentity = PagedKVObservedRuntimeIdentity(
+            hardwareClass: proof.hardwareClass,
+            metallibSHA256: proof.metallibSHA256,
+            kernelIdentifier: proof.kernelIdentifier,
+            parityLabel: proof.parityLabel,
+            moeDispatchProven: false,
+            poolEpoch: proof.poolEpoch,
+            source: .runtimeMeasurement
+        )
+
+        let attached = ModelRuntime(
+            modelID: modelID,
+            modelHash: modelSHA,
+            pagedKVConfig: PagedKVConfig(enabled: true, blockSizeTokens: 32, maxPhysicalBlocks: 64),
+            maxBatch: 2,
+            continuousBatchingMode: .on,
+            warmSwapEnabled: false,
+            pagedKVObservedRuntimeIdentity: observedIdentity,
+            pagedKVHardwareSizingProof: proof,
+            pagedKVRuntimeCacheClass: "KVCacheSimple",
+            pagedKVSchedulerBackendInstalled: true,
+            continuousBatchingBackend: ServingKnobsContinuousBatchingBackend(),
+            loader: { _ in throw TestRuntimeError.notExpected }
+        )
+        let attachedDecision = await attached.pagedKVDecisionForTest()
+        let attachedCapability = await attached.continuousBatchingCapabilityForTest()
+        XCTAssertNotNil(attachedDecision.descriptor)
+        XCTAssertNil(attachedCapability.unsupportedReason)
+
+        let nilObservation = ModelRuntime(
+            modelID: modelID,
+            modelHash: modelSHA,
+            pagedKVConfig: PagedKVConfig(enabled: true, blockSizeTokens: 32, maxPhysicalBlocks: 64),
+            maxBatch: 2,
+            continuousBatchingMode: .on,
+            warmSwapEnabled: false,
+            pagedKVHardwareSizingProof: proof,
+            pagedKVRuntimeCacheClass: "KVCacheSimple",
+            pagedKVSchedulerBackendInstalled: true,
+            loader: { _ in throw TestRuntimeError.notExpected }
+        )
+        let nilObservationDecision = await nilObservation.pagedKVDecisionForTest()
+        let nilObservationCapability = await nilObservation.continuousBatchingCapabilityForTest()
+        XCTAssertNil(nilObservationDecision.descriptor)
+        XCTAssertNotNil(nilObservationCapability.unsupportedReason)
+
+        let noBackend = ModelRuntime(
+            modelID: modelID,
+            modelHash: modelSHA,
+            pagedKVConfig: PagedKVConfig(enabled: true, blockSizeTokens: 32, maxPhysicalBlocks: 64),
+            maxBatch: 2,
+            continuousBatchingMode: .on,
+            warmSwapEnabled: false,
+            pagedKVObservedRuntimeIdentity: observedIdentity,
+            pagedKVHardwareSizingProof: proof,
+            pagedKVRuntimeCacheClass: "KVCacheSimple",
+            pagedKVSchedulerBackendInstalled: false,
+            loader: { _ in throw TestRuntimeError.notExpected }
+        )
+        let noBackendDecision = await noBackend.pagedKVDecisionForTest()
+        let noBackendCapability = await noBackend.continuousBatchingCapabilityForTest()
+        XCTAssertNil(noBackendDecision.descriptor)
+        XCTAssertNotNil(noBackendCapability.unsupportedReason)
+    }
+
     func testRuntimeDefaultMaxBatchIsOne() async throws {
         let runtime = ModelRuntime(
             modelID: "test-model",
@@ -1085,4 +1204,18 @@ final class ServingKnobsConfigTests: XCTestCase {
 
 private enum TestRuntimeError: Error {
     case notExpected
+}
+
+private actor ServingKnobsContinuousBatchingBackend: ContinuousBatchSchedulerBackend {
+    func prefill(rows: [ContinuousBatchPrefillInput]) async throws -> [ContinuousBatchPrefillOutput] {
+        rows.map { ContinuousBatchPrefillOutput(requestID: $0.requestID) }
+    }
+
+    func decode(rows: [ContinuousBatchDecodeInput]) async throws -> [ContinuousBatchDecodeOutcome] {
+        rows.map {
+            .output(ContinuousBatchDecodeOutput(requestID: $0.requestID, token: $0.currentToken))
+        }
+    }
+
+    func cancelInFlight() async {}
 }


### PR DESCRIPTION
## Summary
- Implements SPEC-039 Phase-2 Increment 1 attach for fresh greedy requests behind measured runtime identity and hardware sizing proof gates.
- Adds the shared-forward PagedKV runtime bridge through the existing SPEC-038 continuous batch scheduler while keeping production nil-observation/default-off behavior fail-closed.
- Keeps #887 / FR-PKV10 sticky and contiguous cross-turn cache reattach explicitly out of scope.

## Tests
- `cd phase3-binary && swift test --filter PagedKVRuntimeBridgeTests` (8 tests, 0 failures, 5 skips: local MLX default metallib unavailable)
- `cd phase3-binary && swift test --filter PagedKVRuntimeBridgeTests --filter PagedKVEngineTests --filter ServingKnobsConfigTests --filter ContinuousBatchSchedulerTests --filter PagedKVParityTests` (152 tests, 0 failures, 8 skips)
- `cd phase3-binary && swift test --filter KVConversationColdTierTests` (25 tests, 0 failures, 2 skips)
- `git diff --check`

## Audits
- Code review: `.omc/artifacts/ask/codex-code-review-lane-spec-039-phase-2-increment-1-attach-1474-re-2026-09-11T06-36-42-430Z.md` — PASS, 0 C/H/M
- Security review: `.omc/artifacts/ask/codex-security-review-lane-spec-039-phase-2-increment-1-attach-147-2026-09-11T06-35-24-989Z.md` — PASS, 0 C/H/M
- Architecture review: `.omc/artifacts/ask/codex-architecture-review-lane-spec-039-phase-2-increment-1-attach-2026-09-11T06-34-59-742Z.md` — PASS, 0 C/H/M

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "issue": "https://github.com/Augustas11/macprovider/issues/1474",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-039", "SPEC-038"],
  "requirements": ["SPEC-039-R006", "SPEC-039-R007", "SPEC-039-R009", "SPEC-039-R011", "SPEC-039-R012", "SPEC-038-R003", "SPEC-038-R006", "SPEC-038-R010"],
  "authority_domains": ["paged-kv-attention"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "cd phase3-binary && swift test --filter PagedKVRuntimeBridgeTests",
    "cd phase3-binary && swift test --filter PagedKVRuntimeBridgeTests --filter PagedKVEngineTests --filter ServingKnobsConfigTests --filter ContinuousBatchSchedulerTests --filter PagedKVParityTests",
    "cd phase3-binary && swift test --filter KVConversationColdTierTests",
    "git diff --check",
    "omc ask codex code-reviewer/security-reviewer/architect final audits PASS with 0 C/H/M"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END
