### PR TITLE
Stop Pearl serving proof on exact protected-fleet identity

### DIFF
--- a/ops/pearl-updater/macprovider-pearl-update
+++ b/ops/pearl-updater/macprovider-pearl-update
@@ -5281,6 +5281,10 @@ class Updater:
     def verify_runtime_only_buyer_canary_policy(self, release: Release) -> None:
         if release.catalog is None and self.config.buyer_canary_mode not in BUYER_CANARY_MODES:
             raise UpdateError("runtime-only Pearl release requires an explicit buyer canary mode")
+        if release.catalog is None and self.config.buyer_canary_mode == BUYER_CANARY_MODE_DISABLED:
+            raise UpdateError(
+                "runtime-only Pearl release requires buyer canary mode required"
+            )
 
     def verify_rollout(self, release: Release) -> None:
         self.verify_runtime_only_buyer_canary_policy(release)

--- a/ops/pearl-updater/macprovider-pearl-update
+++ b/ops/pearl-updater/macprovider-pearl-update
@@ -5192,33 +5192,6 @@ class Updater:
             self.config.service_health_timeout_s,
             lambda: self.public_identity_ready(identity),
         )
-        if self.previous_protected_providers:
-            stable_samples = 0
-            relax_previous_baseline = (
-                legacy_rollback_version is not None
-                and self.config.buyer_canary_mode == BUYER_CANARY_MODE_REQUIRED
-            )
-
-            def protected_fleet_stable() -> bool:
-                nonlocal stable_samples
-                try:
-                    ready = self.protected_provider_fleet_ready(
-                        require_previous_baseline=not relax_previous_baseline
-                    )
-                except Exception:
-                    stable_samples = 0
-                    raise
-                if ready:
-                    stable_samples += 1
-                else:
-                    stable_samples = 0
-                return stable_samples >= 3
-
-            self.wait_for(
-                "three consecutive public protected-fleet samples",
-                self.config.provider_recovery_timeout_s,
-                protected_fleet_stable,
-            )
         if legacy_rollback_version is None:
             if self.config.buyer_canary_mode == BUYER_CANARY_MODE_REQUIRED:
                 self.run_canary_gate()
@@ -5230,7 +5203,6 @@ class Updater:
                     mode=BUYER_CANARY_MODE_DISABLED,
                     replacement_gates=(
                         "public_identity,"
-                        "stable_protected_fleet,"
                         "exact_catalog_admission,"
                         "exact_provider_canary"
                     ),
@@ -5245,7 +5217,7 @@ class Updater:
                     "skipped",
                     mode=BUYER_CANARY_MODE_DISABLED,
                     rollback=True,
-                    replacement_gates="public_identity,stable_protected_fleet",
+                    replacement_gates="public_identity",
                 )
 
     def verify_provider_admission_rollout_policy(self) -> None:
@@ -5256,32 +5228,6 @@ class Updater:
             raise UpdateError(
                 "post-rollout ready-provider capacity is below the configured fleet floor"
             )
-        if self.previous_protected_providers:
-            poolz = self.get_authorized_json(
-                "http://127.0.0.1:8444/poolz",
-                self.coordinator_operator_token(),
-            )
-            rows = poolz.get("pool")
-            if not isinstance(rows, list):
-                raise UpdateError("post-rollout operator pool snapshot omitted provider rows")
-            current = {
-                row.get("provider_id"): row
-                for row in rows
-                if isinstance(row, dict) and isinstance(row.get("provider_id"), str)
-            }
-            for expected in self._previous_protected_fleet():
-                provider_id = expected["provider_id"]
-                row = current.get(provider_id)
-                if (
-                    row is None
-                    or row.get("routing_eligible") is not True
-                    or row.get("state") != "ready"
-                    or row.get("model_id") != expected["model_id"]
-                    or row.get("catalog_admission_mode") not in ("legacy_bridge", "current", "previous")
-                ):
-                    raise UpdateError(
-                        f"protected provider lost buyer-serving admission during rollout: {provider_id}"
-                    )
         enforced_raw = self.effective_coordinator_scalar(
             "autotune", "enforce_provider_admission"
         )

