### PR TITLE
SPEC-038 Increment 3: FR-CB4 sticky/cross-turn batching + AC-19 (#1477)

### DIFF
--- a/audits/2026-09-11/spec038-inc3-ac19-architecture-review-final.md
+++ b/audits/2026-09-11/spec038-inc3-ac19-architecture-review-final.md
@@ -1,0 +1,26 @@
+# SPEC-038 Increment 3 AC-19 Architecture Review Final
+
+Commit reviewed: `092f7d71`
+
+Status: CLEAR
+
+Counts by severity:
+- CRITICAL: 0
+- HIGH: 0
+- MEDIUM: 0
+- LOW: 0
+
+Findings:
+- None blocking.
+- FR-PKV10 boundary is preserved: scheduler consumes retained handoff through allocator/bridge/backend APIs, while the engine owns conversation-checked retain/reattach/trim semantics.
+- Scheduler/runtime seam is explicit: runtime passes cache lease state into scheduler, and scheduler rejects positive cached-token requests without retained handoff or invalid ranges.
+- Key isolation is enforced at cache, allocator, and scheduler-test layers.
+- Default-off/runtime-inert posture holds: production runtime starts nil-observation/keyless-first, scheduler backend unavailable, and conversation-key rollout remains policy-blocked.
+- Durable replay authority is gated before scheduler admission, and terminal duplicate replays are non-settling.
+- AC-19 serial parity is covered by raw canonical history: scheduler result separates raw `generatedTokens` from visible `outputTokens`, runtime commits retained cache from raw generated tokens, and the stop-token canonical-prefix test locks that behavior.
+
+Residual test gaps:
+- The architecture audit did not rerun tests; it relied on the provided passing targeted runs.
+- Full CI / packaged real-hardware enable-gate proof remains outside this default-off PR.
+- Durable replay is still not production-wired; current runtime authority is intentionally disabled by default pending a later gate.
+- Production keyed `ModelRuntime` traffic remains intentionally unexercised because conversation-key batching is blocked until later rollout.

--- a/audits/2026-09-11/spec038-inc3-ac19-architecture-review-prompt.md
+++ b/audits/2026-09-11/spec038-inc3-ac19-architecture-review-prompt.md
@@ -1,0 +1,16 @@
+Read-only architecture review for SPEC-038 Increment 3 issue #1477.
+
+Review the full landing diff in this worktree against `origin/main`. Do not edit files. Do not inspect `d-inference` or Layr-Labs source.
+
+Acceptance bar: report findings by CRITICAL/HIGH/MEDIUM/LOW/INFO. The required landing bar is 0 CRITICAL, 0 HIGH, 0 MEDIUM.
+
+Focus questions:
+- Does this remain a consumer of the already-landed FR-PKV10 primitive rather than redefining allocator/storage/kernel semantics?
+- Are ownership boundaries clean between `ConversationCache`, scheduler admission, allocator retain/reattach, bridge materialization, and `ModelRuntime` commit/abort?
+- Is production default-off/runtime-inert preserved with nil observation/backend/hardware proof?
+- Does the design keep SPEC-024 cold-tier persistence out of scope while preserving serial LCP billing semantics?
+- Is terminal KV continuation modeled in the right layer, and does it avoid pretending prompt+generated KV exists when the backend has not committed it?
+- Does the runbook continue to make keyless traffic the first enableable operator scope?
+- Are tests placed at the right seams for AC-19, FR-CB4, and FR-CB6?
+
+Return concise evidence with file/line references and a final CLEAR/BLOCKED verdict.

--- a/audits/2026-09-11/spec038-inc3-ac19-code-review-final.md
+++ b/audits/2026-09-11/spec038-inc3-ac19-code-review-final.md
@@ -1,0 +1,28 @@
+# SPEC-038 Increment 3 AC-19 Code Review Final
+
+Commit reviewed: `092f7d71`
+
+Status: CLEAR
+
+Counts by severity:
+- CRITICAL: 0
+- HIGH: 0
+- MEDIUM: 0
+- LOW: 0
+
+Findings:
+- None.
+
+Evidence checked:
+- Production conversation-key capability remains unsupported by default in `ContinuousBatching.swift`.
+- Production paged-KV observation/backend/scheduler remain inert in `ModelRuntime.swift`.
+- Positive cached credit is rejected without retained FR-PKV10 handoff in `ContinuousBatchScheduler.swift`.
+- Retained cache reattach goes through the injected handoff path.
+- Scheduler separates raw `generatedTokens` from buyer-visible `outputTokens`.
+- Runtime commits retained canonical cache history from `result.generatedTokens`.
+- `ContinuousBatchSchedulerTests.testRetainedStickyStopSequenceCommitsCanonicalGeneratedTokens` covers withheld stop tokens in retained canonical history.
+
+Residual test gaps:
+- Full `swift test` / CI was not rerun in this audit.
+- Dedicated LSP diagnostics were unavailable; SwiftPM targeted compile/test evidence was used instead.
+- Live packaged/runtime enable proof remains out of scope for this default-off increment.

--- a/audits/2026-09-11/spec038-inc3-ac19-code-review-prompt.md
+++ b/audits/2026-09-11/spec038-inc3-ac19-code-review-prompt.md
@@ -1,0 +1,26 @@
+Read-only code review for SPEC-038 Increment 3 issue #1477.
+
+Review the full landing diff in this worktree against `origin/main`, scoped to:
+- `phase3-binary/Sources/MacProviderCore/PagedKVEngine.swift`
+- `phase3-binary/Sources/macprovider-cli/ContinuousBatchScheduler.swift`
+- `phase3-binary/Sources/macprovider-cli/ContinuousBatching.swift`
+- `phase3-binary/Sources/macprovider-cli/ConversationCache.swift`
+- `phase3-binary/Sources/macprovider-cli/ModelRuntime.swift`
+- `phase3-binary/Sources/macprovider-cli/PagedKVRuntimeBridge.swift`
+- changed Swift tests
+- `docs/runbooks/continuous-batching-enable-gate.md`
+
+Do not edit files. Do not inspect `d-inference` or Layr-Labs source.
+
+Acceptance bar: report findings by CRITICAL/HIGH/MEDIUM/LOW/INFO. The required landing bar is 0 CRITICAL, 0 HIGH, 0 MEDIUM.
+
+Focus questions:
+- Can a conversation-keyed fresh request enter batching with `cachedPromptTokens == 0`?
+- Can a positive `cachedPromptTokens` request enter batching without same-conversation retained FR-PKV10 handoff?
+- Does retained reattach preserve token-granular LCP and permit continuation beyond the retained length?
+- Are terminal retained owners retained, discarded, or transferred exactly once?
+- Do duplicate/replay, invalid cached range, and token-sink timeout paths avoid duplicate billing credit?
+- Are old blanket sticky deferral gates removed only for supported cases?
+- Are tests meaningful and not merely renamed deferral tests?
+
+Return concise evidence with file/line references and a final CLEAR/BLOCKED verdict.

--- a/audits/2026-09-11/spec038-inc3-ac19-security-review-final.md
+++ b/audits/2026-09-11/spec038-inc3-ac19-security-review-final.md
@@ -1,0 +1,19 @@
+# SPEC-038 Increment 3 AC-19 Security Review Final
+
+Commit reviewed: `092f7d71`
+
+Status: CLEAR
+
+Counts by severity:
+- CRITICAL: 0
+- HIGH: 0
+- MEDIUM: 0
+- LOW: 0
+
+Findings:
+- None.
+
+Residual test gaps:
+- MLX/default metallib-dependent cases skipped locally: `ContinuousBatchSchedulerTests` 4 skipped, `PagedKVRuntimeBridgeTests` 8 skipped, `KVConversationColdTierTests` 2 skipped.
+- Full packaged-runtime enable proof, live `>32GB` tuple proof, and coordinator/gateway settlement integration were not run in this audit.
+- No standalone LSP diagnostics tool was exposed; SwiftPM test compilation passed for the reviewed Swift surfaces.

--- a/audits/2026-09-11/spec038-inc3-ac19-security-review-prompt.md
+++ b/audits/2026-09-11/spec038-inc3-ac19-security-review-prompt.md
@@ -1,0 +1,16 @@
+Read-only security and reliability review for SPEC-038 Increment 3 issue #1477.
+
+Review the full landing diff in this worktree against `origin/main`. Do not edit files. Do not inspect `d-inference` or Layr-Labs source.
+
+Acceptance bar: report findings by CRITICAL/HIGH/MEDIUM/LOW/INFO. The required landing bar is 0 CRITICAL, 0 HIGH, 0 MEDIUM.
+
+Focus questions:
+- Can key A ever receive key B's retained blocks, cached-token credit, stop state, sampler state, or request result?
+- Do cross-conversation retained reattach attempts fail closed and release ownership?
+- Can cancellation, timeout, retry, terminal replay, TTL sweep, LRU eviction, purge, or fenced commit leak retained paged-KV owners?
+- Can scheduler or `ModelRuntime` emit `cached_prompt_tokens < 0` or `cached_prompt_tokens > prompt_tokens`?
+- Does canary fallback preserve serial sticky billing instead of consuming the serial cache lease?
+- Did the diff enable canary/on, widen the runbook first enableable scope to keyed/sticky, or construct production runtime observation?
+- Did the diff add cold-tier disk persistence for paged blocks or change coordinator/gateway money-path contracts?
+
+Return concise evidence with file/line references and a final CLEAR/BLOCKED verdict.

--- a/docs/runbooks/continuous-batching-enable-gate.md
+++ b/docs/runbooks/continuous-batching-enable-gate.md
@@ -12,17 +12,13 @@ serve real traffic with continuous batching for that tuple.
 
 ## Scope
 
-The first enableable scope is keyless fresh-conversation decode only:
+The first enableable scope remains keyless until a later operator gate:
 
 - keyless requests may enter the batch after the runtime bridge gate opens;
-- under `canary`, any request carrying a conversation key is conservatively
-  serial-routed until the runtime can prove that it has no reusable
-  sticky/cross-turn state;
-- sticky-cache-eligible or cross-turn requests must be serial-routed with
-  reason-coded `batching_unsupported` telemetry under `canary`, or rejected
-  fail-closed under strict `on`, until issue #1477 (SPEC-038 sticky/AC-19
-  consumer) lands **and** this runbook's first enableable scope is widened
-  in a later operator gate;
+- keyed requests and sticky/cross-turn cached-token credit are landed by #1477
+  as runtime-inert code paths, not as permission to canary buyer traffic;
+- positive sticky/cross-turn cached-token credit remains invalid without a
+  same-conversation FR-PKV10 retained paged-KV handoff;
 - the SPEC-039 contiguous-cache primitive (FR-PKV10) already landed in
   #887 / #1476; that merge did **not** lift keyed serving or enable canary;
 - no buyer receipt, usage, billing, model identity, settlement, or API schema
@@ -65,9 +61,10 @@ Stop and roll back to `continuous_batching: off` if any item below is true:
 - `serve` resolves to a worktree/debug binary or `default.metallib` is missing;
 - the SPEC-039 runtime bridge required for the tested path is unavailable;
 - the requested tuple is absent from the local SPEC-039 capability descriptor;
-- any sticky-cache or cross-turn request enters batching before #1477 is
-  closed, or after #1477 lands but before this runbook's first enableable
-  scope is explicitly widened past keyless fresh-conversation decode;
+- any conversation-keyed request enters the batch during the first keyless
+  enablement scope, even when it reports zero cached-token credit;
+- any sticky-cache or cross-turn request reports positive cached-token credit
+  without a same-conversation FR-PKV10 retained paged-KV handoff;
 - any token, stop condition, cancellation, usage field, receipt field, or
   request-log terminal state is attributed to the wrong request;
 - a batch failure and serial retry produce stitched buyer-visible output or a
@@ -89,7 +86,8 @@ only.
 | Hardware tuple | Mac model, chip, RAM, macOS build, power state, thermal state, swap state, and Entry 110 `max_concurrency_override`. |
 | Model tuple | served model id, model SHA-256, tokenizer/template identity when present, cache class, KV dtype, `kv_bits` absence, MoE requirement, metallib SHA-256, kernel identifier, parity label, and pool epoch. |
 | Local descriptor | SPEC-039 descriptor showing the exact tuple is admitted; unsupported tuples must show fail-closed or reason-coded serial routing. |
-| Fresh-conversation scope | Requests used for the batched proof carry no conversation key; separate keyed/sticky/cross-turn requests show canary serial routing or strict rejection with `sticky_cache_bridge_unavailable` or an equivalent #1477-gated reason until that consumer lands **and** this runbook widens first enableable scope. |
+| Sticky/cross-turn scope | #1477 code is present but not enablement: first-scope buyer traffic stays keyless, and positive cached-token credit requires a same-conversation FR-PKV10 retained paged-KV handoff before any later keyed operator gate may admit it. |
+| Durable replay authority | Stable relay request identity is mapped into scheduler replay keys, settlement disposition is propagated through usage/receipt code, and duplicate inference or duplicate settlement is rejected after local terminal-result retention rolls. The in-process `ContinuousBatchRuntimeReplayAuthority` stub is not activation evidence. |
 | MSB-01..05 | Full harness output for MSB-01 single-stream baseline plus MSB-02, MSB-03, MSB-04, and MSB-05. Aggregate TG is total decoded tokens over common wall-clock, warm-up excluded; per-stream and aggregate TG stay separate. |
 | MoE promotion | A descriptor-admitted MoE tuple still fails closed in strict mode (or reason-coded serial-routes in canary) until the representative AC-23 correctness fixture and live-model MSB-04 evidence have landed in a separately reviewed activation change. |
 | Usage/receipt attribution | Concurrent distinct requests prove correct `prompt_tokens`, `output_tokens`, `cached_prompt_tokens`, stop reason, cancellation state, request id, receipt model hash, and settlement inputs with zero cross-request attribution. |
@@ -126,20 +124,14 @@ authorization headers.
 
 ## Canary Enable
 
-No `canary` or `on` buyer traffic is currently enableable. The merged
-SPEC-039 foundation deliberately reports `engineBridgeAvailable: false`, and
-the scheduler backend therefore remains unavailable. Before collecting the
-proofs in this runbook, a separately reviewed SPEC-039 runtime-bridge change
-must install safe `PagedKVCache` injection, kernel bounds validation, request
-leasing, handle release/retain, stop-token holdback, bounded token delivery
-outside scheduler isolation, a hard delivery deadline and scheduler-wide
-delivery-task cap that fail closed without settlement, backend cancellation
-acknowledgement, and a durable request-log replay authority that atomically
-claims a non-secret request fingerprint for the settlement replay horizon. The
-runtime must then
-derive both the requested tuple and
-`schedulerBackendAvailable: true` from that installed state. Until then,
-strict `on` is rejected before provider readiness and `canary` serial-routes.
+No `canary` or `on` buyer traffic is currently enableable from implementation
+presence alone. #1477 may install retained paged-KV bridge code, but operators
+still need a packaged release-candidate tuple whose local descriptor admits the
+requested path, whose runtime derives `schedulerBackendAvailable: true` from
+that installed state, and whose durable replay authority is wired to stable
+relay request identity plus usage/receipt settlement disposition. Until those
+proofs exist for the exact keyless tuple, strict `on` is rejected before
+provider readiness and `canary` serial-routes.
 
 After that prerequisite lands, use `canary` only when every required proof
 above is present for the exact tuple. Leave `continuous_batch_queue_limit`

