### PR TITLE
SPEC-039 Phase-2 Increment 2: FR-PKV10 contiguous KVCache extraction (#887)

### DIFF
--- a/audits/2026-09-11/887-fr-pkv10-inc2-architecture-review-final.md
+++ b/audits/2026-09-11/887-fr-pkv10-inc2-architecture-review-final.md
@@ -1,0 +1,60 @@
+# SPEC-039 Phase 2 Increment 2 / FR-PKV10 Architecture Review Final
+
+Issue: https://github.com/Augustas11/macprovider/issues/887
+Worktree: `/Users/augstar/.codex/worktrees/macprovider/887-spec039-phase2-inc2-pkv10`
+Base: `origin/main`
+
+## Verdict
+
+PASS.
+
+Findings: none after final lockfile restoration.
+
+Gate result:
+- CRITICAL: 0
+- HIGH: 0
+- MEDIUM: 0
+- LOW: 0
+
+## Scope Reviewed
+
+Reviewed the full implementation diff against `origin/main` for SPEC-039
+FR-PKV10 / AC-15 Increment 2 architecture fit:
+- physical-block-backed contiguous extraction;
+- live contiguous `KVCacheSimple` handoff restoration;
+- same-conversation retain/reattach with exact trim;
+- allocator/bridge transaction boundaries;
+- sticky serving and cold-tier consumer boundaries.
+
+## Evidence
+
+The earlier architecture HIGH was fixed. Runtime recording now snapshots
+physical layers from `PagedKVCache.physicalLayerBlocks` rather than logical
+`cache.state`. `physicalLayerBlocks` reads private `keyBlocks` / `valueBlocks`,
+validates block count against `table.physicalBlocks`, pads tail blocks, and
+returns `Data` keyed by physical block ID. Runtime materialization walks
+`table.physicalBlocks` through `record.physicalLayers`, so extraction is backed
+by the allocator's physical table.
+
+Allocator transaction boundaries are preserved: trim and trimmed reattach build
+and validate the prospective table, call the bridge trim hook, and only then
+publish allocator state and free released blocks. Release/discard remove bridge
+records.
+
+The implementation remains an inert primitive. Sticky requests are still
+rejected by `ContinuousBatchScheduler`; this PR does not enable SPEC-038 AC-19
+serving parity and does not wire SPEC-024 cold-tier consumption to the bridge.
+No canary behavior is enabled.
+
+## Validation
+
+Local validation run by the leader:
+- `cd phase3-binary && swift test --filter PagedKVRuntimeBridgeTests` passed: 12 executed, 8 skipped because MLX default metallib is unavailable locally, 0 failures.
+- `cd phase3-binary && swift test --filter PagedKVEngineTests` passed: 33 executed, 0 failures.
+- `cd phase3-binary && swift test --filter KVConversationColdTierTests` passed: 25 executed, 2 skipped because MLX Metal runtime is unavailable locally, 0 failures.
+- `git diff --check` passed.
+
+Independent architecture audit result: PASS, 0 CRITICAL / 0 HIGH / 0 MEDIUM.
+The audit initially observed SwiftPM `Package.resolved` resolver churn as LOW
+while tests were running; the leader restored that file before commit, and the
+final diff contains no `Package.resolved` change.

--- a/audits/2026-09-11/887-fr-pkv10-inc2-architecture-review-prompt.md
+++ b/audits/2026-09-11/887-fr-pkv10-inc2-architecture-review-prompt.md
@@ -1,0 +1,23 @@
+# Issue 887 FR-PKV10 Increment 2 Architecture Review
+
+Review the current working-tree diff in `/Users/augstar/.codex/worktrees/macprovider/887-spec039-phase2-inc2-pkv10` against `origin/main`.
+
+Scope:
+- `phase3-binary/Sources/MacProviderCore/PagedKVEngine.swift`
+- `phase3-binary/Sources/macprovider-cli/ModelRuntime.swift`
+- `phase3-binary/Sources/macprovider-cli/PagedKVRuntimeBridge.swift`
+- `phase3-binary/Tests/MacProviderCoreTests/PagedKVEngineTests.swift`
+- `phase3-binary/Tests/macprovider-cliTests/PagedKVRuntimeBridgeTests.swift`
+
+Intent:
+- Implement SPEC-039 Phase 2 Increment 2 / FR-PKV10 runtime contiguous KVCache extraction for attached-only PagedKV scheduler paths.
+- Preserve Core/CLI layering: Core exposes runtime-independent byte surfaces; CLI owns MLX live cache reconstruction.
+- Keep canary off and sticky serving disabled/rejected.
+
+Architecture focus:
+- Whether the bridge boundaries preserve SPEC-039/SPEC-024/SPEC-038 responsibilities.
+- Whether runtime bridge state ownership, lifecycle, and failure semantics are coherent with continuous batching.
+- Whether retaining and trimming paged block tables introduces hidden coupling or future sticky-serving assumptions.
+- Whether the diff remains Increment 2 scoped and avoids rollout/scheduler policy broadening.
+
+Report only actionable findings. Classify each as CRITICAL, HIGH, MEDIUM, LOW, or INFO with file/line evidence. The gate is 0 CRITICAL, 0 HIGH, and 0 MEDIUM findings.

--- a/audits/2026-09-11/887-fr-pkv10-inc2-code-review-final.md
+++ b/audits/2026-09-11/887-fr-pkv10-inc2-code-review-final.md
@@ -1,0 +1,54 @@
+# SPEC-039 Phase 2 Increment 2 / FR-PKV10 Code Review Final
+
+Issue: https://github.com/Augustas11/macprovider/issues/887
+Worktree: `/Users/augstar/.codex/worktrees/macprovider/887-spec039-phase2-inc2-pkv10`
+Base: `origin/main`
+
+## Verdict
+
+PASS.
+
+Findings: none.
+
+Gate result:
+- CRITICAL: 0
+- HIGH: 0
+- MEDIUM: 0
+- LOW: 0
+
+## Scope Reviewed
+
+Reviewed the full implementation diff against `origin/main`, including:
+- `phase3-binary/Sources/MacProviderCore/PagedKVEngine.swift`
+- `phase3-binary/Sources/macprovider-cli/ModelRuntime.swift`
+- `phase3-binary/Sources/macprovider-cli/PagedKVCache.swift`
+- `phase3-binary/Sources/macprovider-cli/PagedKVRuntimeBridge.swift`
+- `phase3-binary/Tests/MacProviderCoreTests/PagedKVEngineTests.swift`
+- `phase3-binary/Tests/macprovider-cliTests/PagedKVRuntimeBridgeTests.swift`
+
+## Evidence
+
+The prior extraction-path blocker is fixed. Runtime record capture calls
+`PagedKVCache.physicalLayerBlocks(...)`; that method reads private
+`keyBlocks` / `valueBlocks`, maps bytes by `table.physicalBlocks`, and
+`PagedKVRuntimeContiguousCacheBridge.materializeContiguousByteCache` restores
+from `record.physicalLayers` rather than live logical `cache.state`.
+
+Lifecycle behavior is coherent:
+- allocator trim and trimmed reattach call the bridge trim hook before mutating allocator state or releasing blocks;
+- release/discard paths clear bridge records;
+- backend finish preserves retained handoff records;
+- cancellation discards affected records.
+
+Sticky serving remains rejected in `ContinuousBatchScheduler`, and no canary or
+production sticky-serving lift is present.
+
+## Validation
+
+Local validation run by the leader:
+- `cd phase3-binary && swift test --filter PagedKVRuntimeBridgeTests` passed: 12 executed, 8 skipped because MLX default metallib is unavailable locally, 0 failures.
+- `cd phase3-binary && swift test --filter PagedKVEngineTests` passed: 33 executed, 0 failures.
+- `cd phase3-binary && swift test --filter KVConversationColdTierTests` passed: 25 executed, 2 skipped because MLX Metal runtime is unavailable locally, 0 failures.
+- `git diff --check` passed.
+
+Independent code-review audit result: PASS, 0 CRITICAL / 0 HIGH / 0 MEDIUM / 0 LOW.

--- a/audits/2026-09-11/887-fr-pkv10-inc2-code-review-prompt.md
+++ b/audits/2026-09-11/887-fr-pkv10-inc2-code-review-prompt.md
@@ -1,0 +1,23 @@
+# Issue 887 FR-PKV10 Increment 2 Code Review
+
+Review the current working-tree diff in `/Users/augstar/.codex/worktrees/macprovider/887-spec039-phase2-inc2-pkv10` against `origin/main`.
+
+Scope:
+- `phase3-binary/Sources/MacProviderCore/PagedKVEngine.swift`
+- `phase3-binary/Sources/macprovider-cli/ModelRuntime.swift`
+- `phase3-binary/Sources/macprovider-cli/PagedKVRuntimeBridge.swift`
+- `phase3-binary/Tests/MacProviderCoreTests/PagedKVEngineTests.swift`
+- `phase3-binary/Tests/macprovider-cliTests/PagedKVRuntimeBridgeTests.swift`
+
+Intent:
+- Implement SPEC-039 Phase 2 Increment 2 / FR-PKV10 runtime contiguous KVCache extraction for attached-only PagedKV scheduler paths.
+- Keep sticky serving disabled/rejected.
+- Do not enable canary or lift sticky serving.
+
+Review focus:
+- Correctness of paged-to-contiguous byte materialization, live `KVCacheSimple` reconstruction, and byte order with non-identity physical block order.
+- Retain/reattach trimming to mid-block LCP without whole-block rounding or cross-conversation attach.
+- Scheduler/backend lifecycle: record, materialize, discard, cancellation, row completion, and failure behavior.
+- Regression test adequacy and whether skipped MLX tests are properly gated.
+
+Report only actionable findings. Classify each as CRITICAL, HIGH, MEDIUM, LOW, or INFO with file/line evidence. The gate is 0 CRITICAL, 0 HIGH, and 0 MEDIUM findings.

--- a/audits/2026-09-11/887-fr-pkv10-inc2-security-review-final.md
+++ b/audits/2026-09-11/887-fr-pkv10-inc2-security-review-final.md
@@ -1,0 +1,57 @@
+# SPEC-039 Phase 2 Increment 2 / FR-PKV10 Security Review Final
+
+Issue: https://github.com/Augustas11/macprovider/issues/887
+Worktree: `/Users/augstar/.codex/worktrees/macprovider/887-spec039-phase2-inc2-pkv10`
+Base: `origin/main`
+
+## Verdict
+
+PASS.
+
+Findings: none.
+
+Gate result:
+- CRITICAL: 0
+- HIGH: 0
+- MEDIUM: 0
+- LOW: 0
+
+## Scope Reviewed
+
+Reviewed the full implementation diff against `origin/main` for:
+- handle and table isolation;
+- same-conversation-only retain/reattach;
+- trim transaction ordering;
+- stale/cross-handle/cross-table record rejection;
+- cancellation cleanup;
+- accidental canary or sticky-serving enablement;
+- accidental SPEC-024 cold-tier consumption;
+- secret exposure.
+
+## Evidence
+
+Runtime extraction records private physical K/V block bytes through
+`PagedKVCache.physicalLayerBlocks`, stores them by handle/table in
+`PagedKVRuntimeContiguousCacheBridge`, and materializes only from
+`record.physicalLayers`. Exact handle and table checks reject stale,
+cross-handle, and cross-table access.
+
+Allocator reattach remains same-conversation only; trimmed reattach validates
+the retained length and calls the bridge before publishing allocator mutation.
+Release/discard clear bridge records. Backend cancellation discards affected
+snapshots and closes the record-before-store race.
+
+Sticky requests remain rejected, continuous batching remains default-off for
+production, no canary settings were changed, and no cold-tier consumer files
+were modified.
+
+## Validation
+
+Local validation run by the leader:
+- `cd phase3-binary && swift test --filter PagedKVRuntimeBridgeTests` passed: 12 executed, 8 skipped because MLX default metallib is unavailable locally, 0 failures.
+- `cd phase3-binary && swift test --filter PagedKVEngineTests` passed: 33 executed, 0 failures.
+- `cd phase3-binary && swift test --filter KVConversationColdTierTests` passed: 25 executed, 2 skipped because MLX Metal runtime is unavailable locally, 0 failures.
+- `git diff --check` passed.
+
+Independent security audit result: PASS, 0 CRITICAL / 0 HIGH / 0 MEDIUM / 0 LOW.
+Additional security-audit evidence: secret-pattern scan found no matches.

--- a/audits/2026-09-11/887-fr-pkv10-inc2-security-review-prompt.md
+++ b/audits/2026-09-11/887-fr-pkv10-inc2-security-review-prompt.md
@@ -1,0 +1,22 @@
+# Issue 887 FR-PKV10 Increment 2 Security Review
+
+Review the current working-tree diff in `/Users/augstar/.codex/worktrees/macprovider/887-spec039-phase2-inc2-pkv10` against `origin/main`.
+
+Scope:
+- `phase3-binary/Sources/MacProviderCore/PagedKVEngine.swift`
+- `phase3-binary/Sources/macprovider-cli/ModelRuntime.swift`
+- `phase3-binary/Sources/macprovider-cli/PagedKVRuntimeBridge.swift`
+- `phase3-binary/Tests/MacProviderCoreTests/PagedKVEngineTests.swift`
+- `phase3-binary/Tests/macprovider-cliTests/PagedKVRuntimeBridgeTests.swift`
+
+Intent:
+- Implement SPEC-039 Phase 2 Increment 2 / FR-PKV10 runtime contiguous KVCache extraction for attached-only PagedKV scheduler paths.
+- Keep canary off and sticky serving disabled/rejected.
+
+Security focus:
+- Cross-conversation cache isolation and retained-sequence reattach restrictions.
+- Bounds, shape, dtype, overflow, stale handle, cancellation, and mismatch failure behavior.
+- Whether recorded live KV bytes can leak, be replayed across handles, or survive row completion unexpectedly.
+- Whether any rollout gate, canary, sticky serving, trust tier, or buyer-visible behavior is widened.
+
+Report only actionable findings. Classify each as CRITICAL, HIGH, MEDIUM, LOW, or INFO with file/line evidence. The gate is 0 CRITICAL, 0 HIGH, and 0 MEDIUM findings.

--- a/phase3-binary/Sources/MacProviderCore/PagedKVEngine.swift
+++ b/phase3-binary/Sources/MacProviderCore/PagedKVEngine.swift
@@ -565,12 +565,9 @@ public struct PagedKVMaterializedByteLayer: Equatable, Sendable {
     }
 }
 