--- a/ops/pearl-updater/macprovider-pearl-update
+++ b/ops/pearl-updater/macprovider-pearl-update
@@ -5175,6 +5175,11 @@ class Updater:
             for expected in self._previous_protected_fleet()
         )
 
+    def ready_provider_floor_met(self) -> bool:
+        health = self.get_json("http://127.0.0.1:8444/healthz")
+        pool_ready = health.get("pool_ready")
+        return type(pool_ready) is int and pool_ready >= self.config.minimum_pool_ready_after_rollout
+
     def prove_serving_recovery(
         self,
         identity: RuntimeIdentity,
@@ -5191,6 +5196,11 @@ class Updater:
             "public TLS health/version",
             self.config.service_health_timeout_s,
             lambda: self.public_identity_ready(identity),
+        )
+        self.wait_for(
+            "ready-provider floor",
+            self.config.provider_recovery_timeout_s,
+            self.ready_provider_floor_met,
         )
         if legacy_rollback_version is None:
             if self.config.buyer_canary_mode == BUYER_CANARY_MODE_REQUIRED:

--- a/ops/pearl-updater/pearl-updater.conf.example
+++ b/ops/pearl-updater/pearl-updater.conf.example
@@ -30,8 +30,8 @@ PEARL_UPDATER_CANARY_TIMEOUT_S=720
 # Defaults to required. Use disabled only during an explicitly sealed production
 # window where both canary enable gates are absent, the root-owned empty 0644
 # DISABLED sentinel is present, and canary-buyer.timer/service are quiescent.
-# Disabled mode preserves the public identity, stable protected-fleet, exact
-# catalog-admission, and exact physical provider-canary rollout gates.
+# Disabled mode preserves the public identity, exact catalog-admission, and
+# exact physical provider-canary rollout gates.
 PEARL_UPDATER_BUYER_CANARY_MODE=required
 PEARL_UPDATER_REVOKED_VERSIONS_FILE=/etc/macprovider/pearl-updater.revoked
 

--- a/ops/pearl-updater/test_pearl_updater.py
+++ b/ops/pearl-updater/test_pearl_updater.py
@@ -2343,19 +2343,18 @@ class PearlUpdaterTests(unittest.TestCase):
         self.assertEqual(self.updater.audit.call_args.kwargs["pool_ready"], 3)
 
         self.updater.get_authorized_json.return_value = {"pool": admitted_rows[:-1]}
-        with self.assertRaisesRegex(updater_module.UpdateError, "protected provider lost"):
-            self.updater.verify_provider_admission_rollout_policy()
-        self.updater.get_authorized_json.return_value = {"pool": admitted_rows}
+        self.updater.verify_provider_admission_rollout_policy()
         self.updater.get_authorized_json.return_value = {
             "pool": [{**admitted_rows[0], "model_id": "drifted-model"}, *admitted_rows[1:]]
         }
-        with self.assertRaisesRegex(updater_module.UpdateError, "protected provider lost"):
-            self.updater.verify_provider_admission_rollout_policy()
-        self.updater.get_authorized_json.return_value = {"pool": admitted_rows}
+        self.updater.verify_provider_admission_rollout_policy()
+        self.updater.get_authorized_json.assert_not_called()
+        self.updater.get_authorized_json.reset_mock()
 
         self.updater.get_json.return_value = {"pool_size": 3, "pool_ready": 1}
         with self.assertRaisesRegex(updater_module.UpdateError, "fleet floor"):
             self.updater.verify_provider_admission_rollout_policy()
+        self.updater.get_authorized_json.assert_not_called()
 
     def test_bridge_rollout_rejects_strict_enforcement_or_expiring_window(self):
         coordinator = self.root / "coordinator.yaml"
@@ -3292,10 +3291,27 @@ class PearlUpdaterTests(unittest.TestCase):
         self.updater.verify_disabled_buyer_canary_posture = mock.Mock()
         self.updater.run_canary_gate = mock.Mock()
         self.updater.audit = mock.Mock()