--- a/phase3-binary/Sources/MacProviderCore/PagedKVEngine.swift
+++ b/phase3-binary/Sources/MacProviderCore/PagedKVEngine.swift
@@ -921,7 +921,8 @@ public actor PagedKVBlockAllocator {
     public func reattach(
         _ retained: PagedKVRetainedSequence,
         conversationKey: String,
-        trimToLogicalTokens tokens: Int? = nil
+        trimToLogicalTokens tokens: Int? = nil,
+        maxLogicalTokens: Int? = nil
     ) throws -> PagedKVBlockTableHandle {
         guard retained.conversationKey == conversationKey.trimmingCharacters(in: .whitespacesAndNewlines) else {
             throw PagedKVAllocatorError.conversationMismatch
@@ -933,6 +934,12 @@ public actor PagedKVBlockAllocator {
         guard state.logicalTokenCount == retained.logicalTokenCount else {
             throw PagedKVAllocatorError.invalidBlockTable("retained logical length mismatch")
         }
+        let requestedMaxLogicalTokens = maxLogicalTokens.map { max($0, state.maxLogicalTokens) }
+        if let requestedMaxLogicalTokens {
+            guard requestedMaxLogicalTokens >= state.logicalTokenCount else {
+                throw PagedKVAllocatorError.invalidBlockTable("max logical length below retained length")
+            }
+        }
         if let tokens {
             guard tokens >= 0 else { throw PagedKVAllocatorError.invalidBlockTable("negative trim length") }
             guard tokens <= state.logicalTokenCount else {
@@ -940,6 +947,12 @@ public actor PagedKVBlockAllocator {
             }
             var nextState = state
             nextState.logicalTokenCount = tokens
+            if let requestedMaxLogicalTokens {
+                guard requestedMaxLogicalTokens >= tokens else {
+                    throw PagedKVAllocatorError.invalidBlockTable("max logical length below trim length")
+                }
+                nextState.maxLogicalTokens = requestedMaxLogicalTokens
+            }
             let needed = try requiredBlocks(maxTokens: tokens)
             var released: ArraySlice<Int> = []
             if needed < nextState.reservedBlocks.count {
@@ -953,6 +966,9 @@ public actor PagedKVBlockAllocator {
             freeBlocks.append(contentsOf: released.reversed())
             return retained.handle
         }
+        if let requestedMaxLogicalTokens {
+            state.maxLogicalTokens = requestedMaxLogicalTokens
+        }
         state.retained = false
         sequences[retained.handle.id] = state
         return retained.handle
@@ -962,9 +978,16 @@ public actor PagedKVBlockAllocator {
         guard retained.conversationKey == conversationKey.trimmingCharacters(in: .whitespacesAndNewlines) else {
             throw PagedKVAllocatorError.conversationMismatch
         }
+        try discardRetained(retained)
+    }
+
+    public func discardRetained(_ retained: PagedKVRetainedSequence) throws {
         let state = try lookupState(for: retained.handle)
         guard state.retained else {
             throw PagedKVAllocatorError.unknownHandle
+        }
+        guard state.conversationKey == retained.conversationKey else {
+            throw PagedKVAllocatorError.conversationMismatch
         }
         sequences.removeValue(forKey: retained.handle.id)
         freeBlocks.append(contentsOf: state.reservedBlocks.reversed())

--- a/phase3-binary/Sources/macprovider-cli/ContinuousBatchScheduler.swift
+++ b/phase3-binary/Sources/macprovider-cli/ContinuousBatchScheduler.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CryptoKit
+import MLXLMCommon
 import MacProviderCore
 
 enum ContinuousBatchSchedulerTerminalStatus: String, Sendable, Equatable {
@@ -136,7 +137,7 @@ struct ContinuousBatchSchedulerConfiguration: Sendable, Equatable {
     }
 }
 
-struct ContinuousBatchSchedulerRequest: Sendable, Equatable, Codable {
+struct ContinuousBatchSchedulerRequest: Sendable, Equatable, Encodable {
     let id: String
     let conversationKey: String
     let promptTokens: [Int]
@@ -148,6 +149,7 @@ struct ContinuousBatchSchedulerRequest: Sendable, Equatable, Codable {
     let presencePenalty: Double
     let frequencyPenalty: Double
     let cachedPromptTokens: Int
+    let retainedPagedKVSequence: PagedKVRetainedSequence?
 
     init(
         id: String,
@@ -160,7 +162,8 @@ struct ContinuousBatchSchedulerRequest: Sendable, Equatable, Codable {
         topP: Double = 1.0,
         presencePenalty: Double = 0.0,
         frequencyPenalty: Double = 0.0,
-        cachedPromptTokens: Int = 0
+        cachedPromptTokens: Int = 0,
+        retainedPagedKVSequence: PagedKVRetainedSequence? = nil
     ) {
         self.id = id
         self.conversationKey = conversationKey
@@ -173,6 +176,21 @@ struct ContinuousBatchSchedulerRequest: Sendable, Equatable, Codable {
         self.presencePenalty = presencePenalty
         self.frequencyPenalty = frequencyPenalty
         self.cachedPromptTokens = max(0, cachedPromptTokens)
+        self.retainedPagedKVSequence = retainedPagedKVSequence
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case conversationKey
+        case promptTokens
+        case maxOutputTokens
+        case stopTokenSequences
+        case samplerSeed
+        case temperature
+        case topP
+        case presencePenalty
+        case frequencyPenalty
+        case cachedPromptTokens
     }
 }
 
@@ -185,6 +203,8 @@ enum ContinuousBatchSettlementDisposition: String, Sendable, Equatable {
 struct ContinuousBatchSchedulerResult: Sendable, Equatable {
     let requestID: String
     let conversationKey: String
+    /// Raw generated tokens, including stop tokens withheld from buyers.
+    let generatedTokens: [Int]
     let outputTokens: [Int]
     let promptTokens: Int
     let completionTokens: Int
@@ -194,6 +214,7 @@ struct ContinuousBatchSchedulerResult: Sendable, Equatable {
     let errorCode: String?
     let snapshot: ContinuousBatchSchedulerSnapshot?
     let settlementDisposition: ContinuousBatchSettlementDisposition
+    let retainedCache: ContinuousBatchRetainedCache?
 
     func withSettlementDisposition(
         _ disposition: ContinuousBatchSettlementDisposition
@@ -201,6 +222,7 @@ struct ContinuousBatchSchedulerResult: Sendable, Equatable {
         ContinuousBatchSchedulerResult(
             requestID: requestID,
             conversationKey: conversationKey,
+            generatedTokens: generatedTokens,
             outputTokens: outputTokens,
             promptTokens: promptTokens,
             completionTokens: completionTokens,
@@ -209,7 +231,62 @@ struct ContinuousBatchSchedulerResult: Sendable, Equatable {
             terminalStatus: terminalStatus,
             errorCode: errorCode,
             snapshot: snapshot,
-            settlementDisposition: disposition
+            settlementDisposition: disposition,
+            retainedCache: disposition == .eligibleOwner ? retainedCache : nil
+        )
+    }
+
+    func withRetainedCache(_ cache: ContinuousBatchRetainedCache?) -> ContinuousBatchSchedulerResult {
+        ContinuousBatchSchedulerResult(
+            requestID: requestID,
+            conversationKey: conversationKey,
+            generatedTokens: generatedTokens,
+            outputTokens: outputTokens,
+            promptTokens: promptTokens,
+            completionTokens: completionTokens,
+            emittedTokens: emittedTokens,
+            cachedPromptTokens: cachedPromptTokens,
+            terminalStatus: terminalStatus,
+            errorCode: errorCode,
+            snapshot: snapshot,
+            settlementDisposition: settlementDisposition,
+            retainedCache: cache
+        )
+    }
+
+    static func == (lhs: ContinuousBatchSchedulerResult, rhs: ContinuousBatchSchedulerResult) -> Bool {
+        lhs.requestID == rhs.requestID
+            && lhs.conversationKey == rhs.conversationKey
+            && lhs.generatedTokens == rhs.generatedTokens
+            && lhs.outputTokens == rhs.outputTokens
+            && lhs.promptTokens == rhs.promptTokens
+            && lhs.completionTokens == rhs.completionTokens
+            && lhs.emittedTokens == rhs.emittedTokens
+            && lhs.cachedPromptTokens == rhs.cachedPromptTokens
+            && lhs.terminalStatus == rhs.terminalStatus
+            && lhs.errorCode == rhs.errorCode
+            && lhs.snapshot == rhs.snapshot
+            && lhs.settlementDisposition == rhs.settlementDisposition
+            && lhs.retainedCache?.retainedSequence == rhs.retainedCache?.retainedSequence
+    }
+}
+
+final class ContinuousBatchRetainedCache: @unchecked Sendable {
+    let retainedSequence: PagedKVRetainedSequence
+    let layers: [KVCache]
+    let deliveryID: UUID?
+
+    init(retainedSequence: PagedKVRetainedSequence, layers: [KVCache], deliveryID: UUID? = nil) {
+        self.retainedSequence = retainedSequence
+        self.layers = layers
+        self.deliveryID = deliveryID
+    }
+
+    func withDeliveryID(_ deliveryID: UUID?) -> ContinuousBatchRetainedCache {
+        ContinuousBatchRetainedCache(
+            retainedSequence: retainedSequence,
+            layers: layers,
+            deliveryID: deliveryID
         )
     }
 }
@@ -285,6 +362,15 @@ struct ContinuousBatchDecodeInput: Sendable, Equatable {
     let samplerStep: Int
 }
 
+struct ContinuousBatchTerminalKVCommitInput: Sendable, Equatable {
+    let requestID: String
+    let currentToken: Int
+    let binding: PagedKVStorageBinding
+    let blockTable: PagedKVBlockTable
+    let committedKVTokenCount: Int
+    let targetKVTokenCount: Int
+}
+
 struct ContinuousBatchDecodeOutput: Sendable, Equatable {
     let requestID: String
     let token: Int
@@ -312,6 +398,18 @@ protocol ContinuousBatchSchedulerBackend: Sendable {
     /// writes `currentToken` at `committedKVTokenCount` and returns one sampled
     /// token without advancing any other row's cursor.
     func decode(rows: [ContinuousBatchDecodeInput]) async throws -> [ContinuousBatchDecodeOutcome]
+    /// Install a same-conversation retained paged-KV handoff before the row resumes
+    /// prefill at its serial LCP. Backends that cannot consume FR-PKV10 must fail
+    /// closed instead of accepting positive cached-token credit.
+    func installRetainedPagedKVCache(
+        requestID: String,
+        handoff: PagedKVPagedCacheHandoff,
+        binding: PagedKVStorageBinding
+    ) async throws
+    /// Commit the final buyer-visible token into row-local KV state when a row
+    /// stops immediately after sampling it. Retention happens after this step so
+    /// canonical prompt history and retained paged-KV length agree.
+    func commitTerminalKV(_ input: ContinuousBatchTerminalKVCommitInput) async throws
     /// Row-local cleanup hook for backend state that is not owned by the
     /// scheduler/allocator. Called after the scheduler has reached a terminal
     /// result for the request. Implementations that keep no row-local state can
@@ -321,7 +419,26 @@ protocol ContinuousBatchSchedulerBackend: Sendable {
     func cancelInFlight() async
 }
 
+protocol ContinuousBatchRetainedCacheBridge: Sendable {
+    func reattachPagedKVCache(
+        handle: PagedKVBlockTableHandle,
+        table: PagedKVBlockTable
+    ) throws -> PagedKVPagedCacheHandoff
+}
+
 extension ContinuousBatchSchedulerBackend {
+    func installRetainedPagedKVCache(
+        requestID: String,
+        handoff: PagedKVPagedCacheHandoff,
+        binding: PagedKVStorageBinding
+    ) async throws {
+        throw ContinuousBatchSchedulerError.unsupported("continuous_batching_paged_kv_handoff_unavailable")
+    }
+
+    func commitTerminalKV(_ input: ContinuousBatchTerminalKVCommitInput) async throws {
+        throw ContinuousBatchSchedulerError.unsupported("continuous_batching_terminal_kv_commit_unavailable")
+    }
+
     func finish(requestID: String) {}
 }
 
@@ -609,6 +726,10 @@ actor ContinuousBatchScheduler {
         var pendingOutputTokens: [Int]
         var prefillCursor: Int
         var snapshot: ContinuousBatchSchedulerSnapshot
+
+        var retainedLogicalTokenCount: Int {
+            request.promptTokens.count + generatedTokens.count
+        }
     }
 
     private struct PendingTerminalDelivery {
@@ -629,11 +750,17 @@ actor ContinuousBatchScheduler {
         let waiters: [Waiter]
     }
 
+    private struct DeliveredRetainedOwner {
+        let retained: PagedKVRetainedSequence
+        let conversationKey: String
+    }
+
     private let configuration: ContinuousBatchSchedulerConfiguration
     private let schedulerID = UUID()
     private let allocator: PagedKVBlockAllocator
     private let backend: any ContinuousBatchSchedulerBackend
     private let replayAuthority: any ContinuousBatchSchedulerReplayAuthority
+    private let contiguousCacheBridge: (any ContinuousBatchRetainedCacheBridge)?
     private let tokenDeliveryCapacity: ContinuousBatchTokenDeliveryCapacity
 
     private var waiting: [ContinuousBatchSchedulerRequest] = []
@@ -654,6 +781,7 @@ actor ContinuousBatchScheduler {
     private var stoppingWaiterIDs: Set<UUID> = []
     private var stoppingActiveWaiters: [UUID: StoppingActiveWaiter] = [:]
     private var deferredTerminalCompletions: [String: DeferredTerminalCompletion] = [:]
+    private var deliveredRetainedOwners: [UUID: DeliveredRetainedOwner] = [:]
     private var terminalResultOrder: [String] = []
     private var dedupeTombstones: Set<String> = []
     private var dedupeTombstoneOrder: [String] = []
@@ -672,7 +800,8 @@ actor ContinuousBatchScheduler {
         configuration: ContinuousBatchSchedulerConfiguration,
         allocator: PagedKVBlockAllocator,
         backend: any ContinuousBatchSchedulerBackend,
-        replayAuthority: any ContinuousBatchSchedulerReplayAuthority
+        replayAuthority: any ContinuousBatchSchedulerReplayAuthority,
+        contiguousCacheBridge: (any ContinuousBatchRetainedCacheBridge)? = nil
     ) {
         self.configuration = configuration
         self.tokenDeliveryCapacity = ContinuousBatchTokenDeliveryCapacity(
@@ -681,6 +810,7 @@ actor ContinuousBatchScheduler {
         self.allocator = allocator
         self.backend = backend
         self.replayAuthority = replayAuthority
+        self.contiguousCacheBridge = contiguousCacheBridge
     }
 
     static func localCapabilityReason(
@@ -701,8 +831,14 @@ actor ContinuousBatchScheduler {
         _ request: ContinuousBatchSchedulerRequest,
         tokenSink: @escaping ContinuousBatchSchedulerTokenSink = { _ in }
     ) async throws -> ContinuousBatchSchedulerResult {
-        try Task.checkCancellation()
+        do {
+            try Task.checkCancellation()
+        } catch {
+            await discardUnacceptedRetainedCache(for: request)
+            throw error
+        }
         if cleanupFailedClosed {
+            await discardUnacceptedRetainedCache(for: request)
             throw ContinuousBatchSchedulerError.unsupported("continuous_batching_scheduler_failed_closed")
         }
         if let reason = Self.localCapabilityReason(
@@ -711,12 +847,23 @@ actor ContinuousBatchScheduler {
             moePromotionEvidenceAvailable: configuration.moePromotionEvidenceAvailable
         ) {
             record(.localCapabilityMissing)
+            await discardUnacceptedRetainedCache(for: request)
             throw ContinuousBatchSchedulerError.unsupported(reason)
         }
-        if !request.conversationKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            || request.cachedPromptTokens > 0 {
+        if request.cachedPromptTokens > 0 && request.retainedPagedKVSequence == nil {
             record(.stickyCacheUnsupported)
-            throw ContinuousBatchSchedulerError.unsupported("keyed_or_sticky_cache_reuse_deferred_until_paged_kv_cache_bridge")
+            throw ContinuousBatchSchedulerError.unsupported("continuous_batching_paged_kv_handoff_unavailable")
+        }
+        let trimmedConversationKey = request.conversationKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        if request.cachedPromptTokens > 0 && trimmedConversationKey.isEmpty {
+            record(.stickyCacheUnsupported)
+            await discardUnacceptedRetainedCache(for: request)
+            throw ContinuousBatchSchedulerError.unsupported("continuous_batching_cached_tokens_require_conversation_key")
+        }
+        if request.cachedPromptTokens > 0 && request.cachedPromptTokens >= request.promptTokens.count {
+            record(.stickyCacheUnsupported)
+            await discardUnacceptedRetainedCache(for: request)
+            throw ContinuousBatchSchedulerError.requestFailed("continuous_batching_invalid_cached_prompt_tokens")
         }
         guard !request.id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
               request.id.lengthOfBytes(using: .utf8) <= configuration.maxRequestIDBytes,
@@ -730,14 +877,17 @@ actor ContinuousBatchScheduler {
               }),
               let retainedTokenCost = validatedRetainedTokenCost(for: request),
               retainedTokenCost <= configuration.maxRequestTokens else {
+            await discardUnacceptedRetainedCache(for: request)
             throw ContinuousBatchSchedulerError.requestFailed("continuous_batching_invalid_request")
         }
         guard queueHasCapacity(addingTokenCost: retainedTokenCost) else {
             record(.backpressureRejected)
+            await discardUnacceptedRetainedCache(for: request)
             throw ContinuousBatchSchedulerError.backpressure
         }
         guard nextAdmissionSequence < UInt64.max else {
             cleanupFailedClosed = true
+            await discardUnacceptedRetainedCache(for: request)
             throw ContinuousBatchSchedulerError.unsupported("continuous_batching_admission_sequence_exhausted")
         }
         let admissionSequence = nextAdmissionSequence
@@ -751,12 +901,14 @@ actor ContinuousBatchScheduler {
         guard bindingsAreValid else {
             record(.localCapabilityMissing)
             finishAdmissionTurn(admissionSequence)
+            await discardUnacceptedRetainedCache(for: request)
             throw ContinuousBatchSchedulerError.unsupported("continuous_batching_local_binding_mismatch")
         }
         do {
             try Task.checkCancellation()
         } catch {
             finishAdmissionTurn(admissionSequence)
+            await discardUnacceptedRetainedCache(for: request)
             throw error
         }
         let waiterID = UUID()
@@ -804,7 +956,7 @@ actor ContinuousBatchScheduler {
         record(.drained)
         while !waiting.isEmpty {
             let request = waiting.removeFirst()
-            finishQueued(
+            await finishQueued(
                 request,
                 status: .rejected,
                 errorCode: "continuous_batching_draining"
@@ -920,6 +1072,7 @@ actor ContinuousBatchScheduler {
     ) {
         guard let requestFingerprint = RequestFingerprint(request) else {
             delivery.finish()
+            scheduleDiscardUnacceptedRetainedCache(for: request)
             continuation.resume(throwing: ContinuousBatchSchedulerError.requestFailed(
                 "continuous_batching_request_fingerprint_failed"
             ))
@@ -927,16 +1080,19 @@ actor ContinuousBatchScheduler {
         }
         if Task.isCancelled {
             delivery.finish()
+            scheduleDiscardUnacceptedRetainedCache(for: request)
             continuation.resume(throwing: CancellationError())
             return
         }
         if let known = knownRequests[request.id], known != requestFingerprint {
             delivery.finish()
+            scheduleDiscardUnacceptedRetainedCache(for: request)
             continuation.resume(throwing: ContinuousBatchSchedulerError.duplicateRequestMismatch)
             return
         }
         if let terminal = terminalResults[request.id] {
             delivery.finish()
+            scheduleDiscardUnacceptedRetainedCache(for: request)
             continuation.resume(returning: terminal.withSettlementDisposition(.nonSettlingReplay))
             return
         }
@@ -944,9 +1100,11 @@ actor ContinuousBatchScheduler {
             guard pending.waiters.count < configuration.duplicateWaiterLimit else {
                 record(.backpressureRejected)
                 delivery.finish()
+                scheduleDiscardUnacceptedRetainedCache(for: request)
                 continuation.resume(throwing: ContinuousBatchSchedulerError.backpressure)
                 return
             }
+            scheduleDiscardUnacceptedRetainedCache(for: request)
             let waiter = Waiter(
                 id: waiterID,
                 continuation: continuation,
@@ -984,11 +1142,13 @@ actor ContinuousBatchScheduler {
         }
         if dedupeTombstones.contains(request.id) {
             delivery.finish()
+            scheduleDiscardUnacceptedRetainedCache(for: request)
             continuation.resume(throwing: ContinuousBatchSchedulerError.idempotencyWindowExpired)
             return
         }
         if draining {
             delivery.finish()
+            scheduleDiscardUnacceptedRetainedCache(for: request)
             continuation.resume(throwing: ContinuousBatchSchedulerError.drained)
             return
         }
@@ -998,9 +1158,11 @@ actor ContinuousBatchScheduler {
                     < configuration.duplicateWaiterLimit else {
                 record(.backpressureRejected)
                 delivery.finish()
+                scheduleDiscardUnacceptedRetainedCache(for: request)
                 continuation.resume(throwing: ContinuousBatchSchedulerError.backpressure)
                 return
             }
+            scheduleDiscardUnacceptedRetainedCache(for: request)
             requestWaiters[request.id, default: []].append(Waiter(
                 id: waiterID,
                 continuation: continuation,
@@ -1033,6 +1195,7 @@ actor ContinuousBatchScheduler {
               queueHasCapacity(addingTokenCost: retainedTokenCost) else {
             record(.backpressureRejected)
             delivery.finish()
+            scheduleDiscardUnacceptedRetainedCache(for: request)
             continuation.resume(throwing: ContinuousBatchSchedulerError.backpressure)
             return
         }
@@ -1045,15 +1208,18 @@ actor ContinuousBatchScheduler {
                 break
             case .duplicateSameRequest:
                 delivery.finish()
+                scheduleDiscardUnacceptedRetainedCache(for: request)
                 continuation.resume(throwing: ContinuousBatchSchedulerError.idempotencyWindowExpired)
                 return
             case .duplicateMismatchedRequest:
                 delivery.finish()
+                scheduleDiscardUnacceptedRetainedCache(for: request)
                 continuation.resume(throwing: ContinuousBatchSchedulerError.duplicateRequestMismatch)
                 return
             }
         } catch {
             delivery.finish()
+            scheduleDiscardUnacceptedRetainedCache(for: request)
             continuation.resume(throwing: ContinuousBatchSchedulerError.idempotencyAuthorityUnavailable)
             return
         }
@@ -1068,8 +1234,13 @@ actor ContinuousBatchScheduler {
         ensurePump()
     }
 
-    private func cancelWaiter(requestID: String, waiterID: UUID) {
+    private func cancelWaiter(requestID: String, waiterID: UUID) async {
         guard stoppingWaiterIDs.insert(waiterID).inserted else { return }
+        if let delivered = deliveredRetainedOwners.removeValue(forKey: waiterID) {
+            stoppingWaiterIDs.remove(waiterID)
+            await discardRetainedCache(delivered.retained, conversationKey: delivered.conversationKey)
+            return
+        }
         if let waiter = pendingTerminalDeliveries[requestID]?.waiters.first(where: { $0.id == waiterID }) {
             waiter.delivery.stop(afterStopping: {
                 Task { await self.finishStoppedWaiter(requestID: requestID, waiterID: waiterID) }
@@ -1097,7 +1268,7 @@ actor ContinuousBatchScheduler {
         })
     }
 
-    private func finishStoppedWaiter(requestID: String, waiterID: UUID) {
+    private func finishStoppedWaiter(requestID: String, waiterID: UUID) async {
         guard stoppingWaiterIDs.remove(waiterID) != nil else { return }
         if var pending = pendingTerminalDeliveries[requestID],
            pending.remainingWaiterIDs.contains(waiterID),
@@ -1111,6 +1282,7 @@ actor ContinuousBatchScheduler {
                 let failedResult = ContinuousBatchSchedulerResult(
                     requestID: pending.result.requestID,
                     conversationKey: pending.result.conversationKey,
+                    generatedTokens: [],
                     outputTokens: [],
                     promptTokens: pending.result.promptTokens,
                     completionTokens: 0,
@@ -1119,12 +1291,19 @@ actor ContinuousBatchScheduler {
                     terminalStatus: .requestFailed,
                     errorCode: "continuous_batching_stream_delivery_cancelled",
                     snapshot: pending.result.snapshot,
-                    settlementDisposition: .notEligible
+                    settlementDisposition: .notEligible,
+                    retainedCache: nil
                 )
                 finalizeTerminalResult(requestID: requestID, result: failedResult, waiters: pending.waiters)
+                if let retainedCache = pending.result.retainedCache {
+                    await discardRetainedCache(
+                        retainedCache.retainedSequence,
+                        conversationKey: pending.result.conversationKey
+                    )
+                }
             } else if pending.remainingWaiterIDs.isEmpty {
                 pendingTerminalDeliveries.removeValue(forKey: requestID)
-                finalizePendingTerminal(requestID: requestID, pending: pending)
+                await finalizePendingTerminal(requestID: requestID, pending: pending)
             } else {
                 pendingTerminalDeliveries[requestID] = pending
             }
@@ -1237,7 +1416,7 @@ actor ContinuousBatchScheduler {
         var remaining: [ContinuousBatchSchedulerRequest] = []
         for request in waiting {
             if cancelledIDs.contains(request.id) {
-                finishQueued(request, status: .cancelled, errorCode: "request_cancelled")
+                await finishQueued(request, status: .cancelled, errorCode: "request_cancelled")
                 cancelledIDs.remove(request.id)
             } else {
                 remaining.append(request)
@@ -1510,10 +1689,17 @@ actor ContinuousBatchScheduler {
 
         if let terminalStatus {
             activeDecode.removeValue(forKey: row.request.id)
-            let released = await release(row.handle)
-            finish(row, status: released ? terminalStatus : .requestFailed, errorCode: released
-                ? nil
-                : "continuous_batching_cleanup_failed")
+            if let retainedCache = await retainTerminalCache(
+                for: row,
+                targetLogicalTokens: row.retainedLogicalTokenCount
+            ) {
+                finish(row, status: terminalStatus, errorCode: nil, retainedCache: retainedCache)
+            } else {
+                let released = await release(row.handle)
+                finish(row, status: released ? terminalStatus : .requestFailed, errorCode: released
+                    ? nil
+                    : "continuous_batching_cleanup_failed")
+            }
         }
     }
 
@@ -1575,23 +1761,54 @@ actor ContinuousBatchScheduler {
             let request = waiting.removeFirst()
             madeProgress = true
             if cancelledIDs.remove(request.id) != nil {
-                finishQueued(request, status: .cancelled, errorCode: "request_cancelled")
+                await finishQueued(request, status: .cancelled, errorCode: "request_cancelled")
                 continue
             }
 
             admittingRequests[request.id] = request
+            var admissionHandle: PagedKVBlockTableHandle?
             do {
                 let reservation = try initialReservation(for: request)
-                let handle = try await allocator.allocate(
-                    conversationKey: "continuous-batching:\(request.id)",
-                    initialCapacityTokens: reservation.initialCapacityTokens,
-                    maxLogicalTokens: reservation.maxLogicalTokens,
-                    initialTokens: 0
-                )
+                let handle: PagedKVBlockTableHandle
+                let prefillCursor: Int
+                if let retained = request.retainedPagedKVSequence {
+                    guard let contiguousCacheBridge else {
+                        throw ContinuousBatchSchedulerError.unsupported(
+                            "continuous_batching_paged_kv_handoff_unavailable"
+                        )
+                    }
+                    handle = try await allocator.reattach(
+                        retained,
+                        conversationKey: request.conversationKey,
+                        trimToLogicalTokens: request.cachedPromptTokens,
+                        maxLogicalTokens: reservation.maxLogicalTokens
+                    )
+                    admissionHandle = handle
+                    let binding = try await allocator.binding(for: handle)
+                    let handoff = try contiguousCacheBridge.reattachPagedKVCache(
+                        handle: handle,
+                        table: binding.currentTable
+                    )
+                    try await backend.installRetainedPagedKVCache(
+                        requestID: request.id,
+                        handoff: handoff,
+                        binding: binding
+                    )
+                    prefillCursor = request.cachedPromptTokens
+                } else {
+                    handle = try await allocator.allocate(
+                        conversationKey: schedulerConversationKey(for: request),
+                        initialCapacityTokens: reservation.initialCapacityTokens,
+                        maxLogicalTokens: reservation.maxLogicalTokens,
+                        initialTokens: 0
+                    )
+                    admissionHandle = handle
+                    prefillCursor = 0
+                }
                 admittingRequests.removeValue(forKey: request.id)
                 if draining {
                     let released = await release(handle)
-                    finishQueued(
+                    await finishQueued(
                         request,
                         status: released ? .rejected : .requestFailed,
                         errorCode: released ? "continuous_batching_draining" : "continuous_batching_cleanup_failed"
@@ -1600,7 +1817,7 @@ actor ContinuousBatchScheduler {
                     continue
                 } else if cancelledIDs.remove(request.id) != nil {
                     let released = await release(handle)
-                    finishQueued(
+                    await finishQueued(
                         request,
                         status: released ? .cancelled : .requestFailed,
                         errorCode: released ? "request_cancelled" : "continuous_batching_cleanup_failed"
@@ -1617,17 +1834,17 @@ actor ContinuousBatchScheduler {
                     generatedTokens: [],
                     outputTokens: [],
                     pendingOutputTokens: [],
-                    prefillCursor: 0,
+                    prefillCursor: prefillCursor,
                     snapshot: configuration.snapshot
                 )
                 promptOrder.append(request.id)
             } catch PagedKVAllocatorError.capacityExceeded {
                 admittingRequests.removeValue(forKey: request.id)
                 if draining {
-                    finishQueued(request, status: .rejected, errorCode: "continuous_batching_draining")
+                    await finishQueued(request, status: .rejected, errorCode: "continuous_batching_draining")
                 } else if activeDecode.isEmpty && activePrompt.isEmpty && admittingRequests.isEmpty {
                     record(.poolCapacityRejected)
-                    finishQueued(
+                    await finishQueued(
                         request,
                         status: .rejected,
                         errorCode: "continuous_batching_pool_capacity_exhausted"
@@ -1636,9 +1853,24 @@ actor ContinuousBatchScheduler {
                     waiting.insert(request, at: 0)
                     return madeProgress
                 }
+            } catch PagedKVAllocatorError.conversationMismatch {
+                admittingRequests.removeValue(forKey: request.id)
+                if let admissionHandle {
+                    let released = await release(admissionHandle)
+                    if !released { return madeProgress }
+                } else if let retained = request.retainedPagedKVSequence {
+                    await discardRetainedCache(retained)
+                }
+                await finishQueued(request, status: .requestFailed, errorCode: "continuous_batching_admission_failed")
             } catch {
                 admittingRequests.removeValue(forKey: request.id)
-                finishQueued(request, status: .requestFailed, errorCode: "continuous_batching_admission_failed")
+                if let admissionHandle {
+                    let released = await release(admissionHandle)
+                    if !released { return madeProgress }
+                } else {
+                    await discardUnacceptedRetainedCache(for: request)
+                }
+                await finishQueued(request, status: .requestFailed, errorCode: "continuous_batching_admission_failed")
             }
         }
         return madeProgress
@@ -1757,10 +1989,17 @@ actor ContinuousBatchScheduler {
     private func transitionPrefilledRow(_ row: Row) async {
         _ = removePromptRow(row.request.id)
         if row.request.maxOutputTokens == 0 {
-            let released = await release(row.handle)
-            finish(row, status: released ? .length : .requestFailed, errorCode: released
-                ? nil
-                : "continuous_batching_cleanup_failed")
+            if let retainedCache = await retainTerminalCache(
+                for: row,
+                targetLogicalTokens: row.retainedLogicalTokenCount
+            ) {
+                finish(row, status: .length, errorCode: nil, retainedCache: retainedCache)
+            } else {
+                let released = await release(row.handle)
+                finish(row, status: released ? .length : .requestFailed, errorCode: released
+                    ? nil
+                    : "continuous_batching_cleanup_failed")
+            }
         } else {
             activeDecode[row.request.id] = row
             record(.joinedDecode)
@@ -1769,7 +2008,7 @@ actor ContinuousBatchScheduler {
 
     private func failRemainingAfterCleanupFailure() async {
         while !waiting.isEmpty {
-            finishQueued(
+            await finishQueued(
                 waiting.removeFirst(),
                 status: .requestFailed,
                 errorCode: "continuous_batching_scheduler_failed_closed"
@@ -1800,10 +2039,12 @@ actor ContinuousBatchScheduler {
         _ request: ContinuousBatchSchedulerRequest,
         status: ContinuousBatchSchedulerTerminalStatus,
         errorCode: String?
-    ) {
+    ) async {
+        await discardUnacceptedRetainedCache(for: request)
         let result = ContinuousBatchSchedulerResult(
             requestID: request.id,
             conversationKey: request.conversationKey,
+            generatedTokens: [],
             outputTokens: [],
             promptTokens: 0,
             completionTokens: 0,
@@ -1812,9 +2053,20 @@ actor ContinuousBatchScheduler {
             terminalStatus: status,
             errorCode: errorCode,
             snapshot: nil,
-            settlementDisposition: .notEligible
+            settlementDisposition: .notEligible,
+            retainedCache: nil
         )
         complete(requestID: request.id, result: result)
+    }
+
+    private func discardUnacceptedRetainedCache(for request: ContinuousBatchSchedulerRequest) async {
+        guard let retained = request.retainedPagedKVSequence else { return }
+        await discardRetainedCache(retained)
+    }
+
+    private func scheduleDiscardUnacceptedRetainedCache(for request: ContinuousBatchSchedulerRequest) {
+        guard let retained = request.retainedPagedKVSequence else { return }
+        Task { await self.discardRetainedCache(retained) }
     }
 
     private func finish(
@@ -1828,6 +2080,7 @@ actor ContinuousBatchScheduler {
         let result = ContinuousBatchSchedulerResult(
             requestID: row.request.id,
             conversationKey: row.request.conversationKey,
+            generatedTokens: isSuccessful ? row.generatedTokens : [],
             outputTokens: outputTokens,
             promptTokens: row.request.promptTokens.count,
             completionTokens: isSuccessful ? row.generatedTokens.count : 0,
@@ -1836,7 +2089,35 @@ actor ContinuousBatchScheduler {
             terminalStatus: status,
             errorCode: errorCode,
             snapshot: row.snapshot,
-            settlementDisposition: isSuccessful ? .eligibleOwner : .notEligible
+            settlementDisposition: isSuccessful ? .eligibleOwner : .notEligible,
+            retainedCache: nil
+        )
+        complete(requestID: row.request.id, result: result)
+    }
+
+    private func finish(
+        _ row: Row,
+        status: ContinuousBatchSchedulerTerminalStatus,
+        errorCode: String?,
+        retainedCache: ContinuousBatchRetainedCache?
+    ) {
+        record(status == .cancelled ? .cancelled : .stopped)
+        let isSuccessful = status == .stop || status == .length
+        let outputTokens = isSuccessful ? row.outputTokens : []
+        let result = ContinuousBatchSchedulerResult(
+            requestID: row.request.id,
+            conversationKey: row.request.conversationKey,
+            generatedTokens: isSuccessful ? row.generatedTokens : [],
+            outputTokens: outputTokens,
+            promptTokens: row.request.promptTokens.count,
+            completionTokens: isSuccessful ? row.generatedTokens.count : 0,
+            emittedTokens: row.outputTokens.count,
+            cachedPromptTokens: row.request.cachedPromptTokens,
+            terminalStatus: status,
+            errorCode: errorCode,
+            snapshot: row.snapshot,
+            settlementDisposition: isSuccessful ? .eligibleOwner : .notEligible,
+            retainedCache: isSuccessful ? retainedCache : nil
         )
         complete(requestID: row.request.id, result: result)
     }
@@ -1862,6 +2143,14 @@ actor ContinuousBatchScheduler {
     ) {
         guard !waiters.isEmpty else {
             finalizeTerminalResult(requestID: requestID, result: result, waiters: [])
+            if let retainedCache = result.retainedCache {
+                Task {
+                    await self.discardRetainedCache(
+                        retainedCache.retainedSequence,
+                        conversationKey: result.conversationKey
+                    )
+                }
+            }
             return
         }
         pendingTerminalDeliveries[requestID] = PendingTerminalDelivery(
@@ -1882,7 +2171,7 @@ actor ContinuousBatchScheduler {
         }
     }
 
-    private func finishTerminalDelivery(requestID: String, waiterID: UUID, delivered: Bool) {
+    private func finishTerminalDelivery(requestID: String, waiterID: UUID, delivered: Bool) async {
         guard !stoppingWaiterIDs.contains(waiterID) else { return }
         guard var pending = pendingTerminalDeliveries[requestID],
               pending.remainingWaiterIDs.remove(waiterID) != nil else { return }
@@ -1892,10 +2181,10 @@ actor ContinuousBatchScheduler {
             return
         }
         pendingTerminalDeliveries.removeValue(forKey: requestID)
-        finalizePendingTerminal(requestID: requestID, pending: pending)
+        await finalizePendingTerminal(requestID: requestID, pending: pending)
     }
 
-    private func finalizePendingTerminal(requestID: String, pending: PendingTerminalDelivery) {
+    private func finalizePendingTerminal(requestID: String, pending: PendingTerminalDelivery) async {
         let result: ContinuousBatchSchedulerResult
         if pending.deliveryOutcomes.values.contains(true) {
             result = pending.result
@@ -1903,6 +2192,7 @@ actor ContinuousBatchScheduler {
             result = ContinuousBatchSchedulerResult(
                 requestID: pending.result.requestID,
                 conversationKey: pending.result.conversationKey,
+                generatedTokens: [],
                 outputTokens: [],
                 promptTokens: pending.result.promptTokens,
                 completionTokens: 0,
@@ -1911,7 +2201,8 @@ actor ContinuousBatchScheduler {
                 terminalStatus: .requestFailed,
                 errorCode: "continuous_batching_stream_delivery_timed_out",
                 snapshot: pending.result.snapshot,
-                settlementDisposition: .notEligible
+                settlementDisposition: .notEligible,
+                retainedCache: nil
             )
         }
         finalizeTerminalResult(
@@ -1920,6 +2211,13 @@ actor ContinuousBatchScheduler {
             waiters: pending.waiters,
             deliveryOutcomes: pending.deliveryOutcomes
         )
+        if !pending.deliveryOutcomes.values.contains(true),
+           let retainedCache = pending.result.retainedCache {
+            await discardRetainedCache(
+                retainedCache.retainedSequence,
+                conversationKey: pending.result.conversationKey
+            )
+        }
     }
 
     private func finalizeTerminalResult(
@@ -1941,6 +2239,7 @@ actor ContinuousBatchScheduler {
                 waiter.continuation.resume(returning: ContinuousBatchSchedulerResult(
                     requestID: result.requestID,
                     conversationKey: result.conversationKey,
+                    generatedTokens: [],
                     outputTokens: [],
                     promptTokens: result.promptTokens,
                     completionTokens: 0,
@@ -1949,14 +2248,22 @@ actor ContinuousBatchScheduler {
                     terminalStatus: .requestFailed,
                     errorCode: "continuous_batching_stream_delivery_timed_out",
                     snapshot: result.snapshot,
-                    settlementDisposition: .notEligible
+                    settlementDisposition: .notEligible,
+                    retainedCache: nil
                 ))
             } else {
-                waiter.continuation.resume(returning: result.withSettlementDisposition(
-                    waiter.id == settlementOwnerID ? .eligibleOwner : (
-                        result.settlementDisposition == .eligibleOwner ? .nonSettlingReplay : .notEligible
+                let disposition: ContinuousBatchSettlementDisposition = waiter.id == settlementOwnerID
+                    ? .eligibleOwner
+                    : (result.settlementDisposition == .eligibleOwner ? .nonSettlingReplay : .notEligible)
+                var waiterResult = result.withSettlementDisposition(disposition)
+                if disposition == .eligibleOwner, let retainedCache = waiterResult.retainedCache {
+                    deliveredRetainedOwners[waiter.id] = DeliveredRetainedOwner(
+                        retained: retainedCache.retainedSequence,
+                        conversationKey: result.conversationKey
                     )
-                ))
+                    waiterResult = waiterResult.withRetainedCache(retainedCache.withDeliveryID(waiter.id))
+                }
+                waiter.continuation.resume(returning: waiterResult)
             }
         }
         while terminalResultOrder.count > configuration.terminalResultLimit {
@@ -2006,6 +2313,100 @@ actor ContinuousBatchScheduler {
 
     private var occupiedSlots: Int {
         admittingRequests.count + activePrompt.count + activeDecode.count
+    }
+
+    private func schedulerConversationKey(for request: ContinuousBatchSchedulerRequest) -> String {
+        let trimmed = request.conversationKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "continuous-batching:\(request.id)" : trimmed
+    }
+
+    private func retainTerminalCache(for row: Row, targetLogicalTokens: Int) async -> ContinuousBatchRetainedCache? {
+        let trimmedKey = row.request.conversationKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedKey.isEmpty, let contiguousCacheBridge else { return nil }
+        var retainedSequence: PagedKVRetainedSequence?
+        do {
+            let binding = try await allocator.binding(for: row.handle)
+            if targetLogicalTokens > binding.currentTable.logicalTokenCount {
+                _ = try await allocator.extend(
+                    row.handle,
+                    by: targetLogicalTokens - binding.currentTable.logicalTokenCount
+                )
+                let targetBinding = try await allocator.binding(for: row.handle)
+                guard let terminalToken = row.generatedTokens.last else {
+                    throw ContinuousBatchSchedulerError.requestFailed("continuous_batching_terminal_kv_commit_missing_token")
+                }
+                try await backend.commitTerminalKV(ContinuousBatchTerminalKVCommitInput(
+                    requestID: row.request.id,
+                    currentToken: terminalToken,
+                    binding: targetBinding,
+                    blockTable: targetBinding.currentTable,
+                    committedKVTokenCount: binding.currentTable.logicalTokenCount,
+                    targetKVTokenCount: targetLogicalTokens
+                ))
+            } else if targetLogicalTokens < binding.currentTable.logicalTokenCount {
+                _ = try await allocator.trim(row.handle, toLogicalTokens: targetLogicalTokens)
+            }
+            let retained = try await allocator.retain(row.handle)
+            retainedSequence = retained
+            let retainedBinding = try await allocator.binding(for: retained.handle)
+            let handoff = try contiguousCacheBridge.reattachPagedKVCache(
+                handle: retained.handle,
+                table: retainedBinding.currentTable
+            )
+            return ContinuousBatchRetainedCache(
+                retainedSequence: retained,
+                layers: handoff.caches
+            )
+        } catch {
+            if let retainedSequence {
+                do {
+                    _ = try await allocator.reattach(retainedSequence, conversationKey: trimmedKey)
+                } catch {
+                    cleanupFailedClosed = true
+                    record(.cleanupFailed)
+                }
+            }
+            return nil
+        }
+    }
+
+    func discardRetainedCache(_ retained: PagedKVRetainedSequence, conversationKey: String) async {
+        do {
+            try await allocator.discardRetained(retained, conversationKey: conversationKey)
+        } catch PagedKVAllocatorError.unknownHandle {
+            return
+        } catch {
+            cleanupFailedClosed = true
+            record(.cleanupFailed)
+        }
+    }
+
+    func discardRetainedCache(_ retained: PagedKVRetainedSequence) async {
+        do {
+            try await allocator.discardRetained(retained)
+        } catch PagedKVAllocatorError.unknownHandle {
+            return
+        } catch {
+            cleanupFailedClosed = true
+            record(.cleanupFailed)
+        }
+    }
+
+    func acknowledgeRetainedCacheDelivery(_ retainedCache: ContinuousBatchRetainedCache) {
+        guard let deliveryID = retainedCache.deliveryID else { return }
+        deliveredRetainedOwners.removeValue(forKey: deliveryID)
+    }
+
+    func cancelRetainedCacheDelivery(
+        _ retainedCache: ContinuousBatchRetainedCache,
+        conversationKey: String
+    ) async {
+        guard let deliveryID = retainedCache.deliveryID else {
+            await discardRetainedCache(retainedCache.retainedSequence, conversationKey: conversationKey)
+            return
+        }
+        guard let delivered = deliveredRetainedOwners.removeValue(forKey: deliveryID) else { return }
+        await discardRetainedCache(delivered.retained, conversationKey: delivered.conversationKey)
     }
 
     private func admissionPrecedes(_ lhs: String, _ rhs: String) -> Bool {

--- a/phase3-binary/Sources/macprovider-cli/ContinuousBatching.swift
+++ b/phase3-binary/Sources/macprovider-cli/ContinuousBatching.swift
@@ -11,7 +11,9 @@ enum ContinuousBatchingUnsupportedReason: String, Sendable, Equatable {
     case tupleNotAdvertised = "requested_tuple_not_advertised"
     case kvBitsUnsupported = "kv_bits_unsupported"
     case draftSpecDecodeMutualExclusion = "draft_spec_decode_mutual_exclusion"
-    case stickyCacheBridgeUnavailable = "sticky_cache_bridge_unavailable"
+    case stickyCacheHandoffUnavailable = "sticky_cache_handoff_unavailable"
+    case conversationKeyRolloutUnavailable = "conversation_key_rollout_unavailable"
+    case durableReplayAuthorityUnavailable = "durable_replay_authority_unavailable"
     case moePromotionEvidenceUnavailable = "moe_promotion_evidence_unavailable"
     case requestStateUnrepresented = "request_local_state_unrepresented"
 
@@ -21,8 +23,12 @@ enum ContinuousBatchingUnsupportedReason: String, Sendable, Equatable {
             return "continuous_batching_unsupported_kv_bits"
         case .draftSpecDecodeMutualExclusion:
             return "draft_model_capacity_shortfall"
-        case .stickyCacheBridgeUnavailable:
-            return "continuous_batching_sticky_cache_unavailable"
+        case .stickyCacheHandoffUnavailable:
+            return "continuous_batching_paged_kv_handoff_unavailable"
+        case .conversationKeyRolloutUnavailable:
+            return "continuous_batching_conversation_key_rollout_unavailable"
+        case .durableReplayAuthorityUnavailable:
+            return "continuous_batching_durable_replay_authority_unavailable"
         case .moePromotionEvidenceUnavailable:
             return "continuous_batching_moe_promotion_evidence_unavailable"
         case .requestStateUnrepresented:
@@ -36,11 +42,15 @@ enum ContinuousBatchingUnsupportedReason: String, Sendable, Equatable {
     var status: Int {
         switch self {
         case .kvBitsUnsupported, .draftSpecDecodeMutualExclusion,
-             .stickyCacheBridgeUnavailable, .moePromotionEvidenceUnavailable,
+             .stickyCacheHandoffUnavailable,
+             .conversationKeyRolloutUnavailable,
+             .moePromotionEvidenceUnavailable,
              .requestStateUnrepresented,
              .tupleNotAdvertised:
             return 400
-        case .localCapabilityUnavailable, .pagedKVDisabled, .pagedKVCapabilityUnavailable:
+        case .localCapabilityUnavailable, .pagedKVDisabled,
+             .pagedKVCapabilityUnavailable,
+             .durableReplayAuthorityUnavailable:
             return 503
         }
     }
@@ -136,7 +146,6 @@ enum ContinuousBatchingPolicy {
             queueLimit: configuredQueueLimit,
             kvBits: kvBits,
             draftConfigured: draftConfigured,
-            stickyCacheEligible: false,
             descriptor: nil,
             tuple: nil,
             checkLocalCapability: false,
@@ -150,9 +159,10 @@ enum ContinuousBatchingPolicy {
         queueLimit configuredQueueLimit: Int?,
         kvBits: Int?,
         draftConfigured: Bool,
-        stickyCacheEligible: Bool = false,
+        requestHasConversationKey: Bool = false,
         requestStateRepresentable: Bool = true,
         schedulerBackendAvailable: Bool,
+        durableReplayAuthorityAvailable: Bool = true,
         pagedKVDecision: PagedKVAttachDecision,
         requestedTuple: ContinuousBatchingRequestedTuple?
     ) -> ContinuousBatchingCapability {
@@ -162,11 +172,12 @@ enum ContinuousBatchingPolicy {
             queueLimit: configuredQueueLimit,
             kvBits: kvBits,
             draftConfigured: draftConfigured,
-            stickyCacheEligible: stickyCacheEligible,
+            requestHasConversationKey: requestHasConversationKey,
             requestStateRepresentable: requestStateRepresentable,
             descriptor: pagedKVDecision.descriptor,
             tuple: requestedTuple,
             schedulerBackendAvailable: schedulerBackendAvailable,
+            durableReplayAuthorityAvailable: durableReplayAuthorityAvailable,
             checkLocalCapability: true,
             pagedKVDecision: pagedKVDecision
         )
@@ -178,11 +189,12 @@ enum ContinuousBatchingPolicy {
         queueLimit configuredQueueLimit: Int?,
         kvBits: Int?,
         draftConfigured: Bool,
-        stickyCacheEligible: Bool,
+        requestHasConversationKey: Bool = false,
         requestStateRepresentable: Bool = true,
         descriptor: PagedKVDescriptor?,
         tuple: ContinuousBatchingRequestedTuple?,
         schedulerBackendAvailable: Bool = false,
+        durableReplayAuthorityAvailable: Bool = true,
         checkLocalCapability: Bool,
         pagedKVDecision: PagedKVAttachDecision
     ) -> ContinuousBatchingCapability {
@@ -191,23 +203,21 @@ enum ContinuousBatchingPolicy {
         let reason: ContinuousBatchingUnsupportedReason?
         if mode == .off {
             reason = nil
+        } else if requestHasConversationKey {
+            reason = .conversationKeyRolloutUnavailable
         } else if !requestStateRepresentable {
             // The shared-forward backend contract carries only scalar sampling
             // parameters. A request needing row-local generation state the
             // contract does not represent (structured-output/grammar-constrained
             // decoding, tool-forced decoding, custom logit processors) must never
             // enter a batch: serial-route in canary, fail closed in strict. This
-            // gate holds even once the deferred SPEC-039 bridge lands, so a future
-            // backend cannot silently ignore or cross-contaminate that state.
+            // gate holds for the SPEC-039 bridge so a future backend cannot
+            // silently ignore or cross-contaminate that state.
             reason = .requestStateUnrepresented
         } else if draftConfigured {
             reason = .draftSpecDecodeMutualExclusion
         } else if kvBits != nil {
             reason = .kvBitsUnsupported
-        } else if stickyCacheEligible {
-            // FR-PKV10's live contiguous-cache bridge is tracked separately;
-            // fresh conversations remain eligible for the first cut.
-            reason = .stickyCacheBridgeUnavailable
         } else if !checkLocalCapability {
             reason = schedulerBackendAvailable ? nil : .localCapabilityUnavailable
         } else {
@@ -231,6 +241,8 @@ enum ContinuousBatchingPolicy {
                     reason = .moePromotionEvidenceUnavailable
                 } else if !schedulerBackendAvailable {
                     reason = .localCapabilityUnavailable
+                } else if !durableReplayAuthorityAvailable {
+                    reason = .durableReplayAuthorityUnavailable
                 } else {
                     reason = nil
                 }
@@ -274,8 +286,12 @@ enum ContinuousBatchingPolicy {
             return "continuous batching does not support the requested kv_bits tuple"
         case .draftSpecDecodeMutualExclusion:
             return "continuous batching is mutually exclusive with speculative decoding in this release"
-        case .stickyCacheBridgeUnavailable:
-            return "continuous batching requires the local contiguous-cache bridge for sticky-cache requests"
+        case .stickyCacheHandoffUnavailable:
+            return "continuous batching requires a same-conversation FR-PKV10 retained paged-KV handoff before cached-token credit can enter the scheduler"
+        case .conversationKeyRolloutUnavailable:
+            return "continuous batching conversation-keyed traffic is not in the current operator rollout scope"
+        case .durableReplayAuthorityUnavailable:
+            return "continuous batching requires durable replay authority before scheduler activation"
         case .moePromotionEvidenceUnavailable:
             return "continuous batching requires the representative MoE correctness fixture and live MSB-04 promotion evidence"
         case .requestStateUnrepresented:

--- a/phase3-binary/Sources/macprovider-cli/ConversationCache.swift
+++ b/phase3-binary/Sources/macprovider-cli/ConversationCache.swift
@@ -1,12 +1,26 @@
 import CryptoKit
 import Foundation
 import MLXLMCommon
+import MacProviderCore
 
 final class ConversationCacheLayers: @unchecked Sendable {
     let layers: [KVCache]
+    let retainedPagedKVSequence: PagedKVRetainedSequence?
+    private let discardRetainedPagedKVSequence: (@Sendable (PagedKVRetainedSequence, String) async -> Void)?
 
-    init(_ layers: [KVCache]) {
+    init(
+        _ layers: [KVCache],
+        retainedPagedKVSequence: PagedKVRetainedSequence? = nil,
+        discardRetainedPagedKVSequence: (@Sendable (PagedKVRetainedSequence, String) async -> Void)? = nil
+    ) {
         self.layers = layers
+        self.retainedPagedKVSequence = retainedPagedKVSequence
+        self.discardRetainedPagedKVSequence = discardRetainedPagedKVSequence
+    }
+
+    func discardRetainedPagedKV(conversationKey: String) async {
+        guard let retainedPagedKVSequence, let discardRetainedPagedKVSequence else { return }
+        await discardRetainedPagedKVSequence(retainedPagedKVSequence, conversationKey)
     }
 }
 
@@ -33,6 +47,7 @@ final class ConversationCacheLease: @unchecked Sendable {
     /// True when this hit reuses cold-tier-promoted layers (FR-KVP9). Advisory,
     /// used only for telemetry attribution.
     let promotedFromCold: Bool
+    let reusableCanonicalPromptTokens: [Int32]?
 
     init(
         key: String,
@@ -47,7 +62,8 @@ final class ConversationCacheLease: @unchecked Sendable {
         sampledPurgeGeneration: Int = 0,
         localPurgeStamp: Int = 0,
         globalPurgeStamp: Int = 0,
-        promotedFromCold: Bool = false
+        promotedFromCold: Bool = false,
+        reusableCanonicalPromptTokens: [Int32]? = nil
     ) {
         self.key = key
         self.keyHash = keyHash
@@ -62,6 +78,7 @@ final class ConversationCacheLease: @unchecked Sendable {
         self.localPurgeStamp = localPurgeStamp
         self.globalPurgeStamp = globalPurgeStamp
         self.promotedFromCold = promotedFromCold
+        self.reusableCanonicalPromptTokens = reusableCanonicalPromptTokens
     }
 }
 
@@ -129,7 +146,8 @@ actor ConversationCache {
         modelID: String,
         kvBits: Int?,
         now: Date = Date(),
-        cold: ConversationColdContext? = nil
+        cold: ConversationColdContext? = nil,
+        allowRetainedPagedKVHandoff: Bool = false
     ) async -> ConversationCacheLease? {
         guard let key = conversationKey?.trimmingCharacters(in: .whitespacesAndNewlines), !key.isEmpty else {
             return nil
@@ -138,7 +156,7 @@ actor ConversationCache {
         busyKeys.insert(key)
 
         let keyHash = Self.keyHash(key)
-        sweepExpired(now: now)
+        await sweepExpired(now: now)
 
         // SPEC-037 FR-KVP8 — sample the purge stamps at lease acquisition. The
         // store high-watermark is stamped into any disk write; the local counters
@@ -152,13 +170,15 @@ actor ConversationCache {
         }
         func stampedLease(
             reusableCache: ConversationCacheLayers?, cachedPromptTokens: Int, lcp: Int, trimBy: Int,
-            promotedFromCold: Bool = false
+            promotedFromCold: Bool = false,
+            reusableCanonicalPromptTokens: [Int32]? = nil
         ) -> ConversationCacheLease {
             ConversationCacheLease(
                 key: key, keyHash: keyHash, incomingTokens: incomingTokens, modelID: modelID, kvBits: kvBits,
                 reusableCache: reusableCache, cachedPromptTokens: cachedPromptTokens, lcp: lcp, trimBy: trimBy,
                 sampledPurgeGeneration: sampledPurgeGeneration, localPurgeStamp: localPurgeStamp,
-                globalPurgeStamp: globalPurgeStamp, promotedFromCold: promotedFromCold)
+                globalPurgeStamp: globalPurgeStamp, promotedFromCold: promotedFromCold,
+                reusableCanonicalPromptTokens: reusableCanonicalPromptTokens)
         }
 
         // Acquire a candidate entry from the hot tier, or — for a gated key that
@@ -210,6 +230,7 @@ actor ConversationCache {
             if let promotionCandidate {
                 await coldTier?.finishPromotion(promotionCandidate, accepted: false, rejectionReason: reason)
             }
+            await entry.kvCache.discardRetainedPagedKV(conversationKey: key)
             return stampedLease(reusableCache: nil, cachedPromptTokens: 0, lcp: 0, trimBy: 0)
         }
 
@@ -231,13 +252,20 @@ actor ConversationCache {
             log("event=conv_cache action=miss key_hash=\(keyHash) reason=nothing_new lcp=\(lcp) prompt_tokens=\(incomingTokens.count)")
             return await predicateMiss("nothing_new")
         }
-        guard entry.kvCache.layers.allSatisfy(\.isTrimmable) else {
-            log("event=conv_cache action=miss key_hash=\(keyHash) reason=cache_not_trimmable")
-            return await predicateMiss("cache_not_trimmable")
-        }
 
+        let retainedPagedKV = entry.kvCache.retainedPagedKVSequence != nil
+        if retainedPagedKV && !allowRetainedPagedKVHandoff {
+            log("event=conv_cache action=miss key_hash=\(keyHash) reason=retained_paged_kv_requires_handoff")
+            return await predicateMiss("retained_paged_kv_requires_handoff")
+        }
         let trimBy = entry.canonicalPromptTokens.count - lcp
-        if trimBy > 0 {
+        if !retainedPagedKV {
+            guard entry.kvCache.layers.allSatisfy(\.isTrimmable) else {
+                log("event=conv_cache action=miss key_hash=\(keyHash) reason=cache_not_trimmable")
+                return await predicateMiss("cache_not_trimmable")
+            }
+        }
+        if trimBy > 0 && !retainedPagedKV {
             for layer in entry.kvCache.layers {
                 let trimmed = layer.trim(trimBy)
                 if trimmed != trimBy {
@@ -257,20 +285,30 @@ actor ConversationCache {
             cachedPromptTokens: min(lcp, incomingTokens.count),
             lcp: lcp,
             trimBy: trimBy,
-            promotedFromCold: promotionCandidate != nil)
+            promotedFromCold: promotionCandidate != nil,
+            reusableCanonicalPromptTokens: Array(entry.canonicalPromptTokens.prefix(lcp)))
     }
 
     func commit(_ lease: ConversationCacheLease, cache: ConversationCacheLayers, fullTokens: [Int32], now: Date = Date(), cold: ConversationColdContext? = nil) async {
         // SPEC-037 FR-KVP8 — a `commit()` whose stamps predate a purge that landed
         // during the request reinserts nothing (neither RAM nor disk).
-        let fencedLocal = (localPurgeGen[lease.key] ?? 0) > lease.localPurgeStamp
-        let fencedGlobal = globalPurgeGen > lease.globalPurgeStamp
-        guard !fencedLocal, !fencedGlobal else {
+        guard !isFenced(lease) else {
             log("event=conv_cache action=commit_fenced key_hash=\(lease.keyHash)")
+            await cache.discardRetainedPagedKV(conversationKey: lease.key)
             releaseTurn(lease.key)
             return
         }
 
+        if let old = entries.removeValue(forKey: lease.key),
+           old.kvCache.retainedPagedKVSequence?.handle != cache.retainedPagedKVSequence?.handle {
+            await old.kvCache.discardRetainedPagedKV(conversationKey: lease.key)
+        }
+        guard !isFenced(lease) else {
+            log("event=conv_cache action=commit_fenced key_hash=\(lease.keyHash)")
+            await cache.discardRetainedPagedKV(conversationKey: lease.key)
+            releaseTurn(lease.key)
+            return
+        }
         entries[lease.key] = Entry(
             canonicalPromptTokens: fullTokens,
             kvCache: cache,
@@ -280,7 +318,16 @@ actor ConversationCache {
             lastUsedAt: now,
             tokenCount: fullTokens.count
         )
-        enforceLimits()
+        await enforceLimits()
+        guard !isFenced(lease) else {
+            log("event=conv_cache action=commit_fenced key_hash=\(lease.keyHash)")
+            if let current = entries[lease.key], current.kvCache === cache {
+                entries.removeValue(forKey: lease.key)
+                await current.kvCache.discardRetainedPagedKV(conversationKey: lease.key)
+            }
+            releaseTurn(lease.key)
+            return
+        }
 
         // SPEC-037 FR-KVP3 — snapshot-at-commit while the lease is still held: the
         // synchronous deep copy is the only hot-path cost; the disk write is
@@ -314,7 +361,9 @@ actor ConversationCache {
         let key = conversationKey.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !key.isEmpty else { return false }
         localPurgeGen[key, default: 0] += 1
-        let hadHot = entries.removeValue(forKey: key) != nil
+        let removed = entries.removeValue(forKey: key)
+        await removed?.kvCache.discardRetainedPagedKV(conversationKey: key)
+        let hadHot = removed != nil
         let hadPending = await coldTier?.cancelPendingPersist(conversationKey: key) ?? false
         return hadHot || hadPending
     }
@@ -325,7 +374,11 @@ actor ConversationCache {
     /// (CRITICAL-2).
     func purgeAllHot() async {
         globalPurgeGen += 1
+        let removed = entries
         entries.removeAll()
+        for (key, entry) in removed {
+            await entry.kvCache.discardRetainedPagedKV(conversationKey: key)
+        }
         await coldTier?.cancelPendingPersists()
     }
 
@@ -334,8 +387,39 @@ actor ConversationCache {
         await coldTier?.drainPendingPersists(timeoutSeconds: timeoutSeconds)
     }
 
-    func abort(_ lease: ConversationCacheLease) {
+    func abort(_ lease: ConversationCacheLease) async {
+        await lease.reusableCache?.discardRetainedPagedKV(conversationKey: lease.key)
         releaseTurn(lease.key)
+    }
+
+    func abortForSerialFallback(_ lease: ConversationCacheLease, now: Date = Date()) async {
+        defer { releaseTurn(lease.key) }
+        guard let reusableCache = lease.reusableCache,
+              reusableCache.retainedPagedKVSequence == nil,
+              lease.cachedPromptTokens > 0,
+              let reusableCanonicalPromptTokens = lease.reusableCanonicalPromptTokens
+        else {
+            await lease.reusableCache?.discardRetainedPagedKV(conversationKey: lease.key)
+            return
+        }
+        guard !isFenced(lease) else {
+            log("event=conv_cache action=serial_fallback_fenced key_hash=\(lease.keyHash)")
+            return
+        }
+        entries[lease.key] = Entry(
+            canonicalPromptTokens: reusableCanonicalPromptTokens,
+            kvCache: reusableCache,
+            modelID: lease.modelID,
+            kvBits: lease.kvBits,
+            storedAt: now,
+            lastUsedAt: now,
+            tokenCount: reusableCanonicalPromptTokens.count
+        )
+        await enforceLimits()
+        if isFenced(lease), let current = entries[lease.key], current.kvCache === reusableCache {
+            entries.removeValue(forKey: lease.key)
+            log("event=conv_cache action=serial_fallback_fenced key_hash=\(lease.keyHash)")
+        }
     }
 
     func snapshotStats() -> (entries: Int, tokens: Int) {
@@ -370,25 +454,35 @@ actor ConversationCache {
         next.resume()
     }
 
-    private func sweepExpired(now: Date) {
-        for (key, entry) in entries where now.timeIntervalSince(entry.storedAt) > config.ttlSeconds {
+    private func sweepExpired(now: Date) async {
+        let expired = entries.compactMap { key, entry -> (String, Entry)? in
+            now.timeIntervalSince(entry.storedAt) > config.ttlSeconds ? (key, entry) : nil
+        }
+        for (key, entry) in expired {
+            guard let current = entries[key], current.kvCache === entry.kvCache else { continue }
             entries.removeValue(forKey: key)
+            await entry.kvCache.discardRetainedPagedKV(conversationKey: key)
             log("event=conv_cache action=evict key_hash=\(Self.keyHash(key)) reason=ttl_\(Int(config.ttlSeconds / 60))min")
         }
     }
 
-    private func enforceLimits() {
+    private func enforceLimits() async {
         while entries.count > config.maxConversations || currentStats().tokens > config.maxTokens {
             guard let victim = entries.min(by: { lhs, rhs in lhs.value.lastUsedAt < rhs.value.lastUsedAt })?.key else {
                 return
             }
-            entries.removeValue(forKey: victim)
+            let evicted = entries.removeValue(forKey: victim)
+            await evicted?.kvCache.discardRetainedPagedKV(conversationKey: victim)
             log("event=conv_cache action=evict key_hash=\(Self.keyHash(victim)) reason=lru")
         }
     }
 
     private func currentStats() -> (entries: Int, tokens: Int) {
         (entries.count, entries.values.reduce(0) { $0 + $1.tokenCount })
+    }
+
+    private func isFenced(_ lease: ConversationCacheLease) -> Bool {
+        (localPurgeGen[lease.key] ?? 0) > lease.localPurgeStamp || globalPurgeGen > lease.globalPurgeStamp
     }
 
     private static func keyHash(_ key: String) -> String {

--- a/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
+++ b/phase3-binary/Sources/macprovider-cli/ModelRuntime.swift
@@ -756,6 +756,7 @@ actor ModelRuntime: ModelRuntimeServing {
     private var currentPagedKVModelCapabilities: PagedKVRuntimeModelCapabilities
     private var continuousBatchScheduler: ContinuousBatchScheduler?
     private let testContinuousBatchingBackend: (any ContinuousBatchSchedulerBackend)?
+    private let continuousBatchingDurableReplayAuthorityAvailable: Bool
     private let conversationCache: ConversationCache
     /// SPEC-037 stage 5 — set once the serve process activates the encrypted disk
     /// cold tier (FR-KVP7). Gates all per-request cold-tier context construction;
@@ -1113,6 +1114,7 @@ actor ModelRuntime: ModelRuntimeServing {
         maxBatch: Int = 1,
         continuousBatchingMode: ContinuousBatchingMode = .off,
         continuousBatchQueueLimit: Int? = nil,
+        continuousBatchingDurableReplayAuthorityAvailable: Bool = false,
         warmSwapEnabled: Bool = false,
         swapDrainTimeoutSeconds: Int = 30,
         catalogModelIDAlias: String? = nil,
@@ -1161,6 +1163,7 @@ actor ModelRuntime: ModelRuntimeServing {
         self.blockingInferenceExecutor = BlockingInferenceExecutor(label: "live.malibu.provider.inference")
         self.continuousBatchingMode = continuousBatchingMode
         self.continuousBatchQueueLimit = continuousBatchQueueLimit
+        self.continuousBatchingDurableReplayAuthorityAvailable = continuousBatchingDurableReplayAuthorityAvailable
         self.warmSwapEnabled = warmSwapEnabled
         self.swapDrainTimeoutSeconds = swapDrainTimeoutSeconds
         self.verifiedCatalogArtifactSHA256 = verifiedModelArtifactSHA256
@@ -1306,6 +1309,7 @@ actor ModelRuntime: ModelRuntimeServing {
         maxBatch: Int = 1,
         continuousBatchingMode: ContinuousBatchingMode = .off,
         continuousBatchQueueLimit: Int? = nil,
+        continuousBatchingDurableReplayAuthorityAvailable: Bool = false,
         warmSwapEnabled: Bool,
         swapDrainTimeoutSeconds: Int = 30,
         providerStatus: ProviderStatus? = nil,
@@ -1392,6 +1396,7 @@ actor ModelRuntime: ModelRuntimeServing {
         self.blockingInferenceExecutor = BlockingInferenceExecutor(label: "live.malibu.provider.inference")
         self.continuousBatchingMode = continuousBatchingMode
         self.continuousBatchQueueLimit = continuousBatchQueueLimit
+        self.continuousBatchingDurableReplayAuthorityAvailable = continuousBatchingDurableReplayAuthorityAvailable
         self.warmSwapEnabled = warmSwapEnabled
         self.swapDrainTimeoutSeconds = swapDrainTimeoutSeconds
         self.providerStatus = providerStatus
@@ -1975,16 +1980,15 @@ actor ModelRuntime: ModelRuntimeServing {
         maxBatch
     }
 
-    func continuousBatchingCapabilityForTest(stickyCacheEligible: Bool = false) -> ContinuousBatchingCapability {
+    func continuousBatchingCapabilityForTest() -> ContinuousBatchingCapability {
         continuousBatchingCapability(
-            draftConfigured: currentDraftModelID != nil,
-            stickyCacheEligible: stickyCacheEligible
+            draftConfigured: currentDraftModelID != nil
         )
     }
 
     private func continuousBatchingCapability(
         draftConfigured: Bool,
-        stickyCacheEligible: Bool,
+        requestHasConversationKey: Bool = false,
         requestStateRepresentable: Bool = true
     ) -> ContinuousBatchingCapability {
         let requestedTuple = continuousBatchingRequestedTuple()
@@ -2011,9 +2015,10 @@ actor ModelRuntime: ModelRuntimeServing {
             queueLimit: continuousBatchQueueLimit,
             kvBits: kvBitsOverride,
             draftConfigured: draftConfigured,
-            stickyCacheEligible: stickyCacheEligible,
+            requestHasConversationKey: requestHasConversationKey,
             requestStateRepresentable: requestStateRepresentable,
             schedulerBackendAvailable: schedulerBackendAvailable,
+            durableReplayAuthorityAvailable: continuousBatchingDurableReplayAuthorityAvailable,
             pagedKVDecision: pagedKVAttachDecision,
             requestedTuple: requestedTuple
         )
@@ -2114,7 +2119,8 @@ actor ModelRuntime: ModelRuntimeServing {
             ),
             allocator: allocator,
             backend: backend,
-            replayAuthority: ContinuousBatchRuntimeReplayAuthority()
+            replayAuthority: ContinuousBatchRuntimeReplayAuthority(),
+            contiguousCacheBridge: contiguousCacheBridge
         )
     }
 
@@ -2220,8 +2226,8 @@ actor ModelRuntime: ModelRuntimeServing {
     /// contract carries. Structured-output/grammar validation, tool-constrained
     /// decoding, logit_bias, and logprobs all impose row-local decoder state the
     /// contract does not model, so such requests must serial-route (canary) / fail
-    /// closed (strict) before admission — a gate that holds even after the deferred
-    /// SPEC-039 bridge lands, so a future backend cannot silently drop that state.
+    /// closed (strict) before admission — a gate that holds for the SPEC-039 bridge
+    /// so a future backend cannot silently drop that state.
     static func requestStateRepresentable(_ request: ChatCompletionRequest) -> Bool {
         // Structured-output / grammar-constrained decoding.
         if requiresStructuredValidation(request.responseFormat) { return false }
@@ -2278,10 +2284,7 @@ actor ModelRuntime: ModelRuntimeServing {
     ) throws -> ContinuousBatchingCapability {
         let capability = continuousBatchingCapability(
             draftConfigured: snapshot.hasTargetCompatibleDraft || currentDraftModelID != nil,
-            // v0.2 admits keyless fresh requests only. A conversation key is
-            // conservatively treated as sticky/cross-turn until the cache
-            // bridge can prove that it has no reusable state.
-            stickyCacheEligible: request.conversationKey != nil,
+            requestHasConversationKey: Self.nonEmpty(request.conversationKey) != nil,
             requestStateRepresentable: Self.requestStateRepresentable(request)
         )
         // Telemetry is emitted once per request at preflight; execution paths
@@ -2697,6 +2700,38 @@ actor ModelRuntime: ModelRuntimeServing {
         }
     }
 
+    private func serialRouteCanaryCachedHitMissingRetainedHandoff(
+        _ lease: ConversationCacheLease?,
+        capability: ContinuousBatchingCapability
+    ) async -> Bool {
+        guard let lease,
+              Self.canaryShouldSerialRouteCachedHitMissingRetainedHandoff(
+                  mode: capability.mode,
+                  cachedPromptTokens: lease.cachedPromptTokens,
+                  hasRetainedPagedKVHandoff: lease.reusableCache?.retainedPagedKVSequence != nil
+              )
+        else {
+            return false
+        }
+        await conversationCache.abortForSerialFallback(lease)
+        ContinuousBatchingPolicy.logSerialRouteIfNeeded(ContinuousBatchingCapability(
+            mode: capability.mode,
+            maxActiveRows: capability.maxActiveRows,
+            queueLimit: capability.queueLimit,
+            descriptor: capability.descriptor,
+            unsupportedReason: .stickyCacheHandoffUnavailable
+        ))
+        return true
+    }
+
+    static func canaryShouldSerialRouteCachedHitMissingRetainedHandoff(
+        mode: ContinuousBatchingMode,
+        cachedPromptTokens: Int,
+        hasRetainedPagedKVHandoff: Bool
+    ) -> Bool {
+        mode == .canary && cachedPromptTokens > 0 && !hasRetainedPagedKVHandoff
+    }
+
     private func attachedContinuousBatchCompletion(
         request: ChatCompletionRequest,
         snapshot: RuntimeSnapshot,
@@ -2741,78 +2776,143 @@ actor ModelRuntime: ModelRuntimeServing {
         try Task.checkCancellation()
         if shouldCancel() { throw CancellationError() }
         let maxOutputTokens = request.maxTokens ?? max(1, maxContextTokens - prepared.promptTokens.count)
-        let result = try await Self.withDrainAndClientCancellation(drainCancelled, shouldCancel: shouldCancel) {
-            try await scheduler.submit(ContinuousBatchSchedulerRequest(
-                id: UUID().uuidString,
-                conversationKey: "",
-                promptTokens: prepared.promptTokens,
-                maxOutputTokens: maxOutputTokens,
-                stopTokenSequences: prepared.stopTokenSequences,
-                temperature: request.temperature,
-                topP: request.topP,
-                presencePenalty: request.presencePenalty,
-                frequencyPenalty: request.frequencyPenalty,
-                cachedPromptTokens: 0
-            ))
+        let preparedPromptTokenIDs = prepared.promptTokens.map(Int32.init)
+        let batchKVBits = Self.effectiveKVBits(
+            configured: kvBitsOverride,
+            conversationKey: request.conversationKey
+        )
+        let lease = await conversationCache.begin(
+            conversationKey: request.conversationKey,
+            incomingTokens: preparedPromptTokenIDs,
+            modelID: request.model,
+            kvBits: batchKVBits,
+            allowRetainedPagedKVHandoff: true
+        )
+        if await serialRouteCanaryCachedHitMissingRetainedHandoff(lease, capability: capability) {
+            return nil
         }
-        try drainCancelled.check()
-        try Task.checkCancellation()
-        if shouldCancel() { throw CancellationError() }
-        guard result.terminalStatus == .stop || result.terminalStatus == .length else {
-            throw Self.attachedPagedKVUnavailableError(code: result.errorCode ?? "continuous_batching_request_failed")
+        let result: ContinuousBatchSchedulerResult
+        do {
+            result = try await Self.withDrainAndClientCancellation(drainCancelled, shouldCancel: shouldCancel) {
+                try await scheduler.submit(ContinuousBatchSchedulerRequest(
+                    id: UUID().uuidString,
+                    conversationKey: request.conversationKey ?? "",
+                    promptTokens: prepared.promptTokens,
+                    maxOutputTokens: maxOutputTokens,
+                    stopTokenSequences: prepared.stopTokenSequences,
+                    temperature: request.temperature,
+                    topP: request.topP,
+                    presencePenalty: request.presencePenalty,
+                    frequencyPenalty: request.frequencyPenalty,
+                    cachedPromptTokens: lease?.cachedPromptTokens ?? 0,
+                    retainedPagedKVSequence: lease?.reusableCache?.retainedPagedKVSequence
+                ))
+            }
+        } catch {
+            if let lease {
+                await conversationCache.abort(lease)
+            }
+            throw error
         }
-        let completionEndedAt = Date()
-        return try await container.perform { context in
-            let decoded = context.tokenizer.decode(tokenIds: result.outputTokens)
-            guard decoded.utf8.count <= ToolCallParser.SPEC018_ARGUMENTS_PER_RESPONSE_BYTE_CAP else {
-                throw APIError(
-                    status: 502,
-                    message: "Model response exceeded 2097152 bytes",
-                    type: "upstream_provider_error",
-                    code: "response_byte_cap_exceeded",
-                    inferenceRan: true,
-                    settlementRan: true
+        do {
+            try drainCancelled.check()
+            try Task.checkCancellation()
+            if shouldCancel() { throw CancellationError() }
+            guard result.terminalStatus == .stop || result.terminalStatus == .length else {
+                throw Self.attachedPagedKVUnavailableError(code: result.errorCode ?? "continuous_batching_request_failed")
+            }
+            let completionEndedAt = Date()
+            let completion = try await container.perform { context in
+                let decoded = context.tokenizer.decode(tokenIds: result.outputTokens)
+                guard decoded.utf8.count <= ToolCallParser.SPEC018_ARGUMENTS_PER_RESPONSE_BYTE_CAP else {
+                    throw APIError(
+                        status: 502,
+                        message: "Model response exceeded 2097152 bytes",
+                        type: "upstream_provider_error",
+                        code: "response_byte_cap_exceeded",
+                        inferenceRan: true,
+                        settlementRan: true
+                    )
+                }
+                let filtered = Self.applyOutputFilters(
+                    decoded,
+                    stopTokenFilter: stopTokenFilter,
+                    requestStops: request.stop
+                )
+                let parserFinishReason = result.terminalStatus == .length && !filtered.hitStop
+                    ? "length"
+                    : (filtered.hitStop ? "request_stop" : "stop")
+                let parsed = try Self.parseGeneratedOutput(
+                    filteredText: filtered.text,
+                    generatedTokenIDs: result.generatedTokens,
+                    decode: { context.tokenizer.decode(tokenIds: $0) },
+                    request: request,
+                    mode: .complete(finishReason: parserFinishReason),
+                    defaultCompletionTokens: result.completionTokens,
+                    stopTokenFilter: stopTokenFilter,
+                    requestStops: request.stop,
+                    globalHitStop: filtered.hitStop
+                )
+                let finishReason: String
+                if !parsed.toolCalls.isEmpty {
+                    finishReason = "tool_calls"
+                } else if result.terminalStatus == .length, !filtered.hitStop, !parsed.hitStop {
+                    finishReason = "length"
+                } else {
+                    finishReason = "stop"
+                }
+                let kvCacheBytesReused = Self.cachedPromptUTF8Bytes(
+                    promptTokenIds: preparedPromptTokenIDs,
+                    cachedPromptTokens: result.cachedPromptTokens,
+                    decode: { context.tokenizer.decode(tokenIds: $0) }
+                )
+                return try Self.validateStructuredCompletion(CompletionResult(
+                    content: parsed.content,
+                    finishReason: finishReason,
+                    promptTokens: prepared.promptTokens.count,
+                    cachedPromptTokens: result.cachedPromptTokens,
+                    kvCacheBytesReused: kvCacheBytesReused,
+                    completionTokens: parsed.completionTokens,
+                    generatedCompletionTokens: parsed.generatedCompletionTokens,
+                    ttftMilliseconds: nil,
+                    generationMilliseconds: Int64(completionEndedAt.timeIntervalSince(completionStartedAt) * 1000),
+                    toolCalls: parsed.toolCalls.isEmpty ? nil : parsed.toolCalls,
+                    modelHashObserved: Self.validObservedModelHash(snapshot.modelHash)
+                ), request: request)
+            }
+            if let lease, let retainedCache = result.retainedCache {
+                await conversationCache.commit(
+                    lease,
+                    cache: ConversationCacheLayers(
+                        retainedCache.layers,
+                        retainedPagedKVSequence: retainedCache.retainedSequence,
+                        discardRetainedPagedKVSequence: { retained, key in
+                            await scheduler.discardRetainedCache(retained, conversationKey: key)
+                        }
+                    ),
+                    fullTokens: preparedPromptTokenIDs + result.generatedTokens.map(Int32.init)
+                )
+                await scheduler.acknowledgeRetainedCacheDelivery(retainedCache)
+            } else if let retainedCache = result.retainedCache {
+                await scheduler.cancelRetainedCacheDelivery(
+                    retainedCache,
+                    conversationKey: result.conversationKey
+                )
+            } else if let lease {
+                await conversationCache.abort(lease)
+            }
+            return completion
+        } catch {
+            if let retainedCache = result.retainedCache {
+                await scheduler.cancelRetainedCacheDelivery(
+                    retainedCache,
+                    conversationKey: result.conversationKey
                 )
             }
-            let filtered = Self.applyOutputFilters(
-                decoded,
-                stopTokenFilter: stopTokenFilter,
-                requestStops: request.stop
-            )
-            let parserFinishReason = result.terminalStatus == .length && !filtered.hitStop
-                ? "length"
-                : (filtered.hitStop ? "request_stop" : "stop")
-            let parsed = try Self.parseGeneratedOutput(
-                filteredText: filtered.text,
-                generatedTokenIDs: result.outputTokens,
-                decode: { context.tokenizer.decode(tokenIds: $0) },
-                request: request,
-                mode: .complete(finishReason: parserFinishReason),
-                defaultCompletionTokens: result.completionTokens,
-                stopTokenFilter: stopTokenFilter,
-                requestStops: request.stop,
-                globalHitStop: filtered.hitStop
-            )
-            let finishReason: String
-            if !parsed.toolCalls.isEmpty {
-                finishReason = "tool_calls"
-            } else if result.terminalStatus == .length, !filtered.hitStop, !parsed.hitStop {
-                finishReason = "length"
-            } else {
-                finishReason = "stop"
+            if let lease {
+                await conversationCache.abort(lease)
             }
-            return try Self.validateStructuredCompletion(CompletionResult(
-                content: parsed.content,
-                finishReason: finishReason,
-                promptTokens: prepared.promptTokens.count,
-                cachedPromptTokens: result.cachedPromptTokens,
-                completionTokens: parsed.completionTokens,
-                generatedCompletionTokens: parsed.generatedCompletionTokens,
-                ttftMilliseconds: nil,
-                generationMilliseconds: Int64(completionEndedAt.timeIntervalSince(completionStartedAt) * 1000),
-                toolCalls: parsed.toolCalls.isEmpty ? nil : parsed.toolCalls,
-                modelHashObserved: Self.validObservedModelHash(snapshot.modelHash)
-            ), request: request)
+            throw error
         }
     }
 
@@ -2865,106 +2965,171 @@ actor ModelRuntime: ModelRuntimeServing {
         if shouldCancel() { throw CancellationError() }
         let streamState = AttachedPagedKVStreamState()
         let maxOutputTokens = request.maxTokens ?? max(1, maxContextTokens - prepared.promptTokens.count)
-        let result = try await Self.withDrainAndClientCancellation(drainCancelled, shouldCancel: shouldCancel) {
-            try await scheduler.submit(ContinuousBatchSchedulerRequest(
-                id: UUID().uuidString,
-                conversationKey: "",
-                promptTokens: prepared.promptTokens,
-                maxOutputTokens: maxOutputTokens,
-                stopTokenSequences: prepared.stopTokenSequences,
-                temperature: request.temperature,
-                topP: request.topP,
-                presencePenalty: request.presencePenalty,
-                frequencyPenalty: request.frequencyPenalty,
-                cachedPromptTokens: 0
-            ), tokenSink: { event in
-                let eventTokens = event.replayTokens ?? [event.token]
-                guard !eventTokens.isEmpty else { return }
-                let allTokens = streamState.appendTokens(eventTokens)
-                let candidate = await container.perform(nonSendable: allTokens) { context, allTokens in
-                    Self.streamingSafePrefix(
-                        context.tokenizer.decode(tokenIds: allTokens),
-                        stopTokenFilter: stopTokenFilter,
-                        requestStops: requestStops
-                    )
-                }
-                let delta = streamState.delta(to: candidate.text)
-                guard !delta.isEmpty else { return }
-                if let error = structuredAccumulator.append(delta) {
-                    streamState.record(error)
-                    return
-                }
-                idleState.noteContent()
-                onChunk(.content(delta))
-            })
+        let preparedPromptTokenIDs = prepared.promptTokens.map(Int32.init)
+        let batchKVBits = Self.effectiveKVBits(
+            configured: kvBitsOverride,
+            conversationKey: request.conversationKey
+        )
+        let lease = await conversationCache.begin(
+            conversationKey: request.conversationKey,
+            incomingTokens: preparedPromptTokenIDs,
+            modelID: request.model,
+            kvBits: batchKVBits,
+            allowRetainedPagedKVHandoff: true
+        )
+        if await serialRouteCanaryCachedHitMissingRetainedHandoff(lease, capability: capability) {
+            return nil
         }
-        if let error = streamState.error() {
+        let result: ContinuousBatchSchedulerResult
+        do {
+            result = try await Self.withDrainAndClientCancellation(drainCancelled, shouldCancel: shouldCancel) {
+                try await scheduler.submit(ContinuousBatchSchedulerRequest(
+                    id: UUID().uuidString,
+                    conversationKey: request.conversationKey ?? "",
+                    promptTokens: prepared.promptTokens,
+                    maxOutputTokens: maxOutputTokens,
+                    stopTokenSequences: prepared.stopTokenSequences,
+                    temperature: request.temperature,
+                    topP: request.topP,
+                    presencePenalty: request.presencePenalty,
+                    frequencyPenalty: request.frequencyPenalty,
+                    cachedPromptTokens: lease?.cachedPromptTokens ?? 0,
+                    retainedPagedKVSequence: lease?.reusableCache?.retainedPagedKVSequence
+                ), tokenSink: { event in
+                    let eventTokens = event.replayTokens ?? [event.token]
+                    guard !eventTokens.isEmpty else { return }
+                    let allTokens = streamState.appendTokens(eventTokens)
+                    let candidate = await container.perform(nonSendable: allTokens) { context, allTokens in
+                        Self.streamingSafePrefix(
+                            context.tokenizer.decode(tokenIds: allTokens),
+                            stopTokenFilter: stopTokenFilter,
+                            requestStops: requestStops
+                        )
+                    }
+                    let delta = streamState.delta(to: candidate.text)
+                    guard !delta.isEmpty else { return }
+                    if let error = structuredAccumulator.append(delta) {
+                        streamState.record(error)
+                        return
+                    }
+                    idleState.noteContent()
+                    onChunk(.content(delta))
+                })
+            }
+        } catch {
+            if let lease {
+                await conversationCache.abort(lease)
+            }
             throw error
         }
-        try drainCancelled.check()
-        try Task.checkCancellation()
-        if shouldCancel() { throw CancellationError() }
-        guard result.terminalStatus == .stop || result.terminalStatus == .length else {
-            throw Self.attachedPagedKVUnavailableError(code: result.errorCode ?? "continuous_batching_request_failed")
-        }
-        let completionEndedAt = Date()
-        let completion = try await container.perform { context in
-            let decoded = context.tokenizer.decode(tokenIds: result.outputTokens)
-            guard decoded.utf8.count <= ToolCallParser.SPEC018_ARGUMENTS_PER_RESPONSE_BYTE_CAP else {
-                throw APIError(
-                    status: 502,
-                    message: "Model response exceeded 2097152 bytes",
-                    type: "upstream_provider_error",
-                    code: "response_byte_cap_exceeded",
-                    inferenceRan: true,
-                    settlementRan: true
+        do {
+            if let error = streamState.error() {
+                throw error
+            }
+            try drainCancelled.check()
+            try Task.checkCancellation()
+            if shouldCancel() { throw CancellationError() }
+            guard result.terminalStatus == .stop || result.terminalStatus == .length else {
+                throw Self.attachedPagedKVUnavailableError(code: result.errorCode ?? "continuous_batching_request_failed")
+            }
+            let completionEndedAt = Date()
+            let completion = try await container.perform { context in
+                let decoded = context.tokenizer.decode(tokenIds: result.outputTokens)
+                guard decoded.utf8.count <= ToolCallParser.SPEC018_ARGUMENTS_PER_RESPONSE_BYTE_CAP else {
+                    throw APIError(
+                        status: 502,
+                        message: "Model response exceeded 2097152 bytes",
+                        type: "upstream_provider_error",
+                        code: "response_byte_cap_exceeded",
+                        inferenceRan: true,
+                        settlementRan: true
+                    )
+                }
+                let filtered = Self.applyOutputFilters(
+                    decoded,
+                    stopTokenFilter: stopTokenFilter,
+                    requestStops: requestStops
+                )
+                let parserFinishReason = result.terminalStatus == .length && !filtered.hitStop
+                    ? "length"
+                    : (filtered.hitStop ? "request_stop" : "stop")
+                let parsed = try Self.parseGeneratedOutput(
+                    filteredText: filtered.text,
+                    generatedTokenIDs: result.generatedTokens,
+                    decode: { context.tokenizer.decode(tokenIds: $0) },
+                    request: request,
+                    mode: .complete(finishReason: parserFinishReason),
+                    defaultCompletionTokens: result.completionTokens,
+                    stopTokenFilter: stopTokenFilter,
+                    requestStops: requestStops,
+                    globalHitStop: filtered.hitStop
+                )
+                let finishReason: String
+                if !parsed.toolCalls.isEmpty {
+                    finishReason = "tool_calls"
+                } else if result.terminalStatus == .length, !filtered.hitStop, !parsed.hitStop {
+                    finishReason = "length"
+                } else {
+                    finishReason = "stop"
+                }
+                let kvCacheBytesReused = Self.cachedPromptUTF8Bytes(
+                    promptTokenIds: preparedPromptTokenIDs,
+                    cachedPromptTokens: result.cachedPromptTokens,
+                    decode: { context.tokenizer.decode(tokenIds: $0) }
+                )
+                return try Self.validateStructuredCompletion(CompletionResult(
+                    content: parsed.content,
+                    finishReason: finishReason,
+                    promptTokens: prepared.promptTokens.count,
+                    cachedPromptTokens: result.cachedPromptTokens,
+                    kvCacheBytesReused: kvCacheBytesReused,
+                    completionTokens: parsed.completionTokens,
+                    generatedCompletionTokens: parsed.generatedCompletionTokens,
+                    ttftMilliseconds: nil,
+                    generationMilliseconds: Int64(completionEndedAt.timeIntervalSince(completionStartedAt) * 1000),
+                    toolCalls: parsed.toolCalls.isEmpty ? nil : parsed.toolCalls,
+                    modelHashObserved: Self.validObservedModelHash(snapshot.modelHash)
+                ), request: request)
+            }
+            let validated = try Self.validateStructuredStreamingCompletion(
+                completion,
+                request: request,
+                buyerVisibleContent: structuredAccumulator.content
+            )
+            if let lease, let retainedCache = result.retainedCache {
+                await conversationCache.commit(
+                    lease,
+                    cache: ConversationCacheLayers(
+                        retainedCache.layers,
+                        retainedPagedKVSequence: retainedCache.retainedSequence,
+                        discardRetainedPagedKVSequence: { retained, key in
+                            await scheduler.discardRetainedCache(retained, conversationKey: key)
+                        }
+                    ),
+                    fullTokens: preparedPromptTokenIDs + result.generatedTokens.map(Int32.init)
+                )
+                await scheduler.acknowledgeRetainedCacheDelivery(retainedCache)
+            } else if let retainedCache = result.retainedCache {
+                await scheduler.cancelRetainedCacheDelivery(
+                    retainedCache,
+                    conversationKey: result.conversationKey
+                )
+            } else if let lease {
+                await conversationCache.abort(lease)
+            }
+            return validated
+        } catch {
+            if let retainedCache = result.retainedCache {
+                await scheduler.cancelRetainedCacheDelivery(
+                    retainedCache,
+                    conversationKey: result.conversationKey
                 )
             }
-            let filtered = Self.applyOutputFilters(
-                decoded,
-                stopTokenFilter: stopTokenFilter,
-                requestStops: requestStops
-            )
-            let parserFinishReason = result.terminalStatus == .length && !filtered.hitStop
-                ? "length"
-                : (filtered.hitStop ? "request_stop" : "stop")
-            let parsed = try Self.parseGeneratedOutput(
-                filteredText: filtered.text,
-                generatedTokenIDs: result.outputTokens,
-                decode: { context.tokenizer.decode(tokenIds: $0) },
-                request: request,
-                mode: .complete(finishReason: parserFinishReason),
-                defaultCompletionTokens: result.completionTokens,
-                stopTokenFilter: stopTokenFilter,
-                requestStops: requestStops,
-                globalHitStop: filtered.hitStop
-            )
-            let finishReason: String
-            if !parsed.toolCalls.isEmpty {
-                finishReason = "tool_calls"
-            } else if result.terminalStatus == .length, !filtered.hitStop, !parsed.hitStop {
-                finishReason = "length"
-            } else {
-                finishReason = "stop"
+            if let lease {
+                await conversationCache.abort(lease)
             }
-            return try Self.validateStructuredCompletion(CompletionResult(
-                content: parsed.content,
-                finishReason: finishReason,
-                promptTokens: prepared.promptTokens.count,
-                cachedPromptTokens: result.cachedPromptTokens,
-                completionTokens: parsed.completionTokens,
-                generatedCompletionTokens: parsed.generatedCompletionTokens,
-                ttftMilliseconds: nil,
-                generationMilliseconds: Int64(completionEndedAt.timeIntervalSince(completionStartedAt) * 1000),
-                toolCalls: parsed.toolCalls.isEmpty ? nil : parsed.toolCalls,
-                modelHashObserved: Self.validObservedModelHash(snapshot.modelHash)
-            ), request: request)
+            throw error
         }
-        return try Self.validateStructuredStreamingCompletion(
-            completion,
-            request: request,
-            buyerVisibleContent: structuredAccumulator.content
-        )
     }
 
     private nonisolated static func attachedPagedKVUnavailableError(code: String) -> APIError {

--- a/phase3-binary/Sources/macprovider-cli/PagedKVRuntimeBridge.swift
+++ b/phase3-binary/Sources/macprovider-cli/PagedKVRuntimeBridge.swift
@@ -94,7 +94,7 @@ struct PagedKVPagedCacheHandoff {
     let tailValidTokenCount: Int
     let caches: [PagedKVCache]
 
-    fileprivate init(handle: PagedKVBlockTableHandle, blockTable: PagedKVBlockTable, caches: [PagedKVCache]) {
+    init(handle: PagedKVBlockTableHandle, blockTable: PagedKVBlockTable, caches: [PagedKVCache]) {
         self.handle = handle
         self.blockTable = blockTable
         self.logicalTokenCount = blockTable.logicalTokenCount
@@ -418,6 +418,8 @@ final class PagedKVRuntimeContiguousCacheBridge: PagedKVContiguousCacheBridge, P
     }
 }
 
+extension PagedKVRuntimeContiguousCacheBridge: ContinuousBatchRetainedCacheBridge {}
+
 /// SPEC-039 / SPEC-038 Increment 1 runtime bridge.
 ///
 /// This backend is intentionally installable only after the attach gate has a
@@ -542,6 +544,37 @@ final class PagedKVSharedForwardBackend: ContinuousBatchSchedulerBackend, @unche
 
     func finish(requestID: String) {
         removeRowState(for: requestID, discardRecordedCache: false)
+    }
+
+    func installRetainedPagedKVCache(
+        requestID: String,
+        handoff: PagedKVPagedCacheHandoff,
+        binding: PagedKVStorageBinding
+    ) async throws {
+        let state = RowState(caches: handoff.caches, state: nil)
+        try setRowState(state, for: requestID, binding: binding)
+    }
+
+    func commitTerminalKV(_ input: ContinuousBatchTerminalKVCommitInput) async throws {
+        guard beginOperation() else {
+            throw ContinuousBatchSchedulerError.unsupported("continuous_batching_backend_cancelled")
+        }
+        defer { endOperation() }
+        try await container.perform(nonSendable: input) { context, input in
+            var state = self.rowState(
+                for: input.requestID,
+                binding: input.binding,
+                initialOffset: input.committedKVTokenCount
+            )
+            let tokenInput = MLXArray([Int32(input.currentToken)]).reshaped([1, 1])
+            let text = LMInput.Text(tokens: tokenInput)
+            let output = withPreparedCache(state.caches, lengths: text.sequenceLengths) {
+                context.model(text, cache: state.caches, state: state.state)
+            }
+            eval(output.logits)
+            state.state = output.state
+            try self.setRowState(state, for: input.requestID, binding: input.binding)
+        }
     }
 
     func cancelInFlight() async {

--- a/phase3-binary/Tests/macprovider-cliTests/ContinuousBatchSchedulerTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ContinuousBatchSchedulerTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MLX
 @testable import MacProviderCore
 @testable import macprovider_cli
 import XCTest
@@ -55,21 +56,21 @@ final class ContinuousBatchSchedulerTests: XCTestCase {
         XCTAssertEqual(decodeCalls, 0)
     }
 
-    func testHeadUpdateStickyCacheRequestNeverEntersBatch() async throws {
+    func testCachedPromptTokensRequireRetainedPagedKVHandoff() async throws {
         let backend = ScriptedBackend(scripts: [:])
         let scheduler = try await makeScheduler(maxActiveRows: 2, backend: backend)
 
         do {
             _ = try await scheduler.submit(.init(
                 id: "sticky",
-                conversationKey: "",
-                promptTokens: [1],
+                conversationKey: "conversation-1",
+                promptTokens: [1, 2],
                 maxOutputTokens: 1,
                 cachedPromptTokens: 1
             ))
-            XCTFail("expected the deferred contiguous-cache bridge gate")
+            XCTFail("expected retained FR-PKV10 handoff evidence")
         } catch ContinuousBatchSchedulerError.unsupported(let reason) {
-            XCTAssertEqual(reason, "keyed_or_sticky_cache_reuse_deferred_until_paged_kv_cache_bridge")
+            XCTAssertEqual(reason, "continuous_batching_paged_kv_handoff_unavailable")
         }
 
         let prefillCalls = await backend.prefillCallCount()
@@ -80,26 +81,779 @@ final class ContinuousBatchSchedulerTests: XCTestCase {
         XCTAssertTrue(metrics.diagnostics.contains(.stickyCacheUnsupported))
     }
 
-    func testConversationKeyNeverEntersBatchBeforePagedKVCacheBridge() async throws {
-        let backend = ScriptedBackend(scripts: [:])
+    func testConversationKeyWithoutReusableStateBatchesAsFreshRequest() async throws {
+        let backend = ScriptedBackend(scripts: ["keyed": [7]])
         let scheduler = try await makeScheduler(maxActiveRows: 2, backend: backend)
 
-        do {
-            _ = try await scheduler.submit(.init(
-                id: "keyed",
-                conversationKey: "conversation-1",
-                promptTokens: [1],
-                maxOutputTokens: 1
-            ))
-            XCTFail("expected the deferred keyed-cache bridge gate")
-        } catch ContinuousBatchSchedulerError.unsupported(let reason) {
-            XCTAssertEqual(reason, "keyed_or_sticky_cache_reuse_deferred_until_paged_kv_cache_bridge")
-        }
+        let result = try await scheduler.submit(.init(
+            id: "keyed",
+            conversationKey: "conversation-1",
+            promptTokens: [1, 2],
+            maxOutputTokens: 1,
+            temperature: 0.0,
+            topP: 1.0
+        ))
 
         let prefillCalls = await backend.prefillCallCount()
         let decodeCalls = await backend.decodeCallCount()
-        XCTAssertEqual(prefillCalls, 0)
-        XCTAssertEqual(decodeCalls, 0)
+        XCTAssertEqual(result.terminalStatus, .length)
+        XCTAssertEqual(result.conversationKey, "conversation-1")
+        XCTAssertEqual(result.cachedPromptTokens, 0)
+        XCTAssertEqual(result.outputTokens, [7])
+        XCTAssertEqual(prefillCalls, 1)
+        XCTAssertEqual(decodeCalls, 1)
+    }
+
+    func testTerminalRetainFailureReleasesFreshHandleWithoutFailClosing() async throws {
+        let bridge = PagedKVRuntimeContiguousCacheBridge()
+        let allocator = try PagedKVBlockAllocator(
+            blockSizeTokens: 4,
+            maxPhysicalBlocks: 16,
+            contiguousCacheBridge: bridge
+        )
+        let backend = ScriptedBackend(scripts: ["keyed": [7], "unkeyed": [8]])
+        let scheduler = try await makeScheduler(
+            maxActiveRows: 1,
+            backend: backend,
+            allocator: allocator,
+            contiguousCacheBridge: bridge
+        )
+
+        let keyedResult = try await scheduler.submit(.init(
+            id: "keyed",
+            conversationKey: "conversation-1",
+            promptTokens: [1, 2],
+            maxOutputTokens: 1,
+            temperature: 0.0,
+            topP: 1.0
+        ))
+
+        XCTAssertEqual(keyedResult.terminalStatus, .length)
+        XCTAssertNil(keyedResult.retainedCache)
+        let freeBlockCount = await allocator.freeBlockCount()
+        XCTAssertEqual(freeBlockCount, 16)
+
+        let nextResult = try await scheduler.submit(.init(
+            id: "unkeyed",
+            conversationKey: "",
+            promptTokens: [3],
+            maxOutputTokens: 1,
+            temperature: 0.0,
+            topP: 1.0
+        ))
+        XCTAssertEqual(nextResult.terminalStatus, .length)
+        XCTAssertEqual(nextResult.outputTokens, [8])
+    }
+
+    func testRetainedPagedKVHandoffResumesPrefillAtStickyLCP() async throws {
+        let fixture = try await makeRetainedSchedulerFixture(cachedTokens: 34, promptCount: 40)
+
+        let result = try await fixture.scheduler.submit(.init(
+            id: "sticky-hit",
+            conversationKey: "conversation-1",
+            promptTokens: Array(0..<40),
+            maxOutputTokens: 1,
+            temperature: 0.0,
+            topP: 1.0,
+            cachedPromptTokens: 34,
+            retainedPagedKVSequence: fixture.retained
+        ))
+
+        XCTAssertEqual(result.terminalStatus, .length)
+        XCTAssertEqual(result.cachedPromptTokens, 34)
+        XCTAssertNotNil(result.retainedCache)
+        let retainedInstalls = await fixture.backend.retainedInstalls()
+        let prefillCommitted = await fixture.backend.prefillCommittedCounts()
+        let prefillTargets = await fixture.backend.prefillTargetCounts()
+        let decodeCommitted = await fixture.backend.decodeCommittedCounts()
+        XCTAssertEqual(retainedInstalls, ["sticky-hit": 34])
+        XCTAssertEqual(prefillCommitted.first, ["sticky-hit": 34])
+        XCTAssertEqual(prefillTargets.first, ["sticky-hit": 36])
+        XCTAssertEqual(decodeCommitted.last, ["sticky-hit": 39])
+        XCTAssertEqual(result.retainedCache?.retainedSequence.logicalTokenCount, 41)
+        let terminalCommitTargets = await fixture.backend.terminalCommitTargets()
+        XCTAssertEqual(terminalCommitTargets, ["sticky-hit": 41])
+        if let retainedCache = result.retainedCache {
+            await fixture.scheduler.cancelRetainedCacheDelivery(
+                retainedCache,
+                conversationKey: result.conversationKey
+            )
+        }
+    }
+
+    func testRetainedReattachExpandsMaxLogicalTokensForContinuation() async throws {
+        let allocator = try PagedKVBlockAllocator(blockSizeTokens: 4, maxPhysicalBlocks: 16)
+        let handle = try await allocator.allocate(
+            conversationKey: "conversation-1",
+            initialCapacityTokens: 34,
+            maxLogicalTokens: 34,
+            initialTokens: 34
+        )
+        let retained = try await allocator.retain(handle)
+
+        let reattached = try await allocator.reattach(
+            retained,
+            conversationKey: "conversation-1",
+            trimToLogicalTokens: 34,
+            maxLogicalTokens: 48
+        )
+        _ = try await allocator.extend(reattached, by: 7)
+        let binding = try await allocator.binding(for: reattached)
+
+        XCTAssertEqual(binding.currentTable.logicalTokenCount, 41)
+        XCTAssertEqual(binding.maxLogicalTokens, 48)
+        try await allocator.release(reattached)
+    }
+
+    func testCrossConversationRetainedHandoffFailureDiscardsOwner() async throws {
+        let bridge = PagedKVRuntimeContiguousCacheBridge()
+        let allocator = try PagedKVBlockAllocator(
+            blockSizeTokens: 4,
+            maxPhysicalBlocks: 16,
+            contiguousCacheBridge: bridge
+        )
+        let handle = try await allocator.allocate(
+            conversationKey: "conversation-a",
+            initialCapacityTokens: 8,
+            maxLogicalTokens: 8,
+            initialTokens: 6
+        )
+        let retained = try await allocator.retain(handle)
+        let backend = ScriptedBackend(scripts: [:])
+        let scheduler = try await makeScheduler(
+            maxActiveRows: 1,
+            backend: backend,
+            allocator: allocator,
+            contiguousCacheBridge: bridge
+        )
+
+        let result = try await scheduler.submit(.init(
+            id: "cross-key",
+            conversationKey: "conversation-b",
+            promptTokens: Array(0..<8),
+            maxOutputTokens: 1,
+            temperature: 0.0,
+            topP: 1.0,
+            cachedPromptTokens: 6,
+            retainedPagedKVSequence: retained
+        ))
+
+        XCTAssertEqual(result.terminalStatus, .requestFailed)
+        XCTAssertEqual(result.errorCode, "continuous_batching_admission_failed")
+        do {
+            _ = try await allocator.reattach(retained, conversationKey: "conversation-a")
+            XCTFail("retained sequence should have been discarded after cross-key admission failure")
+        } catch PagedKVAllocatorError.unknownHandle {
+        } catch {
+            XCTFail("unexpected retained sequence error: \(error)")
+        }
+        let freeBlockCount = await allocator.freeBlockCount()
+        XCTAssertEqual(freeBlockCount, 16)
+    }
+
+    func testInvalidCachedRangeDiscardsSuppliedRetainedOwner() async throws {
+        let allocator = try PagedKVBlockAllocator(blockSizeTokens: 4, maxPhysicalBlocks: 16)
+        let retained = try await makeRetainedSequence(allocator: allocator)
+        let backend = ScriptedBackend(scripts: [:])
+        let scheduler = try await makeScheduler(
+            maxActiveRows: 1,
+            backend: backend,
+            allocator: allocator
+        )
+
+        do {
+            _ = try await scheduler.submit(.init(
+                id: "invalid-cached-range",
+                conversationKey: "conversation-1",
+                promptTokens: Array(0..<5),
+                maxOutputTokens: 1,
+                cachedPromptTokens: 6,
+                retainedPagedKVSequence: retained
+            ))
+            XCTFail("expected invalid cached-token range rejection")
+        } catch ContinuousBatchSchedulerError.requestFailed(let reason) {
+            XCTAssertEqual(reason, "continuous_batching_invalid_cached_prompt_tokens")
+        }
+
+        try await assertRetainedDiscarded(retained, allocator: allocator, expectedFreeBlockCount: 16)
+    }
+
+    func testFullPromptCachedRangeDiscardsSuppliedRetainedOwner() async throws {
+        let allocator = try PagedKVBlockAllocator(blockSizeTokens: 4, maxPhysicalBlocks: 16)
+        let retained = try await makeRetainedSequence(
+            allocator: allocator,
+            initialCapacityTokens: 8,
+            maxLogicalTokens: 8,
+            initialTokens: 5
+        )
+        let backend = ScriptedBackend(scripts: [:])
+        let scheduler = try await makeScheduler(
+            maxActiveRows: 1,
+            backend: backend,
+            allocator: allocator
+        )
+
+        do {
+            _ = try await scheduler.submit(.init(
+                id: "full-prompt-cached-range",
+                conversationKey: "conversation-1",
+                promptTokens: Array(0..<5),
+                maxOutputTokens: 1,
+                cachedPromptTokens: 5,
+                retainedPagedKVSequence: retained
+            ))
+            XCTFail("expected full-prompt cached-token range rejection")
+        } catch ContinuousBatchSchedulerError.requestFailed(let reason) {
+            XCTAssertEqual(reason, "continuous_batching_invalid_cached_prompt_tokens")
+        }
+
+        try await assertRetainedDiscarded(retained, allocator: allocator, expectedFreeBlockCount: 16)
+    }
+
+    func testTwoRetainedConversationKeysShareDecodeBatchWithoutCrossAttribution() async throws {
+        let decodeGate = AsyncGate()
+        let bridge = HeadlessRetainedCacheBridge()
+        let allocator = try PagedKVBlockAllocator(blockSizeTokens: 4, maxPhysicalBlocks: 16)
+        let retainedA = try await makeRetainedSequence(
+            allocator: allocator,
+            conversationKey: "conversation-a",
+            initialCapacityTokens: 8,
+            maxLogicalTokens: 8,
+            initialTokens: 3
+        )
+        let retainedB = try await makeRetainedSequence(
+            allocator: allocator,
+            conversationKey: "conversation-b",
+            initialCapacityTokens: 8,
+            maxLogicalTokens: 8,
+            initialTokens: 3
+        )
+        let backend = ScriptedBackend(
+            scripts: ["sticky-a": [10, 11], "sticky-b": [20]],
+            decodeGate: decodeGate
+        )
+        let scheduler = try await makeScheduler(
+            maxActiveRows: 2,
+            maxPromptChunkTokens: 4,
+            backend: backend,
+            allocator: allocator,
+            contiguousCacheBridge: bridge
+        )
+
+        let first = Task {
+            try await scheduler.submit(.init(
+                id: "sticky-a",
+                conversationKey: "conversation-a",
+                promptTokens: Array(0..<5),
+                maxOutputTokens: 2,
+                samplerSeed: 101,
+                temperature: 0.0,
+                topP: 1.0,
+                cachedPromptTokens: 3,
+                retainedPagedKVSequence: retainedA
+            ))
+        }
+        try await eventually { await backend.decodeCallCount() == 1 }
+        let second = Task {
+            try await scheduler.submit(.init(
+                id: "sticky-b",
+                conversationKey: "conversation-b",
+                promptTokens: Array(10..<15),
+                maxOutputTokens: 1,
+                samplerSeed: 202,
+                temperature: 0.0,
+                topP: 1.0,
+                cachedPromptTokens: 3,
+                retainedPagedKVSequence: retainedB
+            ))
+        }
+        try await eventually { await scheduler.metrics().waitingCount == 1 }
+        await decodeGate.open()
+
+        let firstResult = try await first.value
+        let secondResult = try await second.value
+
+        XCTAssertEqual(firstResult.conversationKey, "conversation-a")
+        XCTAssertEqual(secondResult.conversationKey, "conversation-b")
+        XCTAssertEqual(firstResult.cachedPromptTokens, 3)
+        XCTAssertEqual(secondResult.cachedPromptTokens, 3)
+        XCTAssertEqual(firstResult.outputTokens, [10, 11])
+        XCTAssertEqual(secondResult.outputTokens, [20])
+        XCTAssertEqual(firstResult.settlementDisposition, .eligibleOwner)
+        XCTAssertEqual(secondResult.settlementDisposition, .eligibleOwner)
+
+        let retainedInstalls = await backend.retainedInstalls()
+        XCTAssertEqual(retainedInstalls, ["sticky-a": 3, "sticky-b": 3])
+        let decodeBatches = await backend.decodeBatches()
+        guard let sharedBatchIndex = decodeBatches.firstIndex(of: ["sticky-a", "sticky-b"]) else {
+            return XCTFail("expected retained sticky rows to share one decode batch; saw \(decodeBatches)")
+        }
+        let currentTokens = await backend.currentTokensByDecodeBatch()
+        let committedCounts = await backend.decodeCommittedCounts()
+        let targetCounts = await backend.decodeTargetCounts()
+        XCTAssertEqual(currentTokens[sharedBatchIndex], ["sticky-a": 10, "sticky-b": 14])
+        XCTAssertEqual(committedCounts[sharedBatchIndex], ["sticky-a": 5, "sticky-b": 4])
+        XCTAssertEqual(targetCounts[sharedBatchIndex], ["sticky-a": 6, "sticky-b": 5])
+        let samplerSeeds = await backend.observedSamplerSeeds()
+        let terminalCommitTargets = await backend.terminalCommitTargets()
+        XCTAssertEqual(samplerSeeds, ["sticky-a": [101, 101], "sticky-b": [202]])
+        XCTAssertEqual(terminalCommitTargets, ["sticky-a": 7, "sticky-b": 6])
+
+        if let retainedCache = firstResult.retainedCache {
+            await scheduler.cancelRetainedCacheDelivery(
+                retainedCache,
+                conversationKey: firstResult.conversationKey
+            )
+        }
+        if let retainedCache = secondResult.retainedCache {
+            await scheduler.cancelRetainedCacheDelivery(
+                retainedCache,
+                conversationKey: secondResult.conversationKey
+            )
+        }
+    }
+
+    func testDeliveredRetainedCacheCanBeReclaimedAfterCallerCancellationRace() async throws {
+        let bridge = HeadlessRetainedCacheBridge()
+        let allocator = try PagedKVBlockAllocator(blockSizeTokens: 4, maxPhysicalBlocks: 16)
+        let originalRetained = try await makeRetainedSequence(
+            allocator: allocator,
+            conversationKey: "conversation-1",
+            initialCapacityTokens: 8,
+            maxLogicalTokens: 8,
+            initialTokens: 6
+        )
+        let backend = ScriptedBackend(scripts: ["sticky-cancel-race": [777]])
+        let scheduler = try await makeScheduler(
+            maxActiveRows: 1,
+            maxPromptChunkTokens: 4,
+            backend: backend,
+            allocator: allocator,
+            contiguousCacheBridge: bridge
+        )
+        let freeBeforeSubmit = await allocator.freeBlockCount()
+
+        let result = try await scheduler.submit(.init(
+            id: "sticky-cancel-race",
+            conversationKey: "conversation-1",
+            promptTokens: Array(0..<8),
+            maxOutputTokens: 1,
+            cachedPromptTokens: 6,
+            retainedPagedKVSequence: originalRetained
+        ))
+
+        XCTAssertEqual(result.terminalStatus, .length)
+        XCTAssertEqual(result.settlementDisposition, .eligibleOwner)
+        guard let retainedCache = result.retainedCache else {
+            return XCTFail("expected terminal retained cache delivery")
+        }
+        XCTAssertNotNil(retainedCache.deliveryID)
+        let freeAfterSubmit = await allocator.freeBlockCount()
+        XCTAssertLessThan(freeAfterSubmit, freeBeforeSubmit)
+
+        await scheduler.cancelRetainedCacheDelivery(retainedCache, conversationKey: result.conversationKey)
+        try await eventually {
+            await allocator.freeBlockCount() == 16
+        }
+        do {
+            _ = try await allocator.reattach(
+                retainedCache.retainedSequence,
+                conversationKey: result.conversationKey
+            )
+            XCTFail("cancelled delivered retained cache should be reclaimed")
+        } catch PagedKVAllocatorError.unknownHandle {
+        } catch {
+            throw error
+        }
+    }
+
+    func testMissingContiguousBridgeAdmissionFailureDiscardsSuppliedRetainedOwner() async throws {
+        let allocator = try PagedKVBlockAllocator(blockSizeTokens: 4, maxPhysicalBlocks: 16)
+        let retained = try await makeRetainedSequence(allocator: allocator)
+        let backend = ScriptedBackend(scripts: [:])
+        let scheduler = try await makeScheduler(
+            maxActiveRows: 1,
+            backend: backend,
+            allocator: allocator
+        )
+
+        let result = try await scheduler.submit(.init(
+            id: "missing-bridge",
+            conversationKey: "conversation-1",
+            promptTokens: Array(0..<8),
+            maxOutputTokens: 1,
+            cachedPromptTokens: 6,
+            retainedPagedKVSequence: retained
+        ))
+
+        XCTAssertEqual(result.terminalStatus, .requestFailed)
+        XCTAssertEqual(result.errorCode, "continuous_batching_admission_failed")
+        try await assertRetainedDiscarded(retained, allocator: allocator, expectedFreeBlockCount: 16)
+    }
+
+    func testTerminalReplayDiscardsSuppliedRetainedOwner() async throws {
+        let allocator = try PagedKVBlockAllocator(blockSizeTokens: 4, maxPhysicalBlocks: 16)
+        let backend = ScriptedBackend(scripts: ["owner": [7]])
+        let scheduler = try await makeScheduler(
+            maxActiveRows: 1,
+            backend: backend,
+            allocator: allocator
+        )
+        let original = try await scheduler.submit(.init(
+            id: "owner",
+            conversationKey: "conversation-1",
+            promptTokens: [1],
+            maxOutputTokens: 1
+        ))
+        XCTAssertEqual(original.terminalStatus, .length)
+
+        let retained = try await makeRetainedSequence(allocator: allocator)
+        let replay = try await scheduler.submit(.init(
+            id: "owner",
+            conversationKey: "conversation-1",
+            promptTokens: [1],
+            maxOutputTokens: 1,
+            retainedPagedKVSequence: retained
+        ))
+
+        XCTAssertEqual(replay.settlementDisposition, .nonSettlingReplay)
+        XCTAssertNil(replay.retainedCache)
+        try await assertRetainedDiscarded(retained, allocator: allocator, expectedFreeBlockCount: 16)
+    }
+
+    func testPositiveCachedTerminalReplayDiscardsSuppliedRetainedOwner() async throws {
+        let allocator = try PagedKVBlockAllocator(blockSizeTokens: 4, maxPhysicalBlocks: 16)
+        let bridge = HeadlessRetainedCacheBridge()
+        let originalRetained = try await makeRetainedSequence(
+            allocator: allocator,
+            initialCapacityTokens: 8,
+            maxLogicalTokens: 8,
+            initialTokens: 6
+        )
+        let backend = ScriptedBackend(scripts: ["owner-positive": [7]])
+        let scheduler = try await makeScheduler(
+            maxActiveRows: 1,
+            backend: backend,
+            allocator: allocator,
+            contiguousCacheBridge: bridge
+        )
+        let original = try await scheduler.submit(.init(
+            id: "owner-positive",
+            conversationKey: "conversation-1",
+            promptTokens: Array(0..<8),
+            maxOutputTokens: 1,
+            cachedPromptTokens: 6,
+            retainedPagedKVSequence: originalRetained
+        ))
+        XCTAssertEqual(original.terminalStatus, .length)
+        XCTAssertEqual(original.cachedPromptTokens, 6)
+        XCTAssertEqual(original.retainedCache?.retainedSequence.logicalTokenCount, 9)
+
+        let retained = try await makeRetainedSequence(allocator: allocator)
+        let replay = try await scheduler.submit(.init(
+            id: "owner-positive",
+            conversationKey: "conversation-1",
+            promptTokens: Array(0..<8),
+            maxOutputTokens: 1,
+            cachedPromptTokens: 6,
+            retainedPagedKVSequence: retained
+        ))
+
+        XCTAssertEqual(replay.settlementDisposition, .nonSettlingReplay)
+        XCTAssertEqual(replay.cachedPromptTokens, 6)
+        XCTAssertNil(replay.retainedCache)
+        try await assertRetainedDiscarded(retained, allocator: allocator, expectedFreeBlockCount: 13)
+        if let retainedCache = original.retainedCache {
+            await scheduler.cancelRetainedCacheDelivery(
+                retainedCache,
+                conversationKey: original.conversationKey
+            )
+        }
+    }
+
+    func testQueuedCancellationDiscardsSuppliedRetainedOwner() async throws {
+        let gate = AsyncGate()
+        let allocator = try PagedKVBlockAllocator(blockSizeTokens: 4, maxPhysicalBlocks: 16)
+        let backend = ScriptedBackend(scripts: ["active": [7]], prefillGate: gate)
+        let scheduler = try await makeScheduler(
+            maxActiveRows: 1,
+            queueLimit: 1,
+            backend: backend,
+            allocator: allocator
+        )
+
+        let active = Task {
+            try await scheduler.submit(.init(
+                id: "active",
+                conversationKey: "",
+                promptTokens: [1, 2],
+                maxOutputTokens: 1
+            ))
+        }
+        try await eventually { await backend.prefillCallCount() == 1 }
+
+        let retained = try await makeRetainedSequence(allocator: allocator)
+        let queued = Task {
+            try await scheduler.submit(.init(
+                id: "queued-retained",
+                conversationKey: "conversation-1",
+                promptTokens: Array(0..<8),
+                maxOutputTokens: 1,
+                cachedPromptTokens: 6,
+                retainedPagedKVSequence: retained
+            ))
+        }
+        try await eventually { await scheduler.metrics().waitingCount == 1 }
+        await scheduler.cancel(requestID: "queued-retained")
+        await gate.open()
+
+        let queuedResult = try await queued.value
+        XCTAssertEqual(queuedResult.terminalStatus, .cancelled)
+        _ = try await active.value
+        try await assertRetainedDiscarded(retained, allocator: allocator, expectedFreeBlockCount: 16)
+    }
+
+    func testTimedOutTerminalDeliveryDiscardsRetainedPagedKVOwner() async throws {
+        let sinkGate = AsyncGate()
+        let fixture = try await makeRetainedSchedulerFixture(
+            cachedTokens: 34,
+            promptCount: 40,
+            tokenDeliveryTimeoutNanoseconds: 20_000_000
+        )
+
+        let timedOut = Task {
+            try await fixture.scheduler.submit(.init(
+                id: "sticky-hit",
+                conversationKey: "conversation-1",
+                promptTokens: Array(0..<40),
+                maxOutputTokens: 1,
+                temperature: 0.0,
+                topP: 1.0,
+                cachedPromptTokens: 34,
+                retainedPagedKVSequence: fixture.retained
+            ), tokenSink: { _ in
+                await sinkGate.wait()
+            })
+        }
+
+        let result = try await timedOut.value
+        XCTAssertEqual(result.terminalStatus, .requestFailed)
+        XCTAssertEqual(result.errorCode, "continuous_batching_stream_delivery_timed_out")
+        XCTAssertNil(result.retainedCache)
+        try await eventually { await fixture.allocator.freeBlockCount() == 32 }
+        await sinkGate.open()
+    }
+
+    func testConversationCacheRetainedPagedKVHitLeavesTrimToSchedulerHandoff() async throws {
+        let fixture = try await makeRetainedSchedulerFixture(
+            cachedTokens: 34,
+            promptCount: 40,
+            retainedTokenCount: 40
+        )
+        let conversationCache = ConversationCache(
+            config: .init(maxConversations: 8, maxTokens: 200_000, ttlSeconds: 900)
+        )
+        let seedTokens = Array(0..<40).map(Int32.init)
+        let seed = await conversationCache.begin(
+            conversationKey: "conversation-1",
+            incomingTokens: seedTokens,
+            modelID: Self.modelID,
+            kvBits: nil
+        )
+        await conversationCache.commit(
+            seed!,
+            cache: ConversationCacheLayers(
+                [fixture.pagedCache],
+                retainedPagedKVSequence: fixture.retained,
+                discardRetainedPagedKVSequence: { retained, key in
+                    await fixture.scheduler.discardRetainedCache(retained, conversationKey: key)
+                }
+            ),
+            fullTokens: seedTokens
+        )
+
+        let incomingTokens = Array(0..<34).map(Int32.init) + Array(100..<106).map(Int32.init)
+        let lease = await conversationCache.begin(
+            conversationKey: "conversation-1",
+            incomingTokens: incomingTokens,
+            modelID: Self.modelID,
+            kvBits: nil,
+            allowRetainedPagedKVHandoff: true
+        )
+
+        XCTAssertEqual(lease?.cachedPromptTokens, 34)
+        XCTAssertEqual(lease?.trimBy, 6)
+        XCTAssertEqual(fixture.pagedCache.offset, 40)
+
+        let result = try await fixture.scheduler.submit(.init(
+            id: "sticky-hit",
+            conversationKey: "conversation-1",
+            promptTokens: Array(0..<34) + Array(100..<106),
+            maxOutputTokens: 1,
+            temperature: 0.0,
+            topP: 1.0,
+            cachedPromptTokens: lease?.cachedPromptTokens ?? 0,
+            retainedPagedKVSequence: lease?.reusableCache?.retainedPagedKVSequence
+        ))
+
+        XCTAssertEqual(result.terminalStatus, .length)
+        XCTAssertEqual(result.cachedPromptTokens, 34)
+        XCTAssertNotNil(result.retainedCache)
+        let retainedInstalls = await fixture.backend.retainedInstalls()
+        let prefillCommitted = await fixture.backend.prefillCommittedCounts()
+        let prefillTargets = await fixture.backend.prefillTargetCounts()
+        XCTAssertEqual(retainedInstalls, ["sticky-hit": 34])
+        XCTAssertEqual(prefillCommitted.first, ["sticky-hit": 34])
+        XCTAssertEqual(prefillTargets.first, ["sticky-hit": 36])
+
+        if let lease, let retainedCache = result.retainedCache {
+            await conversationCache.commit(
+                lease,
+                cache: ConversationCacheLayers(
+                    retainedCache.layers,
+                    retainedPagedKVSequence: retainedCache.retainedSequence,
+                    discardRetainedPagedKVSequence: { retained, key in
+                        await fixture.scheduler.discardRetainedCache(retained, conversationKey: key)
+                    }
+                ),
+                fullTokens: incomingTokens + result.outputTokens.map(Int32.init)
+            )
+            await fixture.scheduler.acknowledgeRetainedCacheDelivery(retainedCache)
+            _ = await conversationCache.purgeHot(conversationKey: "conversation-1")
+        } else if let lease {
+            await conversationCache.abort(lease)
+        }
+    }
+
+    func testRetainedStickyStopSequenceCommitsCanonicalGeneratedTokens() async throws {
+        let bridge = HeadlessRetainedCacheBridge()
+        let allocator = try PagedKVBlockAllocator(blockSizeTokens: 4, maxPhysicalBlocks: 16)
+        let retained = try await makeRetainedSequence(
+            allocator: allocator,
+            conversationKey: "conversation-1",
+            initialCapacityTokens: 40,
+            maxLogicalTokens: 48,
+            initialTokens: 34
+        )
+        let backend = ScriptedBackend(scripts: ["sticky-hit": [5, 7, 8]])
+        let scheduler = try await makeScheduler(
+            maxActiveRows: 1,
+            backend: backend,
+            allocator: allocator,
+            contiguousCacheBridge: bridge
+        )
+
+        let incomingTokens = Array<Int32>(0..<40)
+        let result = try await scheduler.submit(.init(
+            id: "sticky-hit",
+            conversationKey: "conversation-1",
+            promptTokens: incomingTokens.map(Int.init),
+            maxOutputTokens: 3,
+            stopTokenSequences: [[7, 8]],
+            temperature: 0.0,
+            topP: 1.0,
+            cachedPromptTokens: 34,
+            retainedPagedKVSequence: retained
+        ))
+
+        XCTAssertEqual(result.terminalStatus, .stop)
+        XCTAssertEqual(result.generatedTokens, [5, 7, 8])
+        XCTAssertEqual(result.outputTokens, [5])
+        XCTAssertEqual(result.completionTokens, 3)
+        XCTAssertEqual(result.retainedCache?.retainedSequence.logicalTokenCount, 43)
+        let terminalCommitTargets = await backend.terminalCommitTargets()
+        XCTAssertEqual(terminalCommitTargets, ["sticky-hit": 43])
+
+        let conversationCache = ConversationCache(
+            config: .init(maxConversations: 8, maxTokens: 200_000, ttlSeconds: 900)
+        )
+        if let retainedCache = result.retainedCache {
+            let lease = await conversationCache.begin(
+                conversationKey: "conversation-1",
+                incomingTokens: incomingTokens,
+                modelID: "model-a",
+                kvBits: nil,
+                allowRetainedPagedKVHandoff: true
+            )
+            XCTAssertNotNil(lease)
+            await conversationCache.commit(
+                lease!,
+                cache: ConversationCacheLayers(
+                    retainedCache.layers,
+                    retainedPagedKVSequence: retainedCache.retainedSequence,
+                    discardRetainedPagedKVSequence: { retained, key in
+                        await scheduler.discardRetainedCache(retained, conversationKey: key)
+                    }
+                ),
+                fullTokens: incomingTokens + result.generatedTokens.map(Int32.init)
+            )
+            await scheduler.acknowledgeRetainedCacheDelivery(retainedCache)
+            let next = await conversationCache.begin(
+                conversationKey: "conversation-1",
+                incomingTokens: incomingTokens + result.generatedTokens.map(Int32.init) + [42],
+                modelID: "model-a",
+                kvBits: nil,
+                allowRetainedPagedKVHandoff: true
+            )
+            XCTAssertEqual(next?.cachedPromptTokens, 43)
+            await conversationCache.abort(next!)
+            _ = await conversationCache.purgeHot(conversationKey: "conversation-1")
+        } else {
+            XCTFail("expected retained sticky cache")
+        }
+    }
+
+    func testCachedPromptTokensCannotExceedPromptLengthEvenWithRetainedHandoff() async throws {
+        let fixture = try await makeRetainedSchedulerFixture(cachedTokens: 6, promptCount: 6)
+
+        do {
+            _ = try await fixture.scheduler.submit(.init(
+                id: "invalid-cached-range",
+                conversationKey: "conversation-1",
+                promptTokens: Array(0..<5),
+                maxOutputTokens: 1,
+                cachedPromptTokens: 6,
+                retainedPagedKVSequence: fixture.retained
+            ))
+            XCTFail("expected invalid cached-token range rejection")
+        } catch ContinuousBatchSchedulerError.requestFailed(let reason) {
+            XCTAssertEqual(reason, "continuous_batching_invalid_cached_prompt_tokens")
+        }
+        let retainedInstalls = await fixture.backend.retainedInstalls()
+        XCTAssertEqual(retainedInstalls, [:])
+    }
+
+    func testNonSettlingReplayResultDropsRetainedCacheOwnership() async throws {
+        let allocator = try PagedKVBlockAllocator(blockSizeTokens: 4, maxPhysicalBlocks: 4)
+        let handle = try await allocator.allocate(
+            conversationKey: "conversation-1",
+            initialCapacityTokens: 1,
+            maxLogicalTokens: 4,
+            initialTokens: 1
+        )
+        let retained = try await allocator.retain(handle)
+        let retainedCache = ContinuousBatchRetainedCache(retainedSequence: retained, layers: [])
+        let result = ContinuousBatchSchedulerResult(
+            requestID: "sticky-owner",
+            conversationKey: "conversation-1",
+            generatedTokens: [7],
+            outputTokens: [7],
+            promptTokens: 2,
+            completionTokens: 1,
+            emittedTokens: 1,
+            cachedPromptTokens: 1,
+            terminalStatus: .length,
+            errorCode: nil,
+            snapshot: nil,
+            settlementDisposition: .eligibleOwner,
+            retainedCache: retainedCache
+        )
+
+        let replay = result.withSettlementDisposition(.nonSettlingReplay)
+
+        XCTAssertEqual(replay.settlementDisposition, .nonSettlingReplay)
+        XCTAssertNil(replay.retainedCache)
+        try await allocator.discardRetained(retained, conversationKey: "conversation-1")
     }
 
     func testAC24AdmissionPoolCapacityRejectsWithoutRunningInference() async throws {
@@ -1936,9 +2690,12 @@ final class ContinuousBatchSchedulerTests: XCTestCase {
         queueLimit: Int? = nil,
         decodeHeadroomTokens: Int = 2,
         maxPromptChunkTokens: Int = 2,
-        backend: ScriptedBackend
+        tokenDeliveryTimeoutNanoseconds: UInt64 = 5_000_000_000,
+        backend: ScriptedBackend,
+        allocator: PagedKVBlockAllocator? = nil,
+        contiguousCacheBridge: (any ContinuousBatchRetainedCacheBridge)? = nil
     ) async throws -> ContinuousBatchScheduler {
-        let allocator = try PagedKVBlockAllocator(blockSizeTokens: 4, maxPhysicalBlocks: 16)
+        let allocator = try allocator ?? PagedKVBlockAllocator(blockSizeTokens: 4, maxPhysicalBlocks: 16)
         let config = ContinuousBatchSchedulerConfiguration(
             descriptor: descriptor,
             tuple: tuple,
@@ -1948,6 +2705,7 @@ final class ContinuousBatchSchedulerTests: XCTestCase {
             decodeHeadroomTokens: decodeHeadroomTokens,
             maxPrefillRowsPerIteration: 1,
             maxPromptChunkTokens: maxPromptChunkTokens,
+            tokenDeliveryTimeoutNanoseconds: tokenDeliveryTimeoutNanoseconds,
             snapshot: ContinuousBatchSchedulerSnapshot(
                 modelID: Self.modelID,
                 modelSHA256: Self.modelSHA,
@@ -1958,8 +2716,114 @@ final class ContinuousBatchSchedulerTests: XCTestCase {
             configuration: config,
             allocator: allocator,
             backend: backend,
-            replayAuthority: TestReplayAuthority()
+            replayAuthority: TestReplayAuthority(),
+            contiguousCacheBridge: contiguousCacheBridge
         )
+    }
+
+    private func makeRetainedSequence(
+        allocator: PagedKVBlockAllocator,
+        conversationKey: String = "conversation-1",
+        initialCapacityTokens: Int = 8,
+        maxLogicalTokens: Int = 8,
+        initialTokens: Int = 6
+    ) async throws -> PagedKVRetainedSequence {
+        let handle = try await allocator.allocate(
+            conversationKey: conversationKey,
+            initialCapacityTokens: initialCapacityTokens,
+            maxLogicalTokens: maxLogicalTokens,
+            initialTokens: initialTokens
+        )
+        return try await allocator.retain(handle)
+    }
+
+    private func assertRetainedDiscarded(
+        _ retained: PagedKVRetainedSequence,
+        allocator: PagedKVBlockAllocator,
+        expectedFreeBlockCount: Int,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        try await eventually(file: file, line: line) {
+            await allocator.freeBlockCount() == expectedFreeBlockCount
+        }
+        do {
+            _ = try await allocator.reattach(retained, conversationKey: retained.conversationKey)
+            XCTFail("retained sequence should have been discarded", file: file, line: line)
+        } catch PagedKVAllocatorError.unknownHandle {
+        } catch {
+            XCTFail("unexpected retained sequence error: \(error)", file: file, line: line)
+        }
+    }
+
+    private func makeRetainedSchedulerFixture(
+        cachedTokens: Int,
+        promptCount: Int,
+        retainedTokenCount: Int? = nil,
+        scripts: [String: [Int]] = ["sticky-hit": [777]],
+        tokenDeliveryTimeoutNanoseconds: UInt64 = 5_000_000_000
+    ) async throws -> (
+        scheduler: ContinuousBatchScheduler,
+        backend: ScriptedBackend,
+        retained: PagedKVRetainedSequence,
+        pagedCache: PagedKVCache,
+        allocator: PagedKVBlockAllocator
+    ) {
+        guard PagedKVMetallibGate.defaultMetallibExists() else {
+            throw XCTSkip("MLX default metallib is unavailable in this test host")
+        }
+        let descriptor = Self.descriptor(blockSizeTokens: 4, maxPhysicalBlocks: 32)
+        let retainedTokenCount = retainedTokenCount ?? cachedTokens
+        let bridge = PagedKVRuntimeContiguousCacheBridge()
+        let allocator = try PagedKVBlockAllocator(
+            blockSizeTokens: descriptor.blockSizeTokens,
+            maxPhysicalBlocks: descriptor.maxPhysicalBlocks,
+            physicalBlockOrder: [2, 5, 1, 0, 4, 3, 6, 7],
+            contiguousCacheBridge: bridge
+        )
+        let handle = try await allocator.allocate(
+            conversationKey: "conversation-1",
+            initialCapacityTokens: max(promptCount, retainedTokenCount),
+            maxLogicalTokens: max(promptCount, retainedTokenCount) + 8,
+            initialTokens: retainedTokenCount
+        )
+        let binding = try await allocator.binding(for: handle)
+        let keyBytes = Self.fp16Bytes((1...UInt16(retainedTokenCount)).map { $0 })
+        let valueBytes = Self.fp16Bytes((1...UInt16(retainedTokenCount)).map { $0 + 100 })
+        let paged = PagedKVCache(descriptor: descriptor, binding: binding)
+        paged.state = [
+            MLXArray(keyBytes, [1, 1, retainedTokenCount, 1], dtype: .float16),
+            MLXArray(valueBytes, [1, 1, retainedTokenCount, 1], dtype: .float16),
+        ]
+        try bridge.record(caches: [paged], binding: binding)
+        let retained = try await allocator.retain(handle)
+        let backend = ScriptedBackend(
+            scripts: scripts,
+            terminalCommitBridge: bridge,
+            terminalCommitCaches: [paged]
+        )
+        let scheduler = try await makeScheduler(
+            descriptor: descriptor,
+            tuple: Self.tuple(),
+            maxActiveRows: 1,
+            tokenDeliveryTimeoutNanoseconds: tokenDeliveryTimeoutNanoseconds,
+            backend: backend,
+            allocator: allocator,
+            contiguousCacheBridge: bridge
+        )
+        return (scheduler, backend, retained, paged, allocator)
+    }
+
+    private static func fp16Bytes(_ values: [UInt16]) -> Data {
+        var data = Data()
+        data.reserveCapacity(values.count * 2)
+        for value in values {
+            var littleEndian = value.littleEndian
+            withUnsafeBytes(of: &littleEndian) { bytes in
+                data.append(contentsOf: bytes)
+            }
+        }
+        return data
     }
 }
 
@@ -2053,12 +2917,23 @@ private actor SecondDecodeGateBackend: ContinuousBatchSchedulerBackend {
     func decodeCallCount() -> Int { decodeCalls }
 }
 
+private struct HeadlessRetainedCacheBridge: ContinuousBatchRetainedCacheBridge {
+    func reattachPagedKVCache(
+        handle: PagedKVBlockTableHandle,
+        table: PagedKVBlockTable
+    ) throws -> PagedKVPagedCacheHandoff {
+        PagedKVPagedCacheHandoff(handle: handle, blockTable: table, caches: [])
+    }
+}
+
 private actor ScriptedBackend: ContinuousBatchSchedulerBackend {
     private let scripts: [String: [Int]]
     private let prefillGate: AsyncGate?
     private let decodeGate: AsyncGate?
     private let failDecodeCall: Int?
     private let rowFailures: Set<String>
+    private let terminalCommitBridge: PagedKVRuntimeContiguousCacheBridge?
+    private let terminalCommitCaches: [PagedKVCache]
     private var prefillRowsLog: [[String]] = []
     private var decodeRowsLog: [[String]] = []
     private var currentTokenLog: [[String: Int]] = []
@@ -2069,6 +2944,8 @@ private actor ScriptedBackend: ContinuousBatchSchedulerBackend {
     private var blockTableLengthLog: [[String: Int]] = []
     private var samplerSeedLog: [String: [Int]] = [:]
     private var samplerStepLog: [String: [Int]] = [:]
+    private var retainedInstallLog: [String: Int] = [:]
+    private var terminalCommitLog: [String: Int] = [:]
     private var promptChunks: [[Int]] = []
     private var eventLog: [String] = []
     private var decodeCalls = 0
@@ -2078,13 +2955,17 @@ private actor ScriptedBackend: ContinuousBatchSchedulerBackend {
         prefillGate: AsyncGate? = nil,
         decodeGate: AsyncGate? = nil,
         failDecodeCall: Int? = nil,
-        rowFailures: Set<String> = []
+        rowFailures: Set<String> = [],
+        terminalCommitBridge: PagedKVRuntimeContiguousCacheBridge? = nil,
+        terminalCommitCaches: [PagedKVCache] = []
     ) {
         self.scripts = scripts
         self.prefillGate = prefillGate
         self.decodeGate = decodeGate
         self.failDecodeCall = failDecodeCall
         self.rowFailures = rowFailures
+        self.terminalCommitBridge = terminalCommitBridge
+        self.terminalCommitCaches = terminalCommitCaches
     }
 
     func prefill(rows: [ContinuousBatchPrefillInput]) async throws -> [ContinuousBatchPrefillOutput] {
@@ -2101,6 +2982,16 @@ private actor ScriptedBackend: ContinuousBatchSchedulerBackend {
             await prefillGate.wait()
         }
         return rows.map { ContinuousBatchPrefillOutput(requestID: $0.requestID) }
+    }
+
+    func installRetainedPagedKVCache(
+        requestID: String,
+        handoff: PagedKVPagedCacheHandoff,
+        binding: PagedKVStorageBinding
+    ) async throws {
+        XCTAssertEqual(handoff.handle, binding.handle)
+        XCTAssertEqual(handoff.blockTable, binding.currentTable)
+        retainedInstallLog[requestID] = handoff.logicalTokenCount
     }
 
     func decode(rows: [ContinuousBatchDecodeInput]) async throws -> [ContinuousBatchDecodeOutcome] {
@@ -2137,6 +3028,25 @@ private actor ScriptedBackend: ContinuousBatchSchedulerBackend {
         }
     }
 
+    func commitTerminalKV(_ input: ContinuousBatchTerminalKVCommitInput) async throws {
+        terminalCommitLog[input.requestID] = input.targetKVTokenCount
+        guard let terminalCommitBridge else { return }
+        for (layerIndex, cache) in terminalCommitCaches.enumerated() {
+            let tokenCount = input.targetKVTokenCount
+            let keyBytes = Self.fp16Bytes((0..<tokenCount).map {
+                UInt16(truncatingIfNeeded: $0 + 1 + layerIndex * 1_000)
+            })
+            let valueBytes = Self.fp16Bytes((0..<tokenCount).map {
+                UInt16(truncatingIfNeeded: $0 + 101 + layerIndex * 1_000)
+            })
+            cache.state = [
+                MLXArray(keyBytes, [1, 1, tokenCount, 1], dtype: .float16),
+                MLXArray(valueBytes, [1, 1, tokenCount, 1], dtype: .float16),
+            ]
+        }
+        try terminalCommitBridge.record(caches: terminalCommitCaches, binding: input.binding)
+    }
+
     func cancelInFlight() async {
         await prefillGate?.open()
         await decodeGate?.open()
@@ -2156,6 +3066,18 @@ private actor ScriptedBackend: ContinuousBatchSchedulerBackend {
     func blockTableLengthsByDecodeBatch() -> [[String: Int]] { blockTableLengthLog }
     func maxObservedPrefillChunkSize() -> Int? { promptChunks.map(\.count).max() }
     func events() -> [String] { eventLog }
+    func retainedInstalls() -> [String: Int] { retainedInstallLog }
+    func terminalCommitTargets() -> [String: Int] { terminalCommitLog }
+
+    private static func fp16Bytes(_ values: [UInt16]) -> Data {
+        var data = Data()
+        data.reserveCapacity(values.count * 2)
+        for value in values {
+            var littleEndian = value.littleEndian
+            withUnsafeBytes(of: &littleEndian) { data.append(contentsOf: $0) }
+        }
+        return data
+    }
 }
 
 private struct BackendFailure: Error {}

--- a/phase3-binary/Tests/macprovider-cliTests/ConversationCacheTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ConversationCacheTests.swift
@@ -1,4 +1,6 @@
+import Foundation
 import MLXLMCommon
+@testable import MacProviderCore
 @testable import macprovider_cli
 import XCTest
 
@@ -68,6 +70,135 @@ final class ConversationCacheTests: XCTestCase {
         await cache.abort(nonTrim!)
     }
 
+    func testSerialFallbackAbortRestoresNonRetainedCacheForBillingParity() async {
+        let cache = ConversationCache(config: .init(maxConversations: 8, maxTokens: 200_000, ttlSeconds: 900))
+        let seedTokens = int32Range(0..<64)
+        let seed = await cache.begin(conversationKey: "conv:fallback", incomingTokens: seedTokens, modelID: "model-a", kvBits: nil)
+        let layer = trimmableCache(offset: seedTokens.count)
+        await cache.commit(seed!, cache: ConversationCacheLayers([layer]), fullTokens: seedTokens)
+
+        let incoming = int32Range(0..<57) + int32Range(100..<112)
+        let canaryLease = await cache.begin(
+            conversationKey: "conv:fallback",
+            incomingTokens: incoming,
+            modelID: "model-a",
+            kvBits: nil,
+            allowRetainedPagedKVHandoff: true
+        )
+        XCTAssertEqual(canaryLease?.cachedPromptTokens, 57)
+        XCTAssertEqual(layer.offset, 57)
+
+        await cache.abortForSerialFallback(canaryLease!)
+
+        let serialLease = await cache.begin(
+            conversationKey: "conv:fallback",
+            incomingTokens: incoming,
+            modelID: "model-a",
+            kvBits: nil
+        )
+        XCTAssertEqual(serialLease?.cachedPromptTokens, 57)
+        XCTAssertEqual(serialLease?.trimBy, 0)
+        XCTAssertEqual(layer.offset, 57)
+        await cache.abort(serialLease!)
+    }
+
+    func testSerialFallbackAbortDoesNotRestoreAfterPurge() async {
+        let cache = ConversationCache(config: .init(maxConversations: 8, maxTokens: 200_000, ttlSeconds: 900))
+        let seedTokens = int32Range(0..<64)
+        let seed = await cache.begin(conversationKey: "conv:fallback-purge", incomingTokens: seedTokens, modelID: "model-a", kvBits: nil)
+        let layer = trimmableCache(offset: seedTokens.count)
+        await cache.commit(seed!, cache: ConversationCacheLayers([layer]), fullTokens: seedTokens)
+
+        let incoming = int32Range(0..<57) + int32Range(100..<112)
+        let canaryLease = await cache.begin(
+            conversationKey: "conv:fallback-purge",
+            incomingTokens: incoming,
+            modelID: "model-a",
+            kvBits: nil,
+            allowRetainedPagedKVHandoff: true
+        )
+        XCTAssertEqual(canaryLease?.cachedPromptTokens, 57)
+
+        _ = await cache.purgeHot(conversationKey: "conv:fallback-purge")
+        await cache.abortForSerialFallback(canaryLease!)
+
+        let serialLease = await cache.begin(
+            conversationKey: "conv:fallback-purge",
+            incomingTokens: incoming,
+            modelID: "model-a",
+            kvBits: nil
+        )
+        XCTAssertEqual(serialLease?.cachedPromptTokens, 0)
+        await cache.abort(serialLease!)
+    }
+
+    func testTTLSweepDoesNotRemoveEntryCommittedDuringRetainedDiscard() async throws {
+        let cache = ConversationCache(config: .init(maxConversations: 8, maxTokens: 200_000, ttlSeconds: 60))
+        let allocator = try PagedKVBlockAllocator(blockSizeTokens: 4, maxPhysicalBlocks: 16)
+        let oldRetained = try await retainedSequence(
+            allocator: allocator,
+            conversationKey: "conv:ttl-race",
+            tokenCount: 64
+        )
+        let newTokens = int32Range(0..<64)
+        let replacementCommitted = CacheCompletionFlag()
+        let oldTokens = int32Range(100..<164)
+        let oldSeed = await cache.begin(
+            conversationKey: "conv:ttl-race",
+            incomingTokens: oldTokens,
+            modelID: "model-a",
+            kvBits: nil,
+            now: Date(timeIntervalSince1970: 1_000)
+        )
+        await cache.commit(
+            oldSeed!,
+            cache: ConversationCacheLayers(
+                [trimmableCache(offset: oldTokens.count)],
+                retainedPagedKVSequence: oldRetained,
+                discardRetainedPagedKVSequence: { retained, key in
+                    try? await allocator.discardRetained(retained, conversationKey: key)
+                    let replacementSeed = await cache.begin(
+                        conversationKey: "conv:ttl-race",
+                        incomingTokens: newTokens,
+                        modelID: "model-a",
+                        kvBits: nil,
+                        now: Date(timeIntervalSince1970: 1_100)
+                    )
+                    await cache.commit(
+                        replacementSeed!,
+                        cache: ConversationCacheLayers([self.trimmableCache(offset: newTokens.count)]),
+                        fullTokens: newTokens,
+                        now: Date(timeIntervalSince1970: 1_100)
+                    )
+                    await replacementCommitted.markComplete()
+                }
+            ),
+            fullTokens: oldTokens,
+            now: Date(timeIntervalSince1970: 1_000)
+        )
+
+        let trigger = await cache.begin(
+            conversationKey: "conv:trigger",
+            incomingTokens: [1, 2, 3],
+            modelID: "model-a",
+            kvBits: nil,
+            now: Date(timeIntervalSince1970: 1_061)
+        )
+        await cache.abort(trigger!)
+        let didCommitReplacement = await replacementCommitted.isComplete
+        XCTAssertTrue(didCommitReplacement)
+
+        let hit = await cache.begin(
+            conversationKey: "conv:ttl-race",
+            incomingTokens: newTokens + [64],
+            modelID: "model-a",
+            kvBits: nil,
+            now: Date(timeIntervalSince1970: 1_100)
+        )
+        XCTAssertEqual(hit?.cachedPromptTokens, 64)
+        await cache.abort(hit!)
+    }
+
     func testLRUAndTokenCapEviction() async {
         let cache = ConversationCache(config: .init(maxConversations: 2, maxTokens: 10_000, ttlSeconds: 900))
         for index in 0..<3 {
@@ -128,8 +259,386 @@ final class ConversationCacheTests: XCTestCase {
         XCTAssertEqual(bytes, "hi µ".utf8.count)
     }
 
+    func testCommitReplacingConsumedRetainedHandleDoesNotDiscardNewOwner() async throws {
+        let allocator = try PagedKVBlockAllocator(blockSizeTokens: 4, maxPhysicalBlocks: 16)
+        let handle = try await allocator.allocate(
+            conversationKey: "conv:retained",
+            initialCapacityTokens: 64,
+            maxLogicalTokens: 80,
+            initialTokens: 64
+        )
+        let oldRetained = try await allocator.retain(handle)
+        let recorder = RetainedDiscardRecorder()
+        let cache = ConversationCache(config: .init(maxConversations: 8, maxTokens: 200_000, ttlSeconds: 900))
+        let seedTokens = int32Range(0..<64)
+        let seed = await cache.begin(
+            conversationKey: "conv:retained",
+            incomingTokens: seedTokens,
+            modelID: "model-a",
+            kvBits: nil
+        )
+        await cache.commit(
+            seed!,
+            cache: ConversationCacheLayers(
+                [trimmableCache(offset: seedTokens.count)],
+                retainedPagedKVSequence: oldRetained,
+                discardRetainedPagedKVSequence: { retained, _ in
+                    await recorder.record(retained)
+                }
+            ),
+            fullTokens: seedTokens
+        )
+
+        let hit = await cache.begin(
+            conversationKey: "conv:retained",
+            incomingTokens: seedTokens + [64],
+            modelID: "model-a",
+            kvBits: nil,
+            allowRetainedPagedKVHandoff: true
+        )
+        _ = try await allocator.reattach(oldRetained, conversationKey: "conv:retained", trimToLogicalTokens: 64)
+        let newRetained = try await allocator.retain(handle)
+        await cache.commit(
+            hit!,
+            cache: ConversationCacheLayers(
+                [trimmableCache(offset: 65)],
+                retainedPagedKVSequence: newRetained,
+                discardRetainedPagedKVSequence: { retained, _ in
+                    await recorder.record(retained)
+                }
+            ),
+            fullTokens: seedTokens + [64]
+        )
+
+        let discardCount = await recorder.count()
+        XCTAssertEqual(discardCount, 0)
+        let reattached = try await allocator.reattach(
+            newRetained,
+            conversationKey: "conv:retained",
+            trimToLogicalTokens: 64
+        )
+        try await allocator.release(reattached)
+    }
+
+    func testRetainedPagedKVRequiresExplicitHandoffOptIn() async throws {
+        let allocator = try PagedKVBlockAllocator(blockSizeTokens: 4, maxPhysicalBlocks: 16)
+        let retained = try await retainedSequence(
+            allocator: allocator,
+            conversationKey: "conv:handoff",
+            tokenCount: 64
+        )
+        let recorder = RetainedDiscardRecorder()
+        let cache = ConversationCache(config: .init(maxConversations: 8, maxTokens: 200_000, ttlSeconds: 900))
+        let seedTokens = int32Range(0..<64)
+        let seed = await cache.begin(
+            conversationKey: "conv:handoff",
+            incomingTokens: seedTokens,
+            modelID: "model-a",
+            kvBits: nil
+        )
+        await cache.commit(
+            seed!,
+            cache: ConversationCacheLayers(
+                [trimmableCache(offset: seedTokens.count)],
+                retainedPagedKVSequence: retained,
+                discardRetainedPagedKVSequence: { retained, key in
+                    await recorder.record(retained)
+                    try? await allocator.discardRetained(retained, conversationKey: key)
+                }
+            ),
+            fullTokens: seedTokens
+        )
+
+        let hit = await cache.begin(
+            conversationKey: "conv:handoff",
+            incomingTokens: seedTokens + [64],
+            modelID: "model-a",
+            kvBits: nil
+        )
+
+        XCTAssertEqual(hit?.cachedPromptTokens, 0)
+        let discardCount = await recorder.count()
+        XCTAssertEqual(discardCount, 1)
+        await cache.abort(hit!)
+        await assertRetainedSequenceDiscarded(retained, allocator: allocator, conversationKey: "conv:handoff")
+    }
+
+    func testPurgeHotDiscardsRetainedPagedKVOwner() async throws {
+        let allocator = try PagedKVBlockAllocator(blockSizeTokens: 4, maxPhysicalBlocks: 16)
+        let retained = try await retainedSequence(
+            allocator: allocator,
+            conversationKey: "conv:purge",
+            tokenCount: 64
+        )
+        let recorder = RetainedDiscardRecorder()
+        let cache = ConversationCache(config: .init(maxConversations: 8, maxTokens: 200_000, ttlSeconds: 900))
+        let tokens = int32Range(0..<64)
+        let seed = await cache.begin(
+            conversationKey: "conv:purge",
+            incomingTokens: tokens,
+            modelID: "model-a",
+            kvBits: nil
+        )
+        await cache.commit(
+            seed!,
+            cache: ConversationCacheLayers(
+                [trimmableCache(offset: tokens.count)],
+                retainedPagedKVSequence: retained,
+                discardRetainedPagedKVSequence: { retained, key in
+                    await recorder.record(retained)
+                    try? await allocator.discardRetained(retained, conversationKey: key)
+                }
+            ),
+            fullTokens: tokens
+        )
+
+        let hadHot = await cache.purgeHot(conversationKey: "conv:purge")
+
+        XCTAssertTrue(hadHot)
+        let discardCount = await recorder.count()
+        XCTAssertEqual(discardCount, 1)
+        await assertRetainedSequenceDiscarded(retained, allocator: allocator, conversationKey: "conv:purge")
+    }
+
+    func testFencedCommitDiscardsNewRetainedPagedKVOwner() async throws {
+        let allocator = try PagedKVBlockAllocator(blockSizeTokens: 4, maxPhysicalBlocks: 16)
+        let retained = try await retainedSequence(
+            allocator: allocator,
+            conversationKey: "conv:fenced",
+            tokenCount: 64
+        )
+        let recorder = RetainedDiscardRecorder()
+        let cache = ConversationCache(config: .init(maxConversations: 8, maxTokens: 200_000, ttlSeconds: 900))
+        let tokens = int32Range(0..<64)
+        let lease = await cache.begin(
+            conversationKey: "conv:fenced",
+            incomingTokens: tokens,
+            modelID: "model-a",
+            kvBits: nil
+        )
+        _ = await cache.purgeHot(conversationKey: "conv:fenced")
+
+        await cache.commit(
+            lease!,
+            cache: ConversationCacheLayers(
+                [trimmableCache(offset: tokens.count)],
+                retainedPagedKVSequence: retained,
+                discardRetainedPagedKVSequence: { retained, key in
+                    await recorder.record(retained)
+                    try? await allocator.discardRetained(retained, conversationKey: key)
+                }
+            ),
+            fullTokens: tokens
+        )
+
+        let discardCount = await recorder.count()
+        XCTAssertEqual(discardCount, 1)
+        await assertRetainedSequenceDiscarded(retained, allocator: allocator, conversationKey: "conv:fenced")
+    }
+
+    func testCommitFencedDuringReplacementDiscardDoesNotPublishOrLeakNewRetainedOwner() async throws {
+        let allocator = try PagedKVBlockAllocator(blockSizeTokens: 4, maxPhysicalBlocks: 64)
+        let oldRetained = try await retainedSequence(
+            allocator: allocator,
+            conversationKey: "conv:commit-race",
+            tokenCount: 64
+        )
+        let newRetained = try await retainedSequence(
+            allocator: allocator,
+            conversationKey: "conv:commit-race",
+            tokenCount: 65
+        )
+        let oldDiscardGate = RetainedDiscardGate()
+        let newRecorder = RetainedDiscardRecorder()
+        let cache = ConversationCache(config: .init(maxConversations: 8, maxTokens: 200_000, ttlSeconds: 900))
+        let seedTokens = int32Range(0..<64)
+        let seed = await cache.begin(
+            conversationKey: "conv:commit-race",
+            incomingTokens: seedTokens,
+            modelID: "model-a",
+            kvBits: nil
+        )
+        await cache.commit(
+            seed!,
+            cache: ConversationCacheLayers(
+                [trimmableCache(offset: seedTokens.count)],
+                retainedPagedKVSequence: oldRetained,
+                discardRetainedPagedKVSequence: { retained, key in
+                    try? await allocator.discardRetained(retained, conversationKey: key)
+                    await oldDiscardGate.pauseUntilReleased()
+                }
+            ),
+            fullTokens: seedTokens
+        )
+
+        let staleLease = ConversationCacheLease(
+            key: "conv:commit-race",
+            keyHash: "commit-race",
+            incomingTokens: seedTokens + [64],
+            modelID: "model-a",
+            kvBits: nil,
+            reusableCache: nil,
+            cachedPromptTokens: 0,
+            lcp: 0,
+            trimBy: 0,
+            localPurgeStamp: 0,
+            globalPurgeStamp: 0
+        )
+        let commitTask = Task {
+            await cache.commit(
+                staleLease,
+                cache: ConversationCacheLayers(
+                    [self.trimmableCache(offset: seedTokens.count + 1)],
+                    retainedPagedKVSequence: newRetained,
+                    discardRetainedPagedKVSequence: { retained, key in
+                        await newRecorder.record(retained)
+                        try? await allocator.discardRetained(retained, conversationKey: key)
+                    }
+                ),
+                fullTokens: seedTokens + [64]
+            )
+        }
+        await oldDiscardGate.waitUntilPaused()
+        _ = await cache.purgeHot(conversationKey: "conv:commit-race")
+        await oldDiscardGate.release()
+        await commitTask.value
+
+        let stats = await cache.snapshotStats()
+        XCTAssertEqual(stats.entries, 0)
+        let newDiscardCount = await newRecorder.count()
+        XCTAssertEqual(newDiscardCount, 1)
+        await assertRetainedSequenceDiscarded(newRetained, allocator: allocator, conversationKey: "conv:commit-race")
+    }
+
+    func testCommitFencedDuringLimitEnforcementSkipsColdPersist() async throws {
+        let allocator = try PagedKVBlockAllocator(blockSizeTokens: 4, maxPhysicalBlocks: 32)
+        let victimRetained = try await retainedSequence(
+            allocator: allocator,
+            conversationKey: "conv:victim",
+            tokenCount: 64
+        )
+        let currentRetained = try await retainedSequence(
+            allocator: allocator,
+            conversationKey: "conv:cold-race",
+            tokenCount: 64
+        )
+        let victimDiscardGate = RetainedDiscardGate()
+        let currentRecorder = RetainedDiscardRecorder()
+        let coldTier = FakeConversationColdTier()
+        let cache = ConversationCache(
+            config: .init(maxConversations: 1, maxTokens: 200_000, ttlSeconds: 900),
+            coldTier: coldTier
+        )
+        let victimTokens = int32Range(0..<64)
+        let victimSeed = await cache.begin(
+            conversationKey: "conv:victim",
+            incomingTokens: victimTokens,
+            modelID: "model-a",
+            kvBits: nil,
+            now: Date(timeIntervalSince1970: 1_000)
+        )
+        await cache.commit(
+            victimSeed!,
+            cache: ConversationCacheLayers(
+                [trimmableCache(offset: victimTokens.count)],
+                retainedPagedKVSequence: victimRetained,
+                discardRetainedPagedKVSequence: { retained, key in
+                    try? await allocator.discardRetained(retained, conversationKey: key)
+                    await victimDiscardGate.pauseUntilReleased()
+                }
+            ),
+            fullTokens: victimTokens,
+            now: Date(timeIntervalSince1970: 1_000)
+        )
+
+        let currentTokens = int32Range(100..<164)
+        let currentLease = await cache.begin(
+            conversationKey: "conv:cold-race",
+            incomingTokens: currentTokens,
+            modelID: "model-a",
+            kvBits: nil,
+            now: Date(timeIntervalSince1970: 1_100),
+            cold: coldContext(eligible: true)
+        )
+        let commitTask = Task {
+            await cache.commit(
+                currentLease!,
+                cache: ConversationCacheLayers(
+                    [self.trimmableCache(offset: currentTokens.count)],
+                    retainedPagedKVSequence: currentRetained,
+                    discardRetainedPagedKVSequence: { retained, key in
+                        await currentRecorder.record(retained)
+                        try? await allocator.discardRetained(retained, conversationKey: key)
+                    }
+                ),
+                fullTokens: currentTokens,
+                now: Date(timeIntervalSince1970: 1_100),
+                cold: self.coldContext(eligible: true)
+            )
+        }
+        await victimDiscardGate.waitUntilPaused()
+        _ = await cache.purgeHot(conversationKey: "conv:cold-race")
+        await victimDiscardGate.release()
+        await commitTask.value
+
+        let currentDiscardCount = await currentRecorder.count()
+        XCTAssertEqual(currentDiscardCount, 1)
+        XCTAssertEqual(coldTier.captureCount, 0)
+        XCTAssertEqual(coldTier.enqueueCount, 0)
+        await assertRetainedSequenceDiscarded(currentRetained, allocator: allocator, conversationKey: "conv:cold-race")
+    }
+
+    private func coldContext(eligible: Bool) -> ConversationColdContext {
+        ConversationColdContext(
+            eligible: eligible,
+            identity: KVIdentityCore(
+                requestModel: "model-a",
+                servedModelID: "model-a",
+                modelSHA256: String(repeating: "b", count: 64),
+                catalogRevision: "r",
+                tokenizerID: "model-a",
+                tokenizerConfigSHA256: String(repeating: "c", count: 64),
+                chatTemplateSHA256: String(repeating: "d", count: 64),
+                kvBits: nil,
+                kvGroupSize: nil,
+                kvQuantMode: nil,
+                kvQuantPolicy: nil
+            )
+        )
+    }
+
     private func int32Range(_ range: Range<Int>) -> [Int32] {
         range.map(Int32.init)
+    }
+
+    private func retainedSequence(
+        allocator: PagedKVBlockAllocator,
+        conversationKey: String,
+        tokenCount: Int
+    ) async throws -> PagedKVRetainedSequence {
+        let handle = try await allocator.allocate(
+            conversationKey: conversationKey,
+            initialCapacityTokens: tokenCount,
+            maxLogicalTokens: tokenCount + 16,
+            initialTokens: tokenCount
+        )
+        return try await allocator.retain(handle)
+    }
+
+    private func assertRetainedSequenceDiscarded(
+        _ retained: PagedKVRetainedSequence,
+        allocator: PagedKVBlockAllocator,
+        conversationKey: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        do {
+            _ = try await allocator.reattach(retained, conversationKey: conversationKey)
+            XCTFail("retained sequence was still reattachable", file: file, line: line)
+        } catch PagedKVAllocatorError.unknownHandle {
+        } catch {
+            XCTFail("unexpected retained sequence error: \(error)", file: file, line: line)
+        }
     }
 
     private func trimmableCache(offset: Int) -> KVCacheSimple {
@@ -143,4 +652,142 @@ final class ConversationCacheTests: XCTestCase {
         cache.offset = offset
         return cache
     }
+}
+
+private actor RetainedDiscardRecorder {
+    private var retained: [PagedKVRetainedSequence] = []
+
+    func record(_ sequence: PagedKVRetainedSequence) {
+        retained.append(sequence)
+    }
+
+    func count() -> Int {
+        retained.count
+    }
+}
+
+private actor CacheCompletionFlag {
+    private(set) var isComplete = false
+
+    func markComplete() {
+        isComplete = true
+    }
+}
+
+private actor RetainedDiscardGate {
+    private var paused = false
+    private var released = false
+    private var pausedWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func waitUntilPaused() async {
+        if paused { return }
+        await withCheckedContinuation { continuation in
+            pausedWaiters.append(continuation)
+        }
+    }
+
+    func pauseUntilReleased() async {
+        paused = true
+        let waiters = pausedWaiters
+        pausedWaiters.removeAll()
+        waiters.forEach { $0.resume() }
+        if released { return }
+        await withCheckedContinuation { continuation in
+            releaseWaiters.append(continuation)
+        }
+    }
+
+    func release() {
+        released = true
+        let waiters = releaseWaiters
+        releaseWaiters.removeAll()
+        waiters.forEach { $0.resume() }
+    }
+}
+
+private final class FakeConversationColdTier: ConversationColdTier, @unchecked Sendable {
+    private let lock = NSLock()
+    private var captures: [ConversationColdSnapshot] = []
+    private var enqueues: [ConversationColdSnapshot] = []
+
+    var captureCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return captures.count
+    }
+
+    var enqueueCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return enqueues.count
+    }
+
+    func sampledPurgeGeneration(conversationKey: String) async -> Int { 0 }
+
+    func promoteCandidate(conversationKey: String, identity: KVIdentityCore) async -> ColdPromotionCandidate? { nil }
+
+    func finishPromotion(_ candidate: ColdPromotionCandidate, accepted: Bool, rejectionReason: String?) async {}
+
+    func captureSnapshot(
+        conversationKey: String,
+        layers: ConversationCacheLayers,
+        fullTokens: [Int32],
+        sampledPurgeGeneration: Int,
+        identity: KVIdentityCore,
+        nowMillis: Int
+    ) -> ConversationColdSnapshot? {
+        let snapshot = ConversationColdSnapshot(
+            rawKey: conversationKey,
+            tokens: fullTokens,
+            layers: [],
+            identity: Self.writeIdentity,
+            sampledPurgeGeneration: sampledPurgeGeneration,
+            commitSequence: captures.count + 1,
+            createdAtMillis: nowMillis,
+            eligibleUntilMillis: nowMillis,
+            incarnation: "test"
+        )
+        lock.lock()
+        captures.append(snapshot)
+        lock.unlock()
+        return snapshot
+    }
+
+    func enqueuePersist(_ snapshot: ConversationColdSnapshot) {
+        lock.lock()
+        enqueues.append(snapshot)
+        lock.unlock()
+    }
+
+    func cancelPendingPersist(conversationKey: String) async -> Bool { false }
+
+    func cancelPendingPersists() async {}
+
+    func drainPendingPersists(timeoutSeconds: Int) async {}
+
+    func noteReadIdentityUnavailable(conversationKey: String) async {}
+
+    func noteWriteSkippedIdentityUnavailable(conversationKey: String) async {}
+
+    private static let writeIdentity = KVWriteIdentity(
+        requestModel: "model-a",
+        servedModelID: "model-a",
+        modelSHA256: String(repeating: "b", count: 64),
+        catalogRevision: "r",
+        tokenizerID: "model-a",
+        tokenizerConfigSHA256: String(repeating: "c", count: 64),
+        chatTemplateSHA256: String(repeating: "d", count: 64),
+        abiEpoch: 1,
+        mlxSwiftLMRevision: "x",
+        mlxVersion: "y",
+        cacheClass: "KVCacheSimple",
+        layerCount: 1,
+        kvBits: nil,
+        kvGroupSize: nil,
+        kvQuantMode: nil,
+        kvQuantPolicy: nil,
+        decodePath: "ordinary",
+        keyEpoch: 1
+    )
 }

--- a/phase3-binary/Tests/macprovider-cliTests/PagedKVRuntimeBridgeTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/PagedKVRuntimeBridgeTests.swift
@@ -40,6 +40,7 @@ final class PagedKVRuntimeBridgeTests: XCTestCase {
             pagedKVConfig: PagedKVConfig(enabled: true, blockSizeTokens: 32, maxPhysicalBlocks: 64),
             maxBatch: 2,
             continuousBatchingMode: .on,
+            continuousBatchingDurableReplayAuthorityAvailable: true,
             warmSwapEnabled: false,
             pagedKVObservedRuntimeIdentity: observedIdentity,
             pagedKVHardwareSizingProof: proof,
@@ -361,6 +362,7 @@ final class PagedKVRuntimeBridgeTests: XCTestCase {
             pagedKVConfig: PagedKVConfig(enabled: true, blockSizeTokens: 32, maxPhysicalBlocks: 64),
             maxBatch: 2,
             continuousBatchingMode: .on,
+            continuousBatchingDurableReplayAuthorityAvailable: true,
             warmSwapEnabled: false,
             pagedKVObservedRuntimeIdentity: Self.observedIdentity(from: proof),
             pagedKVHardwareSizingProof: proof,
@@ -651,25 +653,24 @@ final class PagedKVRuntimeBridgeTests: XCTestCase {
         }
     }
 
-    func testStickyRequestsRemainRejectedBeforeFRPKV10CacheBridge() async throws {
-        let backend = RuntimeBridgeScriptedBackend(scripts: [:])
+    func testConversationKeyWithoutRetainedHandoffRunsAsFreshSchedulerRow() async throws {
+        let backend = RuntimeBridgeScriptedBackend(scripts: ["keyed": [7]])
         let scheduler = try Self.makeScheduler(maxActiveRows: 2, backend: backend)
 
-        do {
-            _ = try await scheduler.submit(.init(
-                id: "sticky",
-                conversationKey: "conversation-1",
-                promptTokens: [1],
-                maxOutputTokens: 1,
-                temperature: 0.0,
-                topP: 1.0
-            ))
-            XCTFail("sticky requests must not enter the Increment 1 batch path")
-        } catch ContinuousBatchSchedulerError.unsupported(let reason) {
-            XCTAssertEqual(reason, "keyed_or_sticky_cache_reuse_deferred_until_paged_kv_cache_bridge")
-        }
+        let result = try await scheduler.submit(.init(
+            id: "keyed",
+            conversationKey: "conversation-1",
+            promptTokens: [1],
+            maxOutputTokens: 1,
+            temperature: 0.0,
+            topP: 1.0
+        ))
         let decodeCallCount = await backend.decodeCallCount()
-        XCTAssertEqual(decodeCallCount, 0)
+        XCTAssertEqual(result.terminalStatus, .length)
+        XCTAssertEqual(result.conversationKey, "conversation-1")
+        XCTAssertEqual(result.cachedPromptTokens, 0)
+        XCTAssertEqual(result.outputTokens, [7])
+        XCTAssertEqual(decodeCallCount, 1)
     }
 
     private static func makeScheduler(
@@ -817,6 +818,7 @@ final class PagedKVRuntimeBridgeTests: XCTestCase {
             pagedKVConfig: PagedKVConfig(enabled: true, blockSizeTokens: 32, maxPhysicalBlocks: 64),
             maxBatch: 2,
             continuousBatchingMode: .on,
+            continuousBatchingDurableReplayAuthorityAvailable: true,
             warmSwapEnabled: false,
             pagedKVObservedRuntimeIdentity: Self.observedIdentity(from: proof),
             pagedKVHardwareSizingProof: proof,

--- a/phase3-binary/Tests/macprovider-cliTests/ServingKnobsConfigTests.swift
+++ b/phase3-binary/Tests/macprovider-cliTests/ServingKnobsConfigTests.swift
@@ -575,6 +575,79 @@ final class ServingKnobsConfigTests: XCTestCase {
         XCTAssertNoThrow(try ServeCommand.runContinuousBatchingPreflight(config))
     }
 
+    func testCanarySerialRoutesCachedHitWithoutRetainedPagedHandoff() {
+        XCTAssertTrue(ModelRuntime.canaryShouldSerialRouteCachedHitMissingRetainedHandoff(
+            mode: .canary,
+            cachedPromptTokens: 32,
+            hasRetainedPagedKVHandoff: false
+        ))
+        XCTAssertFalse(ModelRuntime.canaryShouldSerialRouteCachedHitMissingRetainedHandoff(
+            mode: .on,
+            cachedPromptTokens: 32,
+            hasRetainedPagedKVHandoff: false
+        ))
+        XCTAssertFalse(ModelRuntime.canaryShouldSerialRouteCachedHitMissingRetainedHandoff(
+            mode: .canary,
+            cachedPromptTokens: 0,
+            hasRetainedPagedKVHandoff: false
+        ))
+        XCTAssertFalse(ModelRuntime.canaryShouldSerialRouteCachedHitMissingRetainedHandoff(
+            mode: .canary,
+            cachedPromptTokens: 32,
+            hasRetainedPagedKVHandoff: true
+        ))
+
+        let capability = ContinuousBatchingCapability(
+            mode: .canary,
+            maxActiveRows: 2,
+            queueLimit: 4,
+            descriptor: nil,
+            unsupportedReason: .stickyCacheHandoffUnavailable
+        )
+        XCTAssertEqual(
+            ContinuousBatchingPolicy.serialRouteTelemetryLine(capability),
+            "event=batching_unsupported action=serial_routed reason=sticky_cache_handoff_unavailable\n"
+        )
+    }
+
+    func testRuntimePolicyKeepsConversationKeysOutOfCurrentBatchingRollout() {
+        let canaryCapability = ContinuousBatchingPolicy.capability(
+            mode: .canary,
+            maxBatch: 2,
+            queueLimit: nil,
+            kvBits: nil,
+            draftConfigured: false,
+            requestHasConversationKey: true,
+            schedulerBackendAvailable: true,
+            pagedKVDecision: .attached(Self.pagedKVDescriptor()),
+            requestedTuple: Self.continuousBatchingTuple()
+        )
+        XCTAssertEqual(canaryCapability.unsupportedReason, .conversationKeyRolloutUnavailable)
+        XCTAssertTrue(canaryCapability.shouldUseSerialPath)
+        XCTAssertEqual(
+            ContinuousBatchingPolicy.serialRouteTelemetryLine(canaryCapability),
+            "event=batching_unsupported action=serial_routed reason=conversation_key_rollout_unavailable\n"
+        )
+
+        let strictCapability = ContinuousBatchingPolicy.capability(
+            mode: .on,
+            maxBatch: 2,
+            queueLimit: nil,
+            kvBits: nil,
+            draftConfigured: false,
+            requestHasConversationKey: true,
+            schedulerBackendAvailable: true,
+            pagedKVDecision: .attached(Self.pagedKVDescriptor()),
+            requestedTuple: Self.continuousBatchingTuple()
+        )
+        XCTAssertEqual(strictCapability.unsupportedReason, .conversationKeyRolloutUnavailable)
+        XCTAssertThrowsError(try ContinuousBatchingPolicy.validateStrictStartup(strictCapability)) { error in
+            let apiError = error as? APIError
+            XCTAssertEqual(apiError?.status, 400)
+            XCTAssertEqual(apiError?.code, "continuous_batching_conversation_key_rollout_unavailable")
+        }
+    }
+
     func testContinuousBatchingPolicyReportsKvBitsBeforeLocalCapability() {
         let capability = ContinuousBatchingPolicy.capability(
             mode: .on,
@@ -692,19 +765,59 @@ final class ServingKnobsConfigTests: XCTestCase {
         XCTAssertTrue(rejected.shouldUseSerialPath)
     }
 
-    func testStickyCacheEligibleRequestSerialRoutesUntilBridgeExists() {
+    func testStickyCacheEligibleRequestUsesLocalCapabilityGateAfterFRPKV10() {
+        let descriptor = PagedKVDescriptor(
+            blockSizeTokens: 16,
+            maxPhysicalBlocks: 32,
+            modelID: "catalog/model",
+            modelSHA256: String(repeating: "a", count: 64),
+            tokenizerSHA256: String(repeating: "b", count: 64),
+            chatTemplateSHA256: String(repeating: "c", count: 64),
+            supportedModelFamilies: ["qwen"],
+            supportsMoEDispatch: false,
+            hardwareClass: "m4-max-64gb",
+            metallibSHA256: String(repeating: "d", count: 64),
+            kernelIdentifier: "paged-attention-v1",
+            parityLabel: "dense-greedy-parity"
+        )
+        let tuple = ContinuousBatchingRequestedTuple(
+            modelID: descriptor.modelID,
+            modelSHA256: descriptor.modelSHA256,
+            tokenizerSHA256: descriptor.tokenizerSHA256,
+            chatTemplateSHA256: descriptor.chatTemplateSHA256,
+            cacheClass: "KVCacheSimple",
+            kvDType: .fp16,
+            requiresMoE: false,
+            hardwareClass: "m4-max-64gb",
+            metallibSHA256: descriptor.metallibSHA256,
+            kernelIdentifier: descriptor.kernelIdentifier,
+            parityLabel: descriptor.parityLabel,
+            poolEpoch: 1
+        )
+        let supported = ContinuousBatchingPolicy.capability(
+            mode: .canary,
+            maxBatch: 2,
+            queueLimit: nil,
+            kvBits: nil,
+            draftConfigured: false,
+            schedulerBackendAvailable: true,
+            pagedKVDecision: .attached(descriptor),
+            requestedTuple: tuple
+        )
+        XCTAssertNil(supported.unsupportedReason)
+        XCTAssertFalse(supported.shouldUseSerialPath)
+
         let capability = ContinuousBatchingPolicy.capability(
             mode: .canary,
             maxBatch: 2,
             queueLimit: nil,
             kvBits: nil,
             draftConfigured: false,
-            stickyCacheEligible: true,
             schedulerBackendAvailable: false,
             pagedKVDecision: .disabled,
             requestedTuple: nil
         )
-        XCTAssertEqual(capability.unsupportedReason, .stickyCacheBridgeUnavailable)
+        XCTAssertEqual(capability.unsupportedReason, .pagedKVDisabled)
         XCTAssertTrue(capability.shouldUseSerialPath)
     }
 
@@ -715,7 +828,6 @@ final class ServingKnobsConfigTests: XCTestCase {
             queueLimit: nil,
             kvBits: nil,
             draftConfigured: false,
-            stickyCacheEligible: false,
             requestStateRepresentable: false,
             schedulerBackendAvailable: true,
             pagedKVDecision: .disabled,
@@ -735,7 +847,6 @@ final class ServingKnobsConfigTests: XCTestCase {
             queueLimit: nil,
             kvBits: nil,
             draftConfigured: false,
-            stickyCacheEligible: false,
             requestStateRepresentable: false,
             schedulerBackendAvailable: true,
             pagedKVDecision: .disabled,
@@ -836,7 +947,6 @@ final class ServingKnobsConfigTests: XCTestCase {
             queueLimit: nil,
             kvBits: nil,
             draftConfigured: false,
-            stickyCacheEligible: false,
             requestStateRepresentable: true,
             schedulerBackendAvailable: false,
             pagedKVDecision: .disabled,
@@ -913,21 +1023,26 @@ final class ServingKnobsConfigTests: XCTestCase {
         }
     }
 
-    func testStrictOnRejectsStickyRequestWithoutCacheBridge() {
+    func testStrictOnRejectsStickyRequestWhenPagedKVUnavailable() {
         let capability = ContinuousBatchingPolicy.capability(
             mode: .on,
             maxBatch: 2,
             queueLimit: nil,
             kvBits: nil,
             draftConfigured: false,
-            stickyCacheEligible: true,
             schedulerBackendAvailable: false,
             pagedKVDecision: .disabled,
             requestedTuple: nil
         )
-        XCTAssertEqual(capability.unsupportedReason, .stickyCacheBridgeUnavailable)
+        XCTAssertEqual(capability.unsupportedReason, .pagedKVDisabled)
         XCTAssertFalse(capability.shouldUseSerialPath)
-        XCTAssertThrowsError(try ContinuousBatchingPolicy.validateStrictStartup(capability))
+        XCTAssertThrowsError(try ContinuousBatchingPolicy.validateStrictStartup(capability)) { error in
+            guard let apiError = error as? APIError else {
+                return XCTFail("expected APIError, got \(error)")
+            }
+            XCTAssertEqual(apiError.status, 503)
+            XCTAssertEqual(apiError.code, "continuous_batching_local_capability_unavailable")
+        }
         XCTAssertNil(ContinuousBatchingPolicy.serialRouteTelemetryLine(capability))
     }
 
@@ -1032,6 +1147,53 @@ final class ServingKnobsConfigTests: XCTestCase {
         }
     }
 
+    func testRuntimeCanarySerialRoutesConversationKeyBeforeSchedulerAdmission() async throws {
+        let runtime = ModelRuntime(
+            modelID: "fixture-model",
+            maxBatch: 2,
+            continuousBatchingMode: .canary,
+            warmSwapEnabled: false,
+            loader: { _ in throw TestRuntimeError.notExpected },
+            testCompletion: { _, _ in
+                CompletionResult(content: "ok", finishReason: "stop", promptTokens: 1, completionTokens: 1)
+            }
+        )
+        let request = try Self.request(model: "fixture-model", conversationKey: "conv:first-rollout-scope")
+        let handle = try await runtime.acquireRequestHandle(request)
+        do {
+            try await runtime.preflight(request, with: handle)
+            await runtime.unregisterInFlight(handle.registrationID)
+        } catch {
+            await runtime.unregisterInFlight(handle.registrationID)
+            throw error
+        }
+    }
+
+    func testRuntimeStrictRejectsConversationKeyBeforeSchedulerAdmission() async throws {
+        let runtime = ModelRuntime(
+            modelID: "fixture-model",
+            maxBatch: 2,
+            continuousBatchingMode: .on,
+            warmSwapEnabled: false,
+            loader: { _ in throw TestRuntimeError.notExpected },
+            testCompletion: { _, _ in
+                XCTFail("strict keyed continuous batching rejection must happen before inference")
+                return CompletionResult(content: "unexpected", finishReason: "stop", promptTokens: 1, completionTokens: 1)
+            }
+        )
+        let request = try Self.request(model: "fixture-model", conversationKey: "conv:first-rollout-scope")
+        let handle = try await runtime.acquireRequestHandle(request)
+        do {
+            try await runtime.preflight(request, with: handle)
+            await runtime.unregisterInFlight(handle.registrationID)
+            XCTFail("expected keyed continuous batching preflight rejection")
+        } catch let error as APIError {
+            await runtime.unregisterInFlight(handle.registrationID)
+            XCTAssertEqual(error.status, 400)
+            XCTAssertEqual(error.code, "continuous_batching_conversation_key_rollout_unavailable")
+        }
+    }
+
     func testRuntimeReceivesMaxBatch() async throws {
         let runtime = ModelRuntime(
             modelID: "test-model",
@@ -1103,6 +1265,7 @@ final class ServingKnobsConfigTests: XCTestCase {
             pagedKVConfig: PagedKVConfig(enabled: true, blockSizeTokens: 32, maxPhysicalBlocks: 64),
             maxBatch: 2,
             continuousBatchingMode: .on,
+            continuousBatchingDurableReplayAuthorityAvailable: true,
             warmSwapEnabled: false,
             pagedKVObservedRuntimeIdentity: observedIdentity,
             pagedKVHardwareSizingProof: proof,
@@ -1152,6 +1315,55 @@ final class ServingKnobsConfigTests: XCTestCase {
         XCTAssertNotNil(noBackendCapability.unsupportedReason)
     }
 
+    func testRuntimeContinuousBatchingRequiresDurableReplayAuthorityBeforeAttachCapability() async throws {
+        let modelID = "mlx-community/Qwen-Test"
+        let modelSHA = String(repeating: "a", count: 64)
+        let proof = PagedKVHardwareSizingProof(
+            modelID: modelID,
+            modelSHA256: modelSHA,
+            tokenizerSHA256: nil,
+            chatTemplateSHA256: nil,
+            modelFamily: "qwen",
+            hardwareClass: "apple-silicon-test",
+            metallibSHA256: String(repeating: "b", count: 64),
+            kernelIdentifier: "macprovider_paged_kv_gather_v1",
+            blockSizeTokens: 32,
+            maxPhysicalBlocks: 64,
+            maxResidentTokens: 2048,
+            parityLabel: "sdpa-parity-v1"
+        )
+        let observedIdentity = PagedKVObservedRuntimeIdentity(
+            hardwareClass: proof.hardwareClass,
+            metallibSHA256: proof.metallibSHA256,
+            kernelIdentifier: proof.kernelIdentifier,
+            parityLabel: proof.parityLabel,
+            moeDispatchProven: false,
+            poolEpoch: proof.poolEpoch,
+            source: .runtimeMeasurement
+        )
+        let runtime = ModelRuntime(
+            modelID: modelID,
+            modelHash: modelSHA,
+            pagedKVConfig: PagedKVConfig(enabled: true, blockSizeTokens: 32, maxPhysicalBlocks: 64),
+            maxBatch: 2,
+            continuousBatchingMode: .on,
+            warmSwapEnabled: false,
+            pagedKVObservedRuntimeIdentity: observedIdentity,
+            pagedKVHardwareSizingProof: proof,
+            pagedKVRuntimeCacheClass: "KVCacheSimple",
+            pagedKVSchedulerBackendInstalled: true,
+            continuousBatchingBackend: ServingKnobsContinuousBatchingBackend(),
+            loader: { _ in throw TestRuntimeError.notExpected }
+        )
+        let capability = await runtime.continuousBatchingCapabilityForTest()
+        XCTAssertEqual(capability.unsupportedReason, .durableReplayAuthorityUnavailable)
+        XCTAssertThrowsError(try ContinuousBatchingPolicy.validateStrictStartup(capability)) { error in
+            let apiError = error as? APIError
+            XCTAssertEqual(apiError?.status, 503)
+            XCTAssertEqual(apiError?.code, "continuous_batching_durable_replay_authority_unavailable")
+        }
+    }
+
     func testRuntimeDefaultMaxBatchIsOne() async throws {
         let runtime = ModelRuntime(
             modelID: "test-model",
@@ -1191,14 +1403,53 @@ final class ServingKnobsConfigTests: XCTestCase {
         XCTAssertNoThrow(try ModelRuntime.validatePromptTokenCount(4096, maxContextTokens: 4096))
     }
 
-    private static func request(model: String, stream: Bool = false) throws -> ChatCompletionRequest {
+    private static func pagedKVDescriptor() -> PagedKVDescriptor {
+        PagedKVDescriptor(
+            blockSizeTokens: 32,
+            maxPhysicalBlocks: 64,
+            modelID: "mlx-community/Qwen-Test",
+            modelSHA256: String(repeating: "a", count: 64),
+            tokenizerSHA256: nil,
+            chatTemplateSHA256: nil,
+            supportedModelFamilies: ["qwen"],
+            supportsMoEDispatch: false,
+            hardwareClass: "apple-silicon-test",
+            metallibSHA256: String(repeating: "b", count: 64),
+            kernelIdentifier: "macprovider_paged_kv_gather_v1",
+            parityLabel: "sdpa-parity-v1"
+        )
+    }
+
+    private static func continuousBatchingTuple() -> ContinuousBatchingRequestedTuple {
+        ContinuousBatchingRequestedTuple(
+            modelID: "mlx-community/Qwen-Test",
+            modelSHA256: String(repeating: "a", count: 64),
+            tokenizerSHA256: nil,
+            chatTemplateSHA256: nil,
+            cacheClass: "KVCacheSimple",
+            kvDType: .fp16,
+            requiresMoE: false,
+            hardwareClass: "apple-silicon-test",
+            metallibSHA256: String(repeating: "b", count: 64),
+            kernelIdentifier: "macprovider_paged_kv_gather_v1",
+            parityLabel: "sdpa-parity-v1",
+            poolEpoch: 1
+        )
+    }
+
+    private static func request(
+        model: String,
+        stream: Bool = false,
+        conversationKey: String? = nil
+    ) throws -> ChatCompletionRequest {
         let body: [String: Any] = [
             "model": model,
             "messages": [["role": "user", "content": "Say hi"]],
             "max_tokens": 1,
             "stream": stream,
         ]
-        return try ChatCompletionRequest.parse(data: try JSONSerialization.data(withJSONObject: body))
+        let parsed = try ChatCompletionRequest.parse(data: try JSONSerialization.data(withJSONObject: body))
+        return parsed.withConversationKey(conversationKey)
     }
 }
 


### PR DESCRIPTION
Closes #1477.

## Summary

- Wire retained FR-PKV10 paged KV handoff through the continuous batch scheduler for conversation-keyed sticky hits under injected test capability.
- Preserve key isolation, token-granular LCP/trim, terminal retained-cache ownership, and AC-19 cached-token parity while keeping production runtime default-off/keyless-first.
- Add durable replay authority gating evidence to the enablement runbook so sticky/cross-turn code cannot be treated as canary/on permission.

## Tests

- `swift test --quiet --filter ContinuousBatchSchedulerTests` (60 executed, 4 skipped: host lacks MLX default metallib)
- `swift test --quiet --filter ServingKnobsConfigTests` (72 executed, 0 failures)
- `swift test --quiet --filter PagedKVRuntimeBridgeTests` (12 executed, 8 skipped: host lacks MLX default metallib)
- `swift test --quiet --filter ConversationCacheTests` (18 executed, 0 failures)
- `swift test --quiet --filter PagedKVEngineTests` (33 executed, 0 failures)
- `swift test --quiet --filter KVConversationColdTierTests` (25 executed, 2 skipped: MLX-gated tests)
- `git diff --check`
- stale deferral-string scan over phase3 sources/tests and continuous batching runbook

## Governance

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "issue": "https://github.com/Augustas11/macprovider/issues/1477",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-038"],
  "requirements": ["SPEC-038-R004", "SPEC-038-R006"],
  "authority_domains": ["continuous-batching-serving"],
  "arbitration": ["CODE_BUG"],
  "tests": [
    "swift test --quiet --filter ContinuousBatchSchedulerTests",
    "swift test --quiet --filter ServingKnobsConfigTests",
    "swift test --quiet --filter PagedKVRuntimeBridgeTests",
    "swift test --quiet --filter ConversationCacheTests",
    "swift test --quiet --filter PagedKVEngineTests",
    "swift test --quiet --filter KVConversationColdTierTests",
    "git diff --check",
    "rg stale continuous batching deferral strings"
  ],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END