-/// Neutral BYTE extraction only (FR-PKV10 scope honesty): this type carries logical-order
-/// K/V bytes reassembled from physical blocks. It is NOT the standalone contiguous
-/// `KVCache` handoff that SPEC-024 (cold-tier residency) and SPEC-038 (continuous batching)
-/// consume — reconstructing a live, injectable contiguous `KVCache` from these bytes is
-/// deferred to the runtime bridge. FR-PKV10 is therefore NOT yet complete as a full
-/// extraction contract; only the neutral byte-materialization primitive exists here.
+/// Runtime-independent K/V bytes reassembled from physical blocks in logical token order.
+/// The CLI runtime bridge turns this validated byte surface into the live contiguous
+/// `KVCache` handoff consumed by SPEC-024/SPEC-038.
 public struct PagedKVMaterializedByteCache: Equatable, Sendable {
     public let handle: PagedKVBlockTableHandle
     public let blockTable: PagedKVBlockTable
@@ -587,14 +584,24 @@ public struct PagedKVMaterializedByteCache: Equatable, Sendable {
     }
 }
 
-/// Neutral byte-extraction bridge only: yields `PagedKVMaterializedByteCache` bytes. The
-/// standalone contiguous `KVCache` handoff SPEC-024/SPEC-038 consume (FR-PKV10 as a full
-/// extraction contract) is deferred to the runtime bridge and is not provided here.
+/// Runtime bridge surface for logical-order byte extraction from paged physical blocks.
+/// The engine keeps MLX types out of Core; callers that need an injectable contiguous
+/// `KVCache` restore these bytes through the CLI/runtime bridge.
 public protocol PagedKVContiguousCacheBridge: Sendable {
     func materializeContiguousByteCache(
         handle: PagedKVBlockTableHandle,
         table: PagedKVBlockTable
     ) throws -> PagedKVMaterializedByteCache
+
+    func trimRecordedContiguousCache(handle: PagedKVBlockTableHandle, table: PagedKVBlockTable) throws
+
+    func discardContiguousCache(handle: PagedKVBlockTableHandle)
+}
+
+public extension PagedKVContiguousCacheBridge {
+    func trimRecordedContiguousCache(handle: PagedKVBlockTableHandle, table: PagedKVBlockTable) throws {}
+
+    func discardContiguousCache(handle: PagedKVBlockTableHandle) {}
 }
 
 public actor PagedKVBlockAllocator {
@@ -670,6 +677,37 @@ public actor PagedKVBlockAllocator {
             throw PagedKVAllocatorError.invalidBlockTable("logical length overflow")
         }
         return adjusted / blockSizeTokens
+    }
+
+    private func validateTable(
+        handle: PagedKVBlockTableHandle,
+        state: SequenceState
+    ) throws -> PagedKVBlockTable {
+        let logicalBlocks = try requiredBlocks(maxTokens: state.logicalTokenCount)
+        guard logicalBlocks <= state.reservedBlocks.count else {
+            throw PagedKVAllocatorError.invalidBlockTable("missing physical block")
+        }
+        let liveBlocks = Array(state.reservedBlocks.prefix(logicalBlocks))
+        guard Set(liveBlocks).count == liveBlocks.count else {
+            throw PagedKVAllocatorError.invalidBlockTable("duplicate writable block")
+        }
+        guard liveBlocks.allSatisfy({ (0..<maxPhysicalBlocks).contains($0) }) else {
+            throw PagedKVAllocatorError.invalidBlockTable("out-of-range block")
+        }
+        let tail = state.logicalTokenCount == 0
+            ? 0
+            : ((state.logicalTokenCount - 1) % blockSizeTokens) + 1
+        guard state.logicalTokenCount == 0 || (1...blockSizeTokens).contains(tail) else {
+            throw PagedKVAllocatorError.invalidBlockTable("invalid tail token count")
+        }
+        return PagedKVBlockTable(
+            handleID: handle.id,
+            blockSizeTokens: blockSizeTokens,
+            logicalTokenCount: state.logicalTokenCount,
+            physicalBlocks: liveBlocks,
+            tailValidTokenCount: tail,
+            poolEpoch: poolEpoch
+        )
     }
 
     public func canAdmitBatch1(maxTokens: Int) -> Bool {
@@ -772,7 +810,7 @@ public actor PagedKVBlockAllocator {
 
     public func trim(_ handle: PagedKVBlockTableHandle, toLogicalTokens tokens: Int) throws -> PagedKVBlockTable {
         guard tokens >= 0 else { throw PagedKVAllocatorError.invalidBlockTable("negative trim length") }
-        var state = try lookupState(for: handle)
+        let state = try lookupState(for: handle)
         guard !state.retained else {
             throw PagedKVAllocatorError.retainedHandleStillLive
         }
@@ -782,15 +820,19 @@ public actor PagedKVBlockAllocator {
         guard tokens <= state.logicalTokenCount else {
             throw PagedKVAllocatorError.invalidBlockTable("trim length exceeds logical length")
         }
-        state.logicalTokenCount = tokens
+        var nextState = state
+        nextState.logicalTokenCount = tokens
         let needed = try requiredBlocks(maxTokens: tokens)
-        if needed < state.reservedBlocks.count {
-            let released = state.reservedBlocks[needed...]
-            state.reservedBlocks.removeSubrange(needed...)
-            freeBlocks.append(contentsOf: released.reversed())
+        var released: ArraySlice<Int> = []
+        if needed < nextState.reservedBlocks.count {
+            released = nextState.reservedBlocks[needed...]
+            nextState.reservedBlocks.removeSubrange(needed...)
         }
-        sequences[handle.id] = state
-        return try validate(handle)
+        let table = try validateTable(handle: handle, state: nextState)
+        try contiguousCacheBridge?.trimRecordedContiguousCache(handle: handle, table: table)
+        sequences[handle.id] = nextState
+        freeBlocks.append(contentsOf: released.reversed())
+        return table
     }
 
     public func table(for handle: PagedKVBlockTableHandle) throws -> PagedKVBlockTable {
@@ -856,31 +898,7 @@ public actor PagedKVBlockAllocator {
     @discardableResult
     public func validate(_ handle: PagedKVBlockTableHandle) throws -> PagedKVBlockTable {
         let state = try lookupState(for: handle)
-        let logicalBlocks = try requiredBlocks(maxTokens: state.logicalTokenCount)
-        guard logicalBlocks <= state.reservedBlocks.count else {
-            throw PagedKVAllocatorError.invalidBlockTable("missing physical block")
-        }
-        let liveBlocks = Array(state.reservedBlocks.prefix(logicalBlocks))
-        guard Set(liveBlocks).count == liveBlocks.count else {
-            throw PagedKVAllocatorError.invalidBlockTable("duplicate writable block")
-        }
-        guard liveBlocks.allSatisfy({ (0..<maxPhysicalBlocks).contains($0) }) else {
-            throw PagedKVAllocatorError.invalidBlockTable("out-of-range block")
-        }
-        let tail = state.logicalTokenCount == 0
-            ? 0
-            : ((state.logicalTokenCount - 1) % blockSizeTokens) + 1
-        guard state.logicalTokenCount == 0 || (1...blockSizeTokens).contains(tail) else {
-            throw PagedKVAllocatorError.invalidBlockTable("invalid tail token count")
-        }
-        return PagedKVBlockTable(
-            handleID: handle.id,
-            blockSizeTokens: blockSizeTokens,
-            logicalTokenCount: state.logicalTokenCount,
-            physicalBlocks: liveBlocks,
-            tailValidTokenCount: tail,
-            poolEpoch: poolEpoch
-        )
+        return try validateTable(handle: handle, state: state)
     }
 
     public func retain(_ handle: PagedKVBlockTableHandle) throws -> PagedKVRetainedSequence {
@@ -900,13 +918,40 @@ public actor PagedKVBlockAllocator {
         )
     }
 
-    public func reattach(_ retained: PagedKVRetainedSequence, conversationKey: String) throws -> PagedKVBlockTableHandle {
+    public func reattach(
+        _ retained: PagedKVRetainedSequence,
+        conversationKey: String,
+        trimToLogicalTokens tokens: Int? = nil
+    ) throws -> PagedKVBlockTableHandle {
         guard retained.conversationKey == conversationKey.trimmingCharacters(in: .whitespacesAndNewlines) else {
             throw PagedKVAllocatorError.conversationMismatch
         }
         var state = try lookupState(for: retained.handle)
         guard state.retained else {
             throw PagedKVAllocatorError.unknownHandle
+        }
+        guard state.logicalTokenCount == retained.logicalTokenCount else {
+            throw PagedKVAllocatorError.invalidBlockTable("retained logical length mismatch")
+        }
+        if let tokens {
+            guard tokens >= 0 else { throw PagedKVAllocatorError.invalidBlockTable("negative trim length") }
+            guard tokens <= state.logicalTokenCount else {
+                throw PagedKVAllocatorError.invalidBlockTable("trim length exceeds logical length")
+            }
+            var nextState = state
+            nextState.logicalTokenCount = tokens
+            let needed = try requiredBlocks(maxTokens: tokens)
+            var released: ArraySlice<Int> = []
+            if needed < nextState.reservedBlocks.count {
+                released = nextState.reservedBlocks[needed...]
+                nextState.reservedBlocks.removeSubrange(needed...)
+            }
+            let table = try validateTable(handle: retained.handle, state: nextState)
+            try contiguousCacheBridge?.trimRecordedContiguousCache(handle: retained.handle, table: table)
+            nextState.retained = false
+            sequences[retained.handle.id] = nextState
+            freeBlocks.append(contentsOf: released.reversed())
+            return retained.handle
         }
         state.retained = false
         sequences[retained.handle.id] = state
@@ -923,6 +968,7 @@ public actor PagedKVBlockAllocator {
         }
         sequences.removeValue(forKey: retained.handle.id)
         freeBlocks.append(contentsOf: state.reservedBlocks.reversed())
+        contiguousCacheBridge?.discardContiguousCache(handle: retained.handle)
     }
 
     public func release(_ handle: PagedKVBlockTableHandle) throws {
@@ -935,6 +981,7 @@ public actor PagedKVBlockAllocator {
         }
         sequences.removeValue(forKey: handle.id)
         freeBlocks.append(contentsOf: state.reservedBlocks.reversed())
+        contiguousCacheBridge?.discardContiguousCache(handle: handle)
     }
 
     public func freeBlockCount() -> Int { freeBlocks.count }

--- a/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
@@ -2079,7 +2079,8 @@ actor ModelRuntime: ModelRuntimeServing {
         modelID: String?,
         modelSHA256: String?,
         weightsGeneration: Int,
-        prefillStepSize: Int
+        prefillStepSize: Int,
+        contiguousCacheBridge: PagedKVRuntimeContiguousCacheBridge? = nil
     ) -> ContinuousBatchScheduler? {
         guard case .attached(let descriptor) = decision,
               let tuple,
@@ -2092,7 +2093,8 @@ actor ModelRuntime: ModelRuntimeServing {
         }
         guard let allocator = try? PagedKVBlockAllocator(
             blockSizeTokens: descriptor.blockSizeTokens,
-            maxPhysicalBlocks: descriptor.maxPhysicalBlocks
+            maxPhysicalBlocks: descriptor.maxPhysicalBlocks,
+            contiguousCacheBridge: contiguousCacheBridge
         ) else {
             return nil
         }
@@ -2155,13 +2157,15 @@ actor ModelRuntime: ModelRuntimeServing {
         else {
             return nil
         }
+        let contiguousCacheBridge = PagedKVRuntimeContiguousCacheBridge()
         return makeContinuousBatchScheduler(
             decision: decision,
             tuple: tuple,
             backend: PagedKVSharedForwardBackend(
                 container: container,
                 descriptor: descriptor,
-                layerCount: layerCount
+                layerCount: layerCount,
+                contiguousCacheBridge: contiguousCacheBridge
             ),
             maxBatch: maxBatch,
             queueLimit: queueLimit,
@@ -2169,7 +2173,8 @@ actor ModelRuntime: ModelRuntimeServing {
             modelID: modelID,
             modelSHA256: modelSHA256,
             weightsGeneration: weightsGeneration,
-            prefillStepSize: prefillStepSize
+            prefillStepSize: prefillStepSize,
+            contiguousCacheBridge: contiguousCacheBridge
         )
     }
 

--- a/phase3-binary/Sources/macprovider-cli/PagedKVCache.swift
+++ b/phase3-binary/Sources/macprovider-cli/PagedKVCache.swift
@@ -274,6 +274,53 @@ final class PagedKVCache: KVCache, CustomDebugStringConvertible {
         return copied
     }
 
+    func physicalLayerBlocks(
+        layerIndex: Int,
+        table: PagedKVBlockTable
+    ) throws -> PagedKVRuntimePhysicalLayerBlocks {
+        guard offset == table.logicalTokenCount,
+              table.blockSizeTokens == descriptor.blockSizeTokens,
+              keyBlocks.count == valueBlocks.count,
+              keyBlocks.count == table.physicalBlocks.count
+        else {
+            throw PagedKVContiguousCacheBridgeError.blockTableMismatch
+        }
+        guard let firstKey = keyBlocks.first,
+              let firstValue = valueBlocks.first,
+              firstKey.shape == firstValue.shape,
+              firstKey.ndim >= 3,
+              firstKey.dtype == firstValue.dtype,
+              try Self.pagedDType(for: firstKey.dtype) == .fp16
+        else {
+            throw PagedKVContiguousCacheBridgeError.invalidLayerState
+        }
+        let sequenceAxis = firstKey.shape.count - 2
+        var fullKeyShape = firstKey.shape
+        var fullValueShape = firstValue.shape
+        fullKeyShape[sequenceAxis] = table.logicalTokenCount
+        fullValueShape[sequenceAxis] = table.logicalTokenCount
+        let bytesPerToken = try Self.bytesPerToken(shape: fullKeyShape, dtype: .fp16)
+        return PagedKVRuntimePhysicalLayerBlocks(
+            layerIndex: layerIndex,
+            keyShape: fullKeyShape,
+            valueShape: fullValueShape,
+            dtype: .fp16,
+            keyBlocks: try Self.physicalBlocks(
+                keyBlocks,
+                table: table,
+                fullShape: fullKeyShape,
+                dtype: .fp16
+            ),
+            valueBlocks: try Self.physicalBlocks(
+                valueBlocks,
+                table: table,
+                fullShape: fullValueShape,
+                dtype: .fp16
+            ),
+            bytesPerToken: bytesPerToken
+        )
+    }
+
     func makeMask(
         n: Int,
         windowSize: Int?,
@@ -320,5 +367,112 @@ final class PagedKVCache: KVCache, CustomDebugStringConvertible {
             start = end
         }
         return blocks
+    }
+
+    private static func physicalBlocks(
+        _ arrays: [MLXArray],
+        table: PagedKVBlockTable,
+        fullShape: [Int],
+        dtype: PagedKVDType
+    ) throws -> [Int: Data] {
+        let sequenceAxis = fullShape.count - 2
+        let outerElements = try product(fullShape.prefix(sequenceAxis))
+        let innerBytes = try innerBytesPerToken(shape: fullShape, dtype: dtype)
+        let blockOuterStride = try checkedMultiply(table.blockSizeTokens, innerBytes)
+        let fullBlockBytes = try checkedMultiply(outerElements, blockOuterStride)
+        var mappedBlocks: [Int: Data] = [:]
+        mappedBlocks.reserveCapacity(table.physicalBlocks.count)
+        for (blockIndex, array) in arrays.enumerated() {
+            let validTokens = blockIndex == table.physicalBlocks.count - 1
+                ? table.tailValidTokenCount
+                : table.blockSizeTokens
+            var expectedShape = fullShape
+            expectedShape[sequenceAxis] = validTokens
+            guard array.shape == expectedShape,
+                  try pagedDType(for: array.dtype) == dtype
+            else {
+                throw PagedKVContiguousCacheBridgeError.blockTableMismatch
+            }
+            let blockData = array.asData(access: .copy)
+            guard blockData.shape == expectedShape,
+                  try pagedDType(for: blockData.dType) == dtype
+            else {
+                throw PagedKVContiguousCacheBridgeError.unsupportedDType
+            }
+            let validBlockBytes = try checkedMultiply(
+                try checkedMultiply(outerElements, validTokens),
+                innerBytes
+            )
+            guard blockData.data.count == validBlockBytes else {
+                throw PagedKVContiguousCacheBridgeError.blockTableMismatch
+            }
+            var padded = Data(repeating: 0, count: fullBlockBytes)
+            let sourceOuterStride = try checkedMultiply(validTokens, innerBytes)
+            for outer in 0..<outerElements {
+                let sourceStart = outer * sourceOuterStride
+                let destinationStart = outer * blockOuterStride
+                padded.replaceSubrange(
+                    destinationStart ..< destinationStart + sourceOuterStride,
+                    with: blockData.data[sourceStart ..< sourceStart + sourceOuterStride]
+                )
+            }
+            let physicalID = table.physicalBlocks[blockIndex]
+            guard mappedBlocks[physicalID] == nil else {
+                throw PagedKVContiguousCacheBridgeError.blockTableMismatch
+            }
+            mappedBlocks[physicalID] = padded
+        }
+        guard mappedBlocks.count == table.physicalBlocks.count else {
+            throw PagedKVContiguousCacheBridgeError.blockTableMismatch
+        }
+        return mappedBlocks
+    }
+
+    private static func pagedDType(for dtype: DType) throws -> PagedKVDType {
+        switch dtype {
+        case .float16:
+            return .fp16
+        default:
+            throw PagedKVContiguousCacheBridgeError.unsupportedDType
+        }
+    }
+
+    private static func innerBytesPerToken(shape: [Int], dtype: PagedKVDType) throws -> Int {
+        guard shape.count >= 3 else { throw PagedKVContiguousCacheBridgeError.blockTableMismatch }
+        let sequenceAxis = shape.count - 2
+        var elements = 1
+        for dim in shape.suffix(from: sequenceAxis + 1) {
+            guard dim > 0 else { throw PagedKVContiguousCacheBridgeError.blockTableMismatch }
+            let (next, overflow) = elements.multipliedReportingOverflow(by: dim)
+            guard !overflow else { throw PagedKVContiguousCacheBridgeError.blockTableMismatch }
+            elements = next
+        }
+        return try checkedMultiply(elements, dtype.byteWidth)
+    }
+
+    private static func bytesPerToken(shape: [Int], dtype: PagedKVDType) throws -> Int {
+        guard shape.count >= 3 else { throw PagedKVContiguousCacheBridgeError.blockTableMismatch }
+        let sequenceAxis = shape.count - 2
+        return try checkedMultiply(
+            try product(shape.prefix(sequenceAxis)),
+            try innerBytesPerToken(shape: shape, dtype: dtype)
+        )
+    }
+
+    private static func product<S: Sequence>(_ values: S) throws -> Int where S.Element == Int {
+        var result = 1
+        for value in values {
+            guard value > 0 else { throw PagedKVContiguousCacheBridgeError.blockTableMismatch }
+            let (next, overflow) = result.multipliedReportingOverflow(by: value)
+            guard !overflow else { throw PagedKVContiguousCacheBridgeError.blockTableMismatch }
+            result = next
+        }
+        return result
+    }
+
+    private static func checkedMultiply(_ lhs: Int, _ rhs: Int) throws -> Int {
+        let (value, overflow) = lhs.multipliedReportingOverflow(by: rhs)
+        guard !overflow else { throw PagedKVContiguousCacheBridgeError.blockTableMismatch }
+        return value
     }
 }

--- a/phase3-binary/Sources/macprovider-cli/PagedKVRuntimeBridge.swift
+++ b/phase3-binary/Sources/macprovider-cli/PagedKVRuntimeBridge.swift
@@ -3,6 +3,421 @@ import MLX
 import MLXLMCommon
 import MacProviderCore
 
+enum PagedKVContiguousCacheBridgeError: Error, Equatable {
+    case noRecordedBlocks
+    case unsupportedDType
+    case invalidLayerState
+    case blockTableMismatch
+    case trimShortfall
+}
+
+struct PagedKVContiguousCacheHandoff {
+    let handle: PagedKVBlockTableHandle
+    private let blockTable: PagedKVBlockTable
+    private(set) var logicalTokenCount: Int
+    private(set) var tailValidTokenCount: Int
+    let caches: [KVCacheSimple]
+
+    init(materializedByteCache cache: PagedKVMaterializedByteCache) throws {
+        self.handle = cache.handle
+        self.blockTable = cache.blockTable
+        self.logicalTokenCount = cache.blockTable.logicalTokenCount
+        self.tailValidTokenCount = cache.blockTable.tailValidTokenCount
+        self.caches = try Self.restoreCaches(from: cache)
+    }
+
+    mutating func trim(toLogicalTokens tokens: Int) throws {
+        guard tokens >= 0, tokens <= logicalTokenCount else {
+            throw PagedKVContiguousCacheBridgeError.blockTableMismatch
+        }
+        let trimCount = logicalTokenCount - tokens
+        guard trimCount > 0 else { return }
+        for cache in caches {
+            guard cache.isTrimmable, cache.trim(trimCount) == trimCount else {
+                throw PagedKVContiguousCacheBridgeError.trimShortfall
+            }
+        }
+        logicalTokenCount = tokens
+        tailValidTokenCount = tokens == 0 ? 0 : ((tokens - 1) % blockTable.blockSizeTokens) + 1
+    }
+
+    private static func restoreCaches(from cache: PagedKVMaterializedByteCache) throws -> [KVCacheSimple] {
+        var restored: [KVCacheSimple] = []
+        for layer in cache.layers.sorted(by: { $0.layerIndex < $1.layerIndex }) {
+            guard layer.dtype == .fp16 else {
+                throw PagedKVContiguousCacheBridgeError.unsupportedDType
+            }
+            guard layer.keyShape == layer.valueShape,
+                  layer.keyShape.count >= 3,
+                  layer.keyShape[layer.keyShape.count - 2] == cache.blockTable.logicalTokenCount,
+                  layer.logicalTokenCount == cache.blockTable.logicalTokenCount
+            else {
+                throw PagedKVContiguousCacheBridgeError.blockTableMismatch
+            }
+            let expectedBytes = try byteCount(shape: layer.keyShape, dtype: layer.dtype)
+            guard layer.keyBytes.count == expectedBytes, layer.valueBytes.count == expectedBytes else {
+                throw PagedKVContiguousCacheBridgeError.blockTableMismatch
+            }
+            let key = MLXArray(layer.keyBytes, layer.keyShape, dtype: .float16)
+            let value = MLXArray(layer.valueBytes, layer.valueShape, dtype: .float16)
+            let contiguous = KVCacheSimple()
+            contiguous.state = [key, value]
+            guard contiguous.offset == cache.blockTable.logicalTokenCount else {
+                throw PagedKVContiguousCacheBridgeError.blockTableMismatch
+            }
+            restored.append(contiguous)
+        }
+        return restored
+    }
+
+    private static func byteCount(shape: [Int], dtype: PagedKVDType) throws -> Int {
+        guard shape.count >= 3, shape.allSatisfy({ $0 >= 0 }) else {
+            throw PagedKVContiguousCacheBridgeError.blockTableMismatch
+        }
+        var elements = 1
+        for dim in shape {
+            let (next, overflow) = elements.multipliedReportingOverflow(by: dim)
+            guard !overflow else { throw PagedKVContiguousCacheBridgeError.blockTableMismatch }
+            elements = next
+        }
+        let (bytes, overflow) = elements.multipliedReportingOverflow(by: dtype.byteWidth)
+        guard !overflow else { throw PagedKVContiguousCacheBridgeError.blockTableMismatch }
+        return bytes
+    }
+
+}
+
+struct PagedKVPagedCacheHandoff {
+    let handle: PagedKVBlockTableHandle
+    let blockTable: PagedKVBlockTable
+    let logicalTokenCount: Int
+    let tailValidTokenCount: Int
+    let caches: [PagedKVCache]
+
+    fileprivate init(handle: PagedKVBlockTableHandle, blockTable: PagedKVBlockTable, caches: [PagedKVCache]) {
+        self.handle = handle
+        self.blockTable = blockTable
+        self.logicalTokenCount = blockTable.logicalTokenCount
+        self.tailValidTokenCount = blockTable.tailValidTokenCount
+        self.caches = caches
+    }
+}
+
+struct PagedKVRuntimePhysicalLayerBlocks: Equatable, Sendable {
+    let layerIndex: Int
+    let keyShape: [Int]
+    let valueShape: [Int]
+    let dtype: PagedKVDType
+    let keyBlocks: [Int: Data]
+    let valueBlocks: [Int: Data]
+    let bytesPerToken: Int
+}
+
+protocol PagedKVRuntimeCacheBridge: Sendable {
+    func record(caches: [PagedKVCache], binding: PagedKVStorageBinding) throws
+    func discard(handle: PagedKVBlockTableHandle)
+    func discardContiguousCache(handle: PagedKVBlockTableHandle)
+}
+
+final class PagedKVRuntimeContiguousCacheBridge: PagedKVContiguousCacheBridge, PagedKVRuntimeCacheBridge, @unchecked Sendable {
+    private struct Record {
+        let version = UUID()
+        let handle: PagedKVBlockTableHandle
+        var table: PagedKVBlockTable
+        let caches: [PagedKVCache]
+        var physicalLayers: [PagedKVRuntimePhysicalLayerBlocks]
+    }
+
+    private let lock = NSLock()
+    private var recordsByHandle: [UUID: Record] = [:]
+
+    func record(caches: [PagedKVCache], binding: PagedKVStorageBinding) throws {
+        let table = binding.currentTable
+        try caches.forEach { cache in
+            try Self.validateHandle(cache.binding.handle, matches: binding.handle)
+        }
+        let physicalLayers = try caches.enumerated().map { layerIndex, cache in
+            try cache.physicalLayerBlocks(layerIndex: layerIndex, table: table)
+        }
+        lock.lock()
+        recordsByHandle[binding.handle.handleID] = Record(
+            handle: binding.handle,
+            table: table,
+            caches: caches,
+            physicalLayers: physicalLayers
+        )
+        lock.unlock()
+    }
+
+    func discard(handle: PagedKVBlockTableHandle) {
+        discardContiguousCache(handle: handle)
+    }
+
+    func discardContiguousCache(handle: PagedKVBlockTableHandle) {
+        lock.lock()
+        recordsByHandle.removeValue(forKey: handle.handleID)
+        lock.unlock()
+    }
+
+    func trimRecordedContiguousCache(
+        handle: PagedKVBlockTableHandle,
+        table: PagedKVBlockTable
+    ) throws {
+        lock.lock()
+        let existing = recordsByHandle[handle.handleID]
+        lock.unlock()
+        guard var record = existing else { return }
+        try Self.validateHandle(handle, matches: record.handle)
+        guard Self.isSameTableIdentity(record.table, table),
+              table.logicalTokenCount <= record.table.logicalTokenCount,
+              record.table.physicalBlocks.prefix(table.physicalBlocks.count).elementsEqual(table.physicalBlocks)
+        else {
+            throw PagedKVContiguousCacheBridgeError.blockTableMismatch
+        }
+        for cache in record.caches {
+            guard cache.offset == record.table.logicalTokenCount, cache.isTrimmable else {
+                throw PagedKVContiguousCacheBridgeError.blockTableMismatch
+            }
+        }
+        lock.lock()
+        let stillCurrent = recordsByHandle[handle.handleID]?.version == record.version
+        lock.unlock()
+        guard stillCurrent else { return }
+        for cache in record.caches {
+            let trimCount = cache.offset - table.logicalTokenCount
+            if trimCount > 0 {
+                guard cache.trim(trimCount) == trimCount else {
+                    discardContiguousCache(handle: handle)
+                    throw PagedKVContiguousCacheBridgeError.trimShortfall
+                }
+            }
+        }
+        if table.logicalTokenCount == 0 {
+            discardContiguousCache(handle: handle)
+            return
+        }
+        for cache in record.caches {
+            try Self.validateRecordableCache(cache, expectedHandle: handle, table: table)
+        }
+        record.physicalLayers = try record.caches.enumerated().map { layerIndex, cache in
+            try cache.physicalLayerBlocks(layerIndex: layerIndex, table: table)
+        }
+        record.table = table
+        lock.lock()
+        if recordsByHandle[handle.handleID]?.version == record.version {
+            recordsByHandle[handle.handleID] = record
+        }
+        lock.unlock()
+    }
+
+    func materializeContiguousByteCache(
+        handle: PagedKVBlockTableHandle,
+        table: PagedKVBlockTable
+    ) throws -> PagedKVMaterializedByteCache {
+        lock.lock()
+        let record = recordsByHandle[handle.handleID]
+        lock.unlock()
+        guard let record else { throw PagedKVContiguousCacheBridgeError.noRecordedBlocks }
+        try Self.validateHandle(handle, matches: record.handle)
+        guard table == record.table else {
+            throw PagedKVContiguousCacheBridgeError.blockTableMismatch
+        }
+        let materializedLayers = try record.physicalLayers.sorted(by: { $0.layerIndex < $1.layerIndex }).map { layer in
+            guard layer.keyBlocks.count == table.physicalBlocks.count,
+                  layer.valueBlocks.count == table.physicalBlocks.count
+            else {
+                throw PagedKVContiguousCacheBridgeError.blockTableMismatch
+            }
+            let keyShape = try Self.shape(layer.keyShape, logicalTokens: table.logicalTokenCount)
+            let valueShape = try Self.shape(layer.valueShape, logicalTokens: table.logicalTokenCount)
+            return PagedKVMaterializedByteLayer(
+                layerIndex: layer.layerIndex,
+                keyShape: keyShape,
+                valueShape: valueShape,
+                dtype: layer.dtype,
+                logicalTokenCount: table.logicalTokenCount,
+                keyBytes: try Self.materializeShapedComponent(
+                    table: table,
+                    physicalBlocks: layer.keyBlocks,
+                    shape: keyShape,
+                    dtype: layer.dtype
+                ),
+                valueBytes: try Self.materializeShapedComponent(
+                    table: table,
+                    physicalBlocks: layer.valueBlocks,
+                    shape: valueShape,
+                    dtype: layer.dtype
+                )
+            )
+        }
+        return PagedKVMaterializedByteCache(handle: handle, blockTable: table, layers: materializedLayers)
+    }
+
+    func materializeContiguousKVCache(
+        handle: PagedKVBlockTableHandle,
+        table: PagedKVBlockTable
+    ) throws -> PagedKVContiguousCacheHandoff {
+        try PagedKVContiguousCacheHandoff(materializedByteCache: materializeContiguousByteCache(
+            handle: handle,
+            table: table
+        ))
+    }
+
+    func reattachPagedKVCache(
+        handle: PagedKVBlockTableHandle,
+        table: PagedKVBlockTable
+    ) throws -> PagedKVPagedCacheHandoff {
+        lock.lock()
+        let record = recordsByHandle[handle.handleID]
+        lock.unlock()
+        guard let record else { throw PagedKVContiguousCacheBridgeError.noRecordedBlocks }
+        try Self.validateHandle(handle, matches: record.handle)
+        guard table == record.table else {
+            throw PagedKVContiguousCacheBridgeError.blockTableMismatch
+        }
+        try record.caches.forEach { cache in
+            try Self.validateRecordableCache(cache, expectedHandle: handle, table: table)
+        }
+        return PagedKVPagedCacheHandoff(handle: handle, blockTable: table, caches: record.caches)
+    }
+
+    private static func validateHandle(
+        _ handle: PagedKVBlockTableHandle,
+        matches recorded: PagedKVBlockTableHandle
+    ) throws {
+        guard handle == recorded else {
+            throw PagedKVContiguousCacheBridgeError.blockTableMismatch
+        }
+    }
+
+    private static func isSameTableIdentity(_ lhs: PagedKVBlockTable, _ rhs: PagedKVBlockTable) -> Bool {
+        lhs.handleID == rhs.handleID
+            && lhs.blockSizeTokens == rhs.blockSizeTokens
+            && lhs.poolEpoch == rhs.poolEpoch
+    }
+
+    private static func validateRecordableCache(
+        _ cache: PagedKVCache,
+        expectedHandle: PagedKVBlockTableHandle,
+        table: PagedKVBlockTable
+    ) throws {
+        try validateHandle(cache.binding.handle, matches: expectedHandle)
+        guard cache.offset == table.logicalTokenCount else {
+            throw PagedKVContiguousCacheBridgeError.blockTableMismatch
+        }
+        _ = try cache.physicalLayerBlocks(layerIndex: 0, table: table)
+    }
+
+    private static func pagedDType(for dtype: DType) throws -> PagedKVDType {
+        switch dtype {
+        case .float16:
+            return .fp16
+        default:
+            throw PagedKVContiguousCacheBridgeError.unsupportedDType
+        }
+    }
+
+    private static func materializeShapedComponent(
+        table: PagedKVBlockTable,
+        physicalBlocks: [Int: Data],
+        shape: [Int],
+        dtype: PagedKVDType
+    ) throws -> Data {
+        guard try sequenceLength(for: shape) == table.logicalTokenCount else {
+            throw PagedKVContiguousCacheBridgeError.blockTableMismatch
+        }
+        let sequenceAxis = shape.count - 2
+        let outerElements = try product(shape.prefix(sequenceAxis))
+        let innerBytes = try innerBytesPerToken(shape: shape, dtype: dtype)
+        let blockOuterStride = table.blockSizeTokens * innerBytes
+        var output = Data()
+        output.reserveCapacity(try totalBytes(shape: shape, dtype: dtype))
+        for outer in 0..<outerElements {
+            for (blockIndex, physicalID) in table.physicalBlocks.enumerated() {
+                guard let block = physicalBlocks[physicalID] else {
+                    throw PagedKVContiguousCacheBridgeError.blockTableMismatch
+                }
+                guard block.count >= (outer + 1) * blockOuterStride else {
+                    throw PagedKVContiguousCacheBridgeError.blockTableMismatch
+                }
+                let validTokens = blockIndex == table.physicalBlocks.count - 1
+                    ? table.tailValidTokenCount
+                    : table.blockSizeTokens
+                let byteCount = validTokens * innerBytes
+                let sourceStart = outer * blockOuterStride
+                output.append(block[sourceStart ..< sourceStart + byteCount])
+            }
+        }
+        guard output.count == (try totalBytes(shape: shape, dtype: dtype)) else {
+            throw PagedKVContiguousCacheBridgeError.blockTableMismatch
+        }
+        return output
+    }
+
+    private static func sequenceLength(for shape: [Int]) throws -> Int {
+        guard shape.count >= 3, shape.allSatisfy({ $0 >= 0 }) else {
+            throw PagedKVContiguousCacheBridgeError.blockTableMismatch
+        }
+        return shape[shape.count - 2]
+    }
+
+    private static func shape(_ shape: [Int], logicalTokens: Int) throws -> [Int] {
+        guard logicalTokens >= 0,
+              shape.count >= 3,
+              try sequenceLength(for: shape) >= logicalTokens
+        else {
+            throw PagedKVContiguousCacheBridgeError.blockTableMismatch
+        }
+        var adjusted = shape
+        adjusted[adjusted.count - 2] = logicalTokens
+        return adjusted
+    }
+
+    private static func innerBytesPerToken(shape: [Int], dtype: PagedKVDType) throws -> Int {
+        guard shape.count >= 3 else { throw PagedKVContiguousCacheBridgeError.blockTableMismatch }
+        let sequenceAxis = shape.count - 2
+        var elements = 1
+        for dim in shape.suffix(from: sequenceAxis + 1) {
+            guard dim > 0 else { throw PagedKVContiguousCacheBridgeError.blockTableMismatch }
+            let (next, overflow) = elements.multipliedReportingOverflow(by: dim)
+            guard !overflow else { throw PagedKVContiguousCacheBridgeError.blockTableMismatch }
+            elements = next
+        }
+        let (bytes, overflow) = elements.multipliedReportingOverflow(by: dtype.byteWidth)
+        guard !overflow else { throw PagedKVContiguousCacheBridgeError.blockTableMismatch }
+        return bytes
+    }
+
+    private static func bytesPerToken(shape: [Int], dtype: PagedKVDType) throws -> Int {
+        guard shape.count >= 3 else { throw PagedKVContiguousCacheBridgeError.blockTableMismatch }
+        let sequenceAxis = shape.count - 2
+        let outerElements = try product(shape.prefix(sequenceAxis))
+        let innerBytes = try innerBytesPerToken(shape: shape, dtype: dtype)
+        let (bytes, overflow) = outerElements.multipliedReportingOverflow(by: innerBytes)
+        guard !overflow else { throw PagedKVContiguousCacheBridgeError.blockTableMismatch }
+        return bytes
+    }
+
+    private static func totalBytes(shape: [Int], dtype: PagedKVDType) throws -> Int {
+        let tokens = try sequenceLength(for: shape)
+        let perToken = try bytesPerToken(shape: shape, dtype: dtype)
+        let (bytes, overflow) = tokens.multipliedReportingOverflow(by: perToken)
+        guard !overflow else { throw PagedKVContiguousCacheBridgeError.blockTableMismatch }
+        return bytes
+    }
+
+    private static func product<S: Sequence>(_ values: S) throws -> Int where S.Element == Int {
+        var result = 1
+        for value in values {
+            guard value > 0 else { throw PagedKVContiguousCacheBridgeError.blockTableMismatch }
+            let (next, overflow) = result.multipliedReportingOverflow(by: value)
+            guard !overflow else { throw PagedKVContiguousCacheBridgeError.blockTableMismatch }
+            result = next
+        }
+        return result
+    }
+}
+
 /// SPEC-039 / SPEC-038 Increment 1 runtime bridge.
 ///
 /// This backend is intentionally installable only after the attach gate has a
@@ -17,16 +432,23 @@ final class PagedKVSharedForwardBackend: ContinuousBatchSchedulerBackend, @unche
     private let container: ModelContainer
     private let descriptor: PagedKVDescriptor
     private let layerCount: Int
+    private let contiguousCacheBridge: (any PagedKVRuntimeCacheBridge)?
     private let lock = NSLock()
     private var rows: [String: RowState] = [:]
     private var activeOperations = 0
     private var cancelRequested = false
     private var cancellationWaiters: [CheckedContinuation<Void, Never>] = []
 
-    init(container: ModelContainer, descriptor: PagedKVDescriptor, layerCount: Int) {
+    init(
+        container: ModelContainer,
+        descriptor: PagedKVDescriptor,
+        layerCount: Int,
+        contiguousCacheBridge: (any PagedKVRuntimeCacheBridge)? = nil
+    ) {
         self.container = container
         self.descriptor = descriptor
         self.layerCount = max(1, layerCount)
+        self.contiguousCacheBridge = contiguousCacheBridge
     }
 
     func prefill(rows inputs: [ContinuousBatchPrefillInput]) async throws -> [ContinuousBatchPrefillOutput] {
@@ -34,7 +456,7 @@ final class PagedKVSharedForwardBackend: ContinuousBatchSchedulerBackend, @unche
             throw ContinuousBatchSchedulerError.unsupported("continuous_batching_backend_cancelled")
         }
         defer { endOperation() }
-        return await container.perform(nonSendable: inputs) { context, inputs in
+        return try await container.perform(nonSendable: inputs) { context, inputs in
             var outputs: [ContinuousBatchPrefillOutput] = []
             outputs.reserveCapacity(inputs.count)
             for input in inputs {
@@ -48,7 +470,7 @@ final class PagedKVSharedForwardBackend: ContinuousBatchSchedulerBackend, @unche
                     eval(output.logits)
                     state.state = output.state
                 }
-                self.setRowState(state, for: input.requestID)
+                try self.setRowState(state, for: input.requestID, binding: input.binding)
                 outputs.append(ContinuousBatchPrefillOutput(requestID: input.requestID))
             }
             return outputs
@@ -94,7 +516,7 @@ final class PagedKVSharedForwardBackend: ContinuousBatchSchedulerBackend, @unche
                 return supportedInputs.map { ContinuousBatchDecodeOutcome.rowFailure(requestID: $0.requestID) }
             }
             for (index, input) in supportedInputs.enumerated() {
-                self.setRowState(rowStates[index], for: input.requestID)
+                try self.setRowState(rowStates[index], for: input.requestID, binding: input.binding)
             }
             return zip(supportedInputs, sampled).map { input, token in
                 ContinuousBatchDecodeOutcome.output(ContinuousBatchDecodeOutput(
@@ -119,20 +541,23 @@ final class PagedKVSharedForwardBackend: ContinuousBatchSchedulerBackend, @unche
     }
 
     func finish(requestID: String) {
-        removeRowState(for: requestID)
+        removeRowState(for: requestID, discardRecordedCache: false)
     }
 
     func cancelInFlight() async {
         await withCheckedContinuation { continuation in
             lock.lock()
             cancelRequested = true
+            let handlesToDiscard = rows.compactMap { $0.value.caches.first?.binding.handle }
             rows.removeAll()
             if activeOperations == 0 {
                 lock.unlock()
+                handlesToDiscard.forEach { contiguousCacheBridge?.discardContiguousCache(handle: $0) }
                 continuation.resume()
             } else {
                 cancellationWaiters.append(continuation)
                 lock.unlock()
+                handlesToDiscard.forEach { contiguousCacheBridge?.discardContiguousCache(handle: $0) }
             }
         }
     }
@@ -183,24 +608,50 @@ final class PagedKVSharedForwardBackend: ContinuousBatchSchedulerBackend, @unche
         )
     }
 
-    private func setRowState(_ state: RowState, for requestID: String) {
+    private func setRowState(
+        _ state: RowState,
+        for requestID: String,
+        binding: PagedKVStorageBinding
+    ) throws {
+        lock.lock()
+        let cancelledBeforeRecord = cancelRequested
+        lock.unlock()
+        guard !cancelledBeforeRecord else {
+            contiguousCacheBridge?.discardContiguousCache(handle: binding.handle)
+            return
+        }
+        try contiguousCacheBridge?.record(caches: state.caches, binding: binding)
         lock.lock()
         if !cancelRequested {
             rows[requestID] = state
+            lock.unlock()
+        } else {
+            lock.unlock()
+            contiguousCacheBridge?.discardContiguousCache(handle: binding.handle)
         }
-        lock.unlock()
     }
 
-    private func removeRowState(for requestID: String) {
+    private func removeRowState(for requestID: String, discardRecordedCache: Bool = true) {
         lock.lock()
-        rows.removeValue(forKey: requestID)
+        let removed = rows.removeValue(forKey: requestID)
         lock.unlock()
+        if discardRecordedCache, let handle = removed?.caches.first?.binding.handle {
+            contiguousCacheBridge?.discard(handle: handle)
+        }
     }
 
     func retainedRowCountForTest() -> Int {
         lock.lock()
         defer { lock.unlock() }
         return rows.count
+    }
+
+    func installRowStateForTest(
+        caches: [PagedKVCache],
+        requestID: String,
+        binding: PagedKVStorageBinding
+    ) throws {
+        try setRowState(RowState(caches: caches, state: nil), for: requestID, binding: binding)
     }
 
     private static func supportsGreedySampling(_ input: ContinuousBatchDecodeInput) -> Bool {

--- a/phase3-binary/Tests/MacProviderCoreTests/PagedKVEngineTests.swift
+++ b/phase3-binary/Tests/MacProviderCoreTests/PagedKVEngineTests.swift
@@ -880,6 +880,83 @@ final class PagedKVEngineTests: XCTestCase {
         }
     }
 
+    func testRetainReattachCanTrimToMidBlockLCPWithoutWholeBlockRounding() async throws {
+        let allocator = try PagedKVBlockAllocator(
+            blockSizeTokens: 4,
+            maxPhysicalBlocks: 4,
+            physicalBlockOrder: [2, 0, 3, 1]
+        )
+        let handle = try await allocator.allocate(
+            conversationKey: "conv:a",
+            initialCapacityTokens: 12,
+            maxLogicalTokens: 12,
+            initialTokens: 7
+        )
+        let retained = try await allocator.retain(handle)
+
+        await XCTAssertThrowsErrorAsync {
+            _ = try await allocator.reattach(retained, conversationKey: "conv:b", trimToLogicalTokens: 5)
+        }
+
+        let reattached = try await allocator.reattach(
+            retained,
+            conversationKey: "conv:a",
+            trimToLogicalTokens: 5
+        )
+        XCTAssertEqual(reattached, handle)
+        let table = try await allocator.table(for: reattached)
+        XCTAssertEqual(table.logicalTokenCount, 5)
+        XCTAssertEqual(table.physicalBlocks, [2, 0])
+        XCTAssertEqual(table.tailValidTokenCount, 1)
+    }
+
+    func testBridgeTrimFailureLeavesAllocatorAndRetainedStateUnchanged() async throws {
+        let bridge = ThrowingTrimContiguousCacheBridge()
+        let allocator = try PagedKVBlockAllocator(
+            blockSizeTokens: 4,
+            maxPhysicalBlocks: 4,
+            physicalBlockOrder: [2, 0, 3, 1],
+            contiguousCacheBridge: bridge
+        )
+        let handle = try await allocator.allocate(
+            conversationKey: "conv:a",
+            initialCapacityTokens: 8,
+            maxLogicalTokens: 8,
+            initialTokens: 7
+        )
+        var freeBlockCount = await allocator.freeBlockCount()
+        XCTAssertEqual(freeBlockCount, 2)
+
+        await XCTAssertThrowsErrorAsync {
+            _ = try await allocator.trim(handle, toLogicalTokens: 3)
+        }
+        var table = try await allocator.table(for: handle)
+        XCTAssertEqual(table.logicalTokenCount, 7)
+        XCTAssertEqual(table.physicalBlocks, [2, 0])
+        freeBlockCount = await allocator.freeBlockCount()
+        XCTAssertEqual(freeBlockCount, 2)
+
+        let retained = try await allocator.retain(handle)
+        await XCTAssertThrowsErrorAsync {
+            _ = try await allocator.reattach(retained, conversationKey: "conv:a", trimToLogicalTokens: 3)
+        }
+        table = try await allocator.table(for: handle)
+        XCTAssertEqual(table.logicalTokenCount, 7)
+        XCTAssertEqual(table.physicalBlocks, [2, 0])
+        freeBlockCount = await allocator.freeBlockCount()
+        XCTAssertEqual(freeBlockCount, 2)
+        await XCTAssertThrowsErrorAsync {
+            try await allocator.release(handle)
+        }
+
+        bridge.shouldThrow = false
+        let reattached = try await allocator.reattach(retained, conversationKey: "conv:a")
+        XCTAssertEqual(reattached, handle)
+        table = try await allocator.table(for: handle)
+        XCTAssertEqual(table.logicalTokenCount, 7)
+        XCTAssertEqual(table.physicalBlocks, [2, 0])
+    }
+
     func testExtendAndTrimRejectDuringInFlightDecodeStep() async throws {
         let allocator = try PagedKVBlockAllocator(blockSizeTokens: 4, maxPhysicalBlocks: 3)
         let handle = try await allocator.allocate(conversationKey: "conv:a", maxTokens: 12, initialTokens: 4)
@@ -1059,6 +1136,26 @@ private struct EmptyContiguousCacheBridge: PagedKVContiguousCacheBridge {
                 ),
             ]
         )
+    }
+}
+
+private final class ThrowingTrimContiguousCacheBridge: PagedKVContiguousCacheBridge, @unchecked Sendable {
+    var shouldThrow = true
+
+    func materializeContiguousByteCache(
+        handle: PagedKVBlockTableHandle,
+        table: PagedKVBlockTable
+    ) throws -> PagedKVMaterializedByteCache {
+        PagedKVMaterializedByteCache(handle: handle, blockTable: table, layers: [])
+    }
+
+    func trimRecordedContiguousCache(
+        handle: PagedKVBlockTableHandle,
+        table: PagedKVBlockTable
+    ) throws {
+        if shouldThrow {
+            throw PagedKVAllocatorError.invalidBlockTable("injected trim failure")
+        }
     }
 }
 

--- a/phase3-binary/Tests/macprovider-cliTests/PagedKVRuntimeBridgeTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/PagedKVRuntimeBridgeTests.swift
@@ -259,8 +259,18 @@ final class PagedKVRuntimeBridgeTests: XCTestCase {
             processor: StandInUserInputProcessor(),
             tokenizer: RuntimeBridgeFakeTokenizer()
         ))
-        let backend = PagedKVSharedForwardBackend(container: container, descriptor: descriptor, layerCount: 1)
-        let allocator = try PagedKVBlockAllocator(blockSizeTokens: descriptor.blockSizeTokens, maxPhysicalBlocks: 16)
+        let contiguousCacheBridge = PagedKVRuntimeContiguousCacheBridge()
+        let backend = PagedKVSharedForwardBackend(
+            container: container,
+            descriptor: descriptor,
+            layerCount: 1,
+            contiguousCacheBridge: contiguousCacheBridge
+        )
+        let allocator = try PagedKVBlockAllocator(
+            blockSizeTokens: descriptor.blockSizeTokens,
+            maxPhysicalBlocks: 16,
+            contiguousCacheBridge: contiguousCacheBridge
+        )
         let handle = try await allocator.allocate(conversationKey: "cancel-row", maxTokens: 8)
         _ = try await allocator.extend(handle, by: 1)
         let binding = try await allocator.binding(for: handle)
@@ -292,6 +302,42 @@ final class PagedKVRuntimeBridgeTests: XCTestCase {
         await cancel.value
         XCTAssertTrue(cancellation.returned())
         XCTAssertEqual(backend.retainedRowCountForTest(), 0)
+        await XCTAssertThrowsErrorAsync {
+            _ = try await allocator.materializeContiguousByteCache(handle)
+        }
+    }
+
+    func testSharedForwardBackendFinishPreservesRetainedPagedHandoffRecord() async throws {
+        let descriptor = Self.bridgeDescriptor(blockSizeTokens: 4, maxPhysicalBlocks: 4)
+        let bridge = RuntimeBridgeRecordingCacheBridge()
+        let backend = PagedKVSharedForwardBackend(
+            container: ModelContainer(context: ModelContext(
+                configuration: ModelConfiguration(id: descriptor.modelID),
+                model: RuntimeBridgeFakeModel(nextTokenByInput: [:]),
+                processor: StandInUserInputProcessor(),
+                tokenizer: RuntimeBridgeFakeTokenizer()
+            )),
+            descriptor: descriptor,
+            layerCount: 1,
+            contiguousCacheBridge: bridge
+        )
+        let allocator = try PagedKVBlockAllocator(
+            blockSizeTokens: descriptor.blockSizeTokens,
+            maxPhysicalBlocks: descriptor.maxPhysicalBlocks
+        )
+        let handle = try await allocator.allocate(conversationKey: "conv:a", maxTokens: 8, initialTokens: 4)
+        let binding = try await allocator.binding(for: handle)
+        let paged = PagedKVCache(descriptor: descriptor, binding: binding, initialOffset: 4)
+        try backend.installRowStateForTest(caches: [paged], requestID: "retained-row", binding: binding)
+        XCTAssertEqual(backend.retainedRowCountForTest(), 1)
+        XCTAssertTrue(bridge.hasRecord(for: handle))
+
+        let retained = try await allocator.retain(handle)
+        backend.finish(requestID: "retained-row")
+        XCTAssertEqual(backend.retainedRowCountForTest(), 0)
+        XCTAssertTrue(bridge.hasRecord(for: handle))
+        XCTAssertEqual(bridge.discardedHandles(), [])
+        _ = try await allocator.reattach(retained, conversationKey: "conv:a")
     }
 
     func testAttachedModelRuntimeServesFreshGreedyRequestsThroughScheduler() async throws {
@@ -415,6 +461,196 @@ final class PagedKVRuntimeBridgeTests: XCTestCase {
         XCTAssertTrue(chunks.chunks().isEmpty)
     }
 
+    func testContiguousCacheBridgeRestoresLiveKVCacheByteExactAndRoundTrips() async throws {
+        guard PagedKVMetallibGate.defaultMetallibExists() else {
+            throw XCTSkip("MLX default metallib is unavailable in this test host")
+        }
+
+        let descriptor = Self.bridgeDescriptor(blockSizeTokens: 2, maxPhysicalBlocks: 6)
+        let bridge = PagedKVRuntimeContiguousCacheBridge()
+        let allocator = try PagedKVBlockAllocator(
+            blockSizeTokens: descriptor.blockSizeTokens,
+            maxPhysicalBlocks: descriptor.maxPhysicalBlocks,
+            physicalBlockOrder: [4, 1, 3, 0, 2, 5],
+            contiguousCacheBridge: bridge
+        )
+        let handle = try await allocator.allocate(conversationKey: "conv:a", maxTokens: 6, initialTokens: 5)
+        let binding = try await allocator.binding(for: handle)
+        XCTAssertEqual(binding.currentTable.physicalBlocks, [4, 1, 3])
+
+        let keyBytes = Self.fp16Bytes([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        let valueBytes = Self.fp16Bytes([101, 102, 103, 104, 105, 106, 107, 108, 109, 110])
+        let paged = PagedKVCache(descriptor: descriptor, binding: binding)
+        paged.state = [
+            MLXArray(keyBytes, [1, 2, 5, 1], dtype: .float16),
+            MLXArray(valueBytes, [1, 2, 5, 1], dtype: .float16),
+        ]
+        try bridge.record(caches: [paged], binding: binding)
+
+        let permutedTable = PagedKVBlockTable(
+            handleID: binding.currentTable.handleID,
+            blockSizeTokens: binding.currentTable.blockSizeTokens,
+            logicalTokenCount: binding.currentTable.logicalTokenCount,
+            physicalBlocks: Array(binding.currentTable.physicalBlocks.reversed()),
+            tailValidTokenCount: binding.currentTable.tailValidTokenCount,
+            poolEpoch: binding.currentTable.poolEpoch
+        )
+        XCTAssertThrowsError(try bridge.materializeContiguousByteCache(handle: handle, table: permutedTable))
+
+        paged.state = [
+            MLXArray(Self.fp16Bytes([201, 202, 203, 204, 205, 206, 207, 208, 209, 210]), [1, 2, 5, 1], dtype: .float16),
+            MLXArray(Self.fp16Bytes([301, 302, 303, 304, 305, 306, 307, 308, 309, 310]), [1, 2, 5, 1], dtype: .float16),
+        ]
+        XCTAssertNotEqual(paged.state[0].asData(access: .copy).data, keyBytes)
+
+        let materialized = try await allocator.materializeContiguousByteCache(handle)
+        XCTAssertEqual(materialized.layers[0].keyBytes, keyBytes)
+        XCTAssertEqual(materialized.layers[0].valueBytes, valueBytes)
+
+        let handoff = try bridge.materializeContiguousKVCache(handle: handle, table: binding.currentTable)
+        XCTAssertEqual(handoff.caches.count, 1)
+        XCTAssertEqual(handoff.caches[0].offset, 5)
+        XCTAssertEqual(handoff.caches[0].state[0].asData(access: .copy).data, keyBytes)
+        XCTAssertEqual(handoff.caches[0].state[1].asData(access: .copy).data, valueBytes)
+
+        let nextKeyBytes = Self.fp16Bytes([11, 12])
+        let nextValueBytes = Self.fp16Bytes([111, 112])
+        let updated = handoff.caches[0].update(
+            keys: MLXArray(nextKeyBytes, [1, 2, 1, 1], dtype: .float16),
+            values: MLXArray(nextValueBytes, [1, 2, 1, 1], dtype: .float16)
+        )
+        eval(updated.0, updated.1)
+        XCTAssertEqual(handoff.caches[0].offset, 6)
+        XCTAssertEqual(
+            handoff.caches[0].state[0].asData(access: .copy).data,
+            Self.fp16Bytes([1, 2, 3, 4, 5, 11, 6, 7, 8, 9, 10, 12])
+        )
+        XCTAssertEqual(
+            handoff.caches[0].state[1].asData(access: .copy).data,
+            Self.fp16Bytes([101, 102, 103, 104, 105, 111, 106, 107, 108, 109, 110, 112])
+        )
+    }
+
+    func testContiguousCacheBridgePreservesMidBlockTrimAcrossExtractAndRetainReattach() async throws {
+        guard PagedKVMetallibGate.defaultMetallibExists() else {
+            throw XCTSkip("MLX default metallib is unavailable in this test host")
+        }
+
+        let descriptor = Self.bridgeDescriptor(blockSizeTokens: 4, maxPhysicalBlocks: 6)
+        let bridge = PagedKVRuntimeContiguousCacheBridge()
+        let allocator = try PagedKVBlockAllocator(
+            blockSizeTokens: descriptor.blockSizeTokens,
+            maxPhysicalBlocks: descriptor.maxPhysicalBlocks,
+            physicalBlockOrder: [2, 5, 1, 0, 4, 3],
+            contiguousCacheBridge: bridge
+        )
+        let handle = try await allocator.allocate(
+            conversationKey: "conv:a",
+            initialCapacityTokens: 8,
+            maxLogicalTokens: 8,
+            initialTokens: 7
+        )
+        let binding = try await allocator.binding(for: handle)
+        XCTAssertEqual(binding.currentTable.tailValidTokenCount, 3)
+
+        let keyBytes = Self.fp16Bytes([1, 2, 3, 4, 5, 6, 7])
+        let valueBytes = Self.fp16Bytes([101, 102, 103, 104, 105, 106, 107])
+        let paged = PagedKVCache(descriptor: descriptor, binding: binding)
+        paged.state = [
+            MLXArray(keyBytes, [1, 1, 7, 1], dtype: .float16),
+            MLXArray(valueBytes, [1, 1, 7, 1], dtype: .float16),
+        ]
+        try bridge.record(caches: [paged], binding: binding)
+
+        var extracted = try bridge.materializeContiguousKVCache(handle: handle, table: binding.currentTable)
+        try extracted.trim(toLogicalTokens: 5)
+        XCTAssertEqual(extracted.caches[0].offset, 5)
+        XCTAssertEqual(extracted.logicalTokenCount, 5)
+        XCTAssertEqual(extracted.tailValidTokenCount, 1)
+        XCTAssertEqual(extracted.caches[0].state[0].asData(access: .copy).data, Self.fp16Bytes([1, 2, 3, 4, 5]))
+
+        let retained = try await allocator.retain(handle)
+        await XCTAssertThrowsErrorAsync {
+            _ = try await allocator.reattach(retained, conversationKey: "conv:b", trimToLogicalTokens: 5)
+        }
+        let reattached = try await allocator.reattach(
+            retained,
+            conversationKey: "conv:a",
+            trimToLogicalTokens: 5
+        )
+        let reattachedTable = try await allocator.table(for: reattached)
+        XCTAssertEqual(reattachedTable.logicalTokenCount, 5)
+        XCTAssertEqual(reattachedTable.tailValidTokenCount, 1)
+        XCTAssertThrowsError(try bridge.materializeContiguousKVCache(handle: handle, table: binding.currentTable))
+
+        let pagedHandoff = try bridge.reattachPagedKVCache(handle: reattached, table: reattachedTable)
+        XCTAssertEqual(pagedHandoff.logicalTokenCount, 5)
+        XCTAssertEqual(pagedHandoff.tailValidTokenCount, 1)
+        XCTAssertEqual(pagedHandoff.caches.count, 1)
+        XCTAssertTrue(pagedHandoff.caches[0] === paged)
+        XCTAssertEqual(pagedHandoff.caches[0].offset, 5)
+        XCTAssertEqual(pagedHandoff.caches[0].state[0].asData(access: .copy).data, Self.fp16Bytes([1, 2, 3, 4, 5]))
+
+        let materializedAfterReattach = try await allocator.materializeContiguousByteCache(reattached)
+        XCTAssertEqual(materializedAfterReattach.layers[0].keyShape, [1, 1, 5, 1])
+        XCTAssertEqual(materializedAfterReattach.layers[0].keyBytes, Self.fp16Bytes([1, 2, 3, 4, 5]))
+        XCTAssertEqual(materializedAfterReattach.layers[0].valueBytes, Self.fp16Bytes([101, 102, 103, 104, 105]))
+
+        _ = try await allocator.extend(reattached, by: 1)
+        let continued = pagedHandoff.caches[0].update(
+            keys: MLXArray(Self.fp16Bytes([6]), [1, 1, 1, 1], dtype: .float16),
+            values: MLXArray(Self.fp16Bytes([106]), [1, 1, 1, 1], dtype: .float16)
+        )
+        eval(continued.0, continued.1)
+        try bridge.record(caches: pagedHandoff.caches, binding: try await allocator.binding(for: reattached))
+        XCTAssertEqual(paged.offset, 6)
+        XCTAssertEqual(pagedHandoff.caches[0].state[0].asData(access: .copy).data, Self.fp16Bytes([1, 2, 3, 4, 5, 6]))
+        let materializedAfterContinuation = try await allocator.materializeContiguousByteCache(reattached)
+        XCTAssertEqual(materializedAfterContinuation.layers[0].keyBytes, Self.fp16Bytes([1, 2, 3, 4, 5, 6]))
+        XCTAssertEqual(materializedAfterContinuation.layers[0].valueBytes, Self.fp16Bytes([101, 102, 103, 104, 105, 106]))
+
+        let zeroRetained = try await allocator.retain(reattached)
+        let zeroReattached = try await allocator.reattach(
+            zeroRetained,
+            conversationKey: "conv:a",
+            trimToLogicalTokens: 0
+        )
+        let zeroTable = try await allocator.table(for: zeroReattached)
+        XCTAssertEqual(zeroTable.logicalTokenCount, 0)
+        XCTAssertEqual(zeroTable.tailValidTokenCount, 0)
+        await XCTAssertThrowsErrorAsync {
+            _ = try await allocator.materializeContiguousByteCache(zeroReattached)
+        }
+    }
+
+    func testContiguousCacheBridgeRejectsCrossHandleCacheRecord() async throws {
+        guard PagedKVMetallibGate.defaultMetallibExists() else {
+            throw XCTSkip("MLX default metallib is unavailable in this test host")
+        }
+
+        let descriptor = Self.bridgeDescriptor(blockSizeTokens: 2, maxPhysicalBlocks: 6)
+        let bridge = PagedKVRuntimeContiguousCacheBridge()
+        let allocator = try PagedKVBlockAllocator(
+            blockSizeTokens: descriptor.blockSizeTokens,
+            maxPhysicalBlocks: descriptor.maxPhysicalBlocks,
+            contiguousCacheBridge: bridge
+        )
+        let first = try await allocator.allocate(conversationKey: "conv:a", maxTokens: 4, initialTokens: 2)
+        let second = try await allocator.allocate(conversationKey: "conv:b", maxTokens: 4, initialTokens: 2)
+        let firstBinding = try await allocator.binding(for: first)
+        let secondBinding = try await allocator.binding(for: second)
+        let paged = PagedKVCache(descriptor: descriptor, binding: firstBinding)
+        paged.state = [
+            MLXArray(Self.fp16Bytes([1, 2]), [1, 1, 2, 1], dtype: .float16),
+            MLXArray(Self.fp16Bytes([101, 102]), [1, 1, 2, 1], dtype: .float16),
+        ]
+
+        XCTAssertThrowsError(try bridge.record(caches: [paged], binding: secondBinding))
+        await XCTAssertThrowsErrorAsync {
+            _ = try await allocator.materializeContiguousByteCache(second)
+        }
+    }
+
     func testStickyRequestsRemainRejectedBeforeFRPKV10CacheBridge() async throws {
         let backend = RuntimeBridgeScriptedBackend(scripts: [:])
         let scheduler = try Self.makeScheduler(maxActiveRows: 2, backend: backend)
@@ -486,10 +722,10 @@ final class PagedKVRuntimeBridgeTests: XCTestCase {
         )
     }
 
-    private static func bridgeDescriptor() -> PagedKVDescriptor {
+    private static func bridgeDescriptor(blockSizeTokens: Int = 4, maxPhysicalBlocks: Int = 16) -> PagedKVDescriptor {
         PagedKVDescriptor(
-            blockSizeTokens: 4,
-            maxPhysicalBlocks: 16,
+            blockSizeTokens: blockSizeTokens,
+            maxPhysicalBlocks: maxPhysicalBlocks,
             modelID: "mlx-community/Qwen-Test",
             modelSHA256: String(repeating: "a", count: 64),
             tokenizerSHA256: nil,
@@ -501,6 +737,18 @@ final class PagedKVRuntimeBridgeTests: XCTestCase {
             kernelIdentifier: "macprovider_paged_kv_gather_v1",
             parityLabel: "sdpa-parity-v1"
         )
+    }
+
+    private static func fp16Bytes(_ values: [UInt16]) -> Data {
+        var data = Data()
+        data.reserveCapacity(values.count * 2)
+        for value in values {
+            var littleEndian = value.littleEndian
+            withUnsafeBytes(of: &littleEndian) { bytes in
+                data.append(contentsOf: bytes)
+            }
+        }
+        return data
     }
 
     private static func decodeInput(
@@ -833,6 +1081,41 @@ private actor RuntimeBridgeScriptedBackend: ContinuousBatchSchedulerBackend {
 
     func decodeBatches() -> [[String]] {
         batches
+    }
+}
+
+private final class RuntimeBridgeRecordingCacheBridge: PagedKVRuntimeCacheBridge, @unchecked Sendable {
+    private let lock = NSLock()
+    private var recorded: Set<UUID> = []
+    private var discarded: [UUID] = []
+
+    func record(caches: [PagedKVCache], binding: PagedKVStorageBinding) throws {
+        lock.lock()
+        recorded.insert(binding.handle.handleID)
+        lock.unlock()
+    }
+
+    func discard(handle: PagedKVBlockTableHandle) {
+        discardContiguousCache(handle: handle)
+    }
+
+    func discardContiguousCache(handle: PagedKVBlockTableHandle) {
+        lock.lock()
+        recorded.remove(handle.handleID)
+        discarded.append(handle.handleID)
+        lock.unlock()
+    }
+
+    func hasRecord(for handle: PagedKVBlockTableHandle) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return recorded.contains(handle.handleID)
+    }
+
+    func discardedHandles() -> [UUID] {
+        lock.lock()
+        defer { lock.unlock() }
+        return discarded
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds the SPEC-039 FR-PKV10 runtime bridge for restoring live contiguous `KVCacheSimple` handoffs from attached paged KV rows.
- Captures extraction bytes from `PagedKVCache` private physical block storage keyed by allocator `table.physicalBlocks`, then materializes from the recorded physical-layer snapshot rather than live logical cache state.
- Adds same-conversation retain/reattach trim support, transactional bridge-trim ordering, retained-record preservation on normal backend finish, and discard cleanup on cancellation/release.

This PR is intentionally inert/default-off. It does not enable canary behavior, does not lift sticky serving, does not claim SPEC-038 AC-19 serving parity, and does not wire SPEC-024 cold-tier consumption to the new bridge.

Closes #887

<!-- SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "issue": "https://github.com/Augustas11/macprovider/issues/887",
  "specs": ["SPEC-039"],
  "requirements": ["SPEC-039-R010", "SPEC-039-R002", "SPEC-039-R009"],
  "authority_domains": ["paged-kv-attention"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "cd phase3-binary && swift test --filter PagedKVRuntimeBridgeTests",
    "cd phase3-binary && swift test --filter PagedKVEngineTests",
    "cd phase3-binary && swift test --filter KVConversationColdTierTests",
    "git diff --check",
    "three-lane audit final"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END -->

## Validation

- `cd phase3-binary && swift test --filter PagedKVRuntimeBridgeTests` passed: 12 executed, 8 skipped because MLX default metallib is unavailable locally, 0 failures.
- `cd phase3-binary && swift test --filter PagedKVEngineTests` passed: 33 executed, 0 failures.
- `cd phase3-binary && swift test --filter KVConversationColdTierTests` passed: 25 executed, 2 skipped because MLX Metal runtime is unavailable locally, 0 failures.
- `git diff --check` passed.
- Final audit gate passed with 0 CRITICAL / 0 HIGH / 0 MEDIUM findings across code, security, and architecture reviews.

Audit artifacts:
- `audits/2026-09-11/887-fr-pkv10-inc2-code-review-final.md`
- `audits/2026-09-11/887-fr-pkv10-inc2-security-review-final.md`
- `audits/2026-09-11/887-fr-pkv10-inc2-architecture-review-final.md`