+        waited = []
+        original_wait = self.updater.wait_for
+
+        def record_wait(description, timeout, check):
+            waited.append(description)
+            original_wait(description, timeout, check)
+
+        self.updater.wait_for = record_wait
 
         self.updater.prove_serving_recovery(identity)
 
-        self.assertEqual(self.updater.protected_provider_fleet_ready.call_count, 3)
+        self.updater.protected_provider_fleet_ready.assert_not_called()
+        self.assertNotIn("three consecutive public protected-fleet samples", waited)
+        self.assertEqual(
+            waited,
+            [
+                "provider reconnect and warmup",
+                "gateway serving status",
+                "public TLS health/version",
+            ],
+        )
         self.updater.verify_disabled_buyer_canary_posture.assert_called_once_with()
         self.updater.run_canary_gate.assert_not_called()
         self.updater.audit.assert_any_call(
@@ -3304,13 +3320,12 @@ class PearlUpdaterTests(unittest.TestCase):
             mode=updater_module.BUYER_CANARY_MODE_DISABLED,
             replacement_gates=(
                 "public_identity,"
-                "stable_protected_fleet,"
                 "exact_catalog_admission,"
                 "exact_provider_canary"
             ),
         )
 
-    def test_rollback_serving_proof_relaxes_baseline_only_with_required_canary(self):
+    def test_rollback_serving_proof_skips_protected_fleet_samples(self):
         identity = updater_module.RuntimeIdentity("v1.8.30", "v1.8.30", "1.8.30")
         self.updater.previous_protected_providers = ["provider-a", "provider-b"]
         self.updater.local_coordinator_identity_ready = mock.Mock(return_value=True)
@@ -3318,26 +3333,24 @@ class PearlUpdaterTests(unittest.TestCase):
         self.updater.public_identity_ready = mock.Mock(return_value=True)
         self.updater.protected_provider_fleet_ready = mock.Mock(return_value=True)
         self.updater.run_canary_gate = mock.Mock()
+        waited = []
+        original_wait = self.updater.wait_for
 
-        def wait_until_success(_description, _timeout, check):
-            for _ in range(4):
-                if check():
-                    return
-            self.fail("wait_for check did not succeed")
+        def record_wait(description, timeout, check):
+            waited.append(description)
+            original_wait(description, timeout, check)
 
-        self.updater.wait_for = wait_until_success
+        self.updater.wait_for = record_wait
 
         self.updater.prove_serving_recovery(identity, legacy_rollback_version="1.8.30")
 
-        self.assertEqual(
-            self.updater.protected_provider_fleet_ready.call_args_list,
-            [mock.call(require_previous_baseline=False)] * 3,
-        )
+        self.updater.protected_provider_fleet_ready.assert_not_called()
+        self.assertNotIn("three consecutive public protected-fleet samples", waited)
         self.updater.run_canary_gate.assert_called_once_with(
             legacy_rollback_version="1.8.30"
         )
 
-    def test_disabled_rollback_serving_proof_keeps_exact_baseline(self):
+    def test_disabled_rollback_serving_proof_skips_protected_fleet_samples(self):
         identity = updater_module.RuntimeIdentity("v1.8.30", "v1.8.30", "1.8.30")
         self.updater.config = updater_module.dataclasses.replace(
             self.updater.config,
@@ -3351,23 +3364,28 @@ class PearlUpdaterTests(unittest.TestCase):
         self.updater.verify_disabled_buyer_canary_posture = mock.Mock()
         self.updater.run_canary_gate = mock.Mock()
         self.updater.audit = mock.Mock()
+        waited = []
+        original_wait = self.updater.wait_for
 
-        def wait_until_success(_description, _timeout, check):
-            for _ in range(4):
-                if check():
-                    return
-            self.fail("wait_for check did not succeed")
+        def record_wait(description, timeout, check):
+            waited.append(description)
+            original_wait(description, timeout, check)
 
-        self.updater.wait_for = wait_until_success
+        self.updater.wait_for = record_wait
 
         self.updater.prove_serving_recovery(identity, legacy_rollback_version="1.8.30")
 
-        self.assertEqual(
-            self.updater.protected_provider_fleet_ready.call_args_list,
-            [mock.call(require_previous_baseline=True)] * 3,
-        )
+        self.updater.protected_provider_fleet_ready.assert_not_called()
+        self.assertNotIn("three consecutive public protected-fleet samples", waited)
         self.updater.verify_disabled_buyer_canary_posture.assert_called_once_with()
         self.updater.run_canary_gate.assert_not_called()
+        self.updater.audit.assert_any_call(
+            "buyer_canary_gate",
+            "skipped",
+            mode=updater_module.BUYER_CANARY_MODE_DISABLED,
+            rollback=True,
+            replacement_gates="public_identity",
+        )
 
     def test_runtime_only_rollout_accepts_disabled_buyer_canary_mode(self):
         self.make_bundle(runtime_only=True)
@@ -3422,7 +3440,7 @@ class PearlUpdaterTests(unittest.TestCase):
             legacy_rollback_version="1.8.82",
         )
 
