### PR TITLE
Make OpenRouter filing evidence fail closed

### DIFF
--- a/docs/runbooks/openrouter-provider-apply.md
+++ b/docs/runbooks/openrouter-provider-apply.md
@@ -6,14 +6,41 @@ only additive ingest URL is `GET /v1/openrouter/models`.
 
 ## Do not apply until soak passes
 
-Run ≥100 requests on the named wholesale `mp_` key against
-`mlx-community/Llama-3.2-3B-Instruct-4bit` (and the `-free` alias) on the live
-pool. Record:
+Run the readiness probe with the named wholesale/OpenRouter `mp_` key against
+`mlx-community/Llama-3.2-3B-Instruct-4bit` and keep its JSON output as the
+public soak artifact:
 
-- success ratio versus the current ~5 rpm / 16% utilization baseline
-- that coordinator 503 `no_provider_available` is translated to gateway 429
-- that stream responses include a final `usage` chunk
-- that free-SKU rows are $0 on the wholesale statement and still credit nodes
+```bash
+MACPROVIDER_SPEC015_API_KEY="$OPENROUTER_WHOLESALE_MP_KEY" \
+  python3 scripts/openrouter_readiness_probe.py \
+    --base-url https://api.malibu.tech \
+    --model mlx-community/Llama-3.2-3B-Instruct-4bit \
+    --benchmark-requests 100 \
+    --benchmark-concurrency 4 \
+    --saturation-requests 16 \
+    --saturation-concurrency 8 \
+    --output "$HOME/.local/state/macprovider/openrouter-readiness/openrouter-readiness-$(date -u +%Y%m%dT%H%M%SZ)-$$.json"
+```
+
+The probe validates:
+
+- OpenRouter schema-2.4-native model rows: typed modalities, modality-owned
+  prices and capacity, an honest deployment-region descriptor, any declared
+  datacenters, `compliance.zdr=false`, the requested paid row, and in
+  filing mode the ready zero-priced free alias row
+- authenticated non-streaming chat completion content plus `usage`
+- authenticated streaming chat completion chunks plus final `usage`; if the
+  stream is shorter than the gateway keepalive tick, the artifact records
+  keepalive as `not_applicable_fast_stream`
+- in filing mode, an authenticated chat smoke against the free alias as well as
+  the paid model
+- bounded TTFT and generated-output-token throughput evidence for
+  OpenRouter-like streaming requests
+- early provider-capacity shedding as `no_provider_available` HTTP 429 in the
+  explicit saturation pass; account/quota/rate-limit 429s do not satisfy this
+  check
+- `/privacy` retaining the plaintext/no-ZDR/no-training disclosure and the
+  default 90-day request-log retention statement
 
 Do not submit the OpenRouter form on a failing soak.
 
@@ -27,11 +54,19 @@ Do not submit the OpenRouter form on a failing soak.
 - Payment: monthly postpaid USD statement (D1a). No Stripe. Unpaid statements
   are an operator kill-switch, never a live HTTP 402.
 - Dual SKU: paid pool id plus `-free` alias on the same Llama 3B nodes
+- OpenRouter catalog slug: `meta-llama/llama-3.2-3b-instruct` for paid and
+  `meta-llama/llama-3.2-3b-instruct:free` for free
 
 Submit at [openrouter.ai/providers/apply](https://openrouter.ai/providers/apply)
 only after the soak and after `/privacy` is live.
 
 ## Operator statement export
+
+Generate the wholesale statement before filing and attach the JSON plus CSV
+headers to the operator evidence packet. The export is invoicing-readiness
+evidence for OpenRouter's postpaid path, not proof that a payment has settled.
+Malibu does not use auto top-up, Stripe checkout, card collection, or live
+request-time HTTP 402 for wholesale accounts.
 
 ```bash
 curl -sS -H "Authorization: Bearer $OPERATOR_KEY" \
@@ -41,4 +76,25 @@ curl -sS -H "Authorization: Bearer $OPERATOR_KEY" \
 
 curl -sS -H "Authorization: Bearer $OPERATOR_KEY" \
   "https://coordinator.internal/admin/ledger/wholesale-statements/<wholesale_statement_id>?format=csv"
+```
+
+The readiness probe can verify the statement endpoint and CSV naming when run
+from an operator network. Filing mode also verifies the live free alias row and
+runs a free-alias chat smoke. Use this command for the final OpenRouter
+application artifact:
+
+```bash
+MACPROVIDER_SPEC015_API_KEY="$OPENROUTER_WHOLESALE_MP_KEY" \
+OPERATOR_KEY="$OPERATOR_KEY" \
+  python3 scripts/openrouter_readiness_probe.py \
+    --base-url https://api.malibu.tech \
+    --admin-url https://coordinator.internal \
+    --statement-account-id acct_openrouter \
+    --statement-period "$(date -u +%Y-%m)" \
+    --filing-mode \
+    --benchmark-requests 100 \
+    --benchmark-concurrency 4 \
+    --saturation-requests 16 \
+    --saturation-concurrency 8 \
+    --output "$HOME/.local/state/macprovider/openrouter-readiness/openrouter-readiness-$(date -u +%Y%m%dT%H%M%SZ)-$$.json"
 ```

--- a/phase5-gateway/internal/router/openrouter_models.go
+++ b/phase5-gateway/internal/router/openrouter_models.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"strconv"
 	"strings"
@@ -11,22 +12,30 @@ import (
 )
 
 const (
-	openRouterModelsPath        = "/v1/openrouter/models"
-	openRouterSchemaVersion     = "2.4"
-	openRouterLlama3BPaidID     = "mlx-community/Llama-3.2-3B-Instruct-4bit"
-	openRouterLlama3BFreeID     = "mlx-community/Llama-3.2-3B-Instruct-4bit-free"
-	openRouterLlama3BCatalogKey = "meta-llama/llama-3.2-3b-instruct"
-	openRouterQwen8BID          = "mlx-community/Qwen3-8B-4bit"
-	openRouterQwen8BCatalogKey  = "qwen3-8b"
-	openRouterRateCardMaxBytes  = 4 << 20
+	openRouterModelsPath               = "/v1/openrouter/models"
+	openRouterSchemaVersion            = "2.4"
+	openRouterLlama3BCreatedAt         = 1729728000
+	openRouterQwen8BCreatedAt          = 1748822400
+	openRouterLlama3BPaidID            = "mlx-community/Llama-3.2-3B-Instruct-4bit"
+	openRouterLlama3BFreeID            = "mlx-community/Llama-3.2-3B-Instruct-4bit-free"
+	openRouterLlama3BCatalogKey        = "meta-llama/llama-3.2-3b-instruct"
+	openRouterQwen8BID                 = "mlx-community/Qwen3-8B-4bit"
+	openRouterQwen8BCatalogKey         = "qwen3-8b"
+	openRouterQwen8BSlug               = "qwen/qwen3-8b"
+	openRouterRateCardMaxBytes         = 4 << 20
+	openRouterRequestsPerMinutePerSlot = 1
+	openRouterTokensPerSecondPerSlot   = 10
 )
 
 type openRouterListingSpec struct {
 	PoolID           string
 	FreeID           string
 	CatalogKey       string
+	OpenRouterSlug   string
 	Name             string
 	HuggingFaceID    string
+	Tokenizer        string
+	Created          int64
 	MinWarmProviders int
 	DualFree         bool
 }
@@ -36,53 +45,105 @@ var openRouterListings = []openRouterListingSpec{
 		PoolID:           openRouterLlama3BPaidID,
 		FreeID:           openRouterLlama3BFreeID,
 		CatalogKey:       openRouterLlama3BCatalogKey,
+		OpenRouterSlug:   openRouterLlama3BCatalogKey,
 		Name:             "Llama 3.2 3B Instruct (4-bit)",
 		HuggingFaceID:    openRouterLlama3BPaidID,
+		Tokenizer:        "Llama3",
+		Created:          openRouterLlama3BCreatedAt,
 		MinWarmProviders: 1,
 		DualFree:         true,
 	},
 	{
 		PoolID:           openRouterQwen8BID,
 		CatalogKey:       openRouterQwen8BCatalogKey,
+		OpenRouterSlug:   openRouterQwen8BSlug,
 		Name:             "Qwen3 8B (4-bit)",
 		HuggingFaceID:    openRouterQwen8BID,
+		Tokenizer:        "Qwen",
+		Created:          openRouterQwen8BCreatedAt,
 		MinWarmProviders: 2,
 	},
 }
 
 type openRouterModelsDocument struct {
-	SchemaVersion string               `json:"schema_version"`
-	Data          []openRouterModelV24 `json:"data"`
+	Data []openRouterModelV24 `json:"data"`
 }
 
 type openRouterModelV24 struct {
-	ID              string                 `json:"id"`
-	Name            string                 `json:"name"`
-	Created         int64                  `json:"created"`
-	Architecture    openRouterArchitecture `json:"architecture"`
-	ContextLength   int                    `json:"context_length"`
-	Quantization    string                 `json:"quantization"`
-	HuggingFaceID   string                 `json:"hugging_face_id"`
-	IsReady         bool                   `json:"is_ready"`
-	IsFree          bool                   `json:"is_free"`
-	CostUSD         openRouterCostUSD      `json:"cost_usd"`
-	Compliance      openRouterCompliance   `json:"compliance"`
-	SupportedParams []string               `json:"supported_parameters"`
+	SchemaVersion    string                      `json:"schema_version"`
+	ID               string                      `json:"id"`
+	Name             string                      `json:"name"`
+	Created          int64                       `json:"created"`
+	Quantization     string                      `json:"quantization"`
+	Tokenizer        string                      `json:"tokenizer,omitempty"`
+	HuggingFaceID    string                      `json:"hugging_face_id"`
+	InputModalities  []openRouterInputModality   `json:"input_modalities"`
+	OutputModalities []openRouterOutputModality  `json:"output_modalities"`
+	Capacity         []openRouterCapacityEntry   `json:"capacity"`
+	DeploymentRegion string                      `json:"deployment_region"`
+	Compliance       openRouterCompliance        `json:"compliance"`
+	IsReady          bool                        `json:"is_ready"`
+	IsFree           bool                        `json:"is_free"`
+	OpenRouter       openRouterIdentityExtension `json:"openrouter"`
 }
 
