### PR TITLE
spec(byom): SPEC-047 v0.1.9 — offer_rejected reserved/unreachable, journey contract reconciled (#1486)

### DIFF
--- a/audits/2026-09-12-spec047-offer-rejected/AUDIT_SPEC047_OFFER_REJECTED.md
+++ b/audits/2026-09-12-spec047-offer-rejected/AUDIT_SPEC047_OFFER_REJECTED.md
@@ -1,0 +1,23 @@
+# SPEC-047 v0.1.9 — offer_rejected reconciliation audit (2026-09-12)
+
+Change: reconcile the `offer_rejected` state (stated unreachable since v0.1.5, no coordinator origin appends it) with SPEC-047-R001 and the JOURNEY-NETWORK-MODEL-ADMISSION evidence contract. Prompted by #1486 (slice-7 capture) where the contributor found the journey required proving a rejected→re-offer path the coordinator cannot produce.
+
+Three codex lanes over `AUDIT_SPEC047_OFFER_REJECTED_PROMPT.md`.
+
+| Lane | R1 C/H/M/L | R2 C/H/M/L |
+|---|---|---|
+| code-reviewer | 0/0/2/2 | 0/0/0/L |
+| security-reviewer | 0/0/1/2 | 0/0/0/0 |
+| architect | 0/1/1/0 | 0/0/0/0 |
+
+All three lanes independently CONFIRMED the reachability premise: operator decisions whitelist only the five non-rejected targets, failed synthetic probes append `revoked` (not `offer_rejected`), and no provider/coordinator append helper targets `offer_rejected`. The reconciliation direction (mark reserved/unreachable, drop the unprovable journey observation) is correct.
+
+R1 findings (all "adjacent file missed", fixed in `8d06f229`):
+- HIGH (arch) / MEDIUM (sec): `journeys/JOURNEY-NETWORK-MODEL-ADMISSION.md` step 11 + observation list still required the rejected path and `rejected_reoffer_required_fresh_evidence` — updated to keep only the reachable withdrawn/revoked re-entry proofs.
+- MEDIUM (code/sec): the admission fixture's step-03 capture asserted a coordinator `offer_rejected` status — replaced with a `local_default` opaque-endpoint refusal (capture renamed, step assertion corrected), which also fixes a pre-existing mislabel (an opaque endpoint is refused by the CLI builder before coordinator contact).
+- MEDIUM (code): SPEC-047 embedded JSON metadata version still 0.1.8 → 0.1.9.
+- LOW: changelog spelled out `withdrawn_reoffer_required_fresh_evidence`; CONFORMANCE gap rationale notes v0.1.9.
+
+R2: 0 C / 0 H / 0 M on all three lanes. Bar met.
+
+The R001/R006 fresh-evidence-on-re-entry invariant remains proven by the reachable `withdrawn` and `revoked` re-entry observations; `offer_rejected` stays in the closed enum (SPEC-044/SPEC-046/transition map) for wire compatibility, reserved and unreachable in v0.2.

--- a/audits/2026-09-12-spec047-offer-rejected/AUDIT_SPEC047_OFFER_REJECTED_PROMPT.md
+++ b/audits/2026-09-12-spec047-offer-rejected/AUDIT_SPEC047_OFFER_REJECTED_PROMPT.md
@@ -1,0 +1,21 @@
+# Audit — SPEC-047 v0.1.9: reconcile `offer_rejected` unreachability with the journey evidence contract (#1486, #1453 slice 7)
+
+METHOD CONSTRAINT: SPEC + governance review. Do NOT modify or commit the worktree. Review the FULL diff `git diff origin/main -- specs scripts` in this worktree against the governing text. Quote what you object to with file:line. Do not read other `audits/` files; form your own view.
+
+## What changed and why
+A slice-7 contributor building the JOURNEY-NETWORK-MODEL-ADMISSION capture driver found that the journey's promotable observation `rejected_reoffer_required_fresh_evidence` (must be TRUE) cannot be produced by a real v0.2 coordinator: SPEC-047's own v0.1.5 changelog states `offer_rejected` is "stated unreachable" and no coordinator origin appends it (a failed synthetic probe yields `revoked (synthetic_probe_failed)`, not `offer_rejected`). SPEC-047-R001 nonetheless listed `offer_rejected` as if exercised, and the governance journey contract required proving a rejected→re-offer path. This is an internal SPEC-047 contradiction.
+
+The reconciliation (v0.1.9):
+- SPEC-047-R001 keeps `offer_rejected` in the closed state enum for wire compatibility but states normatively it is RESERVED and unreachable in v0.2 (no origin appends it); its re-entry edge is listed for enum completeness, not exercised.
+- The governance module drops `rejected_reoffer_required_fresh_evidence` from `NETWORK_MODEL_ADMISSION_TRUE_OBSERVATIONS`; the fixture and the evidence test drop it and the step-11 assertion text; `withdrawn_reoffer_required_fresh_evidence` and `revoked_reoffer_required_fresh_evidence` remain and continue to prove the R001/R006 fresh-evidence-on-re-entry invariant.
+- CONFORMANCE SPEC-047 → 0.1.9; README regenerated.
+
+## Invariants to challenge
+- Is `offer_rejected` truly unreachable in v0.2 (grep the coordinator for any append origin), making the removed observation genuinely unprovable rather than merely unimplemented? If some path DOES reach it, this reconciliation is wrong.
+- Does dropping `rejected_reoffer_required_fresh_evidence` weaken what the signed journey attests about the R001/R006 fresh-evidence-on-re-entry rule, given `withdrawn` and `revoked` re-entry remain proven? Is the fresh-evidence invariant still fully covered?
+- Any dangling reference to the removed observation (step→requirement map, promotable set, fixture, tests, CONFORMANCE, other specs, SPEC-044/046 enums)? Is the closed enum still internally consistent (SPEC-044, SPEC-046, the transition map keep `offer_rejected`)?
+- Is R001's new "reserved/unreachable" wording consistent with the transition table row, the re-entry sentence, and the v0.1.5 changelog it cites? Does it contradict SPEC-044-R... or SPEC-046-R003 which still list `offer_rejected` as a presentable state?
+- Version/changelog/CONFORMANCE hygiene: is the bump correct, the changelog entry accurate, and does the journey step count / observation count stay consistent everywhere it is asserted?
+
+## Lanes to report (this pass is: {{LANE}})
+CRITICAL / HIGH / MEDIUM / LOW / INFO; bar 0 C / 0 H / 0 M. For each finding: severity, the quoted sentence, file:line, why it fails, the minimal edit. End with a table of counts per severity.

--- a/journeys/JOURNEY-NETWORK-MODEL-ADMISSION.md
+++ b/journeys/JOURNEY-NETWORK-MODEL-ADMISSION.md
@@ -65,9 +65,9 @@ The signed result MUST contain these passing steps:
    state meaning, next action, and the distinction between "not earning-eligible
    yet; catalog/receipt path exists" and "no earning path exists in this release".
 11. `step-11-transition-validity` - Attempt at least one invalid transition
-   outside the SPEC-047 matrix, one valid rejected-offer/re-offer path, one valid
-   withdrawal/re-offer path, and one valid revocation/re-offer path; confirm
-   invalid transitions are rejected and re-entry requires refreshed
+   outside the SPEC-047 matrix, one valid withdrawal/re-offer path, and one valid
+   revocation/re-offer path; confirm invalid transitions are rejected and re-entry
+   requires refreshed
    provider-signed evidence.
 12. `step-12-redaction-review` - Review offer packages, coordinator events,
    status, logs, and evidence artifacts for secret, prompt, completion, path,
@@ -110,7 +110,6 @@ The redacted evidence and signed result MUST set these booleans to `true`:
 - `synthetic_probe_used_provider_channel`
 - `settlement_capable_case_verified`
 - `transition_matrix_enforced`
-- `rejected_reoffer_required_fresh_evidence`
 - `withdrawn_reoffer_required_fresh_evidence`
 - `revoked_reoffer_required_fresh_evidence`
 - `withdrawal_verified`

--- a/scripts/check_spec_governance.py
+++ b/scripts/check_spec_governance.py
@@ -490,7 +490,6 @@ NETWORK_MODEL_ADMISSION_TRUE_OBSERVATIONS = {
     "synthetic_probe_used_provider_channel",
     "settlement_capable_case_verified",
     "transition_matrix_enforced",
-    "rejected_reoffer_required_fresh_evidence",
     "withdrawn_reoffer_required_fresh_evidence",
     "revoked_reoffer_required_fresh_evidence",
     "withdrawal_verified",

--- a/scripts/tests/fixtures/byom_journeys/admission/captures/admission-status-opaque-endpoint-refused.json
+++ b/scripts/tests/fixtures/byom_journeys/admission/captures/admission-status-opaque-endpoint-refused.json
@@ -1,6 +1,6 @@
 {
-  "admission_state": "offer_rejected",
-  "admission_state_source": "coordinator",
+  "admission_state": "not_offered",
+  "admission_state_source": "local_default",
   "catalog_model_key": null,
   "provider_guidance": {
     "earning_path_class": "no_earning_path_in_v0_1"

--- a/scripts/tests/fixtures/byom_journeys/admission/run-manifest.json
+++ b/scripts/tests/fixtures/byom_journeys/admission/run-manifest.json
@@ -171,7 +171,7 @@
     {
       "id": "step-11-transition-validity",
       "status": "pass",
-      "assertion": "Invalid transition rejected; rejected, withdrawn, and revoked re-entry each demanded fresh evidence.",
+      "assertion": "Invalid transition rejected; withdrawn and revoked re-entry each demanded fresh evidence.",
       "requirement_ids": [
         "SPEC-047-R001",
         "SPEC-047-R006"
@@ -225,7 +225,6 @@
     "raw_completion_logged": false,
     "raw_prompt_logged": false,
     "rejected_opaque_endpoint_verified": true,
-    "rejected_reoffer_required_fresh_evidence": true,
     "revocation_on_drift_verified": true,
     "revoked_reoffer_required_fresh_evidence": true,
     "sandbox_probe_only_blocked_from_paid_routing": true,

--- a/scripts/tests/fixtures/byom_journeys/admission/run-manifest.json
+++ b/scripts/tests/fixtures/byom_journeys/admission/run-manifest.json
@@ -43,16 +43,16 @@
     {
       "id": "step-03-reject-opaque-endpoint",
       "status": "pass",
-      "assertion": "Opaque candidate was rejected with no catalog economics and no provider credit.",
+      "assertion": "Opaque endpoint refused by the CLI submission builder before any coordinator offer; local-default status only, no coordinator state, no provider credit.",
       "requirement_ids": [
         "SPEC-047-R003",
         "SPEC-047-R007"
       ],
       "documents": [
         {
-          "id": "opaque-endpoint-rejected-status",
+          "id": "opaque-endpoint-refused-status",
           "schema": "model_admission_status.v1",
-          "path": "captures/admission-status-offer-rejected.json"
+          "path": "captures/admission-status-opaque-endpoint-refused.json"
         }
       ]
     },

--- a/scripts/tests/test_byom_journey_evidence.py
+++ b/scripts/tests/test_byom_journey_evidence.py
@@ -1049,7 +1049,6 @@ class BYOMJourneyGovernanceValidatorTests(unittest.TestCase):
                         "synthetic_probe_used_provider_channel",
                         "settlement_capable_case_verified",
                         "transition_matrix_enforced",
-                        "rejected_reoffer_required_fresh_evidence",
                         "withdrawn_reoffer_required_fresh_evidence",
                         "revoked_reoffer_required_fresh_evidence",
                         "withdrawal_verified",

--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -1450,7 +1450,7 @@
         "verdict": "DECISION_REQUIRED",
         "owner": "@Augustas11",
         "issue": "https://github.com/Augustas11/macprovider/issues/1240",
-        "rationale": "SPEC-047 v0.1.8 clarifies settlement-capable guidance as conditional eligibility, freezes coordinator-backed not-offered copy, and rejects catalog-only reuse of per-candidate admission authority. Local CLI/coordinator/routing/buyer safeguards exist and are mapped, but Issue #1240 still needs the full admission policy/probe lifecycle, updated copy evidence, and signed JOURNEY-NETWORK-MODEL-ADMISSION evidence before conformance or production status can be claimed."
+        "rationale": "SPEC-047 v0.1.9 marks offer_rejected reserved/unreachable and drops the rejected-reoffer journey observation; v0.1.8 clarifies settlement-capable guidance as conditional eligibility, freezes coordinator-backed not-offered copy, and rejects catalog-only reuse of per-candidate admission authority. Local CLI/coordinator/routing/buyer safeguards exist and are mapped, but Issue #1240 still needs the full admission policy/probe lifecycle, updated copy evidence, and signed JOURNEY-NETWORK-MODEL-ADMISSION evidence before conformance or production status can be claimed."
       }
     }
   ],

--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -1415,7 +1415,7 @@
     {
       "spec_id": "SPEC-047",
       "title": "Network Model Admission",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "path": "specs/SPEC-047-network-model-admission.md",
       "status": "draft",
       "owner": "@Augustas11",

--- a/specs/README.md
+++ b/specs/README.md
@@ -55,7 +55,7 @@ it can no longer drift. Do not hand-edit the table; edit each spec's
 | SPEC-044 | Malibu Model Catalog Economics | 0.2.8 | draft | complete | pending: 12 | [SPEC-044-malibu-model-catalog-economics.md](SPEC-044-malibu-model-catalog-economics.md) |
 | SPEC-045 | Local Consumer Endpoint Mode | 0.1.0 | draft | complete | conformant: 4, pending: 4 | [SPEC-045-local-consumer-endpoint-mode.md](SPEC-045-local-consumer-endpoint-mode.md) |
 | SPEC-046 | Provider BYOM Discovery | 0.1.5 | draft | complete | pending: 8 | [SPEC-046-provider-byom-discovery.md](SPEC-046-provider-byom-discovery.md) |
-| SPEC-047 | Network Model Admission | 0.1.8 | draft | complete | pending: 9 | [SPEC-047-network-model-admission.md](SPEC-047-network-model-admission.md) |
+| SPEC-047 | Network Model Admission | 0.1.9 | draft | complete | pending: 9 | [SPEC-047-network-model-admission.md](SPEC-047-network-model-admission.md) |
 <!-- AUTOGEN:spec-index END -->
 
 **Version of record is each spec's own `**Version:**` header, not this table.**

--- a/specs/SPEC-047-network-model-admission.md
+++ b/specs/SPEC-047-network-model-admission.md
@@ -6,7 +6,7 @@
 {
   "spec_id": "SPEC-047",
   "title": "Network Model Admission",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "path": "specs/SPEC-047-network-model-admission.md",
   "status": "draft",
   "owner": "@Augustas11",
@@ -210,7 +210,7 @@ implementation slices land. This amendment does not flip those verdicts.
   reachable fresh-evidence re-entry paths are `withdrawn` and `revoked`.
   The JOURNEY-NETWORK-MODEL-ADMISSION evidence contract accordingly drops
   the `rejected_reoffer_required_fresh_evidence` promotable observation
-  (an unreachable state cannot be exercised); `withdrawn_reoffer_` and
+  (an unreachable state cannot be exercised); `withdrawn_reoffer_required_fresh_evidence` and
   `revoked_reoffer_required_fresh_evidence` continue to prove the
   SPEC-047-R001 / R006 fresh-evidence-on-re-entry invariant. No behavior
   change; a journey-evidence-set change only (#1453 slice 7 capture, #1486).

--- a/specs/SPEC-047-network-model-admission.md
+++ b/specs/SPEC-047-network-model-admission.md
@@ -1,6 +1,6 @@
 # SPEC-047 - Network Model Admission
 
-**Version:** 0.1.8
+**Version:** 0.1.9
 
 ```json
 {
@@ -98,7 +98,7 @@ discovery/evaluation.
 | `withdrawn` | The provider withdrew the candidate; local artifacts remain untouched and the candidate is not earning-eligible. | Submit a new signed offer if the provider wants to re-enter admission. | provider CLI withdrawal path | `offer_submitted` |
 | `revoked` | The coordinator removed admission because policy, identity, artifact, health, sanctions, or settlement prerequisites failed. | Resolve the reason code and submit a new signed offer with refreshed evidence if policy allows. | coordinator policy, trust, or sanctions path | `offer_submitted` |
 
-Re-entry from `offer_rejected`, `withdrawn`, or `revoked` to `offer_submitted` MUST require a new provider-signed offer with a fresh nonce or idempotency key and refreshed evidence digests. Demotion from `settlement_capable` or `catalog_priced` takes effect for routing and settlement before any later request attempt can be admitted under the older state.
+Re-entry from `offer_rejected`, `withdrawn`, or `revoked` to `offer_submitted` MUST require a new provider-signed offer with a fresh nonce or idempotency key and refreshed evidence digests. **[v0.1.9]** `offer_rejected` is RESERVED and unreachable in v0.2: no coordinator origin appends it (see §8 v0.1.5, "`offer_rejected` stated unreachable"), so this table lists its legal re-entry edge for enum completeness but the state is never entered and that edge is not exercised. The reachable fresh-evidence re-entry paths a v0.2 journey can prove are `withdrawn` and `revoked`. Demotion from `settlement_capable` or `catalog_priced` takes effect for routing and settlement before any later request attempt can be admitted under the older state.
 
 For rows whose allowed next state is `offer_submitted`, the outbound transition is provider-driven through the signed offer path even when the current state was established by the coordinator, sanctions policy, or a prior provider withdrawal.
 
@@ -203,6 +203,17 @@ implementation slices land. This amendment does not flip those verdicts.
 
 ## 8. Changelog and history
 
+- v0.1.9 - Reconciles `offer_rejected` with its own v0.1.5 unreachability.
+  R001 keeps `offer_rejected` in the closed state enum for wire
+  compatibility but states normatively that in v0.2 no coordinator origin
+  appends it, so its re-entry edge is reserved and not exercised; the
+  reachable fresh-evidence re-entry paths are `withdrawn` and `revoked`.
+  The JOURNEY-NETWORK-MODEL-ADMISSION evidence contract accordingly drops
+  the `rejected_reoffer_required_fresh_evidence` promotable observation
+  (an unreachable state cannot be exercised); `withdrawn_reoffer_` and
+  `revoked_reoffer_required_fresh_evidence` continue to prove the
+  SPEC-047-R001 / R006 fresh-evidence-on-re-entry invariant. No behavior
+  change; a journey-evidence-set change only (#1453 slice 7 capture, #1486).
 - v0.1.8 - Freezes the coordinator-backed `not_offered` English source meaning
   and requires localization/accessibility evidence that distinguishes it from
   the local-default state that has no offer-history authority.


### PR DESCRIPTION
## Summary

SPEC-047 **v0.1.9** — reconcile the `offer_rejected` admission state with its own unreachability and with the JOURNEY-NETWORK-MODEL-ADMISSION evidence contract.

Surfaced by #1486 (BYOM v0.2 slice 7 capture): the journey required proving a rejected-offer → re-offer path and a `rejected_reoffer_required_fresh_evidence` observation, but SPEC-047 has stated `offer_rejected` **unreachable since v0.1.5** and no coordinator origin appends it (operator decisions whitelist only five non-rejected targets; a failed synthetic probe appends `revoked`). The contract demanded evidence a conforming coordinator cannot produce.

**Change (no runtime behavior change — a spec + journey-evidence-set reconciliation):**
- **SPEC-047-R001** keeps `offer_rejected` in the closed state enum for wire compatibility but states normatively it is **reserved and unreachable in v0.2**; its re-entry edge is listed for enum completeness, not exercised.
- The journey evidence contract **drops the `rejected_reoffer_required_fresh_evidence` promotable observation** (an unreachable state cannot be exercised). `withdrawn_reoffer_required_fresh_evidence` and `revoked_reoffer_required_fresh_evidence` remain and continue to prove the SPEC-047-R001 / R006 fresh-evidence-on-re-entry invariant.
- `journeys/JOURNEY-NETWORK-MODEL-ADMISSION.md` step 11 + observation list, the governance validator (`scripts/check_spec_governance.py`), the admission fixture, and `test_byom_journey_evidence.py` are updated to match. The fixture's step-03 capture, which asserted a coordinator `offer_rejected` status, becomes a `local_default` opaque-endpoint refusal — also fixing a pre-existing mislabel (an opaque endpoint is refused by the CLI submission builder before coordinator contact).
- SPEC-047 → 0.1.9 (header, embedded metadata, CONFORMANCE, README).

## Audit
- Codex 3-lane SPEC audit (`audits/2026-09-12-spec047-offer-rejected/`): R1 (arch 1H/1M, code 2M/2L, sec 1M/2L — all "adjacent file missed", all confirming `offer_rejected` is unreachable) → R2 **0 C / 0 H / 0 M** on all three lanes.
- All three lanes independently confirmed no coordinator path appends `offer_rejected`.

## Validation
- `python3 scripts/check_spec_governance.py` and `scripts/gen_spec_index.py` clean.
- `python3 -m unittest scripts.tests.test_byom_journey_evidence` — 114 tests pass.

## Governance
- Issue: #1486 (BYOM v0.2 slice 7); epic #1453.
- Authority boundary: SPEC-047 network model admission (state machine R001, evidence R008).
- No coordinator, money-path, or wire behavior changes; `offer_rejected` stays in every consumer enum (SPEC-044, SPEC-046, transition map).

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "issue": "https://github.com/Augustas11/macprovider/issues/1486",
  "specs": ["SPEC-047"],
  "requirements": ["SPEC-047-R001", "SPEC-047-R008"],
  "authority_domains": ["network-model-admission"],
  "arbitration": ["DECISION_REQUIRED"],
  "tests": ["scripts/tests/test_byom_journey_evidence.py"],
  "journeys": ["JOURNEY-NETWORK-MODEL-ADMISSION"]
}
SPEC-GOVERNANCE-DECLARATION-END

🤖 Generated with [Claude Code](https://claude.com/claude-code)