-    def test_serving_proof_requires_three_consecutive_public_fleet_samples(self):
+    def test_serving_proof_does_not_wait_for_protected_fleet_samples(self):
         identity = updater_module.RuntimeIdentity("v1.8.36", "v1.8.36", "1.8.36")
         self.updater.previous_pool_ready = 2
         self.updater.previous_protected_providers = ["provider-a", "provider-b"]
@@ -3434,16 +3452,33 @@ class PearlUpdaterTests(unittest.TestCase):
         self.updater.gateway_serving_ready = mock.Mock(return_value=True)
         self.updater.public_identity_ready = mock.Mock(return_value=True)
         self.updater.protected_provider_fleet_ready = mock.Mock(
-            side_effect=[True, True, False, True, True, True]
+            side_effect=updater_module.UpdateError("exact 6-node identity snapshot must not gate serving")
         )
         self.updater.run_canary_gate = mock.Mock()
+        waited = []
+        original_wait = self.updater.wait_for
+
+        def record_wait(description, timeout, check):
+            waited.append(description)
+            original_wait(description, timeout, check)
+
+        self.updater.wait_for = record_wait
 
         self.updater.prove_serving_recovery(identity)
 
-        self.assertEqual(self.updater.protected_provider_fleet_ready.call_count, 6)
+        self.updater.protected_provider_fleet_ready.assert_not_called()
+        self.assertNotIn("three consecutive public protected-fleet samples", waited)
+        self.assertEqual(
+            waited,
+            [
+                "provider reconnect and warmup",
+                "gateway serving status",
+                "public TLS health/version",
+            ],
+        )
         self.updater.run_canary_gate.assert_called_once_with()
 
-    def test_serving_proof_resets_consecutive_samples_after_sample_error(self):
+    def test_serving_proof_ignores_protected_fleet_sample_errors(self):
         identity = updater_module.RuntimeIdentity("v1.8.36", "v1.8.36", "1.8.36")
         self.updater.previous_pool_ready = 2
         self.updater.previous_protected_providers = ["provider-a", "provider-b"]
@@ -3451,20 +3486,22 @@ class PearlUpdaterTests(unittest.TestCase):
         self.updater.gateway_serving_ready = mock.Mock(return_value=True)
         self.updater.public_identity_ready = mock.Mock(return_value=True)
         self.updater.protected_provider_fleet_ready = mock.Mock(
-            side_effect=[
-                True,
-                True,
-                updater_module.UpdateError("transient public sample failure"),
-                True,
-                True,
-                True,
-            ]
+            side_effect=updater_module.UpdateError("transient public sample failure")
         )
         self.updater.run_canary_gate = mock.Mock()
+        waited = []
+        original_wait = self.updater.wait_for
+
+        def record_wait(description, timeout, check):
+            waited.append(description)
+            original_wait(description, timeout, check)
+
+        self.updater.wait_for = record_wait
 
         self.updater.prove_serving_recovery(identity)
 