-type openRouterArchitecture struct {
-	InputModalities  []string `json:"input_modalities"`
-	OutputModalities []string `json:"output_modalities"`
-	Modality         string   `json:"modality"`
+type openRouterInputModality struct {
+	Type            string                     `json:"type"`
+	SupportedInputs openRouterTextInputSupport `json:"supported_inputs"`
+	Pricing         []openRouterPricingEntry   `json:"pricing"`
+	Capacity        []openRouterCapacityEntry  `json:"capacity"`
 }
 
-type openRouterCostUSD struct {
+type openRouterTextInputSupport struct {
+	MaxContextLength openRouterIntegerLimit `json:"max_context_length"`
+}
+
+type openRouterIntegerLimit struct {
+	Value int    `json:"value"`
+	Unit  string `json:"unit,omitempty"`
+}
+
+type openRouterPricingEntry struct {
+	Type    string `json:"type"`
+	Unit    string `json:"unit"`
+	CostUSD string `json:"cost_usd"`
+}
+
+type openRouterCapacityEntry struct {
+	Type  string `json:"type"`
+	Unit  string `json:"unit"`
+	Per   string `json:"per,omitempty"`
+	Value int    `json:"value"`
+}
+
+type openRouterOutputModality struct {
+	Type                string                                   `json:"type"`
+	MaxLength           openRouterIntegerLimit                   `json:"max_length"`
+	Streaming           bool                                     `json:"streaming"`
+	SupportedParameters map[string]openRouterParameterDescriptor `json:"supported_parameters"`
+	Pricing             []openRouterPricingEntry                 `json:"pricing"`
+	Capacity            []openRouterCapacityEntry                `json:"capacity"`
+}
+
+type openRouterParameterDescriptor struct {
+	Type     string   `json:"type"`
+	Min      *float64 `json:"min,omitempty"`
+	Max      *float64 `json:"max,omitempty"`
+	Unit     string   `json:"unit,omitempty"`
+	MaxItems int      `json:"max_items,omitempty"`
+}
+
+type openRouterTextCostUSD struct {
 	Prompt     string `json:"prompt"`
 	Completion string `json:"completion"`
 }
 
 type openRouterCompliance struct {
 	ZDR bool `json:"zdr"`
+}
+
+type openRouterIdentityExtension struct {
+	Slug string `json:"slug"`
 }
 
 type openRouterRateCard struct {
@@ -98,7 +159,8 @@ type openRouterRateCardRow struct {
 type openRouterPoolSnapshot struct {
 	ID                 string
 	ReadyProviderCount int
-	SlotsFree          int
+	ReadySlotsTotal    int
+	ReadySlotsFree     int
 	MaxContextTokens   int
 }
 
@@ -122,11 +184,16 @@ func (s *Server) handleOpenRouterModels(w http.ResponseWriter, r *http.Request) 
 		pool = append(pool, openRouterPoolSnapshot{
 			ID:                 model.ID,
 			ReadyProviderCount: model.ReadyProviderCount,
-			SlotsFree:          model.SlotsFree,
+			ReadySlotsTotal:    model.ReadySlotsTotal,
+			ReadySlotsFree:     model.ReadySlotsFree,
 			MaxContextTokens:   model.MaxContextTokens,
 		})
 	}
-	doc := projectOpenRouterModels(pool, rateCard, s.now())
+	doc, err := projectOpenRouterModels(pool, rateCard, s.now())
+	if err != nil {
+		writeError(w, http.StatusBadGateway, "api_error", "coordinator_rate_card_error", "Coordinator rate-card error")
+		return
+	}
 	if r.Method == http.MethodHead {
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("Cache-Control", "public, max-age=15")
@@ -165,7 +232,7 @@ func (s *Server) fetchOpenRouterRateCard(r *http.Request) (openRouterRateCard, e
 	return card, nil
 }
 
-func projectOpenRouterModels(pool []openRouterPoolSnapshot, rateCard openRouterRateCard, now time.Time) openRouterModelsDocument {
+func projectOpenRouterModels(pool []openRouterPoolSnapshot, rateCard openRouterRateCard, now time.Time) (openRouterModelsDocument, error) {
 	byID := make(map[string]openRouterPoolSnapshot, len(pool))
 	for _, model := range pool {
 		byID[model.ID] = model
@@ -177,57 +244,159 @@ func projectOpenRouterModels(pool []openRouterPoolSnapshot, rateCard openRouterR
 		if !ok || live.ReadyProviderCount < listing.MinWarmProviders {
 			continue
 		}
-		ready := live.SlotsFree > 0
+		ready := live.ReadySlotsFree > 0
 		contextLength := live.MaxContextTokens
 		if contextLength < 1 {
 			contextLength = 8192
 		}
-		paidCost := costUSDFromRateCard(rateCard, listing.CatalogKey)
-		data = append(data, openRouterModelRow(listing, listing.PoolID, false, ready, contextLength, paidCost, created))
-		if listing.DualFree && listing.FreeID != "" {
-			freeCost := openRouterCostUSD{Prompt: "0", Completion: "0"}
-			data = append(data, openRouterModelRow(listing, listing.FreeID, true, ready, contextLength, freeCost, created))
+		shareCount := 1
+		if listing.DualFree && listing.FreeID != "" && openRouterBaseConcurrency(live) >= 2 {
+			shareCount = 2
+		}
+		paidCost, err := textCostUSDFromRateCard(rateCard, listing.CatalogKey)
+		if err != nil {
+			return openRouterModelsDocument{}, err
+		}
+		data = append(data, openRouterModelRow(listing, listing.PoolID, false, ready, contextLength, live, 0, shareCount, paidCost, created))
+		if shareCount == 2 {
+			freeCost := openRouterTextCostUSD{Prompt: "0", Completion: "0"}
+			data = append(data, openRouterModelRow(listing, listing.FreeID, true, ready, contextLength, live, 1, shareCount, freeCost, created))
 		}
 	}
-	return openRouterModelsDocument{SchemaVersion: openRouterSchemaVersion, Data: data}
+	return openRouterModelsDocument{Data: data}, nil
 }
 
-func openRouterModelRow(listing openRouterListingSpec, id string, isFree, ready bool, contextLength int, cost openRouterCostUSD, created int64) openRouterModelV24 {
+func openRouterModelRow(listing openRouterListingSpec, id string, isFree, ready bool, contextLength int, live openRouterPoolSnapshot, shareIndex, shareCount int, cost openRouterTextCostUSD, created int64) openRouterModelV24 {
 	name := listing.Name
 	if isFree {
 		name += " (free)"
 	}
+	if listing.Created > 0 {
+		created = listing.Created
+	}
+	maxOutput := contextLength
+	if maxOutput > 4096 {
+		maxOutput = 4096
+	}
+	capacity := openRouterCapacityEntries(live, maxOutput, shareIndex, shareCount)
 	return openRouterModelV24{
+		SchemaVersion: openRouterSchemaVersion,
 		ID:            id,
 		Name:          name,
 		Created:       created,
-		Architecture:  openRouterArchitecture{InputModalities: []string{"text"}, OutputModalities: []string{"text"}, Modality: "text->text"},
-		ContextLength: contextLength,
 		Quantization:  "int4",
+		Tokenizer:     listing.Tokenizer,
 		HuggingFaceID: listing.HuggingFaceID,
-		IsReady:       ready,
-		IsFree:        isFree,
-		CostUSD:       cost,
-		Compliance:    openRouterCompliance{ZDR: false},
-		SupportedParams: []string{
-			"max_tokens", "temperature", "top_p", "stop", "stream", "presence_penalty", "frequency_penalty", "seed",
+		InputModalities: []openRouterInputModality{{
+			Type:            "text",
+			SupportedInputs: openRouterTextInputSupport{MaxContextLength: openRouterIntegerLimit{Value: contextLength, Unit: "token"}},
+			Pricing:         []openRouterPricingEntry{{Type: "prompt", Unit: "token", CostUSD: cost.Prompt}},
+			Capacity:        []openRouterCapacityEntry{{Type: "prompt", Unit: "token", Per: "minute", Value: capacity.TokensPerMinute}},
+		}},
+		OutputModalities: []openRouterOutputModality{{
+			Type:                "text",
+			MaxLength:           openRouterIntegerLimit{Value: maxOutput, Unit: "token"},
+			Streaming:           true,
+			SupportedParameters: openRouterSupportedParameters(maxOutput),
+			Pricing:             []openRouterPricingEntry{{Type: "completion", Unit: "token", CostUSD: cost.Completion}},
+			Capacity:            []openRouterCapacityEntry{{Type: "completion", Unit: "token", Per: "minute", Value: capacity.TokensPerMinute}},
+		}},
+		Capacity: []openRouterCapacityEntry{
+			{Type: "request", Unit: "request", Per: "minute", Value: capacity.RequestsPerMinute},
+			{Type: "concurrency", Unit: "request", Value: capacity.Concurrency},
 		},
+		DeploymentRegion: "global-volunteer-fleet",
+		Compliance:       openRouterCompliance{ZDR: false},
+		IsReady:          ready,
+		IsFree:           isFree,
+		OpenRouter:       openRouterIdentityExtension{Slug: openRouterSlug(listing, isFree)},
 	}
 }
 
-func costUSDFromRateCard(card openRouterRateCard, catalogKey string) openRouterCostUSD {
+type openRouterDerivedCapacity struct {
+	Concurrency       int
+	RequestsPerMinute int
+	TokensPerMinute   int
+}
+
+func openRouterBaseConcurrency(live openRouterPoolSnapshot) int {
+	concurrency := live.ReadySlotsTotal
+	if concurrency < 1 {
+		concurrency = live.ReadyProviderCount
+	}
+	if concurrency < 1 {
+		concurrency = 1
+	}
+	return concurrency
+}
+
+func openRouterCapacityEntries(live openRouterPoolSnapshot, maxOutputTokens int, shareIndex, shareCount int) openRouterDerivedCapacity {
+	concurrency := openRouterBaseConcurrency(live)
+	if shareCount > 1 {
+		base := concurrency / shareCount
+		remainder := concurrency % shareCount
+		concurrency = base
+		if shareIndex < remainder {
+			concurrency++
+		}
+		if concurrency < 1 {
+			concurrency = 1
+		}
+	}
+	requestsPerMinute := concurrency * openRouterRequestsPerMinutePerSlot
+	return openRouterDerivedCapacity{
+		Concurrency:       concurrency,
+		RequestsPerMinute: requestsPerMinute,
+		TokensPerMinute:   max(1, concurrency*openRouterTokensPerSecondPerSlot*60),
+	}
+}
+
+func openRouterSlug(listing openRouterListingSpec, isFree bool) string {
+	if !isFree {
+		return listing.OpenRouterSlug
+	}
+	return listing.OpenRouterSlug + ":free"
+}
+
+func openRouterSupportedParameters(maxTokens int) map[string]openRouterParameterDescriptor {
+	return map[string]openRouterParameterDescriptor{
+		"max_tokens":        openRouterIntegerParameter(1, maxTokens, "token"),
+		"temperature":       openRouterRangeParameter(0, 2),
+		"top_p":             openRouterRangeParameter(0, 1),
+		"stop":              {Type: "array", MaxItems: 4},
+		"stream":            {Type: "boolean"},
+		"presence_penalty":  openRouterRangeParameter(-2, 2),
+		"frequency_penalty": openRouterRangeParameter(-2, 2),
+		"seed":              openRouterIntegerParameter(0, 9007199254740991, ""),
+	}
+}
+
+func openRouterRangeParameter(minValue, maxValue float64) openRouterParameterDescriptor {
+	return openRouterParameterDescriptor{Type: "range", Min: &minValue, Max: &maxValue}
+}
+
+func openRouterIntegerParameter(minValue, maxValue int, unit string) openRouterParameterDescriptor {
+	minFloat := float64(minValue)
+	maxFloat := float64(maxValue)
+	return openRouterParameterDescriptor{Type: "integer", Min: &minFloat, Max: &maxFloat, Unit: unit}
+}
+
+func textCostUSDFromRateCard(card openRouterRateCard, catalogKey string) (openRouterTextCostUSD, error) {
 	row, ok := card.Rows[catalogKey]
 	if !ok {
-		return openRouterCostUSD{Prompt: "0", Completion: "0"}
+		return openRouterTextCostUSD{}, fmt.Errorf("rate-card missing catalog key %q", catalogKey)
+	}
+	if row.PromptRatePerMtok <= 0 || row.CompletionRatePerMtok <= 0 {
+		return openRouterTextCostUSD{}, fmt.Errorf("rate-card invalid non-positive rates for %q", catalogKey)
 	}
 	usd := card.USDPerMillionCredits
-	if usd <= 0 {
-		usd = 1
+	if usd <= 0 || math.IsNaN(usd) || math.IsInf(usd, 0) {
+		return openRouterTextCostUSD{}, fmt.Errorf("rate-card invalid usd_per_million_credits")
 	}
-	return openRouterCostUSD{
+	return openRouterTextCostUSD{
 		Prompt:     formatUSDPerToken(row.PromptRatePerMtok, usd),
 		Completion: formatUSDPerToken(row.CompletionRatePerMtok, usd),
-	}
+	}, nil
 }
 
 func formatUSDPerToken(creditsPerMtok int64, usdPerMillionCredits float64) string {

--- a/phase5-gateway/internal/router/openrouter_models_test.go
+++ b/phase5-gateway/internal/router/openrouter_models_test.go
@@ -11,11 +11,20 @@ import (
 	"github.com/augstar/macprovider-gateway/internal/config"
 )
 
+func mustProjectOpenRouterModels(t *testing.T, pool []openRouterPoolSnapshot, rateCard openRouterRateCard, now time.Time) openRouterModelsDocument {
+	t.Helper()
+	doc, err := projectOpenRouterModels(pool, rateCard, now)
+	if err != nil {
+		t.Fatalf("projectOpenRouterModels: %v", err)
+	}
+	return doc
+}
+
 func TestProjectOpenRouterModelsDualLlamaSKU(t *testing.T) {
 	now := time.Date(2026, 9, 11, 12, 0, 0, 0, time.UTC)
-	doc := projectOpenRouterModels([]openRouterPoolSnapshot{
-		{ID: openRouterLlama3BPaidID, ReadyProviderCount: 6, SlotsFree: 4, MaxContextTokens: 131072},
-		{ID: openRouterQwen8BID, ReadyProviderCount: 1, SlotsFree: 1, MaxContextTokens: 32768},
+	doc := mustProjectOpenRouterModels(t, []openRouterPoolSnapshot{
+		{ID: openRouterLlama3BPaidID, ReadyProviderCount: 6, ReadySlotsTotal: 4, ReadySlotsFree: 4, MaxContextTokens: 131072},
+		{ID: openRouterQwen8BID, ReadyProviderCount: 1, ReadySlotsTotal: 1, ReadySlotsFree: 1, MaxContextTokens: 32768},
 	}, openRouterRateCard{
 		USDPerMillionCredits: 1,
 		Rows: map[string]openRouterRateCardRow{
@@ -23,9 +32,6 @@ func TestProjectOpenRouterModelsDualLlamaSKU(t *testing.T) {
 			openRouterQwen8BCatalogKey:  {PromptRatePerMtok: 13500, CompletionRatePerMtok: 27000},
 		},
 	}, now)
-	if doc.SchemaVersion != openRouterSchemaVersion {
-		t.Fatalf("schema_version=%q", doc.SchemaVersion)
-	}
 	if len(doc.Data) != 2 {
 		t.Fatalf("len(data)=%d want 2 (Qwen stays off until two warm nodes)", len(doc.Data))
 	}
@@ -37,27 +43,148 @@ func TestProjectOpenRouterModelsDualLlamaSKU(t *testing.T) {
 	if free.ID != openRouterLlama3BFreeID || !free.IsFree || !free.IsReady {
 		t.Fatalf("free row: %+v", free)
 	}
-	if paid.CostUSD.Prompt != "0.0000000135" || paid.CostUSD.Completion != "0.000000027" {
-		t.Fatalf("paid cost_usd=%+v", paid.CostUSD)
+	if paid.SchemaVersion != "2.4" || free.SchemaVersion != "2.4" {
+		t.Fatalf("row schema versions paid=%q free=%q", paid.SchemaVersion, free.SchemaVersion)
 	}
-	if free.CostUSD.Prompt != "0" || free.CostUSD.Completion != "0" {
-		t.Fatalf("free cost_usd=%+v", free.CostUSD)
+	if paid.Created != openRouterLlama3BCreatedAt || free.Created != openRouterLlama3BCreatedAt {
+		t.Fatalf("created must be stable listing timestamp paid=%d free=%d", paid.Created, free.Created)
+	}
+	if len(paid.InputModalities) != 1 || paid.InputModalities[0].Type != "text" {
+		t.Fatalf("paid input_modalities=%+v", paid.InputModalities)
+	}
+	if got := paid.InputModalities[0].SupportedInputs.MaxContextLength; got.Value != 131072 || got.Unit != "token" {
+		t.Fatalf("paid max_context_length=%+v", got)
+	}
+	if got := paid.InputModalities[0].Pricing; len(got) != 1 || got[0].Type != "prompt" || got[0].Unit != "token" || got[0].CostUSD != "0.0000000135" {
+		t.Fatalf("paid prompt pricing=%+v", got)
+	}
+	if got := paid.OutputModalities[0].Pricing; len(got) != 1 || got[0].Type != "completion" || got[0].Unit != "token" || got[0].CostUSD != "0.000000027" {
+		t.Fatalf("paid completion pricing=%+v", got)
+	}
+	if got := free.InputModalities[0].Pricing; len(got) != 1 || got[0].CostUSD != "0" {
+		t.Fatalf("free prompt pricing=%+v", got)
+	}
+	if got := free.OutputModalities[0].Pricing; len(got) != 1 || got[0].CostUSD != "0" {
+		t.Fatalf("free completion pricing=%+v", got)
 	}
 	if paid.Quantization != "int4" || paid.Compliance.ZDR {
 		t.Fatalf("quantization/zdr paid=%+v", paid)
 	}
+	if paid.DeploymentRegion != "global-volunteer-fleet" {
+		t.Fatalf("deployment_region paid=%q", paid.DeploymentRegion)
+	}
+	if len(paid.Capacity) != 2 || paid.Capacity[0].Type != "request" || paid.Capacity[1].Type != "concurrency" {
+		t.Fatalf("root capacity=%+v", paid.Capacity)
+	}
+	if paid.Capacity[1].Value != 2 || paid.Capacity[0].Value != 2 {
+		t.Fatalf("capacity must derive conservatively from live ready slots, got %+v", paid.Capacity)
+	}
+	if free.Capacity[1].Value != 2 || free.Capacity[0].Value != 2 {
+		t.Fatalf("free capacity must share the same ready pool, got %+v", free.Capacity)
+	}
+	if len(paid.OutputModalities) != 1 || !paid.OutputModalities[0].Streaming {
+		t.Fatalf("paid output_modalities=%+v", paid.OutputModalities)
+	}
+	for _, param := range []string{"max_tokens", "temperature", "top_p", "stop", "stream", "presence_penalty", "frequency_penalty", "seed"} {
+		if _, ok := paid.OutputModalities[0].SupportedParameters[param]; !ok {
+			t.Fatalf("missing supported parameter %q in %+v", param, paid.OutputModalities[0].SupportedParameters)
+		}
+	}
+	if _, ok := paid.OutputModalities[0].SupportedParameters["tools"]; ok {
+		t.Fatalf("tools must remain undeclared until live reliability is proven: %+v", paid.OutputModalities[0].SupportedParameters)
+	}
 	if paid.HuggingFaceID != openRouterLlama3BPaidID || free.HuggingFaceID != openRouterLlama3BPaidID {
 		t.Fatalf("hugging_face_id paid=%q free=%q", paid.HuggingFaceID, free.HuggingFaceID)
 	}
+	if paid.OpenRouter.Slug != openRouterLlama3BCatalogKey || free.OpenRouter.Slug != openRouterLlama3BCatalogKey+":free" {
+		t.Fatalf("openrouter slug paid=%q free=%q", paid.OpenRouter.Slug, free.OpenRouter.Slug)
+	}
 	raw, _ := json.Marshal(doc)
-	if strings.Contains(string(raw), "us-east-1") || strings.Contains(string(raw), "compute_integrity") || strings.Contains(string(raw), "tier1_disclosure") {
+	for _, forbidden := range []string{"architecture", "supported_parameters\":[", "us-east-1", "compute_integrity", "tier1_disclosure"} {
+		if strings.Contains(string(raw), forbidden) {
+			t.Fatalf("document leaked forbidden field/value %q: %s", forbidden, raw)
+		}
+	}
+	if !strings.Contains(string(raw), `"input_modalities"`) || !strings.Contains(string(raw), `"output_modalities"`) || !strings.Contains(string(raw), `"capacity"`) {
+		t.Fatalf("document missing schema-2.4 modality/capacity fields: %s", raw)
+	}
+	if !strings.Contains(string(raw), `"deployment_region":"global-volunteer-fleet"`) {
+		t.Fatalf("document missing honest deployment_region: %s", raw)
+	}
+}
+
+func TestProjectOpenRouterModelsCapacityTracksLiveSlots(t *testing.T) {
+	doc := mustProjectOpenRouterModels(t, []openRouterPoolSnapshot{
+		{ID: openRouterLlama3BPaidID, ReadyProviderCount: 6, ReadySlotsTotal: 4, ReadySlotsFree: 4, MaxContextTokens: 50000},
+	}, openRouterRateCard{USDPerMillionCredits: 1, Rows: map[string]openRouterRateCardRow{
+		openRouterLlama3BCatalogKey: {PromptRatePerMtok: 13500, CompletionRatePerMtok: 27000},
+	}}, time.Unix(1, 0).UTC())
+	if len(doc.Data) != 2 {
+		t.Fatalf("len(data)=%d", len(doc.Data))
+	}
+	got := doc.Data[0].Capacity
+	if len(got) != 2 || got[0].Value != 2 || got[1].Value != 2 {
+		t.Fatalf("capacity=%+v want 2rpm/2 concurrency for paid half of shared pool", got)
+	}
+	if promptCap := doc.Data[0].InputModalities[0].Capacity[0].Value; promptCap != 2*openRouterTokensPerSecondPerSlot*60 {
+		t.Fatalf("prompt capacity=%d", promptCap)
+	}
+	if completionCap := doc.Data[0].OutputModalities[0].Capacity[0].Value; completionCap != 2*openRouterTokensPerSecondPerSlot*60 {
+		t.Fatalf("completion capacity=%d", completionCap)
+	}
+}
+
+func TestProjectOpenRouterModelsRowsStaySchema24Native(t *testing.T) {
+	doc := mustProjectOpenRouterModels(t, []openRouterPoolSnapshot{
+		{ID: openRouterLlama3BPaidID, ReadyProviderCount: 1, ReadySlotsTotal: 1, ReadySlotsFree: 1, MaxContextTokens: 8192},
+	}, openRouterRateCard{USDPerMillionCredits: 1, Rows: map[string]openRouterRateCardRow{
+		openRouterLlama3BCatalogKey: {PromptRatePerMtok: 13500, CompletionRatePerMtok: 27000},
+	}}, time.Unix(1, 0).UTC())
+	raw, err := json.Marshal(doc.Data[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var row map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &row); err != nil {
+		t.Fatal(err)
+	}
+	for _, required := range []string{"schema_version", "id", "name", "input_modalities", "output_modalities"} {
+		if _, ok := row[required]; !ok {
+			t.Fatalf("row missing required schema-2.4 key %q: %s", required, raw)
+		}
+	}
+	for _, forbidden := range []string{"architecture", "context_length", "cost_usd", "supported_sampling_parameters", "supported_features", "capacity_tpm"} {
+		if _, ok := row[forbidden]; ok {
+			t.Fatalf("row contains legacy key %q: %s", forbidden, raw)
+		}
+	}
+	if string(row["schema_version"]) != `"2.4"` {
+		t.Fatalf("row schema_version=%s", row["schema_version"])
+	}
+	params := doc.Data[0].OutputModalities[0].SupportedParameters
+	if params["max_tokens"].Type != "integer" || params["max_tokens"].Unit != "token" {
+		t.Fatalf("max_tokens descriptor=%+v", params["max_tokens"])
+	}
+	if params["temperature"].Type != "range" || params["stream"].Type != "boolean" {
+		t.Fatalf("parameter descriptors=%+v", params)
+	}
+}
+
+func TestOpenRouterModelDocumentOmitsInventedAttestationRegionClaims(t *testing.T) {
+	doc := mustProjectOpenRouterModels(t, []openRouterPoolSnapshot{
+		{ID: openRouterLlama3BPaidID, ReadyProviderCount: 1, ReadySlotsTotal: 1, ReadySlotsFree: 1, MaxContextTokens: 8192},
+	}, openRouterRateCard{USDPerMillionCredits: 1, Rows: map[string]openRouterRateCardRow{
+		openRouterLlama3BCatalogKey: {PromptRatePerMtok: 13500, CompletionRatePerMtok: 27000},
+	}}, time.Unix(1, 0).UTC())
+	raw, _ := json.Marshal(doc)
+	if strings.Contains(string(raw), "compute_integrity") || strings.Contains(string(raw), "tier1_disclosure") || strings.Contains(string(raw), "us-east-1") {
 		t.Fatalf("document leaked forbidden fields: %s", raw)
 	}
 }
 
 func TestProjectOpenRouterModelsIsReadyRequiresWarmSlot(t *testing.T) {
-	doc := projectOpenRouterModels([]openRouterPoolSnapshot{
-		{ID: openRouterLlama3BPaidID, ReadyProviderCount: 2, SlotsFree: 0, MaxContextTokens: 8192},
+	doc := mustProjectOpenRouterModels(t, []openRouterPoolSnapshot{
+		{ID: openRouterLlama3BPaidID, ReadyProviderCount: 2, ReadySlotsTotal: 2, ReadySlotsFree: 0, MaxContextTokens: 8192},
 	}, openRouterRateCard{USDPerMillionCredits: 1, Rows: map[string]openRouterRateCardRow{
 		openRouterLlama3BCatalogKey: {PromptRatePerMtok: 13500, CompletionRatePerMtok: 27000},
 	}}, time.Unix(1, 0).UTC())
@@ -70,9 +197,9 @@ func TestProjectOpenRouterModelsIsReadyRequiresWarmSlot(t *testing.T) {
 }
 
 func TestProjectOpenRouterModelsIncludesQwenWhenRedundant(t *testing.T) {
-	doc := projectOpenRouterModels([]openRouterPoolSnapshot{
-		{ID: openRouterLlama3BPaidID, ReadyProviderCount: 2, SlotsFree: 1, MaxContextTokens: 8192},
-		{ID: openRouterQwen8BID, ReadyProviderCount: 2, SlotsFree: 1, MaxContextTokens: 32768},
+	doc := mustProjectOpenRouterModels(t, []openRouterPoolSnapshot{
+		{ID: openRouterLlama3BPaidID, ReadyProviderCount: 2, ReadySlotsTotal: 2, ReadySlotsFree: 1, MaxContextTokens: 8192},
+		{ID: openRouterQwen8BID, ReadyProviderCount: 2, ReadySlotsTotal: 2, ReadySlotsFree: 1, MaxContextTokens: 32768},
 	}, openRouterRateCard{USDPerMillionCredits: 1, Rows: map[string]openRouterRateCardRow{
 		openRouterLlama3BCatalogKey: {PromptRatePerMtok: 13500, CompletionRatePerMtok: 27000},
 		openRouterQwen8BCatalogKey:  {PromptRatePerMtok: 13500, CompletionRatePerMtok: 27000},
@@ -84,10 +211,84 @@ func TestProjectOpenRouterModelsIncludesQwenWhenRedundant(t *testing.T) {
 			if row.IsFree {
 				t.Fatal("Qwen row must not be the free alias")
 			}
+			if row.OpenRouter.Slug != openRouterQwen8BSlug {
+				t.Fatalf("Qwen openrouter slug=%q want %q", row.OpenRouter.Slug, openRouterQwen8BSlug)
+			}
 		}
 	}
 	if !sawQwen {
 		t.Fatal("expected Qwen when two warm nodes")
+	}
+}
+
+func TestProjectOpenRouterModelsIgnoresNonReadyCapacity(t *testing.T) {
+	doc := mustProjectOpenRouterModels(t, []openRouterPoolSnapshot{
+		{
+			ID:                 openRouterLlama3BPaidID,
+			ReadyProviderCount: 1,
+			ReadySlotsTotal:    1,
+			ReadySlotsFree:     0,
+			MaxContextTokens:   8192,
+		},
+	}, openRouterRateCard{USDPerMillionCredits: 1, Rows: map[string]openRouterRateCardRow{
+		openRouterLlama3BCatalogKey: {PromptRatePerMtok: 13500, CompletionRatePerMtok: 27000},
+	}}, time.Unix(1, 0).UTC())
+	if len(doc.Data) != 1 {
+		t.Fatalf("len(data)=%d", len(doc.Data))
+	}
+	if doc.Data[0].IsReady {
+		t.Fatal("is_ready must use ready free slots, not aggregate free slots from unavailable providers")
+	}
+	if got := doc.Data[0].Capacity[1].Value; got != 1 {
+		t.Fatalf("concurrency=%d want 1 ready slot", got)
+	}
+}
+
+func TestProjectOpenRouterModelsOmitsFreeAliasWhenCapacityCannotBeShared(t *testing.T) {
+	doc := mustProjectOpenRouterModels(t, []openRouterPoolSnapshot{
+		{ID: openRouterLlama3BPaidID, ReadyProviderCount: 1, ReadySlotsTotal: 1, ReadySlotsFree: 1, MaxContextTokens: 8192},
+	}, openRouterRateCard{USDPerMillionCredits: 1, Rows: map[string]openRouterRateCardRow{
+		openRouterLlama3BCatalogKey: {PromptRatePerMtok: 13500, CompletionRatePerMtok: 27000},
+	}}, time.Unix(1, 0).UTC())
+	if len(doc.Data) != 1 {
+		t.Fatalf("len(data)=%d want 1 paid row until capacity can be split", len(doc.Data))
+	}
+	if doc.Data[0].ID != openRouterLlama3BPaidID || doc.Data[0].IsFree {
+		t.Fatalf("unexpected row: %+v", doc.Data[0])
+	}
+}
+
+func TestProjectOpenRouterModelsFailsClosedOnInvalidPaidRateCard(t *testing.T) {
+	pool := []openRouterPoolSnapshot{
+		{ID: openRouterLlama3BPaidID, ReadyProviderCount: 1, ReadySlotsTotal: 1, ReadySlotsFree: 1, MaxContextTokens: 8192},
+	}
+	tests := []struct {
+		name string
+		card openRouterRateCard
+	}{
+		{
+			name: "missing catalog key",
+			card: openRouterRateCard{USDPerMillionCredits: 1, Rows: map[string]openRouterRateCardRow{}},
+		},
+		{
+			name: "zero usd conversion",
+			card: openRouterRateCard{USDPerMillionCredits: 0, Rows: map[string]openRouterRateCardRow{
+				openRouterLlama3BCatalogKey: {PromptRatePerMtok: 13500, CompletionRatePerMtok: 27000},
+			}},
+		},
+		{
+			name: "zero prompt rate",
+			card: openRouterRateCard{USDPerMillionCredits: 1, Rows: map[string]openRouterRateCardRow{
+				openRouterLlama3BCatalogKey: {PromptRatePerMtok: 0, CompletionRatePerMtok: 27000},
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := projectOpenRouterModels(pool, tt.card, time.Unix(1, 0).UTC()); err == nil {
+				t.Fatal("expected invalid paid rate card to fail closed")
+			}
+		})
 	}
 }
 
@@ -118,7 +319,38 @@ func TestOpenRouterModelsHandlerUnauthenticated(t *testing.T) {
 	if err := json.Unmarshal(resp.Body.Bytes(), &doc); err != nil {
 		t.Fatalf("decode: %v body=%s", err, resp.Body.String())
 	}
-	if doc.SchemaVersion != "2.4" || len(doc.Data) != 2 {
+	if len(doc.Data) != 2 {
 		t.Fatalf("doc=%+v", doc)
+	}
+	if doc.Data[0].SchemaVersion != "2.4" || doc.Data[1].SchemaVersion != "2.4" {
+		t.Fatalf("row schema versions=%q/%q", doc.Data[0].SchemaVersion, doc.Data[1].SchemaVersion)
+	}
+}
+
+func TestOpenRouterModelsHandlerFailsClosedOnMissingRateCardRow(t *testing.T) {
+	poolz := `{"pool":[{"model_id":"mlx-community/Llama-3.2-3B-Instruct-4bit","state":"ready","slots_free":1,"slots_total":1,"max_context_tokens":8192,"auth_state":"bearer_validated"}]}`
+	rateCard := `{"usd_per_million_credits":1,"rows":{}}`
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/poolz"):
+			return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}}, poolz), nil
+		case strings.HasSuffix(r.URL.Path, "/v1/rate-card"):
+			return responseWithBody(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}}, rateCard), nil
+		default:
+			return responseWithBody(http.StatusNotFound, nil, `{}`), nil
+		}
+	})}
+	h, _, _, _ := newTestHarnessConfig(t, fakeOAuth{}, func(cfg *config.Config) {
+		cfg.Coordinator.BuyerURL = "http://coordinator.test"
+		cfg.Coordinator.OperatorURL = "http://operator.test"
+	}, WithHTTPClient(client))
+	resp := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, openRouterModelsPath, nil)
+	h.ServeHTTP(resp, req)
+	if resp.Code != http.StatusBadGateway {
+		t.Fatalf("status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	if !strings.Contains(resp.Body.String(), "coordinator_rate_card_error") {
+		t.Fatalf("body=%s", resp.Body.String())
 	}
 }

--- a/phase5-gateway/internal/router/pages_test.go
+++ b/phase5-gateway/internal/router/pages_test.go
@@ -95,6 +95,8 @@ func TestPrivacyRouteRendersHonestRetention(t *testing.T) {
 		"compliance.zdr",
 		"train foundation models",
 		"us-east-1",
+		"90 days",
+		"storage.request_log_retention_days",
 	} {
 		if !strings.Contains(body, want) && !strings.Contains(lower, strings.ToLower(want)) {
 			t.Fatalf("privacy body missing %q: %s", want, body)

--- a/phase5-gateway/internal/router/server.go
+++ b/phase5-gateway/internal/router/server.go
@@ -922,6 +922,8 @@ type statusModel struct {
 	ReadyProviderCount int    `json:"ready_provider_count"`
 	TotalSlots         int    `json:"total_slots"`
 	SlotsFree          int    `json:"slots_free"`
+	ReadySlotsTotal    int    `json:"-"`
+	ReadySlotsFree     int    `json:"-"`
 	MaxContextTokens   int    `json:"max_context_tokens"`
 	Degraded           bool   `json:"degraded"`
 	Available          bool   `json:"available"`
@@ -1073,6 +1075,8 @@ func aggregateStatus(poolz poolzResponse, readyThreshold int, now time.Time) sta
 		m.SlotsFree += p.SlotsFree
 		if p.State == "ready" {
 			m.ReadyProviderCount++
+			m.ReadySlotsTotal += p.SlotsTotal
+			m.ReadySlotsFree += p.SlotsFree
 		}
 		if p.MaxContextTokens > m.MaxContextTokens {
 			m.MaxContextTokens = p.MaxContextTokens

--- a/phase5-gateway/internal/router/server_test.go
+++ b/phase5-gateway/internal/router/server_test.go
@@ -1699,6 +1699,12 @@ func TestAggregateStatusExcludesBearerlessDuplicatesFromCapacity(t *testing.T) {
 	if m.SlotsFree != 3 {
 		t.Fatalf("model.SlotsFree=%d, want 3 (2 excluded slots omitted)", m.SlotsFree)
 	}
+	if m.ReadySlotsTotal != 3 {
+		t.Fatalf("model.ReadySlotsTotal=%d, want 3", m.ReadySlotsTotal)
+	}
+	if m.ReadySlotsFree != 3 {
+		t.Fatalf("model.ReadySlotsFree=%d, want 3", m.ReadySlotsFree)
+	}
 	if !m.Available || m.Availability != "available" {
 		t.Fatalf("model availability=%+v, want available", m)
 	}

--- a/phase5-gateway/internal/router/templates/privacy.md
+++ b/phase5-gateway/internal/router/templates/privacy.md
@@ -18,7 +18,7 @@ Mac Provider does not train foundation models on buyer prompts.
 
 ## What we retain
 
-Request metadata needed for routing, quota, settlement, and wholesale partner monthly statements is retained in coordinator `request_log` for the configured log lifetime. That metadata includes account identity, model id, token counts, timestamps, and settlement fields. Prompt and completion bodies are not stored as a training corpus.
+Request metadata needed for routing, quota, settlement, and wholesale partner monthly statements is retained in coordinator `request_log` for 90 days by default, matching the shipped coordinator `storage.request_log_retention_days` configuration. Operators may only change that by changing the coordinator configuration. That metadata includes account identity, model id, token counts, timestamps, and settlement fields. Prompt and completion bodies are not stored as a training corpus.
 
 ## Contact
 

--- a/scripts/openrouter_readiness_probe.py
+++ b/scripts/openrouter_readiness_probe.py
@@ -1,0 +1,800 @@
+#!/usr/bin/env python3
+"""Validate Malibu's OpenRouter provider-readiness surfaces.
+
+The probe is intentionally dependency-free so operators can run it from a
+release host or laptop without changing the repo environment.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import decimal
+import io
+import json
+import os
+import statistics
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+
+DEFAULT_MODEL = "mlx-community/Llama-3.2-3B-Instruct-4bit"
+DEFAULT_PROMPT = "OpenRouter provider readiness smoke. Reply with one short sentence."
+MAX_BENCHMARK_REQUESTS = 200
+MAX_BENCHMARK_CONCURRENCY = 8
+DEFAULT_MIN_SUCCESS_RATIO = 0.95
+DEFAULT_MAX_TTFT_P95_MS = 5000
+DEFAULT_MIN_OUTPUT_TOKENS_PER_SECOND = 10.0
+GATEWAY_KEEPALIVE_TICK_SECONDS = 15
+LOCAL_AUTH_HOSTS = {"localhost", "127.0.0.1", "::1"}
+EXPECTED_OPENROUTER_SLUGS = {
+    "mlx-community/Llama-3.2-3B-Instruct-4bit": "meta-llama/llama-3.2-3b-instruct",
+    "mlx-community/Llama-3.2-3B-Instruct-4bit-free": "meta-llama/llama-3.2-3b-instruct:free",
+    "mlx-community/Qwen3-8B-4bit": "qwen/qwen3-8b",
+}
+ROOT_FORBIDDEN_MODEL_KEYS = {
+    "architecture",
+    "context_length",
+    "cost_usd",
+    "supported_sampling_parameters",
+    "supported_features",
+    "capacity_tpm",
+}
+RECURSIVE_FORBIDDEN_DISCLOSURE_KEYS = {
+    "compute_integrity",
+    "tier1_disclosure",
+    "provider_id",
+    "provider_ids",
+    "provider",
+    "providers",
+    "host",
+    "hostname",
+    "ip",
+    "ips",
+    "endpoint",
+    "endpoints",
+}
+
+
+class ProbeError(Exception):
+    pass
+
+
+class NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        raise ProbeError(f"refusing redirect from {req.full_url} to {newurl}")
+
+
+NO_REDIRECT_OPENER = urllib.request.build_opener(NoRedirectHandler)
+
+
+def http_request(method: str, url: str, *, token: str = "", body: object | None = None, stream: bool = False, timeout: float = 45.0):
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ProbeError(f"invalid URL: {url}")
+    if token and parsed.scheme != "https" and parsed.hostname not in LOCAL_AUTH_HOSTS:
+        raise ProbeError(f"refusing to send bearer token over non-HTTPS URL: {url}")
+    data = None
+    headers = {"User-Agent": "macprovider-openrouter-readiness-probe/1.0"}
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    if token:
+        headers["Authorization"] = "Bearer " + token
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        return NO_REDIRECT_OPENER.open(req, timeout=timeout)
+    except ProbeError:
+        raise
+    except urllib.error.HTTPError as exc:
+        return exc
+    except urllib.error.URLError as exc:
+        raise ProbeError(str(exc)) from exc
+
+
+def response_status(resp) -> int:
+    status = getattr(resp, "status", None)
+    if status is None:
+        status = getattr(resp, "code", None)
+    if status is None:
+        raise ProbeError("HTTP response missing status/code")
+    return int(status)
+
+
+def read_json(method: str, url: str, **kwargs):
+    with http_request(method, url, **kwargs) as resp:
+        raw = resp.read()
+        status = response_status(resp)
+        if status < 200 or status > 299:
+            raise ProbeError(f"{url} returned HTTP {status}")
+        return json.loads(raw.decode("utf-8")), status
+
+
+def normalize_base_url(base_url: str) -> str:
+    return base_url.rstrip("/")
+
+
+def v1_url(base_url: str, path: str) -> str:
+    base = normalize_base_url(base_url)
+    if base.endswith("/v1"):
+        return base + path
+    return base + "/v1" + path
+
+
+def expected_free_model_id(model: str) -> str:
+    if model.endswith("-free"):
+        return model
+    return model + "-free"
+
+
+def root_url(base_url: str, path: str) -> str:
+    base = normalize_base_url(base_url)
+    if base.endswith("/v1"):
+        base = base[:-3]
+    return base + path
+
+
+def check_decimal(value: object, label: str) -> None:
+    if not isinstance(value, str) or not value or value.startswith("-"):
+        raise ProbeError(f"{label} must be a non-negative decimal string")
+    try:
+        parsed = decimal.Decimal(value)
+    except decimal.InvalidOperation as exc:
+        raise ProbeError(f"{label} must parse as decimal") from exc
+    if not parsed.is_finite() or parsed < 0:
+        raise ProbeError(f"{label} must be a finite non-negative decimal string")
+
+
+def check_capacity(entries: object, label: str) -> None:
+    if not isinstance(entries, list) or not entries:
+        raise ProbeError(f"{label} must be a non-empty capacity array")
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise ProbeError(f"{label} entries must be objects")
+        if not isinstance(entry.get("value"), int) or entry["value"] < 1:
+            raise ProbeError(f"{label} value must be a positive integer")
+        if entry.get("type") != "concurrency" and entry.get("per") not in {"minute", "hour", "day"}:
+            raise ProbeError(f"{label} non-concurrency entries need a valid per window")
+
+
+def find_forbidden_key(value: object, path: str = "$") -> str | None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if key in RECURSIVE_FORBIDDEN_DISCLOSURE_KEYS:
+                return f"{path}.{key}"
+            found = find_forbidden_key(child, f"{path}.{key}")
+            if found:
+                return found
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            found = find_forbidden_key(child, f"{path}[{index}]")
+            if found:
+                return found
+    return None
+
+
+def model_prices(row: dict) -> tuple[object, object]:
+    prompt = row.get("input_modalities", [{}])[0].get("pricing", [{}])[0].get("cost_usd")
+    completion = row.get("output_modalities", [{}])[0].get("pricing", [{}])[0].get("cost_usd")
+    return prompt, completion
+
+
+def check_models_document(doc: dict, expected_model: str = "", require_free_alias: bool = False) -> dict:
+    rows = doc.get("data")
+    if not isinstance(rows, list) or not rows:
+        raise ProbeError("models document must contain non-empty data array")
+    by_id = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            raise ProbeError("model rows must be objects")
+        row_id = row.get("id")
+        if isinstance(row_id, str):
+            by_id[row_id] = row
+        missing = {"schema_version", "id", "name", "input_modalities", "output_modalities"} - set(row)
+        if missing:
+            raise ProbeError(f"{row.get('id', '<unknown>')} missing required keys: {sorted(missing)}")
+        bad_root = ROOT_FORBIDDEN_MODEL_KEYS & set(row)
+        if bad_root:
+            raise ProbeError(f"{row.get('id', '<unknown>')} contains forbidden root keys: {sorted(bad_root)}")
+        bad_path = find_forbidden_key(row)
+        if bad_path:
+            raise ProbeError(f"{row.get('id', '<unknown>')} contains forbidden disclosure key: {bad_path}")
+        if row["schema_version"] != "2.4":
+            raise ProbeError(f"{row['id']} schema_version={row['schema_version']!r}, want 2.4")
+        inputs = row["input_modalities"]
+        outputs = row["output_modalities"]
+        if not isinstance(inputs, list) or not inputs or inputs[0].get("type") != "text":
+            raise ProbeError(f"{row['id']} must declare text input modality")
+        if not isinstance(outputs, list) or not outputs or outputs[0].get("type") != "text":
+            raise ProbeError(f"{row['id']} must declare text output modality")
+        text_in = inputs[0]
+        text_out = outputs[0]
+        max_context = text_in.get("supported_inputs", {}).get("max_context_length", {})
+        if not isinstance(max_context.get("value"), int) or max_context["value"] < 1:
+            raise ProbeError(f"{row['id']} text max_context_length must be positive")
+        input_prices = text_in.get("pricing")
+        output_prices = text_out.get("pricing")
+        if not isinstance(input_prices, list) or not input_prices:
+            raise ProbeError(f"{row['id']} must declare input pricing")
+        if not isinstance(output_prices, list) or not output_prices:
+            raise ProbeError(f"{row['id']} must declare output pricing")
+        check_decimal(input_prices[0].get("cost_usd"), f"{row['id']} prompt cost_usd")
+        check_decimal(output_prices[0].get("cost_usd"), f"{row['id']} completion cost_usd")
+        if not isinstance(text_out.get("supported_parameters"), dict):
+            raise ProbeError(f"{row['id']} output supported_parameters must be an object")
+        for param in ("max_tokens", "temperature", "top_p", "stop", "stream"):
+            if param not in text_out["supported_parameters"]:
+                raise ProbeError(f"{row['id']} missing supported parameter {param}")
+        check_capacity(row.get("capacity"), f"{row['id']} root capacity")
+        check_capacity(text_in.get("capacity"), f"{row['id']} input capacity")
+        check_capacity(text_out.get("capacity"), f"{row['id']} output capacity")
+        if "datacenters" in row:
+            raise ProbeError(f"{row['id']} must omit datacenters until verified geography provenance exists")
+        if row.get("deployment_region") != "global-volunteer-fleet":
+            raise ProbeError(f"{row['id']} deployment_region must be global-volunteer-fleet")
+        if row.get("compliance", {}).get("zdr") is not False:
+            raise ProbeError(f"{row['id']} must honestly declare compliance.zdr=false")
+        slug = row.get("openrouter", {}).get("slug") if isinstance(row.get("openrouter"), dict) else None
+        if not isinstance(slug, str) or not slug:
+            raise ProbeError(f"{row['id']} must declare openrouter.slug")
+        expected_slug = EXPECTED_OPENROUTER_SLUGS.get(row["id"])
+        if expected_slug and slug != expected_slug:
+            raise ProbeError(f"{row['id']} openrouter.slug={slug!r}, want {expected_slug!r}")
+    if expected_model:
+        paid = by_id.get(expected_model)
+        if paid is None:
+            raise ProbeError(f"models document missing requested model {expected_model}")
+        if paid.get("is_free") is True:
+            raise ProbeError(f"requested model {expected_model} must be the paid row, not free")
+        if require_free_alias and paid.get("is_ready") is not True:
+            raise ProbeError(f"requested model {expected_model} must be is_ready=true for filing mode")
+    if require_free_alias:
+        free_id = expected_free_model_id(expected_model)
+        free = by_id.get(free_id)
+        if free is None:
+            raise ProbeError(f"filing-mode models document missing free alias {free_id}")
+        if free.get("is_free") is not True:
+            raise ProbeError(f"free alias {free_id} must declare is_free=true")
+        if free.get("is_ready") is not True:
+            raise ProbeError(f"free alias {free_id} must declare is_ready=true")
+        prompt, completion = model_prices(free)
+        if prompt != "0" or completion != "0":
+            raise ProbeError(f"free alias {free_id} must declare zero prompt/completion pricing")
+        slug = free.get("openrouter", {}).get("slug") if isinstance(free.get("openrouter"), dict) else ""
+        if not isinstance(slug, str) or not slug.endswith(":free"):
+            raise ProbeError(f"free alias {free_id} openrouter.slug must end with :free")
+    return {"rows": len(rows), "ids": [row["id"] for row in rows]}
+
+
+def check_privacy(base_url: str) -> dict:
+    with http_request("GET", root_url(base_url, "/privacy")) as resp:
+        raw = resp.read().decode("utf-8", "replace")
+        status = response_status(resp)
+        if status != 200:
+            raise ProbeError(f"/privacy returned HTTP {status}")
+    lower = raw.lower()
+    required = (
+        "plaintext",
+        "no zero-data-retention",
+        "compliance.zdr",
+        "false",
+        "90 days",
+        "does not train foundation models on buyer prompts",
+        "not stored as a training corpus",
+    )
+    for text in required:
+        if text not in lower:
+            raise ProbeError(f"/privacy missing disclosure: {text}")
+    forbidden = (
+        "private inference guaranteed",
+        "zdr guarantee",
+        '"zdr": true',
+        "compliance.zdr=true",
+        "compliance.zdr: true",
+        "zero-data-retention guarantee is available",
+        "we train foundation models on buyer prompts",
+        "may train foundation models on buyer prompts",
+    )
+    for text in forbidden:
+        if text in lower:
+            raise ProbeError(f"/privacy contains forbidden claim: {text}")
+    return {"http_status": 200, "mentions_90_days": True, "zdr_false": True, "training_corpus_denied": True}
+
+
+def usage_is_valid(value: object) -> bool:
+    if not isinstance(value, dict):
+        return False
+    keys = ("prompt_tokens", "completion_tokens", "total_tokens")
+    return all(isinstance(value.get(key), int) and value[key] >= 0 for key in keys)
+
+
+def extract_error_code(raw: bytes) -> str:
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return ""
+    error = payload.get("error") if isinstance(payload, dict) else None
+    if isinstance(error, dict):
+        for key in ("code", "type"):
+            value = error.get(key)
+            if isinstance(value, str):
+                return value
+    return ""
+
+
+def is_capacity_shed(result: dict) -> bool:
+    return result.get("status") == 429 and result.get("error_code") == "no_provider_available"
+
+
+def chat_once(base_url: str, token: str, model: str, *, stream: bool, max_tokens: int) -> dict:
+    body = {
+        "model": model,
+        "messages": [{"role": "user", "content": DEFAULT_PROMPT}],
+        "max_tokens": max_tokens,
+        "stream": stream,
+    }
+    if stream:
+        body["stream_options"] = {"include_usage": True}
+    started = time.perf_counter()
+    resp = http_request("POST", v1_url(base_url, "/chat/completions"), token=token, body=body, stream=stream, timeout=90)
+    try:
+        status = response_status(resp)
+        if status != 200:
+            raw = resp.read()
+            return {
+                "status": status,
+                "ok": False,
+                "error_code": extract_error_code(raw),
+                "latency_ms": int((time.perf_counter() - started) * 1000),
+            }
+        if not stream:
+            raw = resp.read()
+            payload = json.loads(raw.decode("utf-8"))
+            content = payload.get("choices", [{}])[0].get("message", {}).get("content")
+            usage = payload.get("usage")
+            return {
+                "status": 200,
+                "ok": bool(content) and usage_is_valid(usage),
+                "usage_ok": usage_is_valid(usage),
+                "content_ok": bool(content),
+                "output_tokens": usage.get("completion_tokens", 0) if usage_is_valid(usage) else 0,
+                "latency_ms": int((time.perf_counter() - started) * 1000),
+            }
+        saw_content = False
+        saw_usage = False
+        saw_keepalive = False
+        first_content_ms = None
+        usage = None
+        for raw_line in resp:
+            line = raw_line.decode("utf-8", "replace").strip()
+            if not line:
+                continue
+            if line.startswith(":"):
+                saw_keepalive = True
+                continue
+            if not line.startswith("data:"):
+                continue
+            data = line[5:].strip()
+            if data == "[DONE]":
+                break
+            payload = json.loads(data)
+            if usage_is_valid(payload.get("usage")):
+                saw_usage = True
+                usage = payload["usage"]
+            choices = payload.get("choices") or []
+            if choices and choices[0].get("delta", {}).get("content"):
+                saw_content = True
+                if first_content_ms is None:
+                    first_content_ms = int((time.perf_counter() - started) * 1000)
+        latency_ms = int((time.perf_counter() - started) * 1000)
+        generation_ms = None
+        if first_content_ms is not None:
+            generation_ms = max(1, latency_ms - first_content_ms)
+        return {
+            "status": 200,
+            "ok": saw_content and saw_usage,
+            "usage_ok": saw_usage,
+            "content_ok": saw_content,
+            "keepalive_observed": saw_keepalive,
+            "keepalive_evidence": "observed" if saw_keepalive else ("not_applicable_fast_stream" if latency_ms < GATEWAY_KEEPALIVE_TICK_SECONDS * 1000 else "missing"),
+            "ttft_ms": first_content_ms,
+            "latency_ms": latency_ms,
+            "generation_ms": generation_ms,
+            "output_tokens": usage.get("completion_tokens", 0) if usage_is_valid(usage) else 0,
+        }
+    finally:
+        resp.close()
+
+
+def check_chat(base_url: str, token: str, model: str, max_tokens: int) -> dict:
+    non_stream = chat_once(base_url, token, model, stream=False, max_tokens=max_tokens)
+    stream = chat_once(base_url, token, model, stream=True, max_tokens=max_tokens)
+    if not non_stream.get("ok"):
+        raise ProbeError(f"non-stream chat usage/content check failed: {non_stream}")
+    if not stream.get("ok"):
+        raise ProbeError(f"stream chat usage/content check failed: {stream}")
+    if stream.get("keepalive_evidence") == "missing":
+        raise ProbeError(f"stream lasted past keepalive tick without SSE comment keepalive: {stream}")
+    return {"non_stream": non_stream, "stream": stream}
+
+
+def percentile(values: list[int], pct: float) -> int:
+    if not values:
+        raise ProbeError("cannot compute percentile without samples")
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, max(0, round((pct / 100) * (len(ordered) - 1))))
+    return ordered[index]
+
+
+def run_benchmark(
+    base_url: str,
+    token: str,
+    model: str,
+    requests: int,
+    concurrency: int,
+    max_tokens: int,
+    min_success_ratio: float,
+    max_ttft_p95_ms: int,
+    min_output_tokens_per_second: float,
+    require_429: bool = False,
+) -> dict:
+    if requests < 1:
+        raise ProbeError("benchmark requests must be positive")
+    if requests > MAX_BENCHMARK_REQUESTS:
+        raise ProbeError(f"benchmark requests must be <= {MAX_BENCHMARK_REQUESTS}")
+    if concurrency < 1 or concurrency > MAX_BENCHMARK_CONCURRENCY:
+        raise ProbeError(f"benchmark concurrency must be in [1,{MAX_BENCHMARK_CONCURRENCY}]")
+    if max_tokens < 1 or max_tokens > 128:
+        raise ProbeError("benchmark max_tokens must be in [1,128]")
+    started = time.perf_counter()
+    results = []
+    remaining = requests
+    while remaining > 0:
+        batch_size = min(concurrency, remaining)
+        batch = []
+        with ThreadPoolExecutor(max_workers=batch_size) as executor:
+            futures = [executor.submit(chat_once, base_url, token, model, stream=True, max_tokens=max_tokens) for _ in range(batch_size)]
+            for future in as_completed(futures):
+                result = future.result()
+                batch.append(result)
+                results.append(result)
+        remaining -= batch_size
+        if require_429 and any(is_capacity_shed(result) for result in batch):
+            break
+    elapsed = max(time.perf_counter() - started, 0.001)
+    statuses = {}
+    ttfts = []
+    generation_seconds = 0.0
+    output_tokens = 0
+    for result in results:
+        statuses[str(result["status"])] = statuses.get(str(result["status"]), 0) + 1
+        if result.get("ttft_ms") is not None:
+            ttfts.append(result["ttft_ms"])
+        if result.get("ok"):
+            output_tokens += int(result.get("output_tokens") or 0)
+            generation_seconds += max((int(result.get("generation_ms") or 0) / 1000), 0.001)
+    ok_count = sum(1 for result in results if result.get("ok"))
+    shed_count = sum(1 for result in results if is_capacity_shed(result))
+    failed = [result for result in results if not result.get("ok") and not is_capacity_shed(result)]
+    if failed:
+        raise ProbeError(f"benchmark had non-capacity-shed failures: {failed[:3]}")
+    success_ratio = ok_count / len(results)
+    if success_ratio < min_success_ratio:
+        raise ProbeError(f"benchmark success ratio {success_ratio:.3f} below required {min_success_ratio:.3f}; statuses={statuses}")
+    if require_429 and shed_count < 1:
+        raise ProbeError(f"saturation benchmark did not observe an early HTTP 429; statuses={statuses}")
+    if require_429 and shed_count > 0 and ok_count == 0:
+        return {
+            "requests": requests,
+            "requests_sent": len(results),
+            "concurrency": concurrency,
+            "elapsed_s": round(elapsed, 3),
+            "requests_per_second": round(len(results) / elapsed, 3),
+            "statuses": statuses,
+            "ok": ok_count,
+            "shed_429": shed_count,
+            "success_ratio": round(success_ratio, 3),
+            "ttft_ms_p50": None,
+            "ttft_ms_p95": None,
+            "ttft_ms_max": None,
+            "output_tokens": output_tokens,
+            "output_tokens_per_second": None,
+        }
+    if not ttfts:
+        raise ProbeError("benchmark produced no successful TTFT samples")
+    ttft_p95 = percentile(ttfts, 95)
+    if max_ttft_p95_ms > 0 and ttft_p95 > max_ttft_p95_ms:
+        raise ProbeError(f"benchmark TTFT p95 {ttft_p95}ms exceeds required {max_ttft_p95_ms}ms")
+    generated_tokens_per_second = output_tokens / max(generation_seconds, 0.001)
+    if min_output_tokens_per_second > 0 and generated_tokens_per_second < min_output_tokens_per_second:
+        raise ProbeError(
+            "benchmark generated-token throughput "
+            f"{generated_tokens_per_second:.3f} tokens/s below required {min_output_tokens_per_second:.3f} tokens/s"
+        )
+    return {
+        "requests": requests,
+        "requests_sent": len(results),
+        "concurrency": concurrency,
+        "elapsed_s": round(elapsed, 3),
+        "requests_per_second": round(len(results) / elapsed, 3),
+        "statuses": statuses,
+        "ok": ok_count,
+        "shed_429": shed_count,
+        "success_ratio": round(success_ratio, 3),
+        "ttft_ms_p50": int(statistics.median(ttfts)) if ttfts else None,
+        "ttft_ms_p95": ttft_p95,
+        "ttft_ms_max": max(ttfts) if ttfts else None,
+        "output_tokens": output_tokens,
+        "output_tokens_per_second": round(generated_tokens_per_second, 3),
+    }
+
+
+def check_wholesale_statement(admin_url: str, token: str, account_id: str, period: str, require_free_line: bool = False) -> dict:
+    endpoint = normalize_base_url(admin_url) + "/admin/ledger/wholesale-statements"
+    statement, _ = read_json("POST", endpoint, token=token, body={"account_id": account_id, "period": period})
+    statement_id = statement.get("wholesale_statement_id")
+    if not isinstance(statement_id, str) or not statement_id:
+        raise ProbeError("wholesale statement response missing wholesale_statement_id")
+    if statement.get("account_id") != account_id:
+        raise ProbeError(f"wholesale statement account_id mismatch: {statement.get('account_id')!r}")
+    if statement.get("period") != period:
+        raise ProbeError(f"wholesale statement period mismatch: {statement.get('period')!r}")
+    if not isinstance(statement.get("usd_micro"), int) or statement["usd_micro"] < 0:
+        raise ProbeError("wholesale statement usd_micro must be a non-negative integer")
+    line_items = statement.get("line_items")
+    if not isinstance(line_items, list) or not line_items:
+        raise ProbeError("wholesale statement line_items must be a non-empty array")
+    total_request_count = 0
+    total_gross_credits = 0
+    has_free_line = False
+    positive_free_credit = False
+    expected_by_model = {}
+    for item in line_items:
+        if not isinstance(item, dict):
+            raise ProbeError("wholesale statement line item must be an object")
+        model = item.get("model")
+        if not isinstance(model, str) or not model:
+            raise ProbeError(f"line item model must be non-empty: {item}")
+        if model in expected_by_model:
+            raise ProbeError(f"duplicate line item model: {model}")
+        if item.get("is_free") is True:
+            has_free_line = True
+        if item.get("is_free") is True and item.get("usd_micro") != 0:
+            raise ProbeError(f"free SKU line item charged non-zero usd_micro: {item}")
+        if not isinstance(item.get("request_count"), int) or item["request_count"] < 0:
+            raise ProbeError(f"line item request_count must be non-negative: {item}")
+        if not isinstance(item.get("gross_credits"), int) or item["gross_credits"] < 0:
+            raise ProbeError(f"line item gross_credits must be non-negative: {item}")
+        if item["request_count"] > 0 and item["gross_credits"] <= 0:
+            raise ProbeError(f"settled line item must carry positive gross_credits: {item}")
+        if item.get("is_free") is True and item["request_count"] > 0 and item["gross_credits"] > 0:
+            positive_free_credit = True
+        total_request_count += item["request_count"]
+        total_gross_credits += item["gross_credits"]
+        expected_by_model[model] = item
+    if total_request_count < 1:
+        raise ProbeError("wholesale statement must include at least one settled request")
+    if total_gross_credits < 1:
+        raise ProbeError("wholesale statement must include positive provider credit evidence")
+    if require_free_line and not has_free_line:
+        raise ProbeError("filing-mode wholesale statement must include a free SKU line item")
+    if require_free_line and not positive_free_credit:
+        raise ProbeError("filing-mode wholesale statement must include a free SKU line item with positive provider credits")
+    csv_url = endpoint + "/" + urllib.parse.quote(statement_id) + "?format=csv"
+    with http_request("GET", csv_url, token=token) as resp:
+        csv_body = resp.read().decode("utf-8", "replace")
+        status = response_status(resp)
+        if status != 200:
+            raise ProbeError(f"statement CSV returned HTTP {status}")
+    if "wholesale_statement_id" not in csv_body:
+        raise ProbeError("statement CSV missing wholesale_statement_id header")
+    if "invoice_id" in csv_body or "buyer_invoice" in csv_body:
+        raise ProbeError("statement CSV leaked forbidden invoice naming")
+    csv_rows = list(csv.DictReader(io.StringIO(csv_body)))
+    if len(csv_rows) != len(line_items):
+        raise ProbeError(f"statement CSV row count {len(csv_rows)} does not match JSON line items {len(line_items)}")
+    for row in csv_rows:
+        if row.get("wholesale_statement_id") != statement_id:
+            raise ProbeError(f"statement CSV id mismatch: {row}")
+        if row.get("account_id") != account_id:
+            raise ProbeError(f"statement CSV account mismatch: {row}")
+        if row.get("period") != period:
+            raise ProbeError(f"statement CSV period mismatch: {row}")
+        model = row.get("model", "")
+        expected = expected_by_model.get(model)
+        if expected is None:
+            raise ProbeError(f"statement CSV has unexpected model row: {row}")
+        for key in ("request_count", "gross_credits", "usd_micro"):
+            try:
+                parsed = int(row.get(key, ""))
+            except ValueError as exc:
+                raise ProbeError(f"statement CSV {key} must be integer: {row}") from exc
+            if parsed != expected[key]:
+                raise ProbeError(f"statement CSV {key} mismatch for {model}: {parsed} != {expected[key]}")
+        if str(expected["is_free"]).lower() != row.get("is_free", "").lower():
+            raise ProbeError(f"statement CSV is_free mismatch for {model}: {row}")
+    return {
+        "wholesale_statement_id": statement_id,
+        "account_id": account_id,
+        "period": period,
+        "line_items": len(line_items),
+        "request_count": total_request_count,
+        "gross_credits": total_gross_credits,
+        "has_free_line": has_free_line,
+        "positive_free_credit": positive_free_credit,
+        "usd_micro": statement["usd_micro"],
+        "csv_ok": True,
+    }
+
+
+def load_token(env_name: str, path: str) -> str:
+    token = os.environ.get(env_name, "")
+    if token:
+        return token.strip()
+    if path:
+        return Path(path).read_text(encoding="utf-8").strip()
+    return ""
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default="https://api.malibu.tech")
+    parser.add_argument("--api-key-env", default="MACPROVIDER_SPEC015_API_KEY")
+    parser.add_argument("--api-key-file", default="")
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--max-tokens", type=int, default=16)
+    parser.add_argument("--benchmark-requests", type=int, default=0)
+    parser.add_argument("--benchmark-concurrency", type=int, default=4)
+    parser.add_argument("--min-success-ratio", type=float, default=DEFAULT_MIN_SUCCESS_RATIO)
+    parser.add_argument("--max-ttft-p95-ms", type=int, default=DEFAULT_MAX_TTFT_P95_MS)
+    parser.add_argument("--min-output-tokens-per-second", type=float, default=DEFAULT_MIN_OUTPUT_TOKENS_PER_SECOND)
+    parser.add_argument("--saturation-requests", type=int, default=0)
+    parser.add_argument("--saturation-concurrency", type=int, default=8)
+    parser.add_argument("--admin-url", default="")
+    parser.add_argument("--operator-key-env", default="OPERATOR_KEY")
+    parser.add_argument("--operator-key-file", default="")
+    parser.add_argument("--statement-account-id", default="")
+    parser.add_argument("--statement-period", default="")
+    parser.add_argument("--continue-on-error", action="store_true", help="collect later checks even when an earlier check fails")
+    parser.add_argument("--filing-mode", action="store_true", help="fail unless chat, benchmark, and statement evidence are all collected")
+    parser.add_argument("--output", default="", help="write the JSON report to this path")
+    args = parser.parse_args(argv)
+    if args.min_success_ratio < 0 or args.min_success_ratio > 1:
+        raise SystemExit("--min-success-ratio must be in [0,1]")
+    if args.filing_mode:
+        if args.benchmark_requests < 100:
+            raise SystemExit("--filing-mode requires --benchmark-requests >= 100")
+        if args.saturation_requests < 1:
+            raise SystemExit("--filing-mode requires --saturation-requests > 0")
+        if not (args.admin_url and args.statement_account_id and args.statement_period):
+            raise SystemExit("--filing-mode requires --admin-url, --statement-account-id, and --statement-period")
+
+    report = {"base_url": args.base_url, "model": args.model, "checks": {}}
+    errors = []
+
+    def record_check(name: str, fn):
+        try:
+            report["checks"][name] = fn()
+        except ProbeError as exc:
+            report["checks"][name] = {"ok": False, "error": str(exc)}
+            errors.append(f"{name}: {exc}")
+            if not args.continue_on_error:
+                raise
+
+    try:
+        record_check(
+            "models",
+            lambda: check_models_document(
+                read_json("GET", v1_url(args.base_url, "/openrouter/models"))[0],
+                args.model,
+                args.filing_mode,
+            ),
+        )
+        record_check("privacy", lambda: check_privacy(args.base_url))
+        token = load_token(args.api_key_env, args.api_key_file)
+        if token:
+            record_check("chat", lambda: check_chat(args.base_url, token, args.model, args.max_tokens))
+            if args.filing_mode:
+                record_check("chat_free", lambda: check_chat(args.base_url, token, expected_free_model_id(args.model), args.max_tokens))
+            if args.benchmark_requests > 0:
+                record_check(
+                    "benchmark",
+                    lambda: run_benchmark(
+                        args.base_url,
+                        token,
+                        args.model,
+                        args.benchmark_requests,
+                        args.benchmark_concurrency,
+                        args.max_tokens,
+                        args.min_success_ratio,
+                        args.max_ttft_p95_ms,
+                        args.min_output_tokens_per_second,
+                    ),
+                )
+            if args.saturation_requests > 0:
+                record_check(
+                    "saturation",
+                    lambda: run_benchmark(
+                        args.base_url,
+                        token,
+                        args.model,
+                        args.saturation_requests,
+                        args.saturation_concurrency,
+                        args.max_tokens,
+                        0.0,
+                        args.max_ttft_p95_ms,
+                        0.0,
+                        True,
+                    ),
+                )
+        else:
+            report["checks"]["chat"] = {"skipped": "missing API key"}
+            report["checks"]["benchmark"] = {"skipped": "missing API key"}
+            report["checks"]["saturation"] = {"skipped": "missing API key"}
+            if args.filing_mode:
+                errors.append("filing mode requires API key")
+        operator_token = load_token(args.operator_key_env, args.operator_key_file)
+        if args.admin_url and operator_token and args.statement_account_id and args.statement_period:
+            record_check(
+                "wholesale_statement",
+                lambda: check_wholesale_statement(
+                    args.admin_url,
+                    operator_token,
+                    args.statement_account_id,
+                    args.statement_period,
+                    args.filing_mode,
+                ),
+            )
+        else:
+            report["checks"]["wholesale_statement"] = {"skipped": "admin URL, operator key, account id, or period missing"}
+            if args.filing_mode:
+                errors.append("filing mode requires wholesale statement evidence")
+    except ProbeError as exc:
+        report["ok"] = False
+        report["error"] = str(exc)
+        return finish(report, args.output, 1)
+    if errors:
+        report["ok"] = False
+        report["errors"] = errors
+        return finish(report, args.output, 1)
+    report["ok"] = True
+    return finish(report, args.output, 0)
+
+
+def finish(report: dict, output: str, code: int) -> int:
+    try:
+        emit_report(report, output)
+    except ProbeError as exc:
+        report["ok"] = False
+        report["output_error"] = str(exc)
+        print(json.dumps(report, indent=2, sort_keys=True))
+        return 1
+    return code
+
+
+def emit_report(report: dict, output: str) -> None:
+    rendered = json.dumps(report, indent=2, sort_keys=True)
+    if output:
+        path = Path(output)
+        path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        try:
+            fd = os.open(path, flags, 0o600)
+        except FileExistsError as exc:
+            raise ProbeError(f"refusing to overwrite existing report: {path}") from exc
+        except OSError as exc:
+            raise ProbeError(f"cannot create report safely at {path}: {exc}") from exc
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(rendered + "\n")
+    print(rendered)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/tests/test_openrouter_readiness_probe.py
+++ b/scripts/tests/test_openrouter_readiness_probe.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+"""Offline tests for the OpenRouter readiness probe."""
+
+from __future__ import annotations
+
+import copy
+import os
+import sys
+import tempfile
+import unittest
+from unittest import mock
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import openrouter_readiness_probe as probe  # noqa: E402
+
+
+class FakeHTTPResponse:
+    def __init__(self, body: bytes, status: int = 200):
+        self._body = body
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self):
+        return self._body
+
+
+def valid_doc():
+    return {
+        "data": [
+            {
+                "schema_version": "2.4",
+                "id": "mlx-community/Llama-3.2-3B-Instruct-4bit",
+                "name": "Llama 3.2 3B Instruct (4-bit)",
+                "created": 1729728000,
+                "quantization": "int4",
+                "tokenizer": "Llama3",
+                "hugging_face_id": "mlx-community/Llama-3.2-3B-Instruct-4bit",
+                "input_modalities": [
+                    {
+                        "type": "text",
+                        "supported_inputs": {"max_context_length": {"value": 50000, "unit": "token"}},
+                        "pricing": [{"type": "prompt", "unit": "token", "cost_usd": "0.0000000135"}],
+                        "capacity": [{"type": "prompt", "unit": "token", "per": "minute", "value": 24576}],
+                    }
+                ],
+                "output_modalities": [
+                    {
+                        "type": "text",
+                        "max_length": {"value": 4096, "unit": "token"},
+                        "streaming": True,
+                        "supported_parameters": {
+                            "max_tokens": {"type": "integer", "min": 1, "max": 4096, "unit": "token"},
+                            "temperature": {"type": "range", "min": 0, "max": 2},
+                            "top_p": {"type": "range", "min": 0, "max": 1},
+                            "stop": {"type": "array", "max_items": 4},
+                            "stream": {"type": "boolean"},
+                        },
+                        "pricing": [{"type": "completion", "unit": "token", "cost_usd": "0.000000027"}],
+                        "capacity": [{"type": "completion", "unit": "token", "per": "minute", "value": 24576}],
+                    }
+                ],
+                "capacity": [
+                    {"type": "request", "unit": "request", "per": "minute", "value": 6},
+                    {"type": "concurrency", "unit": "request", "value": 1},
+                ],
+                "deployment_region": "global-volunteer-fleet",
+                "compliance": {"zdr": False},
+                "is_ready": True,
+                "is_free": False,
+                "openrouter": {"slug": "meta-llama/llama-3.2-3b-instruct"},
+            }
+        ]
+    }
+
+
+class OpenRouterReadinessProbeTests(unittest.TestCase):
+    def test_valid_schema_24_native_document_passes(self):
+        got = probe.check_models_document(valid_doc(), "mlx-community/Llama-3.2-3B-Instruct-4bit")
+        self.assertEqual(got["rows"], 1)
+        self.assertEqual(got["ids"], ["mlx-community/Llama-3.2-3B-Instruct-4bit"])
+
+    def test_models_document_must_include_requested_paid_model(self):
+        doc = valid_doc()
+        doc["data"][0]["id"] = "other-model"
+        with self.assertRaisesRegex(probe.ProbeError, "missing requested model"):
+            probe.check_models_document(doc, "mlx-community/Llama-3.2-3B-Instruct-4bit")
+
+    def test_legacy_model_document_fails(self):
+        doc = valid_doc()
+        row = doc["data"][0]
+        row["architecture"] = {"input_modalities": ["text"], "output_modalities": ["text"]}
+        row["cost_usd"] = {"prompt": "0.1", "completion": "0.1"}
+        with self.assertRaisesRegex(probe.ProbeError, "forbidden root keys"):
+            probe.check_models_document(doc)
+
+    def test_missing_capacity_fails(self):
+        doc = valid_doc()
+        del doc["data"][0]["capacity"]
+        with self.assertRaisesRegex(probe.ProbeError, "capacity"):
+            probe.check_models_document(doc)
+
+    def test_price_strings_must_be_finite_decimals(self):
+        for bad in ("", "-0.1", "NaN", "Infinity", "-Infinity"):
+            with self.subTest(bad=bad):
+                with self.assertRaises(probe.ProbeError):
+                    probe.check_decimal(bad, "cost")
+
+    def test_stream_usage_validator_requires_all_token_counts(self):
+        self.assertTrue(probe.usage_is_valid({"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3}))
+        self.assertFalse(probe.usage_is_valid({"prompt_tokens": 1, "completion_tokens": 2}))
+
+    def test_free_row_zero_pricing_is_valid(self):
+        doc = valid_doc()
+        free = copy.deepcopy(doc["data"][0])
+        free["id"] += "-free"
+        free["is_free"] = True
+        free["openrouter"]["slug"] += ":free"
+        free["input_modalities"][0]["pricing"][0]["cost_usd"] = "0"
+        free["output_modalities"][0]["pricing"][0]["cost_usd"] = "0"
+        doc["data"].append(free)
+        got = probe.check_models_document(doc)
+        self.assertEqual(got["rows"], 2)
+
+    def test_filing_mode_requires_ready_zero_priced_free_alias(self):
+        doc = valid_doc()
+        with self.assertRaisesRegex(probe.ProbeError, "missing free alias"):
+            probe.check_models_document(doc, "mlx-community/Llama-3.2-3B-Instruct-4bit", True)
+        free = copy.deepcopy(doc["data"][0])
+        free["id"] += "-free"
+        free["is_free"] = True
+        free["is_ready"] = True
+        free["openrouter"]["slug"] += ":free"
+        free["input_modalities"][0]["pricing"][0]["cost_usd"] = "0"
+        free["output_modalities"][0]["pricing"][0]["cost_usd"] = "0"
+        doc["data"].append(free)
+        got = probe.check_models_document(doc, "mlx-community/Llama-3.2-3B-Instruct-4bit", True)
+        self.assertEqual(got["rows"], 2)
+        free["is_ready"] = False
+        with self.assertRaisesRegex(probe.ProbeError, "is_ready"):
+            probe.check_models_document(doc, "mlx-community/Llama-3.2-3B-Instruct-4bit", True)
+
+    def test_deployment_region_must_be_the_honest_volunteer_fleet_descriptor(self):
+        doc = valid_doc()
+        doc["data"][0]["deployment_region"] = "us-east-1"
+        with self.assertRaisesRegex(probe.ProbeError, "global-volunteer-fleet"):
+            probe.check_models_document(doc)
+
+    def test_datacenters_are_rejected_until_geography_provenance_exists(self):
+        doc = valid_doc()
+        doc["data"][0]["datacenters"] = [{"country_code": "US"}]
+        with self.assertRaisesRegex(probe.ProbeError, "omit datacenters"):
+            probe.check_models_document(doc)
+
+    def test_forbidden_provider_identity_keys_fail_recursively(self):
+        doc = valid_doc()
+        doc["data"][0]["openrouter"]["provider_id"] = "provider-123"
+        with self.assertRaisesRegex(probe.ProbeError, "provider_id"):
+            probe.check_models_document(doc)
+
+    def test_known_openrouter_slug_must_not_echo_pool_id(self):
+        doc = valid_doc()
+        doc["data"][0]["openrouter"]["slug"] = doc["data"][0]["id"]
+        with self.assertRaisesRegex(probe.ProbeError, "openrouter.slug"):
+            probe.check_models_document(doc)
+
+    def test_http_request_refuses_external_plaintext_bearer(self):
+        with self.assertRaisesRegex(probe.ProbeError, "non-HTTPS"):
+            probe.http_request("GET", "http://example.com/v1/models", token="secret")
+
+    def test_http_request_refuses_authenticated_redirects(self):
+        req = probe.urllib.request.Request("https://api.example.test/v1/chat/completions")
+        with self.assertRaisesRegex(probe.ProbeError, "refusing redirect"):
+            probe.NoRedirectHandler().redirect_request(req, None, 302, "Found", {}, "https://evil.example.test/")
+
+    def test_http_request_refuses_redirects_for_unauthenticated_requests(self):
+        with mock.patch.object(probe.NO_REDIRECT_OPENER, "open", return_value=FakeHTTPResponse(b"{}")) as mocked:
+            got = probe.http_request("GET", "https://api.example.test/v1/openrouter/models")
+        self.assertIsInstance(got, FakeHTTPResponse)
+        self.assertEqual(mocked.call_count, 1)
+
+    def test_read_json_sanitizes_non_2xx_response_bodies(self):
+        with mock.patch.object(probe, "http_request", return_value=FakeHTTPResponse(b'{"secret":"do-not-print"}', status=500)):
+            with self.assertRaisesRegex(probe.ProbeError, "returned HTTP 500") as caught:
+                probe.read_json("POST", "https://admin.example.test/admin/ledger", token="operator")
+        self.assertNotIn("do-not-print", str(caught.exception))
+
+    def test_long_stream_without_keepalive_fails_chat_check(self):
+        with mock.patch.object(
+            probe,
+            "chat_once",
+            side_effect=[
+                {"status": 200, "ok": True, "usage_ok": True, "content_ok": True, "latency_ms": 10, "output_tokens": 1},
+                {
+                    "status": 200,
+                    "ok": True,
+                    "usage_ok": True,
+                    "content_ok": True,
+                    "latency_ms": probe.GATEWAY_KEEPALIVE_TICK_SECONDS * 1000,
+                    "keepalive_evidence": "missing",
+                },
+            ],
+        ):
+            with self.assertRaisesRegex(probe.ProbeError, "keepalive"):
+                probe.check_chat("https://api.example.test", "secret", "model", 16)
+
+    def test_privacy_requires_no_training_and_rejects_zdr_contradictions(self):
+        good = (
+            "Prompts are plaintext. There is no zero-data-retention guarantee. "
+            "The OpenRouter ingest document sets compliance.zdr to false. "
+            "Request metadata is retained for 90 days. "
+            "Mac Provider does not train foundation models on buyer prompts. "
+            "Prompt and completion bodies are not stored as a training corpus."
+        )
+        with mock.patch.object(probe, "http_request", return_value=FakeHTTPResponse(good.encode())):
+            got = probe.check_privacy("https://api.example.test")
+        self.assertTrue(got["training_corpus_denied"])
+        bad = good + " compliance.zdr: true"
+        with mock.patch.object(probe, "http_request", return_value=FakeHTTPResponse(bad.encode())):
+            with self.assertRaisesRegex(probe.ProbeError, "forbidden claim"):
+                probe.check_privacy("https://api.example.test")
+
+    def test_saturation_accepts_all_capacity_shed_batch(self):
+        with mock.patch.object(
+            probe,
+            "chat_once",
+            side_effect=[{"status": 429, "ok": False, "error_code": "no_provider_available", "latency_ms": 1} for _ in range(3)],
+        ):
+            got = probe.run_benchmark("https://api.example.test", "secret", "model", 3, 2, 16, 0.0, 5000, 0.0, True)
+        self.assertEqual(got["ok"], 0)
+        self.assertEqual(got["shed_429"], 2)
+        self.assertIsNone(got["ttft_ms_p95"])
+
+    def test_benchmark_still_fails_when_everything_sheds(self):
+        with mock.patch.object(
+            probe,
+            "chat_once",
+            side_effect=[{"status": 429, "ok": False, "error_code": "no_provider_available", "latency_ms": 1} for _ in range(3)],
+        ):
+            with self.assertRaisesRegex(probe.ProbeError, "success ratio"):
+                probe.run_benchmark("https://api.example.test", "secret", "model", 3, 2, 16, 1.0, 5000, 0.0, False)
+
+    def test_saturation_does_not_count_account_limit_429_as_capacity_shed(self):
+        account_limit = {"status": 429, "ok": False, "error_code": "account_rate_limited", "latency_ms": 1}
+        with mock.patch.object(probe, "chat_once", side_effect=[account_limit]):
+            with self.assertRaisesRegex(probe.ProbeError, "non-capacity-shed"):
+                probe.run_benchmark("https://api.example.test", "secret", "model", 1, 1, 16, 0.0, 5000, 0.0, True)
+
+    def test_benchmark_requires_429_when_saturation_is_requested(self):
+        result = {
+            "status": 200,
+            "ok": True,
+            "ttft_ms": 20,
+            "latency_ms": 60,
+            "generation_ms": 40,
+            "output_tokens": 4,
+        }
+        with mock.patch.object(probe, "chat_once", side_effect=[result, result]):
+            with self.assertRaisesRegex(probe.ProbeError, "did not observe"):
+                probe.run_benchmark("https://api.example.test", "secret", "model", 2, 2, 16, 0.0, 5000, 0.0, True)
+
+    def test_saturation_stops_after_first_capacity_shed_batch(self):
+        ok = {
+            "status": 200,
+            "ok": True,
+            "ttft_ms": 20,
+            "latency_ms": 60,
+            "generation_ms": 40,
+            "output_tokens": 4,
+        }
+        shed = {"status": 429, "ok": False, "error_code": "no_provider_available", "latency_ms": 1}
+        with mock.patch.object(probe, "chat_once", side_effect=[ok, shed, ok, ok]) as mocked:
+            got = probe.run_benchmark("https://api.example.test", "secret", "model", 4, 2, 16, 0.0, 5000, 0.0, True)
+        self.assertEqual(mocked.call_count, 2)
+        self.assertEqual(got["requests_sent"], 2)
+        self.assertEqual(got["shed_429"], 1)
+
+    def test_benchmark_enforces_ttft_and_generated_token_throughput(self):
+        slow_ttft = {
+            "status": 200,
+            "ok": True,
+            "ttft_ms": 6000,
+            "latency_ms": 7000,
+            "generation_ms": 1000,
+            "output_tokens": 10,
+        }
+        with mock.patch.object(probe, "chat_once", side_effect=[slow_ttft]):
+            with self.assertRaisesRegex(probe.ProbeError, "TTFT p95"):
+                probe.run_benchmark("https://api.example.test", "secret", "model", 1, 1, 16, 1.0, 5000, 1.0)
+        low_throughput = {
+            "status": 200,
+            "ok": True,
+            "ttft_ms": 20,
+            "latency_ms": 10020,
+            "generation_ms": 10000,
+            "output_tokens": 1,
+        }
+        with mock.patch.object(probe, "chat_once", side_effect=[low_throughput]):
+            with self.assertRaisesRegex(probe.ProbeError, "throughput"):
+                probe.run_benchmark("https://api.example.test", "secret", "model", 1, 1, 16, 1.0, 5000, 1.0)
+
+    def test_benchmark_rejects_unbounded_stress_inputs(self):
+        with self.assertRaisesRegex(probe.ProbeError, "requests"):
+            probe.run_benchmark(
+                "https://api.example.test",
+                "secret",
+                "model",
+                probe.MAX_BENCHMARK_REQUESTS + 1,
+                1,
+                16,
+                1.0,
+                5000,
+                1.0,
+            )
+
+    def test_wholesale_statement_requires_line_items_and_requests(self):
+        with mock.patch.object(
+            probe,
+            "read_json",
+            return_value=(
+                {
+                    "wholesale_statement_id": "stmt_1",
+                    "account_id": "acct_openrouter",
+                    "period": "2026-09",
+                    "usd_micro": 0,
+                    "line_items": [],
+                },
+                200,
+            ),
+        ):
+            with self.assertRaisesRegex(probe.ProbeError, "non-empty"):
+                probe.check_wholesale_statement("https://admin.example.test", "operator", "acct_openrouter", "2026-09")
+
+    def test_filing_mode_requires_free_sku_statement_line(self):
+        class FakeCSV:
+            status = 200
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return b"wholesale_statement_id,account_id\nstmt_1,acct_openrouter\n"
+
+        statement = {
+            "wholesale_statement_id": "stmt_1",
+            "account_id": "acct_openrouter",
+            "period": "2026-09",
+            "usd_micro": 10,
+            "line_items": [{"model": "paid-model", "is_free": False, "usd_micro": 10, "request_count": 1, "gross_credits": 10}],
+        }
+        with mock.patch.object(probe, "read_json", return_value=(statement, 200)), mock.patch.object(probe, "http_request", return_value=FakeCSV()):
+            with self.assertRaisesRegex(probe.ProbeError, "free SKU"):
+                probe.check_wholesale_statement("https://admin.example.test", "operator", "acct_openrouter", "2026-09", True)
+
+    def test_wholesale_statement_matches_csv_rows_and_free_credit(self):
+        statement = {
+            "wholesale_statement_id": "stmt_1",
+            "account_id": "acct_openrouter",
+            "period": "2026-09",
+            "usd_micro": 10,
+            "line_items": [
+                {"model": "paid-model", "is_free": False, "usd_micro": 10, "request_count": 1, "gross_credits": 10},
+                {"model": "free-model-free", "is_free": True, "usd_micro": 0, "request_count": 1, "gross_credits": 5},
+            ],
+        }
+        csv_body = (
+            "wholesale_statement_id,account_id,period,model,is_free,request_count,prompt_tokens,completion_tokens,gross_credits,usd_micro,usd\n"
+            "stmt_1,acct_openrouter,2026-09,paid-model,false,1,2,3,10,10,0.000010\n"
+            "stmt_1,acct_openrouter,2026-09,free-model-free,true,1,2,3,5,0,0\n"
+        )
+        with mock.patch.object(probe, "read_json", return_value=(statement, 200)), mock.patch.object(
+            probe, "http_request", return_value=FakeHTTPResponse(csv_body.encode())
+        ):
+            got = probe.check_wholesale_statement("https://admin.example.test", "operator", "acct_openrouter", "2026-09", True)
+        self.assertEqual(got["request_count"], 2)
+        self.assertTrue(got["positive_free_credit"])
+
+    def test_wholesale_statement_rejects_csv_mismatches(self):
+        statement = {
+            "wholesale_statement_id": "stmt_1",
+            "account_id": "acct_openrouter",
+            "period": "2026-09",
+            "usd_micro": 10,
+            "line_items": [{"model": "paid-model", "is_free": False, "usd_micro": 10, "request_count": 1, "gross_credits": 10}],
+        }
+        csv_body = (
+            "wholesale_statement_id,account_id,period,model,is_free,request_count,prompt_tokens,completion_tokens,gross_credits,usd_micro,usd\n"
+            "stmt_1,acct_openrouter,2026-09,paid-model,false,1,2,3,10,9,0.000009\n"
+        )
+        with mock.patch.object(probe, "read_json", return_value=(statement, 200)), mock.patch.object(
+            probe, "http_request", return_value=FakeHTTPResponse(csv_body.encode())
+        ):
+            with self.assertRaisesRegex(probe.ProbeError, "usd_micro mismatch"):
+                probe.check_wholesale_statement("https://admin.example.test", "operator", "acct_openrouter", "2026-09")
+
+    def test_emit_report_creates_private_non_overwritten_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp) / "nested" / "report.json"
+            probe.emit_report({"ok": True}, str(output))
+            self.assertEqual(output.stat().st_mode & 0o777, 0o600)
+            with self.assertRaisesRegex(probe.ProbeError, "overwrite"):
+                probe.emit_report({"ok": True}, str(output))
+            self.assertEqual(os.stat(output).st_size, len('{\n  "ok": true\n}\n'))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/specs/CONFORMANCE.json
+++ b/specs/CONFORMANCE.json
@@ -151,7 +151,7 @@
     {
       "spec_id": "SPEC-006",
       "title": "Buyer API Gateway: Mac Provider's first public buyer surface",
-      "version": "0.9.23",
+      "version": "0.9.24",
       "path": "specs/SPEC-006-buyer-api.md",
       "status": "normative",
       "owner": "@Augustas11",
@@ -4734,8 +4734,12 @@
       ],
       "tests": [
         "phase5-gateway/internal/router/openrouter_models_test.go:TestProjectOpenRouterModelsDualLlamaSKU",
+        "phase5-gateway/internal/router/openrouter_models_test.go:TestProjectOpenRouterModelsRowsStaySchema24Native",
+        "phase5-gateway/internal/router/openrouter_models_test.go:TestProjectOpenRouterModelsCapacityTracksLiveSlots",
+        "phase5-gateway/internal/router/pages_test.go:TestPrivacyRouteRendersHonestRetention",
         "phase5-gateway/internal/router/wholesale_partner_test.go:TestWholesaleNoProviderBecomes429",
-        "phase4-coordinator/internal/billing/normalize_model_key_cases_test.go:TestNormalizeModelKeySharedCaseTable"
+        "phase4-coordinator/internal/billing/normalize_model_key_cases_test.go:TestNormalizeModelKeySharedCaseTable",
+        "scripts/tests/test_openrouter_readiness_probe.py:OpenRouterReadinessProbeTests"
       ],
       "journeys": [],
       "evidence": [],

--- a/specs/README.md
+++ b/specs/README.md
@@ -14,7 +14,7 @@ it can no longer drift. Do not hand-edit the table; edit each spec's
 | SPEC-003 | Open Onboarding: Distribution, Lifecycle & Onboarding UX | 0.11.3 | normative | pending | pending: 2 | [SPEC-003-open-onboarding.md](SPEC-003-open-onboarding.md) |
 | SPEC-004 | Smart Router | 0.3.4 | normative | pending | pending corpus migration | [SPEC-004-smart-router.md](SPEC-004-smart-router.md) |
 | SPEC-005 | Billing, Settlement, and Provider Rewards | 0.6.7 | normative | complete | conformant: 3, pending: 8 | [SPEC-005-billing.md](SPEC-005-billing.md) |
-| SPEC-006 | Buyer API Gateway: Mac Provider's first public buyer surface | 0.9.23 | normative | complete | conformant: 1, pending: 9 | [SPEC-006-buyer-api.md](SPEC-006-buyer-api.md) |
+| SPEC-006 | Buyer API Gateway: Mac Provider's first public buyer surface | 0.9.24 | normative | complete | conformant: 1, pending: 9 | [SPEC-006-buyer-api.md](SPEC-006-buyer-api.md) |
 | SPEC-007 | Internal Operator Protocol Explorer | 0.5.1 | normative | pending | pending corpus migration | [SPEC-007-explorer.md](SPEC-007-explorer.md) |
 | SPEC-008 | Tier-2 Trust Layer | 0.6.2 | normative | pending | pending: 1 | [SPEC-008-tier2.md](SPEC-008-tier2.md) |
 | SPEC-009 | MacProvider Console v2 | 0.1 | normative | pending | pending corpus migration | [SPEC-009-console-v2.md](SPEC-009-console-v2.md) |

--- a/specs/SPEC-006-buyer-api.md
+++ b/specs/SPEC-006-buyer-api.md
@@ -1,7 +1,12 @@
 # SPEC-006 - Buyer API Gateway: Mac Provider's first public buyer surface
 
-**Version:** 0.9.23 (2026-09-11, OpenRouter wholesale partner surface)
+**Version:** 0.9.24 (2026-09-13, OpenRouter schema-2.4 native rows)
 **Depends on:** SPEC-001 v1.2.4, SPEC-002 v1.5.4, SPEC-003 v0.7, SPEC-004 v0.3.2
+
+**Change log v0.9.24 (2026-09-13, OpenRouter schema-2.4 native rows):**
+- `GET /v1/openrouter/models` now uses the current OpenRouter model document format for new provider integrations: each model row carries `schema_version: "2.4"`, typed `input_modalities` and `output_modalities`, modality-owned `pricing` and `capacity`, root request/concurrency capacity, an honest volunteer-fleet `deployment_region`, and no `datacenters` entry unless operator-verified geography metadata exists.
+- The legacy row fields `architecture`, `context_length`, root `cost_usd`, flat `supported_sampling_parameters`, `supported_features`, and `capacity_tpm` remain forbidden on this OpenRouter ingest path. Public `/v1/models` is unchanged.
+- `/privacy` MUST name the shipped 90-day default coordinator `storage.request_log_retention_days` window while continuing to disclose plaintext volunteer-Mac processing and `compliance.zdr=false`.
 
 **Change log v0.9.23 (2026-09-11, OpenRouter join on the live pool):**
 - Additive unauthenticated `GET /v1/openrouter/models` schema-2.4 document. Public `GET /v1/models` is unchanged (OpenAI list + integrity/`tier1_disclosure`). OpenRouter ingest MUST NOT be served the sanitized public list.
@@ -1420,33 +1425,65 @@ Authentication: unauthenticated. Subject to `kill_switch.all_public_api` like ot
 
 Response status:
 
-- `200` when the gateway can project from live pool state plus the coordinator rate card.
+- `200` when the gateway can project from live pool state plus complete, positive coordinator rate-card rows for every paid row it will publish.
 - `502` / `503` when coordinator pool or rate-card inputs are unavailable. The document MUST NOT invent `is_ready: true`.
 
 Document shape (schema 2.4):
 
 ```json
 {
-  "schema_version": "2.4",
   "data": [
     {
+      "schema_version": "2.4",
       "id": "mlx-community/Llama-3.2-3B-Instruct-4bit",
       "name": "Llama 3.2 3B Instruct (4-bit)",
-      "architecture": {
-        "input_modalities": ["text"],
-        "output_modalities": ["text"],
-        "modality": "text->text"
-      },
-      "context_length": 131072,
+      "created": 1729728000,
       "quantization": "int4",
+      "tokenizer": "Llama3",
       "hugging_face_id": "mlx-community/Llama-3.2-3B-Instruct-4bit",
+      "input_modalities": [
+        {
+          "type": "text",
+          "supported_inputs": {
+            "max_context_length": { "value": 50000, "unit": "token" }
+          },
+          "pricing": [
+            { "type": "prompt", "unit": "token", "cost_usd": "0.0000000135" }
+          ],
+          "capacity": [
+            { "type": "prompt", "unit": "token", "per": "minute", "value": 600 }
+          ]
+        }
+      ],
+      "output_modalities": [
+        {
+          "type": "text",
+          "max_length": { "value": 4096, "unit": "token" },
+          "streaming": true,
+          "supported_parameters": {
+            "max_tokens": { "type": "integer", "min": 1, "max": 4096, "unit": "token" },
+            "temperature": { "type": "range", "min": 0, "max": 2 },
+            "top_p": { "type": "range", "min": 0, "max": 1 },
+            "stop": { "type": "array", "max_items": 4 },
+            "stream": { "type": "boolean" }
+          },
+          "pricing": [
+            { "type": "completion", "unit": "token", "cost_usd": "0.000000027" }
+          ],
+          "capacity": [
+            { "type": "completion", "unit": "token", "per": "minute", "value": 600 }
+          ]
+        }
+      ],
+      "capacity": [
+        { "type": "request", "unit": "request", "per": "minute", "value": 1 },
+        { "type": "concurrency", "unit": "request", "value": 1 }
+      ],
+      "deployment_region": "global-volunteer-fleet",
+      "compliance": { "zdr": false },
       "is_ready": true,
       "is_free": false,
-      "cost_usd": {
-        "prompt": "0.0000000135",
-        "completion": "0.000000027"
-      },
-      "compliance": { "zdr": false }
+      "openrouter": { "slug": "meta-llama/llama-3.2-3b-instruct" }
     }
   ]
 }
@@ -1454,12 +1491,15 @@ Document shape (schema 2.4):
 
 Normative rules:
 
-- Dual Llama 3B rows when that pool id is present: paid id equals the pool `ModelID`; free id is that string plus `-free` with `is_free: true` and `$0` cost. OpenRouter's catalog `:free` suffix is **their** display form, not the wire id.
-- `is_ready` MUST be true only when that pool id currently has at least one ready slot (`slots_free > 0`).
-- `cost_usd` MUST be decimal per-token strings from the live rate card (`credits_per_mtok × usd_per_million_credits / 1e12`). Free rows MUST be `"0"`.
-- `compliance.zdr` MUST be `false`. Prompts are plaintext on provider Macs. MUST NOT invent a datacenter region such as `us-east-1`.
+- Dual Llama 3B rows when that pool id has enough ready-slot capacity to split without double-counting: paid id equals the pool `ModelID`; free id is that string plus `-free` with `is_free: true` and `$0` cost. OpenRouter's catalog `:free` suffix is **their** display form, not the wire id.
+- `is_ready` MUST be true only when that pool id currently has at least one free slot on a provider in `ready` state.
+- Modality-owned `pricing[].cost_usd` MUST be decimal per-token strings from the live rate card (`credits_per_mtok × usd_per_million_credits / 1e12`). Missing paid catalog keys, non-positive paid rates, and non-positive/non-finite USD conversion inputs MUST fail the document projection instead of emitting a paid `$0` row. Free rows MUST be `"0"`.
+- Root capacity MUST declare conservative request/minute and concurrency limits from live ready slots, and text modalities MUST declare prompt/completion token-per-minute capacity using a conservative generated-token filing cap rather than the maximum output length. Until the gateway carries coordinator per-provider throughput estimates into this projection, that filing cap is 10 generated tokens/second per ready slot. If multiple rows route to the same backing pool, their advertised per-row capacity MUST be split so the rows do not imply independent full-pool capacity.
+- `deployment_region` MUST be an honest volunteer-fleet descriptor. `datacenters` MUST be omitted unless the gateway has operator-verified country/region provenance for the live fleet. Neither field may invent a cloud datacenter region such as `us-east-1` or an unsupported country claim.
+- `compliance.zdr` MUST be `false`. Prompts are plaintext on provider Macs.
+- `openrouter.slug` MUST name the OpenRouter catalog slug for the row, not echo a Malibu pool id.
 - Qwen3-8B and other pool ids MUST stay off this document until the id has more than one warm ready provider.
-- The document MUST NOT include `compute_integrity`, `tier1_disclosure`, provider ids, hostnames, or IPs.
+- The document MUST NOT include legacy fields (`architecture`, `context_length`, root `cost_usd`, flat `supported_sampling_parameters`, `supported_features`, or `capacity_tpm`) and MUST NOT include `compute_integrity`, `tier1_disclosure`, provider ids, hostnames, or IPs.
 - Gateway sanitizer for `/v1/models` MUST NOT run on this path.
 
 ### 5.4 `POST /v1/chat/completions`
@@ -2062,7 +2102,7 @@ Unauthenticated HTML page. MUST state honestly:
 - Prompts and completions are processed as plaintext on volunteer Apple Silicon Macs.
 - There is no zero-data-retention (ZDR) guarantee. `compliance.zdr` on the OpenRouter document is `false`.
 - MacProvider does not train foundation models on buyer prompts.
-- Request metadata needed for routing, quota, settlement, and D1a wholesale statements is retained per coordinator `request_log` lifetime.
+- Request metadata needed for routing, quota, settlement, and D1a wholesale statements is retained for 90 days by default, matching the shipped coordinator `storage.request_log_retention_days` value. If an operator changes that configuration, the public page MUST be updated in the same change.
 
 MUST NOT claim private inference, hardware attestation, or a US datacenter region.
 


### PR DESCRIPTION
## Summary

- emit OpenRouter schema-2.4-native model rows with explicit catalog slugs, honest volunteer-fleet/ZDR disclosures, ready-slot capacity, paid/free split handling, and fail-closed paid rate-card projection
- add a dependency-free OpenRouter readiness probe covering model docs, privacy, paid/free chat smoke, streaming usage, benchmark, saturation 429 evidence, safe report output, and wholesale statement/CSV evidence
- document the filing runbook and SPEC-006 contract updates for the OpenRouter application packet

## Verification

- `go test ./... -count=1` in `phase5-gateway`
- `go vet ./internal/router` in `phase5-gateway`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts.tests.test_openrouter_readiness_probe scripts.tests.test_openrouter_pricing_engine`
- `PYTHONPYCACHEPREFIX=/private/tmp/macprovider-openrouter-pycache python3 -m py_compile scripts/openrouter_readiness_probe.py scripts/tests/test_openrouter_readiness_probe.py`
- `go test ./internal/billing -run 'TestGenerateWholesaleStatementPaidVersusFreeSKU|TestWholesaleStatementAdminExport' -count=1` in `phase4-coordinator`
- `go test ./internal/buyer -run TestSlotQueueDoesNotApplyToWholesalePartner -count=1` in `phase4-coordinator`
- `python3 scripts/check_spec_governance.py --base-ref origin/main`
- `python3 scripts/check_spec_pr_declaration.py --event /tmp/openrouter-readiness-pr-event.json --base origin/main --head HEAD`
- `git diff --cached --check`

## Live Readiness

- Credential-free production probe against `https://api.malibu.tech` currently fails because production still serves the old OpenRouter model document and old privacy text.
- Final OpenRouter filing remains blocked until this branch is deployed and `scripts/openrouter_readiness_probe.py --filing-mode` passes with OpenRouter API key, operator key, statement account, statement period, benchmark, saturation, and wholesale statement evidence.
- Claude final adversarial verification is not included because exporting this private staged diff to external Claude was blocked pending explicit approval.

SPEC-GOVERNANCE-DECLARATION-BEGIN
{
  "schema_version": "spec-pr-governance-v1",
  "behavior_change": "yes",
  "contract_change": "yes",
  "specs": ["SPEC-006", "SPEC-005"],
  "requirements": ["SPEC-006-R010", "SPEC-005-R010"],
  "authority_domains": ["model-catalog-identity", "buyer-api-error-contract", "billing-settlement-formula"],
  "arbitration": ["SPEC_BUG"],
  "tests": ["go test ./... -count=1 (phase5-gateway)", "go vet ./internal/router (phase5-gateway)", "PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts.tests.test_openrouter_readiness_probe scripts.tests.test_openrouter_pricing_engine", "go test ./internal/billing -run 'TestGenerateWholesaleStatementPaidVersusFreeSKU|TestWholesaleStatementAdminExport' -count=1", "go test ./internal/buyer -run TestSlotQueueDoesNotApplyToWholesalePartner -count=1"],
  "journeys": ["not-required"]
}
SPEC-GOVERNANCE-DECLARATION-END