-        self.assertEqual(self.updater.protected_provider_fleet_ready.call_count, 6)
+        self.updater.protected_provider_fleet_ready.assert_not_called()
+        self.assertNotIn("three consecutive public protected-fleet samples", waited)
         self.updater.run_canary_gate.assert_called_once_with()
 
     def test_public_protected_fleet_sample_requires_exact_ready_baseline(self):

--- a/ops/pearl-updater/test_pearl_updater.py
+++ b/ops/pearl-updater/test_pearl_updater.py
@@ -3387,7 +3387,17 @@ class PearlUpdaterTests(unittest.TestCase):
             replacement_gates="public_identity",
         )
 
-    def test_runtime_only_rollout_accepts_disabled_buyer_canary_mode(self):
+    def test_runtime_only_rollout_accepts_required_buyer_canary_mode(self):
+        self.make_bundle(runtime_only=True)
+        release = self.verify()
+        self.updater.config = updater_module.dataclasses.replace(
+            self.updater.config,
+            buyer_canary_mode=updater_module.BUYER_CANARY_MODE_REQUIRED,
+        )
+
+        self.updater.verify_runtime_only_buyer_canary_policy(release)
+
+    def test_runtime_only_rollout_rejects_disabled_buyer_canary_mode(self):
         self.make_bundle(runtime_only=True)
         release = self.verify()
         self.updater.config = updater_module.dataclasses.replace(
@@ -3395,17 +3405,11 @@ class PearlUpdaterTests(unittest.TestCase):
             buyer_canary_mode=updater_module.BUYER_CANARY_MODE_DISABLED,
         )
 
-        self.updater.verify_runtime_only_buyer_canary_policy(release)
-
-    def test_runtime_only_disabled_canary_mode_uses_rollout_replacement_gates(self):
-        self.make_bundle(runtime_only=True)
-        release = self.verify()
-        self.updater.config = updater_module.dataclasses.replace(
-            self.updater.config,
-            buyer_canary_mode=updater_module.BUYER_CANARY_MODE_DISABLED,
-        )
-
-        self.updater.verify_runtime_only_buyer_canary_policy(release)
+        with self.assertRaisesRegex(
+            updater_module.UpdateError,
+            "runtime-only Pearl release requires buyer canary mode required",
+        ):
+            self.updater.verify_runtime_only_buyer_canary_policy(release)
 
     def test_run_canary_gate_rejects_disabled_mode(self):
         self.updater.config = updater_module.dataclasses.replace(

--- a/ops/pearl-updater/test_pearl_updater.py
+++ b/ops/pearl-updater/test_pearl_updater.py
@@ -3270,6 +3270,7 @@ class PearlUpdaterTests(unittest.TestCase):
         self.updater.local_coordinator_identity_ready = mock.Mock(return_value=True)
         self.updater.gateway_serving_ready = mock.Mock(return_value=True)
         self.updater.public_identity_ready = mock.Mock(return_value=True)
+        self.updater.ready_provider_floor_met = mock.Mock(return_value=True)
         self.updater.run_canary_gate = mock.Mock()
         self.updater.wait_for = lambda _description, _timeout, check: self.assertTrue(check())
 
@@ -3287,6 +3288,7 @@ class PearlUpdaterTests(unittest.TestCase):
         self.updater.local_coordinator_identity_ready = mock.Mock(return_value=True)
         self.updater.gateway_serving_ready = mock.Mock(return_value=True)
         self.updater.public_identity_ready = mock.Mock(return_value=True)
+        self.updater.ready_provider_floor_met = mock.Mock(return_value=True)
         self.updater.protected_provider_fleet_ready = mock.Mock(return_value=True)
         self.updater.verify_disabled_buyer_canary_posture = mock.Mock()
         self.updater.run_canary_gate = mock.Mock()
@@ -3310,6 +3312,7 @@ class PearlUpdaterTests(unittest.TestCase):
                 "provider reconnect and warmup",
                 "gateway serving status",
                 "public TLS health/version",
+                "ready-provider floor",
             ],
         )
         self.updater.verify_disabled_buyer_canary_posture.assert_called_once_with()
@@ -3331,6 +3334,7 @@ class PearlUpdaterTests(unittest.TestCase):
         self.updater.local_coordinator_identity_ready = mock.Mock(return_value=True)
         self.updater.gateway_serving_ready = mock.Mock(return_value=True)
         self.updater.public_identity_ready = mock.Mock(return_value=True)
+        self.updater.ready_provider_floor_met = mock.Mock(return_value=True)
         self.updater.protected_provider_fleet_ready = mock.Mock(return_value=True)
         self.updater.run_canary_gate = mock.Mock()
         waited = []
@@ -3360,6 +3364,7 @@ class PearlUpdaterTests(unittest.TestCase):
         self.updater.local_coordinator_identity_ready = mock.Mock(return_value=True)
         self.updater.gateway_serving_ready = mock.Mock(return_value=True)
         self.updater.public_identity_ready = mock.Mock(return_value=True)
+        self.updater.ready_provider_floor_met = mock.Mock(return_value=True)
         self.updater.protected_provider_fleet_ready = mock.Mock(return_value=True)
         self.updater.verify_disabled_buyer_canary_posture = mock.Mock()
         self.updater.run_canary_gate = mock.Mock()
@@ -3455,6 +3460,7 @@ class PearlUpdaterTests(unittest.TestCase):
         self.updater.local_coordinator_identity_ready = mock.Mock(return_value=True)
         self.updater.gateway_serving_ready = mock.Mock(return_value=True)
         self.updater.public_identity_ready = mock.Mock(return_value=True)
+        self.updater.ready_provider_floor_met = mock.Mock(return_value=True)
         self.updater.protected_provider_fleet_ready = mock.Mock(
             side_effect=updater_module.UpdateError("exact 6-node identity snapshot must not gate serving")
         )
@@ -3478,6 +3484,7 @@ class PearlUpdaterTests(unittest.TestCase):
                 "provider reconnect and warmup",
                 "gateway serving status",
                 "public TLS health/version",
+                "ready-provider floor",
             ],
         )
         self.updater.run_canary_gate.assert_called_once_with()
@@ -3489,6 +3496,7 @@ class PearlUpdaterTests(unittest.TestCase):
         self.updater.local_coordinator_identity_ready = mock.Mock(return_value=True)
         self.updater.gateway_serving_ready = mock.Mock(return_value=True)
         self.updater.public_identity_ready = mock.Mock(return_value=True)
+        self.updater.ready_provider_floor_met = mock.Mock(return_value=True)
         self.updater.protected_provider_fleet_ready = mock.Mock(
             side_effect=updater_module.UpdateError("transient public sample failure")
         )
@@ -3506,6 +3514,38 @@ class PearlUpdaterTests(unittest.TestCase):
 
         self.updater.protected_provider_fleet_ready.assert_not_called()
         self.assertNotIn("three consecutive public protected-fleet samples", waited)
+        self.updater.run_canary_gate.assert_called_once_with()
+
+    def test_ready_provider_floor_uses_local_health_not_fleet_identity(self):
+        self.updater.get_json = mock.Mock(return_value={"pool_ready": 2})
+        self.assertTrue(self.updater.ready_provider_floor_met())
+        self.updater.get_json.assert_called_once_with("http://127.0.0.1:8444/healthz")
+
+        self.updater.get_json.return_value = {"pool_ready": 1}
+        self.assertFalse(self.updater.ready_provider_floor_met())
+
+        identity = updater_module.RuntimeIdentity("v1.8.36", "v1.8.36", "1.8.36")
+        self.updater.local_coordinator_identity_ready = mock.Mock(return_value=True)
+        self.updater.gateway_serving_ready = mock.Mock(return_value=True)
+        self.updater.public_identity_ready = mock.Mock(return_value=True)
+        self.updater.ready_provider_floor_met = mock.Mock(return_value=True)
+        self.updater.run_canary_gate = mock.Mock()
+        waited = []
+        original_wait = self.updater.wait_for
+
+        def record_wait(description, timeout, check):
+            waited.append(description)
+            original_wait(description, timeout, check)
+
+        self.updater.wait_for = record_wait
+        self.updater.prove_serving_recovery(identity)
+
+        self.assertIn("ready-provider floor", waited)
+        self.assertLess(
+            waited.index("ready-provider floor"),
+            waited.index("public TLS health/version") + 2,
+        )
+        self.assertEqual(waited[-1], "ready-provider floor")
         self.updater.run_canary_gate.assert_called_once_with()
 
     def test_public_protected_fleet_sample_requires_exact_ready_baseline(self):

--- a/ops/runbooks/pearl-release-updater.md
+++ b/ops/runbooks/pearl-release-updater.md
@@ -383,10 +383,10 @@ sudo test ! -e /run/macprovider-canary-buyer/legacy-rollback.json
    the new coordinator may classify those same exact ID/model/version rows
    `legacy_bridge`; r6 accepts that classification only as a substitute for the
    missing direct signal while retaining every pool, routing, connection, and
-   heartbeat invariant. Before that canary starts, the updater requires three
-   consecutive authenticated public `/poolz` samples that contain every exact
-   protected provider as ready and routing-eligible and retain the captured
-   ready-provider floor. A failed or timed-out canary oneshot is explicitly
+   heartbeat invariant. Before that canary starts, the updater requires provider
+   reconnect, gateway serving, public TLS identity, and the configured
+   ready-provider floor; it does not wait for an exact previous protected-fleet
+   identity snapshot. A failed or timed-out canary oneshot is explicitly
    stopped and proven inactive with no queued job before rollback may touch
    state. The updater requires the post-activation run to exit `0` before it
    emits `provider_install_ready`. Any other reason, classified no-load status

--- a/ops/runbooks/pearl-release-updater.md
+++ b/ops/runbooks/pearl-release-updater.md
@@ -135,9 +135,9 @@ An explicitly sealed production window may instead set
 configuration. That mode never starts the buyer canary. It requires both
 enable gates absent, an empty root-owned `0644` `DISABLED` sentinel, the timer
 disabled/inactive, and the oneshot service inactive. The updater rechecks that
-posture before state capture, after stable public fleet recovery, and after
-the exact physical catalog-provider proof. Public identity, three consecutive
-protected-fleet samples, admission policy, exact catalog admission, and the
+posture before state capture, after public identity recovery, and after
+the exact physical catalog-provider proof. Public identity, the configured
+ready-provider floor, admission policy, exact catalog admission, and the
 physical provider canary remain mandatory. The default remains `required`.
 Runtime-only `pearl_runtime` releases are not eligible for this disabled mode:
 because they deliberately omit the exact catalog/provider gates, apply requires


### PR DESCRIPTION
## Summary
- Delete the Pearl updater serving-proof wait for three consecutive public protected-fleet `/poolz` samples, and the post-rollout loop that failed apply when any captured protected `provider_id`/`model_id` was no longer ready.
- Keep provider reconnect, gateway serving, public TLS, buyer-canary required/disabled branches, exact catalog admission, and the configured `pool_ready` floor (`minimum_pool_ready_after_rollout`).
- Coordinator v1.8.124 is already live; this is the follow-up so the next runtime apply cannot block on an exact 6-node identity snapshot. No Pearl deploy in this PR.

## Test plan
- [x] `python3 -m unittest ops.pearl-updater.test_pearl_updater` (201 tests, 1 skipped, OK)
- [ ] CI `spec-index` / updater tests on this PR

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "none",
  "specs": ["SPEC-002"],
  "requirements": ["SPEC-002-R002"],
  "authority_domains": ["coordinator-admission-routing"],
  "arbitration": ["UNKNOWN"],
  "tests": ["python3 -m unittest ops.pearl-updater.test_pearl_updater"],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END

CONFORMANCE does not map `ops/pearl-updater` or the three-sample protected-fleet wait. The declaration names SPEC-002 / coordinator-admission-routing because the remaining floor is coordinator `pool_ready` and the deleted overlay sampled `/poolz` identity; UNKNOWN because this was operator updater policy, not a mapped requirement. No SPEC/CONFORMANCE edit.

Made with [Cursor](https://cursor.com)